### PR TITLE
[0.x] Use `str_contains` instead of `Str::contains`

### DIFF
--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Prompts;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 
@@ -35,7 +34,7 @@ class AgentPrompt extends Prompt
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->prompt, $string);
+        return str_contains($this->prompt, $string);
     }
 
     /**

--- a/src/Prompts/AudioPrompt.php
+++ b/src/Prompts/AudioPrompt.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Ai\Prompts;
 
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 
 class AudioPrompt
@@ -20,7 +19,7 @@ class AudioPrompt
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->text, $string);
+        return str_contains($this->text, $string);
     }
 
     /**

--- a/src/Prompts/EmbeddingsPrompt.php
+++ b/src/Prompts/EmbeddingsPrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Prompts;
 
 use Countable;
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 
 class EmbeddingsPrompt implements Countable
@@ -20,7 +19,7 @@ class EmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
+        return array_any($this->inputs, fn ($input) => str_contains($input, $string));
     }
 
     /**

--- a/src/Prompts/ImagePrompt.php
+++ b/src/Prompts/ImagePrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Prompts;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 
 class ImagePrompt
@@ -26,7 +25,7 @@ class ImagePrompt
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->prompt, $string);
+        return str_contains($this->prompt, $string);
     }
 
     /**

--- a/src/Prompts/QueuedAudioPrompt.php
+++ b/src/Prompts/QueuedAudioPrompt.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Ai\Prompts;
 
-use Illuminate\Support\Str;
-
 class QueuedAudioPrompt
 {
     public function __construct(
@@ -19,7 +17,7 @@ class QueuedAudioPrompt
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->text, $string);
+        return str_contains($this->text, $string);
     }
 
     /**

--- a/src/Prompts/QueuedEmbeddingsPrompt.php
+++ b/src/Prompts/QueuedEmbeddingsPrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Prompts;
 
 use Countable;
-use Illuminate\Support\Str;
 
 class QueuedEmbeddingsPrompt implements Countable
 {
@@ -19,7 +18,7 @@ class QueuedEmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
+        return array_any($this->inputs, fn ($input) => str_contains($input, $string));
     }
 
     /**

--- a/src/Prompts/QueuedImagePrompt.php
+++ b/src/Prompts/QueuedImagePrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Prompts;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class QueuedImagePrompt
 {
@@ -25,7 +24,7 @@ class QueuedImagePrompt
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->prompt, $string);
+        return str_contains($this->prompt, $string);
     }
 
     /**

--- a/src/Prompts/RerankingPrompt.php
+++ b/src/Prompts/RerankingPrompt.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Prompts;
 
 use Countable;
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
 
 class RerankingPrompt implements Countable
@@ -26,7 +25,7 @@ class RerankingPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->query, $string);
+        return str_contains($this->query, $string);
     }
 
     /**
@@ -34,7 +33,7 @@ class RerankingPrompt implements Countable
      */
     public function documentsContain(string $string): bool
     {
-        return array_any($this->documents, fn ($document) => Str::contains($document, $string));
+        return array_any($this->documents, fn ($document) => str_contains($document, $string));
     }
 
     /**


### PR DESCRIPTION
Use `str_contains` instead of `Str::contains`