### PR TITLE
Add missing chunking_strategy provider option for diarized transcriptions

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -292,6 +292,7 @@ class PrismGateway implements Gateway
                 $request->withProviderOptions(array_filter([
                     'language' => $language,
                     'response_format' => $diarize ? 'diarized_json' : null,
+                    'chunking_strategy' => $diarize ? 'auto' : null,
                 ]));
             }
 


### PR DESCRIPTION
When using `Transcription::fromStorage('audio.mp3')->diarize()->generate()`, the OpenAI API returns a `400` error because `chunking_strategy` is required for diarization models (`gpt-4o-transcribe-diarize`) but the SDK doesn't include it in the provider options passed to Prism.

**Changes:**
- Added `'chunking_strategy' => 'auto'` to provider options when diarization is enabled in `src/Gateway/Prism/PrismGateway.php`

**Note:** This also requires prism-php/prism#892 to forward `chunking_strategy` to the OpenAI API.

It's my first PR for OSS (except doc changes), so help me out if it doesn't make sense.