### PR TITLE
fix: handle nullable usage in PrismUsage::toLaravelUsage

### DIFF
--- a/src/Gateway/Prism/PrismUsage.php
+++ b/src/Gateway/Prism/PrismUsage.php
@@ -10,14 +10,14 @@ class PrismUsage
     /**
      * Convert the Prism usage value object to a Laravel AI SDK usage object.
      */
-    public static function toLaravelUsage(PrismUsageValueObject $usage): Usage
+    public static function toLaravelUsage(?PrismUsageValueObject $usage): Usage
     {
         return new Usage(
-            $usage->promptTokens ?: 0,
-            $usage->completionTokens ?: 0,
-            $usage->cacheWriteInputTokens ?: 0,
-            $usage->cacheReadInputTokens ?: 0,
-            $usage->thoughtTokens ?: 0,
+            $usage->promptTokens ?? 0,
+            $usage->completionTokens ?? 0,
+            $usage->cacheWriteInputTokens ?? 0,
+            $usage->cacheReadInputTokens ?? 0,
+            $usage->thoughtTokens ?? 0,
         );
     }
 }


### PR DESCRIPTION
## Summary

- `PrismUsage::toLaravelUsage()` accepts a non-nullable `PrismUsageValueObject`, but Prism declares `$usage` as nullable in two places:
  - [`StreamEndEvent::$usage`](https://github.com/prism-php/prism/blob/main/src/Streaming/Events/StreamEndEvent.php#L23) — `?Usage $usage = null`
  - [`Audio\TextResponse::$usage`](https://github.com/prism-php/prism/blob/main/src/Audio/TextResponse.php) — `?Usage $usage`
- This causes a `TypeError` when streaming with providers (e.g. OpenRouter) that don't return usage data in their stream end events, or when transcribing audio without usage info

## Error

```
Laravel\Ai\Gateway\Prism\PrismUsage::toLaravelUsage(): Argument #1 ($usage) must be of type Prism\Prism\ValueObjects\Usage, null given, called in vendor/laravel/ai/src/Gateway/Prism/PrismStreamEvent.php on line 106
```

## Affected Call Sites

| Prism Class | Property | Called From |
|---|---|---|
| `StreamEndEvent` | `?Usage $usage = null` | `PrismStreamEvent.php:106` |
| `Audio\TextResponse` | `?Usage $usage` | `PrismGateway.php:313` |

## Changes

- Made `$usage` parameter nullable (`?PrismUsageValueObject`)
- Changed `?:` to `??` — the `?:` operator treats `0` as falsy (returning the fallback for valid zero-token usage), while `??` only catches `null`