### PR TITLE
Return $this when calling location method in WebSearch

### DIFF
--- a/src/Providers/Tools/WebSearch.php
+++ b/src/Providers/Tools/WebSearch.php
@@ -43,6 +43,8 @@ class WebSearch extends ProviderTool
         $this->city = $city;
         $this->region = $region;
         $this->country = $country;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Couldn't use 'location' on WebSearch tool due to missing return type:

<img width="787" height="75" alt="image" src="https://github.com/user-attachments/assets/591c4e8f-2d53-4aa8-9bc6-6a130e077602" />
