### PR TITLE
feat: Add support for custom tool names

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -279,6 +279,52 @@ class MyAgent implements Agent, HasTools
 }
 ```
 
+### Custom Tool Names
+
+Tools can define custom names using the `HasCustomName` trait, enabling dynamic tool definitions without creating separate PHP classes for each tool instance.
+
+```php
+use Laravel\Ai\Tools\Concerns\HasCustomName;
+
+class DynamicTool implements Tool
+{
+    use HasCustomName;
+
+    public function __construct(
+        public string $operation,
+        public string $description,
+    ) {}
+
+    public function description(): string
+    {
+        return $this->description;
+    }
+
+    public function handle(Request $request): string
+    {
+        // Handle the dynamic operation
+        return "Processed {$this->operation}";
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'input' => $schema->string()->required(),
+        ];
+    }
+}
+
+// Use the same tool class with different names
+public function tools(): iterable
+{
+    return [
+        (new DynamicTool('search', 'Search products'))->as('search_products'),
+        (new DynamicTool('categories', 'Search categories'))->as('search_categories'),
+        (new DynamicTool('get', 'Get product details'))->as('get_product'),
+    ];
+}
+```
+
 ### Provider Tools
 
 ```php

--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -45,8 +45,10 @@ trait AddsToolsToPrismRequests
      */
     protected function createPrismTool(Tool $tool): PrismTool
     {
+        $name = $this->resolveToolName($tool);
+
         return (new PrismTool)
-            ->as(class_basename($tool))
+            ->as($name)
             ->for((string) $tool->description())
             ->when(
                 ! empty($tool->schema(new JsonSchemaTypeFactory)),
@@ -56,6 +58,24 @@ trait AddsToolsToPrismRequests
             )
             ->using(fn ($arguments) => $this->invokeTool($tool, $arguments))
             ->withoutErrorHandling();
+    }
+
+    /**
+     * Resolve the name of the given tool.
+     */
+    protected function resolveToolName(Tool $tool): string
+    {
+        // If the tool has a name() method, use it
+        if (method_exists($tool, 'name')) {
+            $name = $tool->name();
+
+            if ($name !== null) {
+                return $name;
+            }
+        }
+
+        // Fall back to class basename
+        return class_basename($tool);
     }
 
     /**

--- a/src/Tools/Concerns/HasCustomName.php
+++ b/src/Tools/Concerns/HasCustomName.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Ai\Tools\Concerns;
+
+trait HasCustomName
+{
+    public ?string $name = null;
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return $this->name ?? class_basename($this);
+    }
+
+    /**
+     * Set the name of the tool.
+     */
+    public function as(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/Feature/Gateway/ToolNameGatewayTest.php
+++ b/tests/Feature/Gateway/ToolNameGatewayTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Gateway;
+
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests;
+use Laravel\Ai\Gateway\Prism\PrismTool;
+use Tests\Feature\Tools\NamedTool;
+use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\TestCase;
+
+class ToolNameGatewayTest extends TestCase
+{
+    protected function createPrismTool(Tool $tool): PrismTool
+    {
+        return (new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => true;
+                $this->toolInvokedCallback = fn () => true;
+            }
+
+            public function createTool(Tool $tool): PrismTool
+            {
+                return $this->createPrismTool($tool);
+            }
+        })->createTool($tool);
+    }
+
+    public function test_it_uses_custom_name_from_trait(): void
+    {
+        $tool = (new NamedTool)->as('custom_name');
+        $prismTool = $this->createPrismTool($tool);
+
+        $this->assertEquals('custom_name', $prismTool->name());
+    }
+
+    public function test_it_falls_back_to_class_basename_without_custom_name(): void
+    {
+        $tool = new RandomNumberGenerator;
+        $prismTool = $this->createPrismTool($tool);
+
+        $this->assertStringContainsString('RandomNumberGenerator', $prismTool->name());
+    }
+
+    public function test_it_preserves_tool_description(): void
+    {
+        $tool = new NamedTool;
+        $prismTool = $this->createPrismTool($tool);
+
+        $this->assertEquals('This is a tool with a custom name.', $prismTool->description());
+    }
+
+    public function test_it_preserves_tool_schema(): void
+    {
+        $tool = new RandomNumberGenerator;
+        $prismTool = $this->createPrismTool($tool);
+
+        $this->assertTrue($prismTool->hasParameters());
+        $this->assertArrayHasKey('schema_definition', $prismTool->parameters());
+    }
+}

--- a/tests/Feature/ToolCustomNameTest.php
+++ b/tests/Feature/ToolCustomNameTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Feature\Tools\NamedTool;
+use Tests\TestCase;
+
+class ToolCustomNameTest extends TestCase
+{
+    public function test_it_defaults_to_class_basename(): void
+    {
+        $tool = new NamedTool;
+
+        $this->assertStringContainsString('NamedTool', $tool->name());
+    }
+
+    public function test_it_allows_custom_name(): void
+    {
+        $tool = (new NamedTool)->as('custom_name');
+
+        $this->assertEquals('custom_name', $tool->name());
+    }
+
+    public function test_it_returns_same_instance(): void
+    {
+        $tool = new NamedTool;
+
+        $this->assertSame($tool, $tool->as('custom_name'));
+    }
+
+    public function test_it_supports_multiple_instances_with_different_names(): void
+    {
+        $tools = [
+            (new NamedTool)->as('search_products'),
+            (new NamedTool)->as('search_categories'),
+        ];
+
+        $this->assertEquals('search_products', $tools[0]->name());
+        $this->assertEquals('search_categories', $tools[1]->name());
+    }
+
+    public function test_tool_without_trait_does_not_have_name_method(): void
+    {
+        $tool = new FixedNumberGenerator;
+
+        $this->assertFalse(method_exists($tool, 'name'));
+    }
+
+    public function test_it_preserves_description(): void
+    {
+        $tool = (new NamedTool)->as('my_search_tool');
+
+        $this->assertEquals('my_search_tool', $tool->name());
+        $this->assertEquals('This is a tool with a custom name.', $tool->description());
+    }
+}

--- a/tests/Feature/Tools/NamedTool.php
+++ b/tests/Feature/Tools/NamedTool.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Concerns\HasCustomName;
+use Laravel\Ai\Tools\Request;
+
+class NamedTool implements Tool
+{
+    use HasCustomName;
+
+    public function __construct(public bool $throwsException = false) {}
+
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'This is a tool with a custom name.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        if ($this->throwsException) {
+            throw new \Exception('Forced to throw exception.');
+        }
+
+        return 'Output from the tool';
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Adds the ability for tools to define custom names using the HasCustomName trait, enabling dynamic tool definitions without creating separate PHP classes for each tool instance. This is particularly useful when integrating external systems where tools are discovered at runtime.

Fixes: #41 