### PR TITLE
[0.x] Fix ThinkingComplete stream event passing undefined $delta property

### DIFF
--- a/src/Gateway/Prism/PrismStreamEvent.php
+++ b/src/Gateway/Prism/PrismStreamEvent.php
@@ -41,7 +41,7 @@ class PrismStreamEvent
             PrismStreamEventType::TextComplete => new TextEnd($id ?? $event->id, strtolower($event->messageId), $event->timestamp),
             PrismStreamEventType::ThinkingStart => new ReasoningStart($id ?? $event->id, strtolower($event->reasoningId), $event->timestamp),
             PrismStreamEventType::ThinkingDelta => new ReasoningDelta($id ?? $event->id, strtolower($event->reasoningId), $event->delta, $event->timestamp, $event->summary),
-            PrismStreamEventType::ThinkingComplete => new ReasoningEnd($id ?? $event->id, strtolower($event->reasoningId), $event->delta, $event->timestamp, $event->summary),
+            PrismStreamEventType::ThinkingComplete => new ReasoningEnd($id ?? $event->id, strtolower($event->reasoningId), $event->timestamp, $event->summary ?? null),
             PrismStreamEventType::ToolCall => static::toToolCallEvent($event),
             PrismStreamEventType::ToolResult => static::toToolResultEvent($event),
             PrismStreamEventType::ProviderToolEvent => static::toProviderToolEvent($event),

--- a/tests/Unit/Gateway/Prism/PrismStreamEventTest.php
+++ b/tests/Unit/Gateway/Prism/PrismStreamEventTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use Laravel\Ai\Gateway\Prism\PrismStreamEvent;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use PHPUnit\Framework\TestCase;
+use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
+
+class PrismStreamEventTest extends TestCase
+{
+    public function test_thinking_complete_event_maps_to_reasoning_end(): void
+    {
+        $event = new ThinkingCompleteEvent(
+            id: 'event-1',
+            timestamp: 1234567890,
+            reasoningId: 'reasoning-1',
+            summary: ['text' => 'Summary of reasoning'],
+        );
+
+        $result = PrismStreamEvent::toLaravelStreamEvent('invocation-1', $event, 'openai', 'gpt-4');
+
+        $this->assertInstanceOf(ReasoningEnd::class, $result);
+        $this->assertEquals('event-1', $result->id);
+        $this->assertEquals('reasoning-1', $result->reasoningId);
+        $this->assertEquals(1234567890, $result->timestamp);
+        $this->assertEquals(['text' => 'Summary of reasoning'], $result->summary);
+    }
+
+    public function test_thinking_complete_event_handles_null_summary(): void
+    {
+        $event = new ThinkingCompleteEvent(
+            id: 'event-2',
+            timestamp: 1234567890,
+            reasoningId: 'reasoning-2',
+        );
+
+        $result = PrismStreamEvent::toLaravelStreamEvent('invocation-1', $event, 'openai', 'gpt-4');
+
+        $this->assertInstanceOf(ReasoningEnd::class, $result);
+        $this->assertNull($result->summary);
+    }
+}


### PR DESCRIPTION
## Summary

The `ThinkingComplete` case in `PrismStreamEvent::toLaravelStreamEvent()` passes `$event->delta`
 to the `ReasoningEnd` constructor, but `Prism\Prism\Streaming\Events\ThinkingCompleteEvent`
does not have a `$delta` property (unlike `ThinkingDeltaEvent`). This causes a fatal
**"Undefined property"** error when streaming responses from any model that emits
reasoning/thinking tokens.

The bug was likely introduced by copy-pasting the `ThinkingDelta` line without removing the
`$event->delta` argument.

## The fix

```diff
- PrismStreamEventType::ThinkingComplete => new ReasoningEnd($id ?? $event->id,
strtolower($event->reasoningId), $event->delta, $event->timestamp, $event->summary),
+ PrismStreamEventType::ThinkingComplete => new ReasoningEnd($id ?? $event->id,
strtolower($event->reasoningId), $event->timestamp, $event->summary ?? null),
```

This aligns the constructor call with the actual ReasoningEnd signature:
```php
public function __construct(
    public string $id,
    public string $reasoningId,
    public int $timestamp,
    public ?array $summary = null,
)
```

And removes the reference to $delta which does not exist on ThinkingCompleteEvent:
```php
// ThinkingCompleteEvent — no $delta property
public function __construct(
    string $id,
    int $timestamp,
    public string $reasoningId,
    public ?array $summary = null,
)
```
### Affected providers

Any provider whose stream handler emits ThinkingCompleteEvent is affected. Based on the Prism
source, this includes: Anthropic, OpenAI, OpenRouter, DeepSeek, Ollama, and XAI.

## How to reproduce

### Before the fix

Stream a response from any model that emits thinking/reasoning tokens. For example, using
Anthropic with extended thinking enabled:
```php
$response = app(\Prism\Prism\Prism::class)->text()
    ->using('anthropic', 'claude-sonnet-4-5-20250929', [
        'api_key' => config('ai.providers.anthropic.key'),
    ])
    ->withSystemPrompt('You are a helpful assistant.')
    ->withPrompt('What is the square root of 144? Think step by step.')
    ->withMaxTokens(16000)
    ->withProviderOptions([
        'thinking' => [
            'enabled' => true,
            'budgetTokens' => 4096,
        ],
    ])
    ->asStream();

foreach ($response as $event) {
    $laravelEvent = \Laravel\Ai\Gateway\Prism\PrismStreamEvent::toLaravelStreamEvent(
        'test', $event, 'anthropic', 'claude-sonnet-4-5-20250929'
    );
}
```
Result: Undefined property: Prism\Prism\Streaming\Events\ThinkingCompleteEvent::$delta at
PrismStreamEvent.php:44

The same crash occurs with any OpenAI-compatible provider (via the OpenRouter driver) when the
model returns reasoning tokens, or with Ollama when using a model that produces structured
thinking events.

### After the fix

The same code completes successfully, with ThinkingCompleteEvent correctly mapped to
ReasoningEnd including the proper timestamp and summary values.

### Test plan

- Added unit tests for PrismStreamEvent covering ThinkingComplete → ReasoningEnd mapping
- Tests verify correct property assignment (id, reasoningId, timestamp, summary)
- Tests cover both with-summary and null-summary cases
- Verified across multiple providers and models:
```
┌────────────┬───────────────────────┬─────────────────┬─────────────┬──────────┐
│  Provider  │         Model         │ Thinking events │ Without fix │ With fix │
├────────────┼───────────────────────┼─────────────────┼─────────────┼──────────┤
│ Anthropic  │ claude-haiku-4-5      │  Yes (opt-in)   │    Crash    │    OK    │
├────────────┼───────────────────────┼─────────────────┼─────────────┼──────────┤
│ Anthropic  │ claude-sonnet-4-5     │  Yes (opt-in)   │    Crash    │    OK    │
├────────────┼───────────────────────┼─────────────────┼─────────────┼──────────┤
│ Anthropic  │ claude-opus-4-6       │  Yes (opt-in)   │    Crash    │    OK    │
├────────────┼───────────────────────┼─────────────────┼─────────────┼──────────┤
│ OpenRouter │ internal-gpt-oss-120b │ Yes (automatic) │    Crash    │    OK    │
├────────────┼───────────────────────┼─────────────────┼─────────────┼──────────┤
│ Ollama     │ mistral-nemo          │       No        │     OK      │    OK    │
├────────────┼───────────────────────┼─────────────────┼─────────────┼──────────┤
│ Ollama     │ deepseek-r1:14b       │   No (inline)   │     OK      │    OK    │
└────────────┴───────────────────────┴─────────────────┴─────────────┴──────────┘
```
- Existing test suite unaffected (all non-integration tests pass)