### PR TITLE
Allow passing connection config parameters in provider configuration (#32)

### DIFF
--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -83,7 +83,7 @@ trait CreatesPrismTextRequests
             static::toPrismProvider($provider),
             $model,
             array_filter([
-                ...$provider->connectionConfig(),
+                ...$provider->additionalConfiguration(),
                 ...($provider->driver() === 'anthropic')
                    ? ['anthropic_beta' => 'web-fetch-2025-09-10']
                    : [],

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -181,7 +181,7 @@ class PrismGateway implements Gateway
     ): ImageResponse {
         try {
             $response = Prism::image()
-                ->using(static::toPrismProvider($provider), $model, $provider->connectionConfig())
+                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
                 ->withPrompt($prompt, $this->toPrismImageAttachments($attachments))
                 ->withProviderOptions($provider->defaultImageOptions($size, $quality))
                 ->withClientOptions([
@@ -246,7 +246,7 @@ class PrismGateway implements Gateway
 
         try {
             $response = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->connectionConfig())
+                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
                 ->withInput($text)
                 ->withVoice($voice)
                 ->withProviderOptions(array_filter([
@@ -281,7 +281,7 @@ class PrismGateway implements Gateway
             }
 
             $request = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->connectionConfig())
+                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
                 ->withInput(match (true) {
                     $audio instanceof TranscribableAudio => Audio::fromBase64(
                         base64_encode($audio->content()), $audio->mimeType()

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -39,9 +39,9 @@ abstract class Provider
     }
 
     /**
-     * Get the provider connection configuration.
+     * Get the provider connection configuration other than the driver, key, and name.
      */
-    public function connectionConfig(): array
+    public function additionalConfiguration(): array
     {
         return array_diff_key($this->config, array_flip(['driver', 'key', 'name']));
     }


### PR DESCRIPTION
Adds support for passing connection config parameters (e.g. `url`, `organization`) directly in provider configuration, enabling custom endpoints and provider-specific settings.

Closes #32

```php                                                                                                                               
  // config/ai.php
  'custom-openai' => [
      'driver' => 'openai',
      'key' => env('CUSTOM_OPENAI_API_KEY'),
      'url' => 'https://my-self-hosted-llm.com/v1',
      'organization' => 'my-org',
  ],
```