### PR TITLE
update concern to match stub data type

### DIFF
--- a/src/Contracts/Tool.php
+++ b/src/Contracts/Tool.php
@@ -4,18 +4,19 @@ namespace Laravel\Ai\Contracts;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Tools\Request;
+use Stringable;
 
 interface Tool
 {
     /**
      * Get the description of the tool's purpose.
      */
-    public function description(): string;
+    public function description(): Stringable|string;
 
     /**
      * Execute the tool.
      */
-    public function handle(Request $request): string;
+    public function handle(Request $request): Stringable|string;
 
     /**
      * Get the tool's schema definition.


### PR DESCRIPTION
The stub file has Stringable|string but the concern only had string. Was causing mismatch and pint to crash on a test implementation.

I think the desired output is Stringable|string and not simply string.
I could have this in reverse though.