### PR TITLE
Add subagent

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -23,10 +23,11 @@ function agent(
     iterable $messages = [],
     iterable $tools = [],
     ?Closure $schema = null,
+    iterable $agents = [],
 ): Agent {
     return $schema
-        ? new StructuredAnonymousAgent($instructions, $messages, $tools, $schema)
-        : new AnonymousAgent($instructions, $messages, $tools);
+        ? new StructuredAnonymousAgent($instructions, $messages, $tools, $schema, $agents)
+        : new AnonymousAgent($instructions, $messages, $tools, $agents);
 }
 
 /**

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Stringable;
 use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
+use Laravel\Ai\Console\Commands\MakeSubAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Storage\DatabaseConversationStore;
@@ -93,6 +94,7 @@ class AiServiceProvider extends ServiceProvider
         $this->commands([
             // ChatCommand::class,
             MakeAgentCommand::class,
+            MakeSubAgentCommand::class,
             MakeToolCommand::class,
         ]);
     }
@@ -109,6 +111,7 @@ class AiServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../stubs/agent.stub' => base_path('stubs/agent.stub'),
             __DIR__.'/../stubs/structured-agent.stub' => base_path('stubs/structured-agent.stub'),
+            __DIR__.'/../stubs/subagent.stub' => base_path('stubs/subagent.stub'),
             __DIR__.'/../stubs/tool.stub' => base_path('stubs/tool.stub'),
         ], 'ai-stubs');
 

--- a/src/AnonymousAgent.php
+++ b/src/AnonymousAgent.php
@@ -4,13 +4,19 @@ namespace Laravel\Ai;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasSubAgents;
 use Laravel\Ai\Contracts\HasTools;
 
-class AnonymousAgent implements Agent, Conversational, HasTools
+class AnonymousAgent implements Agent, Conversational, HasSubAgents, HasTools
 {
     use Promptable;
 
-    public function __construct(public string $instructions, public iterable $messages, public iterable $tools) {}
+    public function __construct(
+        public string $instructions,
+        public iterable $messages,
+        public iterable $tools,
+        public iterable $agents = [],
+    ) {}
 
     public function instructions(): string
     {
@@ -25,5 +31,12 @@ class AnonymousAgent implements Agent, Conversational, HasTools
     public function tools(): iterable
     {
         return $this->tools;
+    }
+
+    public function subAgents(): array
+    {
+        return is_array($this->agents)
+            ? $this->agents
+            : iterator_to_array($this->agents, false);
     }
 }

--- a/src/Console/Commands/MakeSubAgentCommand.php
+++ b/src/Console/Commands/MakeSubAgentCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Laravel\Ai\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:subagent')]
+class MakeSubAgentCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:subagent';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new subagent';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'SubAgent';
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Ai\Agents';
+    }
+
+    /**
+     * Get the stub file for the generator.
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/subagent.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.'/../../../'.$stub;
+    }
+
+    /**
+     * Get the console command arguments.
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the subagent even if the subagent already exists'],
+        ];
+    }
+}

--- a/src/Contracts/HasSubAgents.php
+++ b/src/Contracts/HasSubAgents.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+interface HasSubAgents
+{
+    /**
+     * Get the subagents available to the primary agent.
+     *
+     * @return SubAgent[]
+     */
+    public function subAgents(): array;
+}

--- a/src/Contracts/SubAgent.php
+++ b/src/Contracts/SubAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use Stringable;
+
+interface SubAgent extends Agent
+{
+    /**
+     * Get the subagent name.
+     */
+    public function name(): string;
+
+    /**
+     * Get the description of the subagent's purpose.
+     */
+    public function description(): Stringable|string;
+}

--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -16,6 +16,7 @@ class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOu
         public iterable $messages,
         public iterable $tools,
         Closure $schema,
+        public iterable $agents = [],
     ) {
         $this->schema = new SerializableClosure($schema);
     }

--- a/src/Tools/SubAgentTool.php
+++ b/src/Tools/SubAgentTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Ai\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\SubAgent;
+use Laravel\Ai\Contracts\Tool;
+use Stringable;
+
+class SubAgentTool implements Tool
+{
+    public function __construct(
+        protected SubAgent $subAgent,
+        protected ?string $provider = null,
+        protected ?string $model = null,
+    ) {}
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return $this->subAgent->name();
+    }
+
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): Stringable|string
+    {
+        return $this->subAgent->description();
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): Stringable|string
+    {
+        return $this->subAgent->prompt(
+            (string) $request->string('task'),
+            provider: $this->provider,
+            model: $this->model,
+        )->text;
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'task' => $schema->string()->required(),
+        ];
+    }
+}

--- a/stubs/subagent.stub
+++ b/stubs/subagent.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace {{ namespace }};
+
+use Laravel\Ai\Contracts\SubAgent;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+class {{ class }} implements SubAgent
+{
+    use Promptable;
+
+    /**
+     * Get the subagent name.
+     */
+    public function name(): string
+    {
+        return '{{ class }}';
+    }
+
+    /**
+     * Get the instructions that the subagent should follow.
+     */
+    public function instructions(): Stringable|string
+    {
+        return 'You are a helpful subagent.';
+    }
+
+    /**
+     * Get the description of the subagent's purpose.
+     */
+    public function description(): Stringable|string
+    {
+        return 'A description of the subagent.';
+    }
+}

--- a/tests/Feature/Agents/CalledTrackingSubAgent.php
+++ b/tests/Feature/Agents/CalledTrackingSubAgent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\SubAgent;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+class CalledTrackingSubAgent implements HasMiddleware, SubAgent
+{
+    use Promptable;
+
+    public static array $tasks = [];
+
+    public function name(): string
+    {
+        return 'called_tracking_subagent';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a delegated executor that echoes completed tasks.';
+    }
+
+    public function middleware(): array
+    {
+        return [function (AgentPrompt $prompt, $next) {
+            static::$tasks[] = $prompt->prompt;
+
+            return $next($prompt);
+        }];
+    }
+
+    public function description(): string
+    {
+        return 'Executes delegated tasks and returns completion text.';
+    }
+}

--- a/tests/Feature/Agents/DeterministicSubAgent.php
+++ b/tests/Feature/Agents/DeterministicSubAgent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\SubAgent;
+use Laravel\Ai\Promptable;
+
+class DeterministicSubAgent implements SubAgent
+{
+    use Promptable;
+
+    public function name(): string
+    {
+        return 'deterministic_subagent';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a deterministic subagent.';
+    }
+
+    public function description(): string
+    {
+        return 'Handles delegated tasks deterministically for tests.';
+    }
+}

--- a/tests/Feature/Agents/OllamaDelegatingAgent.php
+++ b/tests/Feature/Agents/OllamaDelegatingAgent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasSubAgents;
+use Laravel\Ai\Promptable;
+
+#[MaxSteps(4)]
+#[Temperature(0.0)]
+class OllamaDelegatingAgent implements Agent, HasSubAgents
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You must call the called_tracking_subagent tool exactly once for any user task. Pass through the exact task string and return only the tool output.';
+    }
+
+    public function subAgents(): array
+    {
+        return [new CalledTrackingSubAgent];
+    }
+}

--- a/tests/Feature/Agents/PrimaryWithSubAgentsAgent.php
+++ b/tests/Feature/Agents/PrimaryWithSubAgentsAgent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasSubAgents;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Feature\Tools\FixedNumberGenerator;
+
+class PrimaryWithSubAgentsAgent implements Agent, HasSubAgents, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a primary agent that can delegate to subagents.';
+    }
+
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator];
+    }
+
+    public function subAgents(): array
+    {
+        return [new DeterministicSubAgent];
+    }
+}

--- a/tests/Feature/Console/MakeSubAgentCommandTest.php
+++ b/tests/Feature/Console/MakeSubAgentCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+class MakeSubAgentCommandTest extends TestCase
+{
+    public function test_can_create_a_subagent_class(): void
+    {
+        $response = $this->artisan('make:subagent', [
+            'name' => 'TestSubAgent',
+        ]);
+
+        $response->assertExitCode(0)->run();
+
+        $this->assertFileExists(app_path('Ai/Agents/TestSubAgent.php'));
+    }
+
+    public function test_may_publish_custom_subagent_stub(): void
+    {
+        $this->artisan('vendor:publish', [
+            '--tag' => 'ai-stubs',
+            '--force' => true,
+        ])->assertExitCode(0)->run();
+
+        $this->assertFileExists(base_path('stubs/subagent.stub'));
+    }
+}

--- a/tests/Feature/OllamaSubAgentIntegrationTest.php
+++ b/tests/Feature/OllamaSubAgentIntegrationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Tools\SubAgentTool;
+use Tests\Feature\Agents\CalledTrackingSubAgent;
+use Tests\Feature\Agents\OllamaDelegatingAgent;
+use Tests\TestCase;
+
+class OllamaSubAgentIntegrationTest extends TestCase
+{
+    protected string $provider = 'ollama';
+
+    protected string $model = 'qwen3:8b';
+
+    public function test_ollama_can_invoke_subagent_tool(): void
+    {
+        if (! filter_var(env('RUN_OLLAMA_INTEGRATION', false), FILTER_VALIDATE_BOOL)) {
+            $this->markTestSkipped('Set RUN_OLLAMA_INTEGRATION=true to run Ollama integration tests.');
+        }
+
+        CalledTrackingSubAgent::$tasks = [];
+
+        Event::fake();
+
+        $response = (new OllamaDelegatingAgent)->prompt(
+            'Delegate to called_tracking_subagent with task exactly "integration ping". Return only the delegated output.',
+            provider: $this->provider,
+            model: $this->model,
+        );
+
+        $this->assertNotEmpty(
+            CalledTrackingSubAgent::$tasks,
+            sprintf(
+                "Sub-agent tool was not called. Response text: %s\nTool calls: %s\nTool results: %s",
+                $response->text,
+                json_encode($response->toolCalls->toArray(), JSON_PRETTY_PRINT),
+                json_encode($response->toolResults->toArray(), JSON_PRETTY_PRINT),
+            )
+        );
+        $this->assertSame('integration ping', CalledTrackingSubAgent::$tasks[0]);
+        $this->assertSame('ollama', $response->meta->provider);
+        $this->assertSame($this->model, $response->meta->model);
+
+        Event::assertDispatched(InvokingTool::class, function ($event) {
+            return $event->tool instanceof SubAgentTool
+                && ($event->arguments['task'] ?? null) === 'integration ping';
+        });
+
+        Event::assertDispatched(ToolInvoked::class, function ($event) {
+            return $event->tool instanceof SubAgentTool
+                && ($event->arguments['task'] ?? null) === 'integration ping';
+        });
+    }
+}

--- a/tests/Feature/SubAgentIntegrationTest.php
+++ b/tests/Feature/SubAgentIntegrationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasSubAgents;
+use Laravel\Ai\Providers\Concerns\GeneratesText;
+use Laravel\Ai\Tools\Request;
+use Laravel\Ai\Tools\SubAgentTool;
+use Tests\Feature\Agents\DeterministicSubAgent;
+use Tests\Feature\Agents\PrimaryWithSubAgentsAgent;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class SubAgentIntegrationTest extends TestCase
+{
+    public function test_subagent_tool_executes_with_a_task_string(): void
+    {
+        DeterministicSubAgent::fake(['subagent: summarize this']);
+
+        $tool = new SubAgentTool(new DeterministicSubAgent);
+
+        $this->assertSame('deterministic_subagent', $tool->name());
+        $this->assertSame('subagent: summarize this', (string) $tool->handle(new Request([
+            'task' => 'summarize this',
+        ])));
+
+        DeterministicSubAgent::assertPrompted('summarize this');
+    }
+
+    public function test_primary_agent_tools_include_mapped_subagents(): void
+    {
+        $harness = new class
+        {
+            use GeneratesText;
+
+            public function toolsFor(Agent $agent): array
+            {
+                return $this->gatherToolsFor($agent);
+            }
+        };
+
+        $tools = $harness->toolsFor(new PrimaryWithSubAgentsAgent);
+
+        $this->assertCount(2, $tools);
+        $this->assertInstanceOf(FixedNumberGenerator::class, $tools[0]);
+        $this->assertInstanceOf(SubAgentTool::class, $tools[1]);
+    }
+
+    public function test_empty_agents_array_does_not_add_subagent_tools(): void
+    {
+        $harness = new class
+        {
+            use GeneratesText;
+
+            public function toolsFor(Agent $agent): array
+            {
+                return $this->gatherToolsFor($agent);
+            }
+        };
+
+        $tools = $harness->toolsFor(new class implements Agent, HasSubAgents
+        {
+            use \Laravel\Ai\Promptable;
+
+            public function instructions(): string
+            {
+                return 'No tools';
+            }
+
+            public function subAgents(): array
+            {
+                return [];
+            }
+        });
+
+        $this->assertSame([], $tools);
+    }
+
+    public function test_anonymous_agent_helper_accepts_subagents(): void
+    {
+        $agent = agent(agents: [new DeterministicSubAgent]);
+
+        $this->assertInstanceOf(HasSubAgents::class, $agent);
+        /** @var HasSubAgents $agent */
+        $this->assertCount(1, $agent->subAgents());
+        $this->assertInstanceOf(DeterministicSubAgent::class, $agent->subAgents()[0]);
+    }
+
+    public function test_structured_anonymous_agent_helper_accepts_subagents(): void
+    {
+        $agent = agent(
+            schema: fn ($schema) => ['value' => $schema->string()->required()],
+            agents: [new DeterministicSubAgent],
+        );
+
+        $this->assertInstanceOf(HasSubAgents::class, $agent);
+        /** @var HasSubAgents $agent */
+        $this->assertCount(1, $agent->subAgents());
+        $this->assertInstanceOf(DeterministicSubAgent::class, $agent->subAgents()[0]);
+    }
+}


### PR DESCRIPTION
fix #58 

example:

```php
class PrimaryWithSubAgentsAgent implements Agent, HasSubAgents, HasTools
{
    use Promptable;

    public function instructions(): string
    {
        return 'You are a primary agent that can delegate to subagents.';
    }

    public function subAgents(): array
    {
        return [new SubAgent];
    }
}
```

Edit: rename `agents` to `subAgents`