### PR TITLE
Fix ToolCall arguments passed as JSON string instead of array

### DIFF
--- a/src/Gateway/Prism/PrismTool.php
+++ b/src/Gateway/Prism/PrismTool.php
@@ -86,9 +86,6 @@ class PrismTool extends Tool
 
     /**
      * Normalize arguments to an array, decoding JSON strings when necessary.
-     *
-     * Some providers (e.g., Anthropic) return schema_definition as a JSON string
-     * instead of an array.
      */
     protected static function normalizeArguments(mixed $arguments): array
     {


### PR DESCRIPTION
## Description

When using the Anthropic provider with tools, `schema_definition` may be returned as a JSON-encoded string rather than an array. This causes a TypeError in the `ToolCall` constructor which expects an array.

## Error

```
TypeError: Laravel\Ai\Responses\Data\ToolCall::__construct(): Argument #3 ($arguments) must be of type array, string given
```

## Changes

This PR decodes `schema_definition` if it's a string in both `toLaravelToolCall()` and `toLaravelToolResult()` methods in `PrismTool.php`.

```php
$arguments = $toolCall->arguments()['schema_definition'] ?? [];
if (is_string($arguments)) {
    $arguments = json_decode($arguments, true) ?? [];
}
```

Fixes #36