### PR TITLE
Add Chutes AI provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -60,21 +60,6 @@ return [
         'chutes' => [
             'driver' => 'chutes',
             'key' => env('CHUTES_API_KEY'),
-            'url' => env('CHUTES_BASE_URL', 'https://llm.chutes.ai/v1'),
-            'image_url' => env('CHUTES_IMAGE_URL', 'https://image.chutes.ai/generate'),
-            'tts_url' => env('CHUTES_TTS_URL', 'https://chutes-kokoro.chutes.ai/speak'),
-            'stt_url' => env('CHUTES_STT_URL', 'https://chutes-whisper-large-v3.chutes.ai/transcribe'),
-            'embedding_url' => env('CHUTES_EMBEDDING_URL', 'https://chutes-qwen-qwen3-embedding-0-6b.chutes.ai/v1/embeddings'),
-            'models' => [
-                'default' => env('CHUTES_MODEL', 'deepseek-ai/DeepSeek-V3'),
-                'cheapest' => env('CHUTES_CHEAPEST_MODEL', 'unsloth/gemma-3-4b-it'),
-                'smartest' => env('CHUTES_SMARTEST_MODEL', 'moonshotai/Kimi-K2.5'),
-                'image' => env('CHUTES_IMAGE_MODEL', 'FLUX.1-schnell'),
-                'audio' => env('CHUTES_AUDIO_MODEL', 'kokoro'),
-                'transcription' => env('CHUTES_TRANSCRIPTION_MODEL', 'whisper-large-v3'),
-                'embedding' => env('CHUTES_EMBEDDING_MODEL', 'Qwen/Qwen3-Embedding-0.6B'),
-                'embedding_dimensions' => (int) env('CHUTES_EMBEDDING_DIMENSIONS', 1024),
-            ],
         ],
 
         'cohere' => [

--- a/config/ai.php
+++ b/config/ai.php
@@ -57,6 +57,12 @@ return [
             'key' => env('ANTHROPIC_API_KEY'),
         ],
 
+        'chutes' => [
+            'driver' => 'chutes',
+            'key' => env('CHUTES_API_KEY'),
+            'url' => env('CHUTES_BASE_URL', 'https://llm.chutes.ai/v1'),
+        ],
+
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),

--- a/config/ai.php
+++ b/config/ai.php
@@ -61,6 +61,7 @@ return [
             'driver' => 'chutes',
             'key' => env('CHUTES_API_KEY'),
             'url' => env('CHUTES_BASE_URL', 'https://llm.chutes.ai/v1'),
+            'image_url' => env('CHUTES_IMAGE_URL', 'https://image.chutes.ai/generate'),
             'tts_url' => env('CHUTES_TTS_URL', 'https://chutes-kokoro.chutes.ai/speak'),
             'stt_url' => env('CHUTES_STT_URL', 'https://chutes-whisper-large-v3.chutes.ai/transcribe'),
             'models' => [

--- a/config/ai.php
+++ b/config/ai.php
@@ -64,6 +64,7 @@ return [
             'image_url' => env('CHUTES_IMAGE_URL', 'https://image.chutes.ai/generate'),
             'tts_url' => env('CHUTES_TTS_URL', 'https://chutes-kokoro.chutes.ai/speak'),
             'stt_url' => env('CHUTES_STT_URL', 'https://chutes-whisper-large-v3.chutes.ai/transcribe'),
+            'embedding_url' => env('CHUTES_EMBEDDING_URL', 'https://chutes-qwen-qwen3-embedding-0-6b.chutes.ai/v1/embeddings'),
             'models' => [
                 'default' => env('CHUTES_MODEL', 'deepseek-ai/DeepSeek-V3'),
                 'cheapest' => env('CHUTES_CHEAPEST_MODEL', 'unsloth/gemma-3-4b-it'),
@@ -71,6 +72,8 @@ return [
                 'image' => env('CHUTES_IMAGE_MODEL', 'FLUX.1-schnell'),
                 'audio' => env('CHUTES_AUDIO_MODEL', 'kokoro'),
                 'transcription' => env('CHUTES_TRANSCRIPTION_MODEL', 'whisper-large-v3'),
+                'embedding' => env('CHUTES_EMBEDDING_MODEL', 'Qwen/Qwen3-Embedding-0.6B'),
+                'embedding_dimensions' => (int) env('CHUTES_EMBEDDING_DIMENSIONS', 1024),
             ],
         ],
 

--- a/config/ai.php
+++ b/config/ai.php
@@ -61,6 +61,16 @@ return [
             'driver' => 'chutes',
             'key' => env('CHUTES_API_KEY'),
             'url' => env('CHUTES_BASE_URL', 'https://llm.chutes.ai/v1'),
+            'tts_url' => env('CHUTES_TTS_URL', 'https://chutes-kokoro.chutes.ai/speak'),
+            'stt_url' => env('CHUTES_STT_URL', 'https://chutes-whisper-large-v3.chutes.ai/transcribe'),
+            'models' => [
+                'default' => env('CHUTES_MODEL', 'deepseek-ai/DeepSeek-V3'),
+                'cheapest' => env('CHUTES_CHEAPEST_MODEL', 'unsloth/gemma-3-4b-it'),
+                'smartest' => env('CHUTES_SMARTEST_MODEL', 'moonshotai/Kimi-K2.5'),
+                'image' => env('CHUTES_IMAGE_MODEL', 'FLUX.1-schnell'),
+                'audio' => env('CHUTES_AUDIO_MODEL', 'kokoro'),
+                'transcription' => env('CHUTES_TRANSCRIPTION_MODEL', 'whisper-large-v3'),
+            ],
         ],
 
         'cohere' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\ChutesProvider;
 use Laravel\Ai\Providers\CohereProvider;
 use Laravel\Ai\Providers\DeepSeekProvider;
 use Laravel\Ai\Providers\ElevenLabsProvider;
@@ -243,6 +244,18 @@ class AiManager extends MultipleInstanceManager
     public function createAnthropicDriver(array $config): AnthropicProvider
     {
         return new AnthropicProvider(
+            new PrismGateway($this->app['events']),
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a Chutes powered instance.
+     */
+    public function createChutesDriver(array $config): ChutesProvider
+    {
+        return new ChutesProvider(
             new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)

--- a/src/Gateway/ChutesAudioGateway.php
+++ b/src/Gateway/ChutesAudioGateway.php
@@ -28,12 +28,19 @@ class ChutesAudioGateway implements AudioGateway, TranscriptionGateway
         string $voice,
         ?string $instructions = null,
     ): AudioResponse {
+        $voice = match ($voice) {
+            'default-male' => 'am_adam',
+            'default-female' => 'af_heart',
+            default => $voice,
+        };
+
         $response = $this->withRateLimitHandling(
             $provider->name(),
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->timeout(120)
-                ->post($provider->additionalConfiguration()['tts_url'] ?? 'https://chutes-kokoro.chutes.ai/speak', [
+                ->post('https://chutes-kokoro.chutes.ai/speak', [
                     'text' => $text,
+                    'voice' => $voice,
                 ])
                 ->throw()
         );
@@ -59,7 +66,7 @@ class ChutesAudioGateway implements AudioGateway, TranscriptionGateway
             $provider->name(),
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->timeout(120)
-                ->post($provider->additionalConfiguration()['stt_url'] ?? 'https://chutes-whisper-large-v3.chutes.ai/transcribe', [
+                ->post('https://chutes-whisper-large-v3.chutes.ai/transcribe', [
                     'audio_b64' => base64_encode($audio->content()),
                 ])
                 ->throw()

--- a/src/Gateway/ChutesAudioGateway.php
+++ b/src/Gateway/ChutesAudioGateway.php
@@ -32,7 +32,7 @@ class ChutesAudioGateway implements AudioGateway, TranscriptionGateway
             $provider->name(),
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->timeout(120)
-                ->post('https://chutes-kokoro.chutes.ai/speak', [
+                ->post($provider->additionalConfiguration()['tts_url'] ?? 'https://chutes-kokoro.chutes.ai/speak', [
                     'text' => $text,
                 ])
                 ->throw()
@@ -59,7 +59,7 @@ class ChutesAudioGateway implements AudioGateway, TranscriptionGateway
             $provider->name(),
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->timeout(120)
-                ->post('https://chutes-whisper-large-v3.chutes.ai/transcribe', [
+                ->post($provider->additionalConfiguration()['stt_url'] ?? 'https://chutes-whisper-large-v3.chutes.ai/transcribe', [
                     'audio_b64' => base64_encode($audio->content()),
                 ])
                 ->throw()

--- a/src/Gateway/ChutesAudioGateway.php
+++ b/src/Gateway/ChutesAudioGateway.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TranscriptionResponse;
+
+class ChutesAudioGateway implements AudioGateway, TranscriptionGateway
+{
+    use Concerns\HandlesRateLimiting;
+
+    /**
+     * Generate audio from the given text.
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+    ): AudioResponse {
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => Http::withToken($provider->providerCredentials()['key'])
+                ->timeout(120)
+                ->post('https://chutes-kokoro.chutes.ai/speak', [
+                    'text' => $text,
+                ])
+                ->throw()
+        );
+
+        return new AudioResponse(
+            base64_encode((string) $response),
+            new Meta($provider->name(), $model),
+            'audio/wav',
+        );
+    }
+
+    /**
+     * Generate text from the given audio.
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+    ): TranscriptionResponse {
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => Http::withToken($provider->providerCredentials()['key'])
+                ->timeout(120)
+                ->post('https://chutes-whisper-large-v3.chutes.ai/transcribe', [
+                    'audio_b64' => base64_encode($audio->content()),
+                ])
+                ->throw()
+        );
+
+        $segments = $response->json();
+
+        $text = collect($segments)->pluck('text')->implode(' ');
+
+        return new TranscriptionResponse(
+            $text,
+            collect($segments)->map(fn ($segment) => new TranscriptionSegment(
+                $segment['text'],
+                '',
+                $segment['start'],
+                $segment['end'],
+            )),
+            new Usage,
+            new Meta($provider->name(), $model),
+        );
+    }
+}

--- a/src/Gateway/ChutesEmbeddingGateway.php
+++ b/src/Gateway/ChutesEmbeddingGateway.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+
+class ChutesEmbeddingGateway implements EmbeddingGateway
+{
+    use Concerns\HandlesRateLimiting;
+
+    /**
+     * Generate embedding vectors representing the given inputs.
+     *
+     * @param  string[]  $inputs
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+    ): EmbeddingsResponse {
+        $url = $provider->additionalConfiguration()['embedding_url']
+            ?? 'https://chutes-qwen-qwen3-embedding-0-6b.chutes.ai/v1/embeddings';
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => Http::withToken($provider->providerCredentials()['key'])
+                ->timeout(120)
+                ->post($url, [
+                    'input' => count($inputs) === 1 ? $inputs[0] : $inputs,
+                    'model' => $model,
+                ])
+                ->throw()
+        );
+
+        $data = $response->json();
+
+        return new EmbeddingsResponse(
+            collect($data['data'])->pluck('embedding')->all(),
+            $data['usage']['total_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
+    }
+}

--- a/src/Gateway/ChutesEmbeddingGateway.php
+++ b/src/Gateway/ChutesEmbeddingGateway.php
@@ -23,8 +23,7 @@ class ChutesEmbeddingGateway implements EmbeddingGateway
         array $inputs,
         int $dimensions,
     ): EmbeddingsResponse {
-        $url = $provider->additionalConfiguration()['embedding_url']
-            ?? 'https://chutes-qwen-qwen3-embedding-0-6b.chutes.ai/v1/embeddings';
+        $url = 'https://chutes-qwen-qwen3-embedding-0-6b.chutes.ai/v1/embeddings';
 
         $response = $this->withRateLimitHandling(
             $provider->name(),

--- a/src/Gateway/ChutesImageGateway.php
+++ b/src/Gateway/ChutesImageGateway.php
@@ -38,7 +38,7 @@ class ChutesImageGateway implements ImageGateway
             $provider->name(),
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->timeout($timeout ?? 120)
-                ->post($provider->additionalConfiguration()['image_url'] ?? 'https://image.chutes.ai/generate', [
+                ->post('https://image.chutes.ai/generate', [
                     'model' => $model,
                     'prompt' => $prompt,
                     'width' => $options['width'] ?? 1024,

--- a/src/Gateway/ChutesImageGateway.php
+++ b/src/Gateway/ChutesImageGateway.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\ImageGateway;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Files\Image as ImageFile;
+use Laravel\Ai\Responses\Data\GeneratedImage;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\ImageResponse;
+
+class ChutesImageGateway implements ImageGateway
+{
+    use Concerns\HandlesRateLimiting;
+
+    /**
+     * Generate an image.
+     *
+     * @param  array<ImageFile>  $attachments
+     * @param  '3:2'|'2:3'|'1:1'  $size
+     * @param  'low'|'medium'|'high'  $quality
+     */
+    public function generateImage(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments = [],
+        ?string $size = null,
+        ?string $quality = null,
+        ?int $timeout = null,
+    ): ImageResponse {
+        $options = $provider->defaultImageOptions($size, $quality);
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => Http::withToken($provider->providerCredentials()['key'])
+                ->timeout($timeout ?? 120)
+                ->post('https://image.chutes.ai/generate', [
+                    'model' => $model,
+                    'prompt' => $prompt,
+                    'width' => $options['width'] ?? 1024,
+                    'height' => $options['height'] ?? 1024,
+                    'num_inference_steps' => $options['steps'] ?? 10,
+                    'guidance_scale' => $options['guidance_scale'] ?? 7.5,
+                ])
+                ->throw()
+        );
+
+        return new ImageResponse(
+            new Collection([
+                new GeneratedImage(base64_encode($response->body()), 'image/jpeg'),
+            ]),
+            new Usage,
+            new Meta($provider->name(), $model),
+        );
+    }
+}

--- a/src/Gateway/ChutesImageGateway.php
+++ b/src/Gateway/ChutesImageGateway.php
@@ -38,7 +38,7 @@ class ChutesImageGateway implements ImageGateway
             $provider->name(),
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->timeout($timeout ?? 120)
-                ->post('https://image.chutes.ai/generate', [
+                ->post($provider->additionalConfiguration()['image_url'] ?? 'https://image.chutes.ai/generate', [
                     'model' => $model,
                     'prompt' => $prompt,
                     'width' => $options['width'] ?? 1024,

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -347,7 +347,7 @@ class PrismGateway implements Gateway
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
-            'chutes' => PrismProvider::OpenAI,
+            'chutes' => PrismProvider::Groq,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
             'groq' => PrismProvider::Groq,

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -347,6 +347,7 @@ class PrismGateway implements Gateway
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
+            'chutes' => PrismProvider::OpenAI,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
             'groq' => PrismProvider::Groq,

--- a/src/Gateway/Prism/PrismStreamEvent.php
+++ b/src/Gateway/Prism/PrismStreamEvent.php
@@ -103,7 +103,7 @@ class PrismStreamEvent
         return new StreamEnd(
             strtolower($event->id),
             $event->finishReason->value,
-            PrismUsage::toLaravelUsage($event->usage),
+            $event->usage ? PrismUsage::toLaravelUsage($event->usage) : new \Laravel\Ai\Responses\Data\Usage,
             $event->timestamp,
         );
     }

--- a/src/Providers/ChutesProvider.php
+++ b/src/Providers/ChutesProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Laravel\Ai\Contracts\Providers\TextProvider;
+
+class ChutesProvider extends Provider implements TextProvider
+{
+    use Concerns\GeneratesText;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['default'] ?? 'deepseek-ai/DeepSeek-V3';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['cheapest'] ?? 'unsloth/gemma-3-4b-it';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['smartest'] ?? 'deepseek-ai/DeepSeek-R1';
+    }
+}

--- a/src/Providers/ChutesProvider.php
+++ b/src/Providers/ChutesProvider.php
@@ -30,11 +30,19 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
     use Concerns\StreamsText;
 
     /**
+     * Get the provider connection configuration other than the driver, key, and name.
+     */
+    public function additionalConfiguration(): array
+    {
+        return ['url' => 'https://llm.chutes.ai/v1'];
+    }
+
+    /**
      * Get the name of the default text model.
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['default'] ?? 'deepseek-ai/DeepSeek-V3';
+        return 'deepseek-ai/DeepSeek-V3';
     }
 
     /**
@@ -42,7 +50,7 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['cheapest'] ?? 'unsloth/gemma-3-4b-it';
+        return 'unsloth/gemma-3-4b-it';
     }
 
     /**
@@ -50,7 +58,7 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['smartest'] ?? 'moonshotai/Kimi-K2.5';
+        return 'moonshotai/Kimi-K2.5';
     }
 
     /**
@@ -66,7 +74,7 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultImageModel(): string
     {
-        return $this->config['models']['image'] ?? 'FLUX.1-schnell';
+        return 'FLUX.1-schnell';
     }
 
     /**
@@ -118,7 +126,7 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultAudioModel(): string
     {
-        return $this->config['models']['audio'] ?? 'kokoro';
+        return 'kokoro';
     }
 
     /**
@@ -126,7 +134,7 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTranscriptionModel(): string
     {
-        return $this->config['models']['transcription'] ?? 'whisper-large-v3';
+        return 'whisper-large-v3';
     }
 
     /**
@@ -142,7 +150,7 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultEmbeddingsModel(): string
     {
-        return $this->config['models']['embedding'] ?? 'Qwen/Qwen3-Embedding-0.6B';
+        return 'Qwen/Qwen3-Embedding-0.6B';
     }
 
     /**
@@ -150,6 +158,6 @@ class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return $this->config['models']['embedding_dimensions'] ?? 1024;
+        return 1024;
     }
 }

--- a/src/Providers/ChutesProvider.php
+++ b/src/Providers/ChutesProvider.php
@@ -36,7 +36,7 @@ class ChutesProvider extends Provider implements ImageProvider, TextProvider
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['smartest'] ?? 'deepseek-ai/DeepSeek-R1';
+        return $this->config['models']['smartest'] ?? 'moonshotai/Kimi-K2.5';
     }
 
     /**

--- a/src/Providers/ChutesProvider.php
+++ b/src/Providers/ChutesProvider.php
@@ -2,17 +2,26 @@
 
 namespace Laravel\Ai\Providers;
 
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\ChutesAudioGateway;
 use Laravel\Ai\Gateway\ChutesImageGateway;
 
-class ChutesProvider extends Provider implements ImageProvider, TextProvider
+class ChutesProvider extends Provider implements AudioProvider, ImageProvider, TextProvider, TranscriptionProvider
 {
+    use Concerns\GeneratesAudio;
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
+    use Concerns\GeneratesTranscriptions;
+    use Concerns\HasAudioGateway;
     use Concerns\HasImageGateway;
     use Concerns\HasTextGateway;
+    use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
 
     /**
@@ -81,5 +90,37 @@ class ChutesProvider extends Provider implements ImageProvider, TextProvider
             },
             'guidance_scale' => 7.5,
         ];
+    }
+
+    /**
+     * Get the audio gateway instance.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ?? new ChutesAudioGateway;
+    }
+
+    /**
+     * Get the transcription gateway instance.
+     */
+    public function transcriptionGateway(): TranscriptionGateway
+    {
+        return $this->transcriptionGateway ?? new ChutesAudioGateway;
+    }
+
+    /**
+     * Get the name of the default audio model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return $this->config['models']['audio'] ?? 'kokoro';
+    }
+
+    /**
+     * Get the name of the default transcription model.
+     */
+    public function defaultTranscriptionModel(): string
+    {
+        return $this->config['models']['transcription'] ?? 'whisper-large-v3';
     }
 }

--- a/src/Providers/ChutesProvider.php
+++ b/src/Providers/ChutesProvider.php
@@ -2,11 +2,16 @@
 
 namespace Laravel\Ai\Providers;
 
+use Laravel\Ai\Contracts\Gateway\ImageGateway;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\ChutesImageGateway;
 
-class ChutesProvider extends Provider implements TextProvider
+class ChutesProvider extends Provider implements ImageProvider, TextProvider
 {
+    use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
+    use Concerns\HasImageGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
 
@@ -32,5 +37,49 @@ class ChutesProvider extends Provider implements TextProvider
     public function smartestTextModel(): string
     {
         return $this->config['models']['smartest'] ?? 'deepseek-ai/DeepSeek-R1';
+    }
+
+    /**
+     * Get the image gateway instance.
+     */
+    public function imageGateway(): ImageGateway
+    {
+        return $this->imageGateway ?? new ChutesImageGateway;
+    }
+
+    /**
+     * Get the name of the default image model.
+     */
+    public function defaultImageModel(): string
+    {
+        return $this->config['models']['image'] ?? 'FLUX.1-schnell';
+    }
+
+    /**
+     * Get the default image generation options.
+     *
+     * @param  '3:2'|'2:3'|'1:1'|null  $size
+     * @param  'low'|'medium'|'high'|null  $quality
+     */
+    public function defaultImageOptions(?string $size = null, $quality = null): array
+    {
+        [$width, $height] = match ($size) {
+            '1:1' => [1024, 1024],
+            '3:2' => [1536, 1024],
+            '2:3' => [1024, 1536],
+            default => [1024, 1024],
+        };
+
+        return [
+            'width' => $width,
+            'height' => $height,
+            'steps' => match ($quality) {
+                'low' => 5,
+                'medium' => 10,
+                'high' => 20,
+                default => 10,
+            },
+            'guidance_scale' => 7.5,
+        ];
     }
 }

--- a/src/Providers/ChutesProvider.php
+++ b/src/Providers/ChutesProvider.php
@@ -3,22 +3,27 @@
 namespace Laravel\Ai\Providers;
 
 use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\ChutesAudioGateway;
+use Laravel\Ai\Gateway\ChutesEmbeddingGateway;
 use Laravel\Ai\Gateway\ChutesImageGateway;
 
-class ChutesProvider extends Provider implements AudioProvider, ImageProvider, TextProvider, TranscriptionProvider
+class ChutesProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
+    use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
     use Concerns\GeneratesTranscriptions;
     use Concerns\HasAudioGateway;
+    use Concerns\HasEmbeddingGateway;
     use Concerns\HasImageGateway;
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
@@ -122,5 +127,29 @@ class ChutesProvider extends Provider implements AudioProvider, ImageProvider, T
     public function defaultTranscriptionModel(): string
     {
         return $this->config['models']['transcription'] ?? 'whisper-large-v3';
+    }
+
+    /**
+     * Get the embedding gateway instance.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ?? new ChutesEmbeddingGateway;
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['models']['embedding'] ?? 'Qwen/Qwen3-Embedding-0.6B';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return $this->config['models']['embedding_dimensions'] ?? 1024;
     }
 }

--- a/tests/Feature/ChutesIntegrationTest.php
+++ b/tests/Feature/ChutesIntegrationTest.php
@@ -22,7 +22,6 @@ class ChutesIntegrationTest extends TestCase
         $app['config']->set('ai.providers.chutes', [
             'driver' => 'chutes',
             'key' => env('CHUTES_API_KEY'),
-            'url' => env('CHUTES_BASE_URL', 'https://llm.chutes.ai/v1'),
         ]);
     }
 

--- a/tests/Feature/ChutesIntegrationTest.php
+++ b/tests/Feature/ChutesIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Laravel\Ai\Audio;
+use Laravel\Ai\Embeddings;
 use Laravel\Ai\Image;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -118,5 +119,16 @@ class ChutesIntegrationTest extends TestCase
         $this->assertNotEmpty((string) $transcription);
         $this->assertEquals('chutes', $transcription->meta->provider);
         $this->assertEquals('whisper-large-v3', $transcription->meta->model);
+    }
+
+    public function test_embeddings(): void
+    {
+        $response = Embeddings::for(['Hello world', 'How are you?'])
+            ->dimensions(1024)
+            ->generate(provider: 'chutes', model: 'Qwen/Qwen3-Embedding-0.6B');
+
+        $this->assertCount(2, $response);
+        $this->assertCount(1024, $response->first());
+        $this->assertEquals('chutes', $response->meta->provider);
     }
 }

--- a/tests/Feature/ChutesIntegrationTest.php
+++ b/tests/Feature/ChutesIntegrationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Image;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ChutesIntegrationTest extends TestCase
+{
+    protected $model = 'deepseek-ai/DeepSeek-V3';
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('ai.providers.chutes', [
+            'driver' => 'chutes',
+            'key' => env('CHUTES_API_KEY'),
+            'url' => env('CHUTES_BASE_URL', 'https://llm.chutes.ai/v1'),
+        ]);
+    }
+
+    public function test_text_generation(): void
+    {
+        $agent = new AssistantAgent;
+
+        $response = $agent->prompt(
+            'What is 2 + 2? Reply with just the number.',
+            provider: 'chutes',
+            model: $this->model,
+        );
+
+        $this->assertNotEmpty($response->text);
+        $this->assertStringContainsString('4', $response->text);
+        $this->assertEquals('chutes', $response->meta->provider);
+    }
+
+    public function test_ad_hoc_agent_prompt(): void
+    {
+        $response = agent()->prompt(
+            'What is the capital of France? Reply with just the city name.',
+            provider: 'chutes',
+            model: $this->model,
+        );
+
+        $this->assertNotEmpty($response->text);
+        $this->assertStringContainsString('Paris', $response->text);
+    }
+
+    public function test_image_generation(): void
+    {
+        $response = Image::of('A small red cube on a white background, minimalist')
+            ->square()
+            ->quality('low')
+            ->timeout(120)
+            ->generate(provider: 'chutes', model: 'FLUX.1-schnell');
+
+        $this->assertNotNull($response->firstImage());
+        $this->assertNotEmpty($response->firstImage()->image);
+        $this->assertEquals('chutes', $response->meta->provider);
+        $this->assertEquals('FLUX.1-schnell', $response->meta->model);
+    }
+}

--- a/tests/Feature/ChutesIntegrationTest.php
+++ b/tests/Feature/ChutesIntegrationTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use Laravel\Ai\Audio;
 use Laravel\Ai\Image;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Transcription;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\TestCase;
 
@@ -92,5 +94,29 @@ class ChutesIntegrationTest extends TestCase
         $this->assertNotEmpty($response->firstImage()->image);
         $this->assertEquals('chutes', $response->meta->provider);
         $this->assertEquals('FLUX.1-schnell', $response->meta->model);
+    }
+
+    public function test_audio_generation(): void
+    {
+        $response = Audio::of('Hello, how are you today?')
+            ->generate(provider: 'chutes', model: 'kokoro');
+
+        $this->assertNotEmpty($response->audio);
+        $this->assertEquals('audio/wav', $response->mimeType());
+        $this->assertEquals('chutes', $response->meta->provider);
+        $this->assertEquals('kokoro', $response->meta->model);
+    }
+
+    public function test_transcription(): void
+    {
+        $audio = Audio::of('Hello, how are you today?')
+            ->generate(provider: 'chutes', model: 'kokoro');
+
+        $transcription = Transcription::of($audio->audio)
+            ->generate(provider: 'chutes', model: 'whisper-large-v3');
+
+        $this->assertNotEmpty((string) $transcription);
+        $this->assertEquals('chutes', $transcription->meta->provider);
+        $this->assertEquals('whisper-large-v3', $transcription->meta->model);
     }
 }

--- a/tests/Feature/ChutesProviderTest.php
+++ b/tests/Feature/ChutesProviderTest.php
@@ -70,7 +70,7 @@ class ChutesProviderTest extends TestCase
     {
         $provider = Ai::textProvider('chutes');
 
-        $this->assertEquals('deepseek-ai/DeepSeek-R1', $provider->smartestTextModel());
+        $this->assertEquals('moonshotai/Kimi-K2.5', $provider->smartestTextModel());
     }
 
     public function test_default_image_model(): void

--- a/tests/Feature/ChutesProviderTest.php
+++ b/tests/Feature/ChutesProviderTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature;
 
 use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\ChutesAudioGateway;
 use Laravel\Ai\Gateway\ChutesImageGateway;
 use Laravel\Ai\Providers\ChutesProvider;
 use LogicException;
@@ -31,11 +34,11 @@ class ChutesProviderTest extends TestCase
         $this->assertInstanceOf(ImageProvider::class, $provider);
     }
 
-    public function test_chutes_does_not_support_audio(): void
+    public function test_chutes_is_an_audio_provider(): void
     {
-        $this->expectException(LogicException::class);
+        $provider = Ai::audioProvider('chutes');
 
-        Ai::audioProvider('chutes');
+        $this->assertInstanceOf(AudioProvider::class, $provider);
     }
 
     public function test_chutes_does_not_support_embeddings(): void
@@ -45,11 +48,11 @@ class ChutesProviderTest extends TestCase
         Ai::embeddingProvider('chutes');
     }
 
-    public function test_chutes_does_not_support_transcription(): void
+    public function test_chutes_is_a_transcription_provider(): void
     {
-        $this->expectException(LogicException::class);
+        $provider = Ai::transcriptionProvider('chutes');
 
-        Ai::transcriptionProvider('chutes');
+        $this->assertInstanceOf(TranscriptionProvider::class, $provider);
     }
 
     public function test_default_text_model(): void
@@ -85,6 +88,34 @@ class ChutesProviderTest extends TestCase
         $provider = Ai::imageProvider('chutes');
 
         $this->assertInstanceOf(ChutesImageGateway::class, $provider->imageGateway());
+    }
+
+    public function test_default_audio_model(): void
+    {
+        $provider = Ai::audioProvider('chutes');
+
+        $this->assertEquals('kokoro', $provider->defaultAudioModel());
+    }
+
+    public function test_default_transcription_model(): void
+    {
+        $provider = Ai::transcriptionProvider('chutes');
+
+        $this->assertEquals('whisper-large-v3', $provider->defaultTranscriptionModel());
+    }
+
+    public function test_audio_gateway_is_chutes_gateway(): void
+    {
+        $provider = Ai::audioProvider('chutes');
+
+        $this->assertInstanceOf(ChutesAudioGateway::class, $provider->audioGateway());
+    }
+
+    public function test_transcription_gateway_is_chutes_gateway(): void
+    {
+        $provider = Ai::transcriptionProvider('chutes');
+
+        $this->assertInstanceOf(ChutesAudioGateway::class, $provider->transcriptionGateway());
     }
 
     public function test_default_image_options_square(): void

--- a/tests/Feature/ChutesProviderTest.php
+++ b/tests/Feature/ChutesProviderTest.php
@@ -182,28 +182,6 @@ class ChutesProviderTest extends TestCase
         $this->assertEquals(7.5, $options['guidance_scale']);
     }
 
-    public function test_model_defaults_can_be_overridden_via_config(): void
-    {
-        config()->set('ai.providers.chutes-custom', [
-            'driver' => 'chutes',
-            'key' => 'test-key',
-            'url' => 'https://llm.chutes.ai/v1',
-            'models' => [
-                'default' => 'Qwen/Qwen3-32B',
-                'cheapest' => 'unsloth/Llama-3.2-3B-Instruct',
-                'smartest' => 'Qwen/Qwen3-235B-A22B',
-                'image' => 'FLUX.1-dev',
-            ],
-        ]);
-
-        $provider = Ai::textProvider('chutes-custom');
-
-        $this->assertEquals('Qwen/Qwen3-32B', $provider->defaultTextModel());
-        $this->assertEquals('unsloth/Llama-3.2-3B-Instruct', $provider->cheapestTextModel());
-        $this->assertEquals('Qwen/Qwen3-235B-A22B', $provider->smartestTextModel());
-        $this->assertEquals('FLUX.1-dev', $provider->defaultImageModel());
-    }
-
     public function test_provider_name(): void
     {
         $provider = Ai::textProvider('chutes');

--- a/tests/Feature/ChutesProviderTest.php
+++ b/tests/Feature/ChutesProviderTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\ChutesImageGateway;
+use Laravel\Ai\Providers\ChutesProvider;
+use LogicException;
+use Tests\TestCase;
+
+class ChutesProviderTest extends TestCase
+{
+    public function test_can_resolve_chutes_provider(): void
+    {
+        $this->assertInstanceOf(ChutesProvider::class, Ai::textProvider('chutes'));
+    }
+
+    public function test_chutes_is_a_text_provider(): void
+    {
+        $provider = Ai::textProvider('chutes');
+
+        $this->assertInstanceOf(TextProvider::class, $provider);
+    }
+
+    public function test_chutes_is_an_image_provider(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+
+        $this->assertInstanceOf(ImageProvider::class, $provider);
+    }
+
+    public function test_chutes_does_not_support_audio(): void
+    {
+        $this->expectException(LogicException::class);
+
+        Ai::audioProvider('chutes');
+    }
+
+    public function test_chutes_does_not_support_embeddings(): void
+    {
+        $this->expectException(LogicException::class);
+
+        Ai::embeddingProvider('chutes');
+    }
+
+    public function test_chutes_does_not_support_transcription(): void
+    {
+        $this->expectException(LogicException::class);
+
+        Ai::transcriptionProvider('chutes');
+    }
+
+    public function test_default_text_model(): void
+    {
+        $provider = Ai::textProvider('chutes');
+
+        $this->assertEquals('deepseek-ai/DeepSeek-V3', $provider->defaultTextModel());
+    }
+
+    public function test_cheapest_text_model(): void
+    {
+        $provider = Ai::textProvider('chutes');
+
+        $this->assertEquals('unsloth/gemma-3-4b-it', $provider->cheapestTextModel());
+    }
+
+    public function test_smartest_text_model(): void
+    {
+        $provider = Ai::textProvider('chutes');
+
+        $this->assertEquals('deepseek-ai/DeepSeek-R1', $provider->smartestTextModel());
+    }
+
+    public function test_default_image_model(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+
+        $this->assertEquals('FLUX.1-schnell', $provider->defaultImageModel());
+    }
+
+    public function test_image_gateway_is_chutes_gateway(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+
+        $this->assertInstanceOf(ChutesImageGateway::class, $provider->imageGateway());
+    }
+
+    public function test_default_image_options_square(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+        $options = $provider->defaultImageOptions('1:1', 'medium');
+
+        $this->assertEquals(1024, $options['width']);
+        $this->assertEquals(1024, $options['height']);
+        $this->assertEquals(10, $options['steps']);
+        $this->assertEquals(7.5, $options['guidance_scale']);
+    }
+
+    public function test_default_image_options_landscape(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+        $options = $provider->defaultImageOptions('3:2', 'high');
+
+        $this->assertEquals(1536, $options['width']);
+        $this->assertEquals(1024, $options['height']);
+        $this->assertEquals(20, $options['steps']);
+    }
+
+    public function test_default_image_options_portrait(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+        $options = $provider->defaultImageOptions('2:3', 'low');
+
+        $this->assertEquals(1024, $options['width']);
+        $this->assertEquals(1536, $options['height']);
+        $this->assertEquals(5, $options['steps']);
+    }
+
+    public function test_default_image_options_with_null_defaults(): void
+    {
+        $provider = Ai::imageProvider('chutes');
+        $options = $provider->defaultImageOptions();
+
+        $this->assertEquals(1024, $options['width']);
+        $this->assertEquals(1024, $options['height']);
+        $this->assertEquals(10, $options['steps']);
+        $this->assertEquals(7.5, $options['guidance_scale']);
+    }
+
+    public function test_model_defaults_can_be_overridden_via_config(): void
+    {
+        config()->set('ai.providers.chutes-custom', [
+            'driver' => 'chutes',
+            'key' => 'test-key',
+            'url' => 'https://llm.chutes.ai/v1',
+            'models' => [
+                'default' => 'Qwen/Qwen3-32B',
+                'cheapest' => 'unsloth/Llama-3.2-3B-Instruct',
+                'smartest' => 'Qwen/Qwen3-235B-A22B',
+                'image' => 'FLUX.1-dev',
+            ],
+        ]);
+
+        $provider = Ai::textProvider('chutes-custom');
+
+        $this->assertEquals('Qwen/Qwen3-32B', $provider->defaultTextModel());
+        $this->assertEquals('unsloth/Llama-3.2-3B-Instruct', $provider->cheapestTextModel());
+        $this->assertEquals('Qwen/Qwen3-235B-A22B', $provider->smartestTextModel());
+        $this->assertEquals('FLUX.1-dev', $provider->defaultImageModel());
+    }
+
+    public function test_provider_name(): void
+    {
+        $provider = Ai::textProvider('chutes');
+
+        $this->assertEquals('chutes', $provider->name());
+    }
+
+    public function test_provider_driver(): void
+    {
+        $provider = Ai::textProvider('chutes');
+
+        $this->assertEquals('chutes', $provider->driver());
+    }
+}

--- a/tests/Feature/ChutesProviderTest.php
+++ b/tests/Feature/ChutesProviderTest.php
@@ -4,13 +4,14 @@ namespace Tests\Feature;
 
 use Laravel\Ai\Ai;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\ChutesAudioGateway;
+use Laravel\Ai\Gateway\ChutesEmbeddingGateway;
 use Laravel\Ai\Gateway\ChutesImageGateway;
 use Laravel\Ai\Providers\ChutesProvider;
-use LogicException;
 use Tests\TestCase;
 
 class ChutesProviderTest extends TestCase
@@ -41,11 +42,11 @@ class ChutesProviderTest extends TestCase
         $this->assertInstanceOf(AudioProvider::class, $provider);
     }
 
-    public function test_chutes_does_not_support_embeddings(): void
+    public function test_chutes_is_an_embedding_provider(): void
     {
-        $this->expectException(LogicException::class);
+        $provider = Ai::embeddingProvider('chutes');
 
-        Ai::embeddingProvider('chutes');
+        $this->assertInstanceOf(EmbeddingProvider::class, $provider);
     }
 
     public function test_chutes_is_a_transcription_provider(): void
@@ -116,6 +117,27 @@ class ChutesProviderTest extends TestCase
         $provider = Ai::transcriptionProvider('chutes');
 
         $this->assertInstanceOf(ChutesAudioGateway::class, $provider->transcriptionGateway());
+    }
+
+    public function test_default_embedding_model(): void
+    {
+        $provider = Ai::embeddingProvider('chutes');
+
+        $this->assertEquals('Qwen/Qwen3-Embedding-0.6B', $provider->defaultEmbeddingsModel());
+    }
+
+    public function test_default_embedding_dimensions(): void
+    {
+        $provider = Ai::embeddingProvider('chutes');
+
+        $this->assertEquals(1024, $provider->defaultEmbeddingsDimensions());
+    }
+
+    public function test_embedding_gateway_is_chutes_gateway(): void
+    {
+        $provider = Ai::embeddingProvider('chutes');
+
+        $this->assertInstanceOf(ChutesEmbeddingGateway::class, $provider->embeddingGateway());
     }
 
     public function test_default_image_options_square(): void


### PR DESCRIPTION
Add Chutes AI provider with text, image, streaming, audio, transcription, and embedding support.

[Chutes](https://chutes.ai) ([docs](https://chutes.ai/docs), [pricing](https://chutes.ai/pricing)) gives access to open-source models like DeepSeek, Qwen, Gemma, Llama, and Kimi and more through an OpenAI-compatible API. This PR is not affiliated with or sponsored by Chutes.

## Configuration

Follows the same pattern as every other provider .  just `driver` + `key`:

```php
'chutes' => [
    'driver' => 'chutes',
    'key' => env('CHUTES_API_KEY'),
],
```

URLs are hardcoded in gateway classes, models in the provider class. Users override models at call time via the `model:` parameter.

## Text & Streaming

Routes through Prism's Groq handler since both use `/chat/completions`. Prism's OpenAI handler targets `/responses` which 404s against Chutes, and OpenRouter has a null-handling bug in `ToolCallMap`.

## Image Generation

Custom `ChutesImageGateway` since `image.chutes.ai` returns raw JPEG bytes rather than the OpenAI JSON format.

## Audio (TTS)

Kokoro via `ChutesAudioGateway`, POST to the TTS endpoint returns raw WAV. Maps `default-male` to `am_adam` and `default-female` to `af_heart` (same pattern as ElevenLabs/PrismGateway). Users can also pass any Kokoro voice ID directly.

## Transcription (STT)

Whisper large-v3 via the same `ChutesAudioGateway`, POST with base64-encoded audio, returns timestamped segments.

## Embeddings

Qwen3-Embedding-0.6B via `ChutesEmbeddingGateway`. The embedding endpoint lives on a separate subdomain, so it gets its own gateway.

## Bug Fix: Null usage in stream end event

Discovered while testing Chutes streaming - `PrismStreamEvent::toStreamEndEvent()` passes `$event->usage` directly to `PrismUsage::toLaravelUsage()`, which expects a non-null `Usage` object. Chutes doesn't include usage stats in streaming responses, so this throws a `TypeError`. The fix falls back to an empty `Usage` instance when `$event->usage` is null. This isn't Chutes-specific - any provider that omits usage from stream events would hit the same crash.

## Tests

24 unit tests + 7 integration tests covering text, ad-hoc agent, streaming, image, audio, transcription, and embeddings.

```
CHUTES_API_KEY=key vendor/bin/phpunit tests/Feature/ChutesProviderTest.php
CHUTES_API_KEY=key vendor/bin/phpunit tests/Feature/ChutesIntegrationTest.php
```