### PR TITLE
AI Diagnose command

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -316,10 +316,6 @@ $response = (new ChatBot)->continue($conversationId, as: $user)->prompt('More...
 $response = (new MyAgent)->prompt('Hello', provider: ['openai', 'anthropic']);
 ```
 
-## Diagnostics
-
-Use `php artisan ai:diagnose` to check SDK configuration, provider connectivity, and capability support.
-
 ## Testing and Faking
 
 Each capability supports `fake()` with assertions:
@@ -402,16 +398,6 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 
 Use agents and entry-point classes (`Image`, `Audio`, etc.) — not `Prism::text()` directly. The AI SDK wraps Prism internally.
 
-## Provider Support
+## Provider Support and Diagnostics
 
-| Provider   | Text | Image | Audio | STT | Embeddings | Reranking | Files | Stores |
-| ---------- | ---- | ----- | ----- | --- | ---------- | --------- | ----- | ------ |
-| OpenAI     | Y    | Y     | Y     | Y   | Y          | -         | Y     | Y      |
-| Anthropic  | Y    | -     | -     | -   | -          | -         | Y     | -      |
-| Gemini     | Y    | Y     | -     | -   | Y          | -         | Y     | Y      |
-| xAI        | Y    | Y     | -     | -   | -          | -         | -     | -      |
-| Groq       | Y    | -     | -     | -   | -          | -         | -     | -      |
-| OpenRouter | Y    | -     | -     | -   | -          | -         | -     | -      |
-| ElevenLabs | -    | -     | Y     | Y   | -          | -         | -     | -      |
-| Cohere     | -    | -     | -     | -   | Y          | Y         | -     | -      |
-| Jina       | -    | -     | -     | -   | Y          | Y         | -     | -      |
+Use `php artisan ai:diagnose` to check SDK configuration, provider support and connectivity, and capability support.

--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -316,6 +316,10 @@ $response = (new ChatBot)->continue($conversationId, as: $user)->prompt('More...
 $response = (new MyAgent)->prompt('Hello', provider: ['openai', 'anthropic']);
 ```
 
+## Diagnostics
+
+Use `php artisan ai:diagnose` to check SDK configuration, provider connectivity, and capability support.
+
 ## Testing and Faking
 
 Each capability supports `fake()` with assertions:
@@ -370,7 +374,7 @@ $store->assertAdded('file_id');
 - Agent pattern: Implement the `Agent` interface and use the `Promptable` trait
 - Optional interfaces: `HasTools`, `HasMiddleware`, `HasStructuredOutput`, `Conversational`
 - Entry-point classes: `Image`, `Audio`, `Transcription`, `Embeddings`, `Reranking`, `Stores`
-- Artisan commands: `php artisan make:agent`, `php artisan make:tool`
+- Artisan commands: `php artisan make:agent`, `php artisan make:tool`, `php artisan ai:diagnose`
 - Global helper: `agent()` for anonymous agents
 
 ## Common Pitfalls

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Stringable;
 use Laravel\Ai\Console\Commands\ChatCommand;
+use Laravel\Ai\Console\Commands\DiagnoseCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
@@ -92,6 +93,7 @@ class AiServiceProvider extends ServiceProvider
     {
         $this->commands([
             // ChatCommand::class,
+            DiagnoseCommand::class,
             MakeAgentCommand::class,
             MakeToolCommand::class,
         ]);

--- a/src/Console/Commands/DiagnoseCommand.php
+++ b/src/Console/Commands/DiagnoseCommand.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Laravel\Ai\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\FileProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
+use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Image;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Reranking;
+use Throwable;
+
+use function Laravel\Ai\agent;
+
+class DiagnoseCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ai:diagnose {--provider=* : Diagnose specific providers} {--skip-requests : Skip live test requests}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Diagnose AI provider configuration and connectivity';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $providers = $this->configuredProviders();
+
+        if (empty($providers)) {
+            $this->error('No AI providers are configured. Set ai.providers in your configuration.');
+        }
+
+        $this->info('AI Diagnostics');
+
+        $rows = [];
+        $failures = 0;
+
+        foreach ($providers as $name => $config) {
+            $hasKey = $this->hasKey($name, $config);
+            $provider = $this->resolveProvider($name);
+
+            if (! $hasKey || ! $provider) {
+                $rows[] = [
+                    Str::ucfirst($name),
+                    data_get($config, 'driver', 'N/A'),
+                    "Missing key",
+                    'N/A',
+                    'Unable to resolve provider'
+                ];
+                $failures++;
+
+                continue;
+            }
+
+            $capabilities = implode(', ', $this->capabilitiesFor($provider));
+            $requestStatus = $this->runTestRequest($name, $provider, $hasKey);
+
+            if ($requestStatus['success'] === false) {
+                $failures++;
+            }
+
+            $rows[] = [Str::ucfirst($name), $provider->driver(), 'SET', $capabilities, $requestStatus['label']];
+        }
+
+        $this->table(['Provider', 'Driver', 'Key', 'Capabilities', 'Request'], $rows);
+    }
+
+    /**
+     * Get the configured providers that should be diagnosed.
+     */
+    protected function configuredProviders(): array
+    {
+        $providers = config('ai.providers', []);
+        $only = array_filter($this->option('provider'));
+
+        if (empty($only)) {
+            return $providers;
+        }
+
+        $selected = [];
+
+        foreach ($only as $name) {
+            if (! array_key_exists($name, $providers)) {
+                $this->warn("Provider [{$name}] is not configured in ai.providers.");
+
+                continue;
+            }
+
+            $selected[$name] = $providers[$name];
+        }
+
+        return $selected;
+    }
+
+    /**
+     * Determine if a provider has a key.
+     */
+    protected function hasKey(string $name, array $config): bool
+    {
+        $key = data_get($config, 'key');
+
+        return is_string($key) && trim($key) !== '';
+    }
+
+    /**
+     * Resolve a provider instance from the manager.
+     */
+    protected function resolveProvider(string $name): ?Provider
+    {
+        $manager = app(AiManager::class);
+
+        try {
+            if (method_exists($manager, 'instance')) {
+                return $manager->instance($name);
+            }
+
+            if (method_exists($manager, 'driver')) {
+                return $manager->driver($name);
+            }
+        } catch (Throwable $e) {
+            $this->error("Failed to resolve provider [{$name}]: {$e->getMessage()}");
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the list of capabilities supported by the provider.
+     */
+    protected function capabilitiesFor(Provider $provider): array
+    {
+        $capabilities = [];
+
+        $map = [
+            TextProvider::class => 'text',
+            ImageProvider::class => 'image',
+            AudioProvider::class => 'audio',
+            TranscriptionProvider::class => 'transcription',
+            EmbeddingProvider::class => 'embeddings',
+            RerankingProvider::class => 'reranking',
+            FileProvider::class => 'files',
+            StoreProvider::class => 'stores',
+            SupportsWebSearch::class => 'web_search',
+            SupportsWebFetch::class => 'web_fetch',
+            SupportsFileSearch::class => 'file_search',
+        ];
+
+        foreach ($map as $interface => $label) {
+            if ($provider instanceof $interface) {
+                $capabilities[] = $label;
+            }
+        }
+
+        return $capabilities;
+    }
+
+    /**
+     * Run the minimal test request for the provider.
+     */
+    protected function runTestRequest(string $name, Provider $provider, bool $hasKey): array
+    {
+        if ($this->option('skip-requests')) {
+            return ['label' => 'SKIPPED', 'success' => null];
+        }
+
+        if (! $hasKey) {
+            return ['label' => 'SKIPPED (missing key)', 'success' => null];
+        }
+
+        $probe = $this->probeFor($name, $provider);
+
+        if (! $probe) {
+            return ['label' => 'SKIPPED (no requestable capabilities)', 'success' => null];
+        }
+
+        try {
+            $probe();
+
+            return ['label' => 'OK', 'success' => true];
+        } catch (Throwable $e) {
+            return ['label' => 'FAILED - '.$e->getMessage(), 'success' => false];
+        }
+    }
+
+    /**
+     * Get the probe closure for a provider.
+     */
+    protected function probeFor(string $name, Provider $provider): ?callable
+    {
+        if ($provider instanceof TextProvider) {
+            return function () use ($name) {
+                $agent = agent('You are a diagnostic assistant.');
+
+                $agent->prompt('diagnostic ping', provider: $name);
+            };
+        }
+
+        if ($provider instanceof EmbeddingProvider) {
+            return fn () => Embeddings::for(['diagnostic ping'])->generate(provider: $name);
+        }
+
+        if ($provider instanceof RerankingProvider) {
+            return fn () => Reranking::of(['diagnostic ping', 'diagnostic pong'])
+                ->limit(1)
+                ->rerank('diagnostic ping', $name);
+        }
+
+        if ($provider instanceof ImageProvider) {
+            return fn () => Image::of('diagnostic image')
+                ->square()
+                ->generate(provider: $name);
+        }
+
+        if ($provider instanceof AudioProvider) {
+            return fn () => Audio::of('diagnostic audio')
+                ->generate(provider: $name);
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/Console/DiagnoseCommandTest.php
+++ b/tests/Feature/Console/DiagnoseCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+class DiagnoseCommandTest extends TestCase
+{
+    public function test_reports_error_on_failing_provider(): void
+    {
+        config()->set('ai.providers', [
+            'foo' => [
+                'driver' => 'bar',
+                'key' => null,
+            ]
+        ]);
+
+        $this->artisan('ai:diagnose', [
+            '--skip-requests' => true,
+        ])
+            ->expectsOutputToContain('Unable to resolve provider')
+            ->assertExitCode(0)
+            ->run();
+    }
+
+    public function test_runs_minimal_requests_for_supported_providers(): void
+    {
+        $this->artisan('ai:diagnose', [
+            '--provider' => ['openai'],
+        ])
+            ->expectsOutputToContain('OK')
+            ->assertExitCode(0)
+            ->run();
+    }
+}


### PR DESCRIPTION
## Overview

- Add `ai:diagnose` console command to validate configured AI providers, report capabilities, and optionally run minimal live probes.
- Register the new command in the service provider.
- Add feature tests covering failing provider resolution and successful probe execution.
- Update SKILL to add support for the `ai:diagnose` command.

## Why

- Provide a quick, standardized way to verify provider configuration and connectivity.
- Surface actionable diagnostics (missing keys, unsupported capabilities, request failures) before runtime usage.


## How it looks

This is a run for all providers:
<img width="1925" height="507" alt="ai-diagnose" src="https://github.com/user-attachments/assets/3042b5ba-72a8-433d-a3de-ff68e073d393" />


This is a run for a specific provider:
<img width="1525" height="241" alt="ai-diagnose-2" src="https://github.com/user-attachments/assets/ae0e062d-2ff2-4a60-9719-1178de189095" />


This is a run skipping the live requests:
<img width="1842" height="272" alt="ai-diagnose-3" src="https://github.com/user-attachments/assets/bf13c05a-65f7-485c-b421-92e55c58e446" />
