### PR TITLE
Add Azure OpenAI provider integration (#38)

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -57,6 +57,13 @@ return [
             'key' => env('ANTHROPIC_API_KEY'),
         ],
 
+        'azure' => [
+            'driver' => 'azure',
+            'key' => env('AZURE_OPENAI_API_KEY'),
+            'url' => env('AZURE_OPENAI_URL'),
+            'api_version' => env('AZURE_OPENAI_API_VERSION'),
+        ],
+
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\AzureProvider;
 use Laravel\Ai\Providers\CohereProvider;
 use Laravel\Ai\Providers\ElevenLabsProvider;
 use Laravel\Ai\Providers\GeminiProvider;
@@ -234,6 +235,18 @@ class AiManager extends MultipleInstanceManager
         return $this->storesAreFaked()
             ? (clone $provider)->useStoreGateway($this->fakeStoreGateway())
             : $provider;
+    }
+
+    /**
+     * Create an Azure OpenAI powered instance.
+     */
+    public function createAzureDriver(array $config): AzureProvider
+    {
+        return new AzureProvider(
+            new PrismGateway($this->app['events']),
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
     }
 
     /**

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -10,7 +10,9 @@ use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Gateway\Prism\Providers\AzureOpenAI;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Prism\Prism\PrismManager;
 
 class AiServiceProvider extends ServiceProvider
 {
@@ -25,6 +27,16 @@ class AiServiceProvider extends ServiceProvider
         $this->app->singleton(ConversationStore::class, DatabaseConversationStore::class);
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');
+
+        $this->app->resolving(PrismManager::class, function (PrismManager $manager) {
+            $manager->extend('azure', function ($app, array $config) {
+                return new AzureOpenAI(
+                    apiKey: $config['api_key'] ?? '',
+                    url: $config['url'] ?? '',
+                    apiVersion: $config['api_version'] ?? null,
+                );
+            });
+        });
     }
 
     /**

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -80,22 +80,16 @@ trait CreatesPrismTextRequests
      */
     protected function configure($prism, Provider $provider, string $model): mixed
     {
-        $credentials = $provider->providerCredentials();
-
-        $providerConfig = array_filter([
-            ...($provider->driver() === 'anthropic')
-               ? ['anthropic_beta' => 'web-fetch-2025-09-10']
-               : [],
-            ...($provider instanceof AzureProvider)
-               ? array_filter(['url' => $credentials['url'], 'api_version' => $credentials['api_version']])
-               : [],
-            'api_key' => $credentials['key'],
-        ]);
-
         return $prism->using(
             static::toPrismProvider($provider),
             $model,
-            $providerConfig,
+            array_filter([
+                ...$provider->additionalConfiguration(),
+                ...($provider->driver() === 'anthropic')
+                   ? ['anthropic_beta' => 'web-fetch-2025-09-10']
+                   : [],
+                'api_key' => $provider->providerCredentials()['key'],
+            ]),
         );
     }
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -31,7 +31,6 @@ use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
-use Prism\Prism\Enums\Provider as PrismProvider;
 use Prism\Prism\Exceptions\PrismException as PrismVendorException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\ValueObjects\Media\Audio;
@@ -185,7 +184,7 @@ class PrismGateway implements Gateway
                 ->withPrompt($prompt, $this->toPrismImageAttachments($attachments))
                 ->withProviderOptions($provider->defaultImageOptions($size, $quality))
                 ->withClientOptions([
-                    'timeout' => $timeout ?? 120
+                    'timeout' => $timeout ?? 120,
                 ])
                 ->generate();
         } catch (PrismVendorException $e) {
@@ -343,15 +342,16 @@ class PrismGateway implements Gateway
     /**
      * Map the given Laravel AI provider to a Prism provider.
      */
-    protected static function toPrismProvider(Provider $provider): PrismProvider
+    protected static function toPrismProvider(Provider $provider): \Prism\Prism\Enums\Provider|string
     {
         return match ($provider->driver()) {
-            'anthropic' => PrismProvider::Anthropic,
-            'gemini' => PrismProvider::Gemini,
-            'groq' => PrismProvider::Groq,
-            'openai' => PrismProvider::OpenAI,
-            'openrouter' => PrismProvider::OpenRouter,
-            'xai' => PrismProvider::XAI,
+            'anthropic' => \Prism\Prism\Enums\Provider::Anthropic,
+            'azure' => 'azure',
+            'gemini' => \Prism\Prism\Enums\Provider::Gemini,
+            'groq' => \Prism\Prism\Enums\Provider::Groq,
+            'openai' => \Prism\Prism\Enums\Provider::OpenAI,
+            'openrouter' => \Prism\Prism\Enums\Provider::OpenRouter,
+            'xai' => \Prism\Prism\Enums\Provider::XAI,
             default => throw new InvalidArgumentException('Gateway does not support provider ['.$provider.'].'),
         };
     }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -31,6 +31,7 @@ use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
+use Prism\Prism\Enums\Provider as PrismProvider;
 use Prism\Prism\Exceptions\PrismException as PrismVendorException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\ValueObjects\Media\Audio;
@@ -342,16 +343,20 @@ class PrismGateway implements Gateway
     /**
      * Map the given Laravel AI provider to a Prism provider.
      */
-    protected static function toPrismProvider(Provider $provider): \Prism\Prism\Enums\Provider|string
+    protected static function toPrismProvider(Provider $provider): PrismProvider|string
     {
         return match ($provider->driver()) {
-            'anthropic' => \Prism\Prism\Enums\Provider::Anthropic,
+            'anthropic' => PrismProvider::Anthropic,
             'azure' => 'azure',
-            'gemini' => \Prism\Prism\Enums\Provider::Gemini,
-            'groq' => \Prism\Prism\Enums\Provider::Groq,
-            'openai' => \Prism\Prism\Enums\Provider::OpenAI,
-            'openrouter' => \Prism\Prism\Enums\Provider::OpenRouter,
-            'xai' => \Prism\Prism\Enums\Provider::XAI,
+            'deepseek' => PrismProvider::DeepSeek,
+            'gemini' => PrismProvider::Gemini,
+            'groq' => PrismProvider::Groq,
+            'mistral' => PrismProvider::Mistral,
+            'ollama' => PrismProvider::Ollama,
+            'openai' => PrismProvider::OpenAI,
+            'openrouter' => PrismProvider::OpenRouter,
+            'voyageai' => PrismProvider::VoyageAI,
+            'xai' => PrismProvider::XAI,
             default => throw new InvalidArgumentException('Gateway does not support provider ['.$provider.'].'),
         };
     }

--- a/src/Gateway/Prism/Providers/AzureOpenAI.php
+++ b/src/Gateway/Prism/Providers/AzureOpenAI.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Prism\Providers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
+use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
+use Prism\Prism\Providers\OpenAI\OpenAI;
+
+class AzureOpenAI extends OpenAI
+{
+    public function __construct(
+        #[\SensitiveParameter] string $apiKey,
+        string $url,
+        public readonly ?string $apiVersion,
+    ) {
+        parent::__construct(
+            apiKey: $apiKey,
+            url: $url,
+            organization: null,
+            project: null,
+        );
+    }
+
+    #[\Override]
+    public function handleRequestException(string $model, RequestException $e): never
+    {
+        match ($e->response->getStatusCode()) {
+            429 => throw PrismRateLimitedException::make(
+                rateLimits: $this->processRateLimits($e->response),
+                retryAfter: (int) $e->response->header('retry-after')
+            ),
+            529 => throw PrismProviderOverloadedException::make('Azure OpenAI'),
+            413 => throw PrismRequestTooLargeException::make('Azure OpenAI'),
+            default => $this->handleResponseErrors($e),
+        };
+    }
+
+    #[\Override]
+    protected function handleResponseErrors(RequestException $e): never
+    {
+        $data = $e->response->json() ?? [];
+        $message = data_get($data, 'error.message');
+        $message = is_array($message) ? implode(', ', $message) : $message;
+
+        throw PrismException::providerRequestErrorWithDetails(
+            provider: 'Azure OpenAI',
+            statusCode: $e->response->getStatusCode(),
+            errorType: data_get($data, 'error.type'),
+            errorMessage: $message,
+            previous: $e
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @param  array<mixed>  $retry
+     */
+    #[\Override]
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
+    {
+        return $this->baseClient()
+            ->withHeaders([
+                'api-key' => $this->apiKey,
+            ])
+            ->when($this->apiVersion, fn ($client) => $client->withQueryParameters([
+                'api-version' => $this->apiVersion,
+            ]))
+            ->withOptions($options)
+            ->when($retry !== [], fn ($client) => $client->retry(...$retry))
+            ->baseUrl($baseUrl ?? $this->url);
+    }
+}

--- a/src/Providers/AzureProvider.php
+++ b/src/Providers/AzureProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+
+class AzureProvider extends Provider implements EmbeddingProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    /**
+     * Get the credentials for the underlying AI provider.
+     */
+    public function providerCredentials(): array
+    {
+        return [
+            'key' => $this->config['key'],
+            'url' => $this->config['url'],
+            'api_version' => $this->config['api_version'],
+        ];
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return 'gpt-4o';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return 'gpt-4o-mini';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return 'gpt-4o';
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return 'text-embedding-3-small';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return 1536;
+    }
+}

--- a/src/Providers/AzureProvider.php
+++ b/src/Providers/AzureProvider.php
@@ -14,15 +14,14 @@ class AzureProvider extends Provider implements EmbeddingProvider, TextProvider
     use Concerns\StreamsText;
 
     /**
-     * Get the credentials for the underlying AI provider.
+     * Get additional configuration for the underlying AI provider.
      */
-    public function providerCredentials(): array
+    public function additionalConfiguration(): array
     {
-        return [
-            'key' => $this->config['key'],
-            'url' => $this->config['url'],
-            'api_version' => $this->config['api_version'],
-        ];
+        return array_filter([
+            'url' => $this->config['url'] ?? null,
+            'api_version' => $this->config['api_version'] ?? null,
+        ]);
     }
 
     /**

--- a/tests/Feature/AzureProviderTest.php
+++ b/tests/Feature/AzureProviderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\AzureProvider;
+use Tests\TestCase;
+
+class AzureProviderTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('ai.providers.azure', [
+            'driver' => 'azure',
+            'name' => 'azure',
+            'key' => 'test-azure-api-key',
+            'url' => 'https://my-resource.openai.azure.com/openai/deployments/gpt-4o',
+            'api_version' => '2024-12-01-preview',
+        ]);
+    }
+
+    public function test_can_resolve_azure_provider(): void
+    {
+        $provider = Ai::textProvider('azure');
+
+        $this->assertInstanceOf(AzureProvider::class, $provider);
+    }
+
+    public function test_azure_provider_has_correct_credentials(): void
+    {
+        $provider = Ai::textProvider('azure');
+
+        $this->assertEquals([
+            'key' => 'test-azure-api-key',
+            'url' => 'https://my-resource.openai.azure.com/openai/deployments/gpt-4o',
+            'api_version' => '2024-12-01-preview',
+        ], $provider->providerCredentials());
+    }
+
+    public function test_azure_provider_sends_correct_headers_and_query_params(): void
+    {
+        Http::fake([
+            'my-resource.openai.azure.com/*' => Http::response([
+                'id' => 'resp-123',
+                'object' => 'response',
+                'model' => 'gpt-4o',
+                'output' => [
+                    [
+                        'type' => 'message',
+                        'status' => 'completed',
+                        'role' => 'assistant',
+                        'content' => [
+                            [
+                                'type' => 'output_text',
+                                'text' => 'Hello from Azure!',
+                            ],
+                        ],
+                    ],
+                ],
+                'usage' => [
+                    'input_tokens' => 10,
+                    'output_tokens' => 5,
+                ],
+            ]),
+        ]);
+
+        $response = (new \Tests\Feature\Agents\AssistantAgent)->prompt(
+            'Say hello',
+            provider: 'azure',
+            model: 'gpt-4o',
+        );
+
+        $this->assertEquals('Hello from Azure!', $response->text);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('api-key', 'test-azure-api-key')
+                && ! $request->hasHeader('Authorization')
+                && str_contains($request->url(), 'api-version=2024-12-01-preview')
+                && str_contains($request->url(), 'my-resource.openai.azure.com');
+        });
+    }
+
+    public function test_azure_provider_is_also_an_embedding_provider(): void
+    {
+        $provider = Ai::embeddingProvider('azure');
+
+        $this->assertInstanceOf(AzureProvider::class, $provider);
+        $this->assertEquals('text-embedding-3-small', $provider->defaultEmbeddingsModel());
+        $this->assertEquals(1536, $provider->defaultEmbeddingsDimensions());
+    }
+}


### PR DESCRIPTION
Adds Azure OpenAI as a provider, supporting both legacy and v1 API formats.

Configuration

```php
  // config/ai.php
  'azure' => [
      'driver' => 'azure',
      'key' => env('AZURE_OPENAI_API_KEY'),
      'url' => env('AZURE_OPENAI_URL'),
      'api_version' => env('AZURE_OPENAI_API_VERSION'),
],
```
Usage

v1 API (recommended)
AZURE_OPENAI_URL=https://my-resource.openai.azure.com/openai/v1

Legacy API
AZURE_OPENAI_URL=https://my-resource.openai.azure.com/openai/deployments/gpt-4o
AZURE_OPENAI_API_VERSION=2024-10-21

Supports text generation, streaming, structured output, and embeddings.

How it works

Extends Prism's OpenAI provider via PrismManager::extend(), inheriting all OpenAI-compatible capabilities
Uses api-key header instead of Bearer auth
Conditionally adds api-version query param only when configured