### PR TITLE
Update provider support section to use a table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,14 @@ The default models used for text, images, audio, transcription, and embeddings m
 
 ### Provider Support
 
-**Text:** OpenAI, Anthropic, Gemini, Groq, xAI
-
-**Images:** OpenAI, Gemini, xAI
-
-**TTS:** OpenAI, ElevenLabs
-
-**STT:** OpenAI, ElevenLabs
-
-**Embeddings:** OpenAI, Gemini
+| Provider     | Text | Images | TTS | STT | Embeddings |
+|--------------|------|--------|-----|-----|------------|
+| OpenAI       | ✓    | ✓      | ✓   | ✓   | ✓          |
+| Anthropic    | ✓    | ×      | ×   | ×   | ×          |
+| Gemini       | ✓    | ✓      | ×   | ×   | ✓          |
+| Groq         | ✓    | ×      | ×   | ×   | ×          |
+| xAI          | ✓    | ✓      | ×   | ×   | ×          |
+| ElevenLabs   | ×    | ×      | ✓   | ✓   | ×          |
 
 ## Agents
 


### PR DESCRIPTION
Table looks much better to show provider support visualisation.
<img width="505" height="276" alt="Screenshot 2025-12-24 at 5 27 08 AM" src="https://github.com/user-attachments/assets/c6d985ef-f926-4a72-bd5d-a9cd39bb4d72" />
