### PR TITLE
fix: remove invalid $event->delta access on ThinkingCompleteEvent

### DIFF
--- a/src/Gateway/Prism/PrismStreamEvent.php
+++ b/src/Gateway/Prism/PrismStreamEvent.php
@@ -41,7 +41,7 @@ class PrismStreamEvent
             PrismStreamEventType::TextComplete => new TextEnd($id ?? $event->id, strtolower($event->messageId), $event->timestamp),
             PrismStreamEventType::ThinkingStart => new ReasoningStart($id ?? $event->id, strtolower($event->reasoningId), $event->timestamp),
             PrismStreamEventType::ThinkingDelta => new ReasoningDelta($id ?? $event->id, strtolower($event->reasoningId), $event->delta, $event->timestamp, $event->summary),
-            PrismStreamEventType::ThinkingComplete => new ReasoningEnd($id ?? $event->id, strtolower($event->reasoningId), $event->delta, $event->timestamp, $event->summary),
+            PrismStreamEventType::ThinkingComplete => new ReasoningEnd($id ?? $event->id, strtolower($event->reasoningId), $event->timestamp, $event->summary),
             PrismStreamEventType::ToolCall => static::toToolCallEvent($event),
             PrismStreamEventType::ToolResult => static::toToolResultEvent($event),
             PrismStreamEventType::ProviderToolEvent => static::toProviderToolEvent($event),


### PR DESCRIPTION
The `ThinkingComplete` case in `PrismStreamEvent::toLaravelStreamEvent()` passes `$event->delta` to the `ReasoningEnd` constructor, but Prism's `ThinkingCompleteEvent` does not have a `$delta` property.

This causes an `Undefined property: Prism\Prism\Streaming\Events\ThinkingCompleteEvent::$delta` error when streaming models that emit thinking tokens (e.g. `qwen/qwen3-8b` via OpenRouter).

Additionally, `$event->delta` was passed as the third argument where `ReasoningEnd` expects `int $timestamp`, causing a type mismatch.

**Fix:** Remove `$event->delta` from the constructor call to match the `ReasoningEnd(id, reasoningId, timestamp, summary)` signature.