### PR TITLE
[0.x] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /.phpunit.cache
+/.fleet
+/.idea
+/.vscode
 /composer.lock
 /phpunit.xml
 /tmp


### PR DESCRIPTION
Ignores .fleet, .idea and .vscode like the framework repo to stop : 

<img width="633" height="97" alt="image" src="https://github.com/user-attachments/assets/54c3d009-7f01-4270-b5c0-7d877181856a" />
