### PR TITLE
Rename prismConfig to connectionConfig and flatten provider config API

### DIFF
--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -83,7 +83,7 @@ trait CreatesPrismTextRequests
             static::toPrismProvider($provider),
             $model,
             array_filter([
-                ...$provider->prismConfig(),
+                ...$provider->connectionConfig(),
                 ...($provider->driver() === 'anthropic')
                    ? ['anthropic_beta' => 'web-fetch-2025-09-10']
                    : [],

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -181,7 +181,7 @@ class PrismGateway implements Gateway
     ): ImageResponse {
         try {
             $response = Prism::image()
-                ->using(static::toPrismProvider($provider), $model, $provider->prismConfig())
+                ->using(static::toPrismProvider($provider), $model, $provider->connectionConfig())
                 ->withPrompt($prompt, $this->toPrismImageAttachments($attachments))
                 ->withProviderOptions($provider->defaultImageOptions($size, $quality))
                 ->withClientOptions([
@@ -246,7 +246,7 @@ class PrismGateway implements Gateway
 
         try {
             $response = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->prismConfig())
+                ->using(static::toPrismProvider($provider), $model, $provider->connectionConfig())
                 ->withInput($text)
                 ->withVoice($voice)
                 ->withProviderOptions(array_filter([
@@ -281,7 +281,7 @@ class PrismGateway implements Gateway
             }
 
             $request = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->prismConfig())
+                ->using(static::toPrismProvider($provider), $model, $provider->connectionConfig())
                 ->withInput(match (true) {
                     $audio instanceof TranscribableAudio => Audio::fromBase64(
                         base64_encode($audio->content()), $audio->mimeType()

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -39,11 +39,11 @@ abstract class Provider
     }
 
     /**
-     * Get the Prism provider configuration.
+     * Get the provider connection configuration.
      */
-    public function prismConfig(): array
+    public function connectionConfig(): array
     {
-        return $this->config['prism'] ?? [];
+        return array_diff_key($this->config, array_flip(['driver', 'key', 'name']));
     }
 
     /**


### PR DESCRIPTION
Adds support for a `prism` key in provider config that gets forwarded to Prism's `using()` method, enabling custom endpoints and provider-specific parameters.

Closes #32 

```php
  // config/ai.php                                                                                                                       
  'custom-openai' => [
      'driver' => 'openai',                                                                                                              
      'key' => env('CUSTOM_OPENAI_API_KEY'),                                                                                           
      'url' => 'https://my-self-hosted-llm.com/v1',
      'organization' => 'my-org',
  ],
```