### PR TITLE
Add Model attribute

### DIFF
--- a/src/Attributes/Model.php
+++ b/src/Attributes/Model.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Model
+{
+    public function __construct(public string $value)
+    {
+        //
+    }
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Container\Container;
 use Illuminate\Queue\SerializesModels;
+use Laravel\Ai\Attributes\Model as ModelAttribute;
 use Laravel\Ai\Attributes\Provider as ProviderAttribute;
 use Laravel\Ai\Attributes\Timeout as TimeoutAttribute;
 use Laravel\Ai\Attributes\UseCheapestModel;
@@ -171,8 +172,14 @@ trait Promptable
             }
         }
 
-        if (! is_array($provider) && is_null($model) && method_exists($this, 'model')) {
-            $model = $this->model();
+        if (! is_array($provider) && is_null($model)) {
+            if (method_exists($this, 'model')) {
+                $model = $this->model();
+            } else {
+                $attributes = (new ReflectionClass($this))->getAttributes(ModelAttribute::class);
+
+                $model = ! empty($attributes) ? $attributes[0]->newInstance()->value : null;
+            }
         }
 
         return Provider::formatProviderAndModelList(


### PR DESCRIPTION
This introduces a `Model` attribute that can be used in conjunction with the `Provider` attribute.

The code already supports providing some configuration with methods on your agent - there are `method_exists` calls for `timeout`, `provider` and `model`. These aren't documented but can make a PR for those. My use-case is that I use GPT 4.1 Nano specifically for some tasks.

(Another thought is that the model could be a second argument to the `Provider` attribute, given that they are tied together - happy to make that change if preferable).