### PR TITLE
Rename index for agent conversations table

### DIFF
--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -34,7 +34,7 @@ return new class extends AiMigration
             $table->text('meta');
             $table->timestamps();
 
-            $table->index(['conversation_id', 'user_id', 'updated_at'], 'acm_conv_user_updated_index');
+            $table->index(['conversation_id', 'user_id', 'updated_at'], 'conversation_index');
             $table->index(['user_id']);
         });
     }


### PR DESCRIPTION
This pull request makes a minor update to the `2026_01_11_000001_create_agent_conversations_table.php` migration file to limit the character length of the index name.

Fixes #26