### PR TITLE
Add Azure OpenAI support

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -87,6 +87,15 @@ return [
             'key' => env('JINA_API_KEY'),
         ],
 
+        'azure' => [
+            'driver' => 'azure',
+            'endpoint' => env('AZURE_OPENAI_ENDPOINT'),
+            'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
+            'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+            'key' => env('AZURE_OPENAI_API_KEY'),
+            'api_version' => env('AZURE_OPENAI_API_VERSION', '2024-10-21'),
+        ],
+
         'openai' => [
             'driver' => 'openai',
             'key' => env('OPENAI_API_KEY'),

--- a/config/ai.php
+++ b/config/ai.php
@@ -57,6 +57,15 @@ return [
             'key' => env('ANTHROPIC_API_KEY'),
         ],
 
+        'azure' => [
+            'driver' => 'azure',
+            'key' => env('AZURE_OPENAI_API_KEY'),
+            'url' => env('AZURE_OPENAI_URL'),
+            'api_version' => env('AZURE_OPENAI_API_VERSION', '2024-10-21'),
+            'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
+            'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+        ],
+
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),
@@ -85,15 +94,6 @@ return [
         'jina' => [
             'driver' => 'jina',
             'key' => env('JINA_API_KEY'),
-        ],
-
-        'azure' => [
-            'driver' => 'azure',
-            'endpoint' => env('AZURE_OPENAI_ENDPOINT'),
-            'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
-            'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
-            'key' => env('AZURE_OPENAI_API_KEY'),
-            'api_version' => env('AZURE_OPENAI_API_VERSION', '2024-10-21'),
         ],
 
         'openai' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\AzureOpenAiProvider;
 use Laravel\Ai\Providers\CohereProvider;
 use Laravel\Ai\Providers\DeepSeekProvider;
 use Laravel\Ai\Providers\ElevenLabsProvider;
@@ -243,6 +244,18 @@ class AiManager extends MultipleInstanceManager
     public function createAnthropicDriver(array $config): AnthropicProvider
     {
         return new AnthropicProvider(
+            new PrismGateway($this->app['events']),
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create an Azure OpenAI powered instance.
+     */
+    public function createAzureDriver(array $config): AzureOpenAiProvider
+    {
+        return new AzureOpenAiProvider(
             new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -347,6 +347,7 @@ class PrismGateway implements Gateway
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
+            'azure' => PrismProvider::OpenAI, 
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
             'groq' => PrismProvider::Groq,

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -12,11 +12,10 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextPro
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
-    
 
     /**
      * Get the credentials for the AI provider.
-     * 
+     *
      * Azure OpenAI uses API key authentication via the `api-key` header.
      */
     public function providerCredentials(): array
@@ -24,28 +23,6 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextPro
         return [
             'key' => $this->config['key'],
         ];
-    }
-
-    /**
-     * Get the provider connection configuration other than the driver, key, and name.
-     */
-    public function additionalConfiguration(): array
-    {
-        return array_filter([
-            'url' => $this->buildAzureBaseUrl(),
-            'api_version' => $this->config['api_version'] ?? '2024-10-21',
-        ]);
-    }
-
-    /**
-     * Build the Azure OpenAI base URL.
-     */
-    protected function buildAzureBaseUrl(): string
-    {
-        $endpoint = rtrim($this->config['endpoint'] ?? '', '/');
-        
-        // Use OpenAI-compatible endpoint format
-        return "{$endpoint}/openai/v1";
     }
 
     /**
@@ -86,5 +63,26 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextPro
     public function defaultEmbeddingsDimensions(): int
     {
         return 1536;
+    }
+
+    /**
+     * Get the provider connection configuration other than the driver, key, and name.
+     */
+    public function additionalConfiguration(): array
+    {
+        return array_filter([
+            'url' => $this->buildAzureBaseUrl(),
+            'api_version' => $this->config['api_version'] ?? '2024-10-21',
+        ]);
+    }
+
+    /**
+     * Build the Azure OpenAI base URL.
+     */
+    protected function buildAzureBaseUrl(): string
+    {
+        $url = rtrim($this->config['url'] ?? '', '/');
+
+        return "{$url}/openai/v1";
     }
 }

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+
+class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+    
+
+    /**
+     * Get the credentials for the AI provider.
+     * 
+     * Azure OpenAI uses API key authentication via the `api-key` header.
+     */
+    public function providerCredentials(): array
+    {
+        return [
+            'key' => $this->config['key'],
+        ];
+    }
+
+    /**
+     * Get the provider connection configuration other than the driver, key, and name.
+     */
+    public function additionalConfiguration(): array
+    {
+        return array_filter([
+            'url' => $this->buildAzureBaseUrl(),
+            'api_version' => $this->config['api_version'] ?? '2024-10-21',
+        ]);
+    }
+
+    /**
+     * Build the Azure OpenAI base URL.
+     */
+    protected function buildAzureBaseUrl(): string
+    {
+        $endpoint = rtrim($this->config['endpoint'] ?? '', '/');
+        
+        // Use OpenAI-compatible endpoint format
+        return "{$endpoint}/openai/v1";
+    }
+
+    /**
+     * Get the name of the default (deployment name) text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['deployment'] ?? 'gpt-4o';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['deployment'] ?? 'gpt-4o-mini';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['deployment'] ?? 'gpt-4o';
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['embedding_deployment'] ?? 'text-embedding-3-small';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return 1536;
+    }
+}


### PR DESCRIPTION
Added Azure OpenAI as a provider option.

Uses Azure's /openai/v1 endpoint so it works with Prism's OpenAI provider.



### Supports:
Text generation
Streaming
Embeddings

```
AZURE_OPENAI_ENDPOINT=
AZURE_OPENAI_API_KEY=
AZURE_OPENAI_DEPLOYMENT=
AZURE_OPENAI_API_VERSION=
```