### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -26,6 +26,8 @@ use function Laravel\Ai\pipeline;
 
 trait GeneratesText
 {
+    protected string $currentToolInvocationId;
+    
     /**
      * Invoke the given agent.
      */


### PR DESCRIPTION
This property doesn't exist and PHP is unhappy.

```
[2026-01-15 04:33:26] local.WARNING: Creation of dynamic property Laravel\Ai\Providers\OpenAiProvider::$currentToolInvocationId is deprecated in /app/vendor/laravel/ai/src/Providers/Concerns/GeneratesText.php on line 73 
```

<img width="1010" height="480" alt="Screenshot 2026-01-15 at 16 07 02" src="https://github.com/user-attachments/assets/4bccfe76-87b2-450b-a268-5f32a9e104e6" />
