### PR TITLE
[0.x] use `array_any`

### DIFF
--- a/src/Prompts/EmbeddingsPrompt.php
+++ b/src/Prompts/EmbeddingsPrompt.php
@@ -20,13 +20,7 @@ class EmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        foreach ($this->inputs as $input) {
-            if (Str::contains($input, $string)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
     }
 
     /**

--- a/src/Prompts/QueuedEmbeddingsPrompt.php
+++ b/src/Prompts/QueuedEmbeddingsPrompt.php
@@ -19,13 +19,7 @@ class QueuedEmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        foreach ($this->inputs as $input) {
-            if (Str::contains($input, $string)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
     }
 
     /**

--- a/src/Prompts/RerankingPrompt.php
+++ b/src/Prompts/RerankingPrompt.php
@@ -34,13 +34,7 @@ class RerankingPrompt implements Countable
      */
     public function documentsContain(string $string): bool
     {
-        foreach ($this->documents as $document) {
-            if (Str::contains($document, $string)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->documents, fn ($document) => Str::contains($document, $string));
     }
 
     /**


### PR DESCRIPTION
Prefer `array_any`, which is standard PHP 8.4 syntax.