### PR TITLE
[0.x] Use `contains` and `doesntCountain` for all assertions

### DIFF
--- a/src/Concerns/InteractsWithFakeAgents.php
+++ b/src/Concerns/InteractsWithFakeAgents.php
@@ -88,9 +88,9 @@ trait InteractsWithFakeAgents
             : $callback;
 
         PHPUnit::assertTrue(
-            (new Collection($prompts ?? $this->recordedPrompts[$agent] ?? []))->filter(function ($prompt) use ($callback) {
+            (new Collection($prompts ?? $this->recordedPrompts[$agent] ?? []))->contains(function ($prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             $message ?? 'An expected prompt was not received.'
         );
 
@@ -124,9 +124,9 @@ trait InteractsWithFakeAgents
             : $callback;
 
         PHPUnit::assertTrue(
-            (new Collection($prompts ?? $this->recordedPrompts[$agent] ?? []))->filter(function ($prompt) use ($callback) {
+            (new Collection($prompts ?? $this->recordedPrompts[$agent] ?? []))->doesntContain(function ($prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             $message ?? 'An unexpected prompt was received.'
         );
 

--- a/src/Concerns/InteractsWithFakeAudio.php
+++ b/src/Concerns/InteractsWithFakeAudio.php
@@ -54,9 +54,9 @@ trait InteractsWithFakeAudio
     public function assertAudioGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedAudioGenerations))->filter(function (AudioPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedAudioGenerations))->contains(function (AudioPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected audio generation was not recorded.'
         );
 
@@ -69,9 +69,9 @@ trait InteractsWithFakeAudio
     public function assertAudioNotGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedAudioGenerations))->filter(function (AudioPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedAudioGenerations))->doesntContain(function (AudioPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected audio generation was recorded.'
         );
 
@@ -97,9 +97,9 @@ trait InteractsWithFakeAudio
     public function assertAudioQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedAudioGenerations))->filter(function (QueuedAudioPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedAudioGenerations))->contains(function (QueuedAudioPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected queued audio generation was not recorded.'
         );
 
@@ -112,9 +112,9 @@ trait InteractsWithFakeAudio
     public function assertAudioNotQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedAudioGenerations))->filter(function (QueuedAudioPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedAudioGenerations))->doesntContain(function (QueuedAudioPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected queued audio generation was recorded.'
         );
 

--- a/src/Concerns/InteractsWithFakeEmbeddings.php
+++ b/src/Concerns/InteractsWithFakeEmbeddings.php
@@ -54,9 +54,9 @@ trait InteractsWithFakeEmbeddings
     public function assertEmbeddingsGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedEmbeddingsGenerations))->filter(function (EmbeddingsPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedEmbeddingsGenerations))->contains(function (EmbeddingsPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected embeddings generation was not recorded.'
         );
 
@@ -69,9 +69,9 @@ trait InteractsWithFakeEmbeddings
     public function assertEmbeddingsNotGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedEmbeddingsGenerations))->filter(function (EmbeddingsPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedEmbeddingsGenerations))->doesntContain(function (EmbeddingsPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected embeddings generation was recorded.'
         );
 
@@ -97,9 +97,9 @@ trait InteractsWithFakeEmbeddings
     public function assertEmbeddingsQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedEmbeddingsGenerations))->filter(function (QueuedEmbeddingsPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedEmbeddingsGenerations))->contains(function (QueuedEmbeddingsPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected queued embeddings generation was not recorded.'
         );
 
@@ -112,9 +112,9 @@ trait InteractsWithFakeEmbeddings
     public function assertEmbeddingsNotQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedEmbeddingsGenerations))->filter(function (QueuedEmbeddingsPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedEmbeddingsGenerations))->doesntContain(function (QueuedEmbeddingsPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected queued embeddings generation was recorded.'
         );
 

--- a/src/Concerns/InteractsWithFakeFiles.php
+++ b/src/Concerns/InteractsWithFakeFiles.php
@@ -61,9 +61,9 @@ trait InteractsWithFakeFiles
     public function assertFileUploaded(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileUploads))->filter(function (array $upload) use ($callback) {
+            (new Collection($this->recordedFileUploads))->contains(function (array $upload) use ($callback) {
                 return $callback($upload['file']);
-            })->count() > 0,
+            }),
             'An expected file upload was not recorded.'
         );
 
@@ -76,9 +76,9 @@ trait InteractsWithFakeFiles
     public function assertFileNotUploaded(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileUploads))->filter(function (array $upload) use ($callback) {
+            (new Collection($this->recordedFileUploads))->doesntContain(function (array $upload) use ($callback) {
                 return $callback($upload['file']);
-            })->count() === 0,
+            }),
             'An unexpected file upload was recorded.'
         );
 
@@ -109,9 +109,9 @@ trait InteractsWithFakeFiles
         }
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileDeletions))->filter(function (string $id) use ($callback) {
+            (new Collection($this->recordedFileDeletions))->contains(function (string $id) use ($callback) {
                 return $callback($id);
-            })->count() > 0,
+            }),
             'An expected file deletion was not recorded.'
         );
 
@@ -129,9 +129,9 @@ trait InteractsWithFakeFiles
         }
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileDeletions))->filter(function (string $id) use ($callback) {
+            (new Collection($this->recordedFileDeletions))->doesntContain(function (string $id) use ($callback) {
                 return $callback($id);
-            })->count() === 0,
+            }),
             'An unexpected file deletion was recorded.'
         );
 

--- a/src/Concerns/InteractsWithFakeImages.php
+++ b/src/Concerns/InteractsWithFakeImages.php
@@ -54,9 +54,9 @@ trait InteractsWithFakeImages
     public function assertImageGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedImageGenerations))->filter(function (ImagePrompt $prompt) use ($callback) {
+            (new Collection($this->recordedImageGenerations))->contains(function (ImagePrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected image generation was not recorded.'
         );
 
@@ -69,9 +69,9 @@ trait InteractsWithFakeImages
     public function assertImageNotGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedImageGenerations))->filter(function (ImagePrompt $prompt) use ($callback) {
+            (new Collection($this->recordedImageGenerations))->doesntContain(function (ImagePrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected image generation was recorded.'
         );
 
@@ -97,9 +97,9 @@ trait InteractsWithFakeImages
     public function assertImageQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedImageGenerations))->filter(function (QueuedImagePrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedImageGenerations))->contains(function (QueuedImagePrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected queued image generation was not recorded.'
         );
 
@@ -112,9 +112,9 @@ trait InteractsWithFakeImages
     public function assertImageNotQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedImageGenerations))->filter(function (QueuedImagePrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedImageGenerations))->doesntContain(function (QueuedImagePrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected queued image generation was recorded.'
         );
 

--- a/src/Concerns/InteractsWithFakeReranking.php
+++ b/src/Concerns/InteractsWithFakeReranking.php
@@ -44,9 +44,9 @@ trait InteractsWithFakeReranking
     public function assertReranked(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedRerankings))->filter(function (RerankingPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedRerankings))->contains(function (RerankingPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected reranking was not recorded.'
         );
 
@@ -59,9 +59,9 @@ trait InteractsWithFakeReranking
     public function assertNotReranked(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedRerankings))->filter(function (RerankingPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedRerankings))->doesntContain(function (RerankingPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected reranking was recorded.'
         );
 

--- a/src/Concerns/InteractsWithFakeStores.php
+++ b/src/Concerns/InteractsWithFakeStores.php
@@ -118,14 +118,14 @@ trait InteractsWithFakeStores
         }
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedStoreCreations))->filter(function (array $creation) use ($callback) {
+            (new Collection($this->recordedStoreCreations))->contains(function (array $creation) use ($callback) {
                 return $callback(
                     $creation['name'],
                     $creation['description'],
                     $creation['fileIds'],
                     $creation['expiresWhenIdleFor'],
                 );
-            })->count() > 0,
+            }),
             'An expected store creation was not recorded.'
         );
 
@@ -143,14 +143,14 @@ trait InteractsWithFakeStores
         }
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedStoreCreations))->filter(function (array $creation) use ($callback) {
+            (new Collection($this->recordedStoreCreations))->doesntContain(function (array $creation) use ($callback) {
                 return $callback(
                     $creation['name'],
                     $creation['description'],
                     $creation['fileIds'],
                     $creation['expiresWhenIdleFor'],
                 );
-            })->count() === 0,
+            }),
             'An unexpected store creation was recorded.'
         );
 
@@ -181,9 +181,9 @@ trait InteractsWithFakeStores
         }
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedStoreDeletions))->filter(function (string $id) use ($callback) {
+            (new Collection($this->recordedStoreDeletions))->contains(function (string $id) use ($callback) {
                 return $callback($id);
-            })->count() > 0,
+            }),
             'An expected store deletion was not recorded.'
         );
 
@@ -201,9 +201,9 @@ trait InteractsWithFakeStores
         }
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedStoreDeletions))->filter(function (string $id) use ($callback) {
+            (new Collection($this->recordedStoreDeletions))->doesntContain(function (string $id) use ($callback) {
                 return $callback($id);
-            })->count() === 0,
+            }),
             'An unexpected store deletion was recorded.'
         );
 
@@ -231,9 +231,9 @@ trait InteractsWithFakeStores
         $callback = $this->fileMatchingCallback($storeId, $fileId);
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileAdditions))->filter(function (array $addition) use ($callback) {
+            (new Collection($this->recordedFileAdditions))->contains(function (array $addition) use ($callback) {
                 return $callback($addition['storeId'], $addition['file']);
-            })->count() > 0,
+            }),
             'An expected file addition was not recorded.'
         );
 
@@ -248,9 +248,9 @@ trait InteractsWithFakeStores
         $callback = $this->fileMatchingCallback($storeId, $fileId);
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileAdditions))->filter(function (array $addition) use ($callback) {
+            (new Collection($this->recordedFileAdditions))->doesntContain(function (array $addition) use ($callback) {
                 return $callback($addition['storeId'], $addition['file']);
-            })->count() === 0,
+            }),
             'An unexpected file addition was recorded.'
         );
 
@@ -265,9 +265,9 @@ trait InteractsWithFakeStores
         $callback = $this->fileMatchingCallback($storeId, $fileId);
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileRemovals))->filter(function (array $removal) use ($callback) {
+            (new Collection($this->recordedFileRemovals))->contains(function (array $removal) use ($callback) {
                 return $callback($removal['storeId'], $removal['fileId']);
-            })->count() > 0,
+            }),
             'An expected file removal was not recorded.'
         );
 
@@ -282,9 +282,9 @@ trait InteractsWithFakeStores
         $callback = $this->fileMatchingCallback($storeId, $fileId);
 
         PHPUnit::assertTrue(
-            (new Collection($this->recordedFileRemovals))->filter(function (array $removal) use ($callback) {
+            (new Collection($this->recordedFileRemovals))->doesntContain(function (array $removal) use ($callback) {
                 return $callback($removal['storeId'], $removal['fileId']);
-            })->count() === 0,
+            }),
             'An unexpected file removal was recorded.'
         );
 

--- a/src/Concerns/InteractsWithFakeTranscriptions.php
+++ b/src/Concerns/InteractsWithFakeTranscriptions.php
@@ -54,9 +54,9 @@ trait InteractsWithFakeTranscriptions
     public function assertTranscriptionGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedTranscriptionGenerations))->filter(function (TranscriptionPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedTranscriptionGenerations))->contains(function (TranscriptionPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected transcription generation was not recorded.'
         );
 
@@ -69,9 +69,9 @@ trait InteractsWithFakeTranscriptions
     public function assertTranscriptionNotGenerated(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedTranscriptionGenerations))->filter(function (TranscriptionPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedTranscriptionGenerations))->doesntContain(function (TranscriptionPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected transcription generation was recorded.'
         );
 
@@ -97,9 +97,9 @@ trait InteractsWithFakeTranscriptions
     public function assertTranscriptionQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedTranscriptionGenerations))->filter(function (QueuedTranscriptionPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedTranscriptionGenerations))->contains(function (QueuedTranscriptionPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() > 0,
+            }),
             'An expected queued transcription generation was not recorded.'
         );
 
@@ -112,9 +112,9 @@ trait InteractsWithFakeTranscriptions
     public function assertTranscriptionNotQueued(Closure $callback): self
     {
         PHPUnit::assertTrue(
-            (new Collection($this->recordedQueuedTranscriptionGenerations))->filter(function (QueuedTranscriptionPrompt $prompt) use ($callback) {
+            (new Collection($this->recordedQueuedTranscriptionGenerations))->doesntContain(function (QueuedTranscriptionPrompt $prompt) use ($callback) {
                 return $callback($prompt);
-            })->count() === 0,
+            }),
             'An unexpected queued transcription generation was recorded.'
         );
 


### PR DESCRIPTION
Use `contains` and `doesntCountain` for all assertions, which is faster than mapping and counting