### PR TITLE
Support user string IDs

### DIFF
--- a/src/Contracts/ConversationStore.php
+++ b/src/Contracts/ConversationStore.php
@@ -11,22 +11,22 @@ interface ConversationStore
     /**
      * Get the most recent conversation ID for a given user.
      */
-    public function latestConversationId(int $userId): ?string;
+    public function latestConversationId(int|string $userId): ?string;
 
     /**
      * Store a new conversation and return its ID.
      */
-    public function storeConversation(int $userId, string $title): string;
+    public function storeConversation(int|string $userId, string $title): string;
 
     /**
      * Store a new user message for the given conversation and return its ID.
      */
-    public function storeUserMessage(string $conversationId, int $userId, AgentPrompt $prompt): string;
+    public function storeUserMessage(string $conversationId, int|string $userId, AgentPrompt $prompt): string;
 
     /**
      * Store a new assistant message for the given conversation and return its ID.
      */
-    public function storeAssistantMessage(string $conversationId, int $userId, AgentPrompt $prompt, AgentResponse $response): string;
+    public function storeAssistantMessage(string $conversationId, int|string $userId, AgentPrompt $prompt, AgentResponse $response): string;
 
     /**
      * Get the latest messages for the given conversation.

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -15,7 +15,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Get the most recent conversation ID for a given user.
      */
-    public function latestConversationId(int $userId): ?string
+    public function latestConversationId(int|string $userId): ?string
     {
         return DB::table('agent_conversations')
             ->where('user_id', $userId)
@@ -26,7 +26,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Store a new conversation and return its ID.
      */
-    public function storeConversation(int $userId, string $title): string
+    public function storeConversation(int|string $userId, string $title): string
     {
         $conversationId = (string) Str::uuid7();
 
@@ -44,7 +44,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Store a new user message for the given conversation and return its ID.
      */
-    public function storeUserMessage(string $conversationId, int $userId, AgentPrompt $prompt): string
+    public function storeUserMessage(string $conversationId, int|string $userId, AgentPrompt $prompt): string
     {
         $messageId = (string) Str::uuid7();
 
@@ -70,7 +70,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Store a new assistant message for the given conversation and return its ID.
      */
-    public function storeAssistantMessage(string $conversationId, int $userId, AgentPrompt $prompt, AgentResponse $response): string
+    public function storeAssistantMessage(string $conversationId, int|string $userId, AgentPrompt $prompt, AgentResponse $response): string
     {
         $messageId = (string) Str::uuid7();
 


### PR DESCRIPTION
Currently the SDK expects user IDs to be an integer. However, if the user model is using the `HasUuids` or `HasUlids` trait, the ID will be a string.

This PR updates the SDK to support both integers and strings for the `$userId`.

I've left the migration as a `foreignId` as that is the default for a new laravel project and as with other packages, it's expected that developers change the migration if they use something different.