### PR TITLE
provide abstract and concrete to scoped

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -17,7 +17,7 @@ class AiServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->scoped(fn ($app): AiManager => new AiManager($app));
+        $this->app->scoped(AiManager::class, fn ($app): AiManager => new AiManager($app));
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');
     }


### PR DESCRIPTION
When trying to run `php artisan queue:work` I was getting this error:
```txt
Cannot unset offset of type Closure on array {"exception":"[object] (TypeError(code: 0): Cannot unset offset of type Closure on array at /Users/devon/Herd/gong/vendor/laravel/framework/src/Illuminate/Container/Container.php:1719)
```
Updating the `$this->app->scoped()` to provide the abstract as the classname alleviated the issue.

*note: this did not effect `php artisan queue:listen`*