### PR TITLE
Add Agent Skills support (discovery, activation, resource reading)

### DIFF
--- a/src/Concerns/LoadsSkills.php
+++ b/src/Concerns/LoadsSkills.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Ai\Concerns;
+
+use Illuminate\Support\Facades\Cache;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillLoader;
+
+trait LoadsSkills
+{
+    /**
+     * The resolved skills (memoized per-instance).
+     *
+     * @var array<Skill>|null
+     */
+    protected ?array $resolvedSkills = null;
+
+    /**
+     * Get the skills available to the agent.
+     *
+     * By default, loads skills from `resource_path('ai/skills')` with
+     * automatic caching. Override this method to load from any source
+     * (database, S3, API, etc.).
+     *
+     * @return array<Skill>
+     */
+    public function skills(): array
+    {
+        if ($this->resolvedSkills !== null) {
+            return $this->resolvedSkills;
+        }
+
+        $paths = $this->skillPaths();
+
+        if (empty($paths)) {
+            return $this->resolvedSkills = [];
+        }
+
+        $cacheKey = 'laravel_ai_skills:'.md5(static::class.'|'.implode('|', $paths));
+
+        try {
+            return $this->resolvedSkills = Cache::remember(
+                $cacheKey,
+                $this->skillCacheTtl(),
+                fn () => $this->loadSkillsFromPaths($paths),
+            );
+        } catch (\Throwable) {
+            return $this->resolvedSkills = $this->loadSkillsFromPaths($paths);
+        }
+    }
+
+    /**
+     * Get the filesystem paths to load skills from.
+     *
+     * Defaults to `resource_path('ai/skills')`. Override to customize.
+     *
+     * @return array<string>
+     */
+    protected function skillPaths(): array
+    {
+        return [
+            resource_path('ai/skills'),
+        ];
+    }
+
+    /**
+     * Get the cache TTL for skills in seconds.
+     */
+    protected function skillCacheTtl(): int
+    {
+        return 3600;
+    }
+
+    /**
+     * Load skills from the given directory paths.
+     *
+     * @param  array<string>  $paths
+     * @return array<Skill>
+     */
+    protected function loadSkillsFromPaths(array $paths): array
+    {
+        $loader = new SkillLoader;
+        $skills = [];
+
+        foreach ($paths as $path) {
+            foreach ($loader->loadFromDirectory($path) as $skill) {
+                $skills[] = $skill;
+            }
+        }
+
+        return $skills;
+    }
+
+    /**
+     * Clear the resolved skills cache (both in-memory and persistent).
+     */
+    public function clearSkillCache(): void
+    {
+        $this->resolvedSkills = null;
+
+        $paths = $this->skillPaths();
+
+        if (! empty($paths)) {
+            try {
+                Cache::forget('laravel_ai_skills:'.md5(static::class.'|'.implode('|', $paths)));
+            } catch (\Throwable) {
+                //
+            }
+        }
+    }
+}

--- a/src/Contracts/SupportSkills.php
+++ b/src/Contracts/SupportSkills.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use Laravel\Ai\Skills\Skill;
+
+interface SupportSkills
+{
+    /**
+     * Get the skills available to the agent.
+     *
+     * Skills may be loaded from any source: local filesystem, S3,
+     * database, or any other storage backend.
+     *
+     * @return array<Skill>
+     */
+    public function skills(): array;
+}

--- a/src/Skills/ActivateSkillTool.php
+++ b/src/Skills/ActivateSkillTool.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class ActivateSkillTool implements Tool
+{
+    /**
+     * Create a new tool instance.
+     */
+    public function __construct(protected SkillRegistry $registry) {}
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return 'activate_skill';
+    }
+
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'Activate a skill by name to get its full instructions. Use when a task matches one of the available skills.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        $skill = $this->registry->findOrFail($request->string('name'));
+
+        $output = $skill->content;
+
+        $resources = $skill->resources();
+
+        if (! empty($resources)) {
+            $output .= "\n\n<available_resources>\n";
+            $output .= implode("\n", $resources);
+            $output .= "\n</available_resources>";
+        }
+
+        return $output;
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->description('The name of the skill to activate.')->required(),
+        ];
+    }
+}

--- a/src/Skills/Exceptions/SkillException.php
+++ b/src/Skills/Exceptions/SkillException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Ai\Skills\Exceptions;
+
+use Laravel\Ai\Exceptions\AiException;
+
+class SkillException extends AiException
+{
+    //
+}

--- a/src/Skills/Exceptions/SkillNotFoundException.php
+++ b/src/Skills/Exceptions/SkillNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Skills\Exceptions;
+
+class SkillNotFoundException extends SkillException
+{
+    /**
+     * Create a new exception instance.
+     */
+    public static function forName(string $name): self
+    {
+        return new self("Skill [{$name}] not found.");
+    }
+}

--- a/src/Skills/Exceptions/SkillParseException.php
+++ b/src/Skills/Exceptions/SkillParseException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Ai\Skills\Exceptions;
+
+class SkillParseException extends SkillException
+{
+    /**
+     * Create a new exception for missing SKILL.md.
+     */
+    public static function missingSkillFile(string $path): self
+    {
+        return new self("SKILL.md not found in [{$path}].");
+    }
+
+    /**
+     * Create a new exception for invalid frontmatter.
+     */
+    public static function invalidFrontmatter(string $message): self
+    {
+        return new self("Invalid SKILL.md frontmatter: {$message}");
+    }
+
+    /**
+     * Create a new exception for missing required field.
+     */
+    public static function missingRequiredField(string $field): self
+    {
+        return new self("Missing required field in SKILL.md frontmatter: {$field}");
+    }
+}

--- a/src/Skills/ReadSkillResourceTool.php
+++ b/src/Skills/ReadSkillResourceTool.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class ReadSkillResourceTool implements Tool
+{
+    /**
+     * Create a new tool instance.
+     */
+    public function __construct(protected SkillRegistry $registry) {}
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return 'read_skill_resource';
+    }
+
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'Read a resource file from an activated skill. Resources include scripts, references, and assets referenced in the skill instructions.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        $skill = $this->registry->findOrFail($request->string('skill'));
+
+        $content = $skill->resource($request->string('path'));
+
+        if ($content === null) {
+            return 'Resource not found.';
+        }
+
+        return $content;
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'skill' => $schema->string()->description('The name of the skill.')->required(),
+            'path' => $schema->string()->description('The relative path to the resource file, e.g. scripts/lint.sh or references/STYLE_GUIDE.md.')->required(),
+        ];
+    }
+}

--- a/src/Skills/Skill.php
+++ b/src/Skills/Skill.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Support\Facades\File;
+use Stringable;
+
+class Skill implements Stringable
+{
+    /**
+     * Create a new skill instance.
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $description,
+        public readonly string $content,
+        public readonly string $path,
+        public readonly ?string $license = null,
+        public readonly ?string $compatibility = null,
+        public readonly ?string $allowedTools = null,
+        public readonly array $metadata = [],
+    ) {}
+
+    /**
+     * Get the relative paths of all resource files in the skill directory.
+     *
+     * @return array<string>
+     */
+    public function resources(): array
+    {
+        $resources = [];
+
+        foreach (['scripts', 'references', 'assets'] as $directory) {
+            $directoryPath = $this->path.'/'.$directory;
+
+            if (! File::isDirectory($directoryPath)) {
+                continue;
+            }
+
+            foreach (File::allFiles($directoryPath) as $file) {
+                $resources[] = $directory.'/'.$file->getRelativePathname();
+            }
+        }
+
+        sort($resources);
+
+        return $resources;
+    }
+
+    /**
+     * Read the contents of a resource file.
+     */
+    public function resource(string $relativePath): ?string
+    {
+        $fullPath = $this->path.'/'.$relativePath;
+
+        if (! File::exists($fullPath) || ! str_starts_with(realpath($fullPath), realpath($this->path))) {
+            return null;
+        }
+
+        return File::get($fullPath);
+    }
+
+    /**
+     * Get the skill properties as an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'description' => $this->description,
+            'license' => $this->license,
+            'compatibility' => $this->compatibility,
+            'allowed_tools' => $this->allowedTools,
+            'metadata' => ! empty($this->metadata) ? $this->metadata : null,
+        ], fn ($value) => $value !== null);
+    }
+
+    /**
+     * Get the skill XML representation for agent prompts.
+     */
+    public function toXml(): string
+    {
+        $xml = "<skill>\n";
+        $xml .= "<name>\n{$this->name}\n</name>\n";
+        $xml .= "<description>\n{$this->description}\n</description>\n";
+        $xml .= "</skill>";
+
+        return $xml;
+    }
+
+    /**
+     * Get the string representation of the skill.
+     */
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Skills/SkillLoader.php
+++ b/src/Skills/SkillLoader.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Ai\Skills\Exceptions\SkillParseException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class SkillLoader
+{
+    /**
+     * Load a skill from a directory.
+     */
+    public function load(string $skillPath): Skill
+    {
+        $skillMdPath = $this->findSkillMd($skillPath);
+
+        if (! $skillMdPath) {
+            throw SkillParseException::missingSkillFile($skillPath);
+        }
+
+        $content = File::get($skillMdPath);
+        [$frontmatter, $body] = $this->parseFrontmatter($content);
+
+        $this->validateRequiredFields($frontmatter);
+
+        return new Skill(
+            name: trim($frontmatter['name']),
+            description: trim($frontmatter['description']),
+            content: $body,
+            path: $skillPath,
+            license: $frontmatter['license'] ?? null,
+            compatibility: $frontmatter['compatibility'] ?? null,
+            allowedTools: $frontmatter['allowed-tools'] ?? null,
+            metadata: $frontmatter['metadata'] ?? [],
+        );
+    }
+
+    /**
+     * Load all skills from a directory.
+     *
+     * @return array<Skill>
+     */
+    public function loadFromDirectory(string $directory): array
+    {
+        if (! File::isDirectory($directory)) {
+            return [];
+        }
+
+        $skills = [];
+
+        foreach (File::directories($directory) as $skillPath) {
+            try {
+                $skills[] = $this->load($skillPath);
+            } catch (SkillParseException) {
+                // Skip directories that aren't valid skills
+                continue;
+            }
+        }
+
+        return $skills;
+    }
+
+    /**
+     * Find the SKILL.md file in a skill directory.
+     */
+    protected function findSkillMd(string $skillPath): ?string
+    {
+        foreach (['SKILL.md', 'skill.md'] as $filename) {
+            $path = $skillPath.'/'.$filename;
+            if (File::exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse YAML frontmatter from SKILL.md content.
+     *
+     * @return array{array<string, mixed>, string}
+     */
+    protected function parseFrontmatter(string $content): array
+    {
+        if (! str_starts_with($content, '---')) {
+            throw SkillParseException::invalidFrontmatter('SKILL.md must start with YAML frontmatter (---)');
+        }
+
+        $parts = explode('---', $content, 3);
+
+        if (count($parts) < 3) {
+            throw SkillParseException::invalidFrontmatter('SKILL.md frontmatter not properly closed with ---');
+        }
+
+        try {
+            $frontmatter = Yaml::parse($parts[1]);
+        } catch (ParseException $e) {
+            throw SkillParseException::invalidFrontmatter($e->getMessage());
+        }
+
+        if (! is_array($frontmatter)) {
+            throw SkillParseException::invalidFrontmatter('Frontmatter must be a YAML mapping');
+        }
+
+        $body = trim($parts[2]);
+
+        return [$frontmatter, $body];
+    }
+
+    /**
+     * Validate that required fields are present.
+     *
+     * @param  array<string, mixed>  $frontmatter
+     */
+    protected function validateRequiredFields(array $frontmatter): void
+    {
+        if (! isset($frontmatter['name']) || ! is_string($frontmatter['name']) || trim($frontmatter['name']) === '') {
+            throw SkillParseException::missingRequiredField('name');
+        }
+
+        if (! isset($frontmatter['description']) || ! is_string($frontmatter['description']) || trim($frontmatter['description']) === '') {
+            throw SkillParseException::missingRequiredField('description');
+        }
+    }
+}

--- a/src/Skills/SkillRegistry.php
+++ b/src/Skills/SkillRegistry.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Laravel\Ai\Skills\Exceptions\SkillNotFoundException;
+
+class SkillRegistry
+{
+    /**
+     * The registered skills.
+     *
+     * @var array<string, Skill>
+     */
+    protected array $skills = [];
+
+    /**
+     * Create a registry from a directory of skills.
+     */
+    public static function fromDirectory(string $directory): static
+    {
+        $registry = new static;
+
+        foreach ((new SkillLoader)->loadFromDirectory($directory) as $skill) {
+            $registry->register($skill);
+        }
+
+        return $registry;
+    }
+
+    /**
+     * Register a skill.
+     */
+    public function register(Skill $skill): void
+    {
+        $this->skills[$skill->name] = $skill;
+    }
+
+    /**
+     * Get all registered skills.
+     *
+     * @return array<Skill>
+     */
+    public function all(): array
+    {
+        return array_values($this->skills);
+    }
+
+    /**
+     * Find a skill by name.
+     */
+    public function find(string $name): ?Skill
+    {
+        return $this->skills[$name] ?? null;
+    }
+
+    /**
+     * Find a skill by name or throw an exception.
+     *
+     * @throws SkillNotFoundException
+     */
+    public function findOrFail(string $name): Skill
+    {
+        $skill = $this->find($name);
+
+        if (! $skill) {
+            throw SkillNotFoundException::forName($name);
+        }
+
+        return $skill;
+    }
+
+    /**
+     * Check if a skill is registered.
+     */
+    public function has(string $name): bool
+    {
+        return isset($this->skills[$name]);
+    }
+
+    /**
+     * Get the count of registered skills.
+     */
+    public function count(): int
+    {
+        return count($this->skills);
+    }
+
+    /**
+     * Generate XML prompt for all registered skills.
+     */
+    public function toPrompt(): string
+    {
+        if (empty($this->skills)) {
+            return '';
+        }
+
+        $xml = "<available_skills>\n";
+
+        foreach ($this->skills as $skill) {
+            $xml .= $skill->toXml()."\n";
+        }
+
+        $xml .= '</available_skills>';
+
+        return $xml;
+    }
+}

--- a/tests/Feature/Skills/Fixtures/customer-support/SKILL.md
+++ b/tests/Feature/Skills/Fixtures/customer-support/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: customer-support
+description: Handle customer support inquiries, ticket routing, and response templates. Use when assisting with customer service, support tickets, or customer communication.
+license: MIT
+compatibility: Requires access to the ticketing system
+allowed-tools: Bash(curl:*) Read
+metadata:
+  author: test-author
+  version: "1.0"
+---
+
+# Customer Support Skill
+
+## When to use this skill
+
+Use this skill whenever handling:
+- Customer support inquiries
+- Ticket prioritization and routing
+- Response templates for common issues
+- Escalation procedures
+
+## Support tiers
+
+### Priority levels
+
+1. **Critical** - System down, blocking all users
+2. **High** - Major feature broken, affecting multiple users
+3. **Medium** - Minor feature issue, workaround available
+4. **Low** - Enhancement requests, questions
+
+### Response time SLAs
+
+- Critical: 1 hour
+- High: 4 hours
+- Medium: 24 hours
+- Low: 48 hours
+
+## Ticket triage
+
+Use the included script for automated ticket routing:
+
+```bash
+scripts/triage.sh
+```
+
+See [the response templates](references/TEMPLATES.md) for standard replies.
+
+## Common issues
+
+### Account access
+
+For password reset or login issues:
+1. Verify user identity
+2. Send password reset link
+3. Check for account lockout

--- a/tests/Feature/Skills/Fixtures/customer-support/references/TEMPLATES.md
+++ b/tests/Feature/Skills/Fixtures/customer-support/references/TEMPLATES.md
@@ -1,0 +1,9 @@
+# Response Templates
+
+## Greeting
+
+- Hello! Thank you for contacting support.
+
+## Closing
+
+- Is there anything else I can help you with?

--- a/tests/Feature/Skills/Fixtures/customer-support/scripts/triage.sh
+++ b/tests/Feature/Skills/Fixtures/customer-support/scripts/triage.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Running ticket triage..."

--- a/tests/Feature/Skills/Fixtures/order-fulfillment/SKILL.md
+++ b/tests/Feature/Skills/Fixtures/order-fulfillment/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: order-fulfillment
+description: Process orders, manage inventory, and handle shipping workflows. Use when working with orders, inventory management, or shipping logistics.
+---
+
+# Order Fulfillment Skill
+
+## When to use
+
+Use this skill for:
+- Order processing workflows
+- Inventory availability checks
+- Shipping carrier selection
+- Order status updates
+
+## Order lifecycle
+
+### Status progression
+
+1. **Pending** - Payment received, awaiting processing
+2. **Processing** - Being prepared for shipment
+3. **Shipped** - En route to customer
+4. **Delivered** - Confirmed delivery
+5. **Cancelled** - Order cancelled
+
+### Inventory checks
+
+Before confirming an order:
+- Verify item availability
+- Reserve inventory
+- Check warehouse location
+- Estimate shipping time
+
+### Shipping rules
+
+- Free shipping over $50
+- Express shipping available for in-stock items
+- International orders require customs forms

--- a/tests/Feature/Skills/SkillIntegrationTest.php
+++ b/tests/Feature/Skills/SkillIntegrationTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Skills\ActivateSkillTool;
+use Laravel\Ai\Skills\Exceptions\SkillNotFoundException;
+use Laravel\Ai\Skills\ReadSkillResourceTool;
+use Laravel\Ai\Skills\SkillLoader;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Tools\Request;
+use Tests\TestCase;
+
+class SkillIntegrationTest extends TestCase
+{
+    public function test_agent_can_use_skills_in_instructions(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $agent = new ExampleAgentWithSkills($registry);
+        $instructions = $agent->instructions();
+
+        $this->assertStringContainsString('<available_skills>', $instructions);
+        $this->assertStringContainsString('customer-support', $instructions);
+        $this->assertStringContainsString('order-fulfillment', $instructions);
+    }
+
+    public function test_agent_without_skills_has_clean_instructions(): void
+    {
+        $registry = new SkillRegistry;
+
+        $agent = new ExampleAgentWithSkills($registry);
+        $instructions = $agent->instructions();
+
+        $this->assertStringNotContainsString('<available_skills>', $instructions);
+        $this->assertStringContainsString('You are a helpful assistant', $instructions);
+    }
+
+    public function test_activate_skill_tool_returns_full_content(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ActivateSkillTool($registry);
+
+        $result = $tool->handle(new Request(['name' => 'customer-support']));
+
+        $this->assertStringContainsString('Customer Support Skill', $result);
+        $this->assertStringContainsString('Priority levels', $result);
+    }
+
+    public function test_activate_skill_tool_includes_available_resources(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ActivateSkillTool($registry);
+
+        $result = $tool->handle(new Request(['name' => 'customer-support']));
+
+        $this->assertStringContainsString('<available_resources>', $result);
+        $this->assertStringContainsString('scripts/triage.sh', $result);
+        $this->assertStringContainsString('references/TEMPLATES.md', $result);
+    }
+
+    public function test_activate_skill_tool_omits_resources_when_none_exist(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ActivateSkillTool($registry);
+
+        $result = $tool->handle(new Request(['name' => 'order-fulfillment']));
+
+        $this->assertStringNotContainsString('<available_resources>', $result);
+    }
+
+    public function test_read_skill_resource_returns_file_content(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ReadSkillResourceTool($registry);
+
+        $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => 'scripts/triage.sh']));
+
+        $this->assertStringContainsString('Running ticket triage', $result);
+    }
+
+    public function test_read_skill_resource_returns_reference_content(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ReadSkillResourceTool($registry);
+
+        $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => 'references/TEMPLATES.md']));
+
+        $this->assertStringContainsString('Response Templates', $result);
+        $this->assertStringContainsString('Thank you for contacting support', $result);
+    }
+
+    public function test_read_skill_resource_returns_not_found_for_missing_file(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ReadSkillResourceTool($registry);
+
+        $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => 'scripts/nonexistent.sh']));
+
+        $this->assertSame('Resource not found.', $result);
+    }
+
+    public function test_read_skill_resource_prevents_path_traversal(): void
+    {
+        $loader = new SkillLoader;
+        $registry = new SkillRegistry;
+
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+        foreach ($skills as $skill) {
+            $registry->register($skill);
+        }
+
+        $tool = new ReadSkillResourceTool($registry);
+
+        $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => '../order-fulfillment/SKILL.md']));
+
+        $this->assertSame('Resource not found.', $result);
+    }
+
+    public function test_activate_skill_tool_throws_for_unknown_skill(): void
+    {
+        $registry = new SkillRegistry;
+        $tool = new ActivateSkillTool($registry);
+
+        $this->expectException(SkillNotFoundException::class);
+
+        $tool->handle(new Request(['name' => 'nonexistent']));
+    }
+
+    public function test_agent_exposes_skill_tools(): void
+    {
+        $registry = new SkillRegistry;
+        $agent = new ExampleAgentWithSkills($registry);
+
+        $tools = iterator_to_array($agent->tools());
+
+        $this->assertCount(2, $tools);
+        $this->assertInstanceOf(ActivateSkillTool::class, $tools[0]);
+        $this->assertInstanceOf(ReadSkillResourceTool::class, $tools[1]);
+    }
+}
+
+class ExampleAgentWithSkills implements Agent, HasTools
+{
+    use Promptable;
+
+    public function __construct(protected SkillRegistry $skills) {}
+
+    public function instructions(): string
+    {
+        $instructions = 'You are a helpful assistant.';
+
+        if ($this->skills->count() > 0) {
+            $instructions .= "\n\n".$this->skills->toPrompt();
+        }
+
+        return $instructions;
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new ActivateSkillTool($this->skills),
+            new ReadSkillResourceTool($this->skills),
+        ];
+    }
+}

--- a/tests/Feature/Skills/SkillIntegrationTest.php
+++ b/tests/Feature/Skills/SkillIntegrationTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Feature\Skills;
 
+use Laravel\Ai\Concerns\LoadsSkills;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\SupportSkills;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Skills\ActivateSkillTool;
 use Laravel\Ai\Skills\Exceptions\SkillNotFoundException;
 use Laravel\Ai\Skills\ReadSkillResourceTool;
+use Laravel\Ai\Skills\Skill;
 use Laravel\Ai\Skills\SkillLoader;
 use Laravel\Ai\Skills\SkillRegistry;
 use Laravel\Ai\Tools\Request;
@@ -17,43 +20,26 @@ class SkillIntegrationTest extends TestCase
 {
     public function test_agent_can_use_skills_in_instructions(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
 
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
+        $agent = new ManualSkillsAgent($registry);
 
-        $agent = new ExampleAgentWithSkills($registry);
-        $instructions = $agent->instructions();
-
-        $this->assertStringContainsString('<available_skills>', $instructions);
-        $this->assertStringContainsString('customer-support', $instructions);
-        $this->assertStringContainsString('order-fulfillment', $instructions);
+        $this->assertStringContainsString('<available_skills>', $agent->instructions());
+        $this->assertStringContainsString('customer-support', $agent->instructions());
+        $this->assertStringContainsString('order-fulfillment', $agent->instructions());
     }
 
     public function test_agent_without_skills_has_clean_instructions(): void
     {
-        $registry = new SkillRegistry;
+        $agent = new ManualSkillsAgent(new SkillRegistry);
 
-        $agent = new ExampleAgentWithSkills($registry);
-        $instructions = $agent->instructions();
-
-        $this->assertStringNotContainsString('<available_skills>', $instructions);
-        $this->assertStringContainsString('You are a helpful assistant', $instructions);
+        $this->assertStringNotContainsString('<available_skills>', $agent->instructions());
+        $this->assertStringContainsString('You are a helpful assistant', $agent->instructions());
     }
 
     public function test_activate_skill_tool_returns_full_content(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ActivateSkillTool($registry);
 
         $result = $tool->handle(new Request(['name' => 'customer-support']));
@@ -64,14 +50,7 @@ class SkillIntegrationTest extends TestCase
 
     public function test_activate_skill_tool_includes_available_resources(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ActivateSkillTool($registry);
 
         $result = $tool->handle(new Request(['name' => 'customer-support']));
@@ -83,14 +62,7 @@ class SkillIntegrationTest extends TestCase
 
     public function test_activate_skill_tool_omits_resources_when_none_exist(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ActivateSkillTool($registry);
 
         $result = $tool->handle(new Request(['name' => 'order-fulfillment']));
@@ -98,16 +70,17 @@ class SkillIntegrationTest extends TestCase
         $this->assertStringNotContainsString('<available_resources>', $result);
     }
 
+    public function test_activate_skill_tool_throws_for_unknown_skill(): void
+    {
+        $tool = new ActivateSkillTool(new SkillRegistry);
+
+        $this->expectException(SkillNotFoundException::class);
+        $tool->handle(new Request(['name' => 'nonexistent']));
+    }
+
     public function test_read_skill_resource_returns_file_content(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ReadSkillResourceTool($registry);
 
         $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => 'scripts/triage.sh']));
@@ -117,14 +90,7 @@ class SkillIntegrationTest extends TestCase
 
     public function test_read_skill_resource_returns_reference_content(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ReadSkillResourceTool($registry);
 
         $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => 'references/TEMPLATES.md']));
@@ -135,14 +101,7 @@ class SkillIntegrationTest extends TestCase
 
     public function test_read_skill_resource_returns_not_found_for_missing_file(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ReadSkillResourceTool($registry);
 
         $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => 'scripts/nonexistent.sh']));
@@ -152,14 +111,7 @@ class SkillIntegrationTest extends TestCase
 
     public function test_read_skill_resource_prevents_path_traversal(): void
     {
-        $loader = new SkillLoader;
-        $registry = new SkillRegistry;
-
-        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
-        foreach ($skills as $skill) {
-            $registry->register($skill);
-        }
-
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
         $tool = new ReadSkillResourceTool($registry);
 
         $result = $tool->handle(new Request(['skill' => 'customer-support', 'path' => '../order-fulfillment/SKILL.md']));
@@ -167,20 +119,9 @@ class SkillIntegrationTest extends TestCase
         $this->assertSame('Resource not found.', $result);
     }
 
-    public function test_activate_skill_tool_throws_for_unknown_skill(): void
+    public function test_manual_agent_exposes_skill_tools(): void
     {
-        $registry = new SkillRegistry;
-        $tool = new ActivateSkillTool($registry);
-
-        $this->expectException(SkillNotFoundException::class);
-
-        $tool->handle(new Request(['name' => 'nonexistent']));
-    }
-
-    public function test_agent_exposes_skill_tools(): void
-    {
-        $registry = new SkillRegistry;
-        $agent = new ExampleAgentWithSkills($registry);
+        $agent = new ManualSkillsAgent(new SkillRegistry);
 
         $tools = iterator_to_array($agent->tools());
 
@@ -188,9 +129,79 @@ class SkillIntegrationTest extends TestCase
         $this->assertInstanceOf(ActivateSkillTool::class, $tools[0]);
         $this->assertInstanceOf(ReadSkillResourceTool::class, $tools[1]);
     }
+
+    public function test_loads_skills_trait_loads_from_skill_paths(): void
+    {
+        $agent = new FixtureSkillsAgent;
+
+        $skills = $agent->skills();
+
+        $this->assertCount(2, $skills);
+
+        $names = array_map(fn (Skill $s) => $s->name, $skills);
+        $this->assertContains('customer-support', $names);
+        $this->assertContains('order-fulfillment', $names);
+    }
+
+    public function test_loads_skills_returns_empty_when_paths_empty(): void
+    {
+        $agent = new EmptyPathSkillsAgent;
+
+        $this->assertEmpty($agent->skills());
+    }
+
+    public function test_loads_skills_returns_empty_for_nonexistent_paths(): void
+    {
+        $agent = new NonexistentPathSkillsAgent;
+
+        $this->assertEmpty($agent->skills());
+    }
+
+    public function test_loads_skills_memoizes_within_instance(): void
+    {
+        $agent = new FixtureSkillsAgent;
+
+        $first = $agent->skills();
+        $second = $agent->skills();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function test_clear_skill_cache_resets_memoization(): void
+    {
+        $agent = new FixtureSkillsAgent;
+
+        $first = $agent->skills();
+        $agent->clearSkillCache();
+        $second = $agent->skills();
+
+        $this->assertNotSame($first, $second);
+        $this->assertCount(2, $second);
+    }
+
+    public function test_support_skills_agent_instructions_stay_clean(): void
+    {
+        $agent = new FixtureSkillsAgent;
+
+        // Instructions should NOT contain skills — the SDK injects them automatically.
+        $this->assertSame('You are a helpful assistant.', $agent->instructions());
+    }
+
+    public function test_agent_can_override_skills_entirely(): void
+    {
+        $loader = new SkillLoader;
+        $skills = $loader->loadFromDirectory(__DIR__.'/Fixtures');
+
+        $agent = new DirectSkillsAgent($skills);
+
+        $this->assertCount(2, $agent->skills());
+    }
 }
 
-class ExampleAgentWithSkills implements Agent, HasTools
+/**
+ * Manual approach — user manages registry and tools themselves.
+ */
+class ManualSkillsAgent implements Agent, HasTools
 {
     use Promptable;
 
@@ -213,5 +224,81 @@ class ExampleAgentWithSkills implements Agent, HasTools
             new ActivateSkillTool($this->skills),
             new ReadSkillResourceTool($this->skills),
         ];
+    }
+}
+
+/**
+ * Convention approach — uses LoadsSkills trait with a fixture path.
+ * In production, defaults to resource_path('ai/skills').
+ */
+class FixtureSkillsAgent implements Agent, SupportSkills
+{
+    use LoadsSkills, Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    protected function skillPaths(): array
+    {
+        return [__DIR__.'/Fixtures'];
+    }
+}
+
+/**
+ * Agent whose skillPaths() returns an empty array — no skills loaded.
+ */
+class EmptyPathSkillsAgent implements Agent, SupportSkills
+{
+    use LoadsSkills, Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    protected function skillPaths(): array
+    {
+        return [];
+    }
+}
+
+/**
+ * Agent whose skillPaths() returns a path that doesn't exist.
+ */
+class NonexistentPathSkillsAgent implements Agent, SupportSkills
+{
+    use LoadsSkills, Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    protected function skillPaths(): array
+    {
+        return ['/tmp/nonexistent-skills-'.uniqid()];
+    }
+}
+
+/**
+ * Fully custom — load skills from DB, S3, or any source.
+ * Just implement skills() directly, no trait needed.
+ */
+class DirectSkillsAgent implements Agent, SupportSkills
+{
+    use Promptable;
+
+    public function __construct(protected array $loadedSkills = []) {}
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function skills(): array
+    {
+        return $this->loadedSkills;
     }
 }

--- a/tests/Feature/Skills/SkillLoaderTest.php
+++ b/tests/Feature/Skills/SkillLoaderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skills\Exceptions\SkillParseException;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillLoader;
+use Tests\TestCase;
+
+class SkillLoaderTest extends TestCase
+{
+    protected SkillLoader $loader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loader = new SkillLoader;
+    }
+
+    public function test_can_load_skill_from_directory(): void
+    {
+        $skill = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+
+        $this->assertInstanceOf(Skill::class, $skill);
+        $this->assertEquals('customer-support', $skill->name);
+        $this->assertStringContainsString('Handle customer support inquiries', $skill->description);
+        $this->assertEquals('MIT', $skill->license);
+        $this->assertEquals('Requires access to the ticketing system', $skill->compatibility);
+        $this->assertEquals('Bash(curl:*) Read', $skill->allowedTools);
+        $this->assertEquals(['author' => 'test-author', 'version' => '1.0'], $skill->metadata);
+        $this->assertStringContainsString('Customer Support Skill', $skill->content);
+    }
+
+    public function test_can_load_skill_with_minimal_frontmatter(): void
+    {
+        $skill = $this->loader->load(__DIR__.'/Fixtures/order-fulfillment');
+
+        $this->assertInstanceOf(Skill::class, $skill);
+        $this->assertEquals('order-fulfillment', $skill->name);
+        $this->assertStringContainsString('Process orders', $skill->description);
+        $this->assertNull($skill->license);
+        $this->assertEmpty($skill->metadata);
+    }
+
+    public function test_throws_exception_for_missing_skill_file(): void
+    {
+        $this->expectException(SkillParseException::class);
+        $this->expectExceptionMessage('SKILL.md not found');
+
+        $this->loader->load(__DIR__.'/Fixtures/nonexistent');
+    }
+
+    public function test_throws_exception_for_missing_required_name(): void
+    {
+        $this->expectException(SkillParseException::class);
+        $this->expectExceptionMessage('Missing required field');
+
+        // Create temporary skill without name
+        $tempDir = sys_get_temp_dir().'/test-skill-'.uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir.'/SKILL.md', "---\ndescription: Test\n---\nContent");
+
+        try {
+            $this->loader->load($tempDir);
+        } finally {
+            unlink($tempDir.'/SKILL.md');
+            rmdir($tempDir);
+        }
+    }
+
+    public function test_can_load_multiple_skills_from_directory(): void
+    {
+        $skills = $this->loader->loadFromDirectory(__DIR__.'/Fixtures');
+
+        $this->assertCount(2, $skills);
+        $this->assertContainsOnlyInstancesOf(Skill::class, $skills);
+
+        $skillNames = array_map(fn ($skill) => $skill->name, $skills);
+        $this->assertContains('customer-support', $skillNames);
+        $this->assertContains('order-fulfillment', $skillNames);
+    }
+
+    public function test_load_from_directory_returns_empty_array_for_nonexistent_directory(): void
+    {
+        $skills = $this->loader->loadFromDirectory(__DIR__.'/Fixtures/nonexistent');
+
+        $this->assertIsArray($skills);
+        $this->assertEmpty($skills);
+    }
+
+    public function test_skill_to_array_includes_all_fields(): void
+    {
+        $skill = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+
+        $array = $skill->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('description', $array);
+        $this->assertArrayHasKey('license', $array);
+        $this->assertArrayHasKey('metadata', $array);
+        $this->assertEquals('customer-support', $array['name']);
+        $this->assertEquals('MIT', $array['license']);
+    }
+
+    public function test_skill_to_xml_generates_proper_format(): void
+    {
+        $skill = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+
+        $xml = $skill->toXml();
+
+        $this->assertStringContainsString('<skill>', $xml);
+        $this->assertStringContainsString('<name>', $xml);
+        $this->assertStringContainsString('customer-support', $xml);
+        $this->assertStringContainsString('<description>', $xml);
+        $this->assertStringContainsString('</skill>', $xml);
+    }
+}

--- a/tests/Feature/Skills/SkillRegistryTest.php
+++ b/tests/Feature/Skills/SkillRegistryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skills\Exceptions\SkillNotFoundException;
+use Laravel\Ai\Skills\SkillLoader;
+use Laravel\Ai\Skills\SkillRegistry;
+use Tests\TestCase;
+
+class SkillRegistryTest extends TestCase
+{
+    protected SkillRegistry $registry;
+
+    protected SkillLoader $loader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registry = new SkillRegistry;
+        $this->loader = new SkillLoader;
+    }
+
+    public function test_can_register_and_retrieve_skill(): void
+    {
+        $skill = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+
+        $this->registry->register($skill);
+
+        $this->assertTrue($this->registry->has('customer-support'));
+        $this->assertEquals($skill, $this->registry->find('customer-support'));
+    }
+
+    public function test_all_returns_all_registered_skills(): void
+    {
+        $skill1 = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+        $skill2 = $this->loader->load(__DIR__.'/Fixtures/order-fulfillment');
+
+        $this->registry->register($skill1);
+        $this->registry->register($skill2);
+
+        $all = $this->registry->all();
+
+        $this->assertCount(2, $all);
+        $this->assertContains($skill1, $all);
+        $this->assertContains($skill2, $all);
+    }
+
+    public function test_find_returns_null_for_nonexistent_skill(): void
+    {
+        $skill = $this->registry->find('nonexistent');
+
+        $this->assertNull($skill);
+    }
+
+    public function test_find_or_fail_throws_exception_for_nonexistent_skill(): void
+    {
+        $this->expectException(SkillNotFoundException::class);
+        $this->expectExceptionMessage('Skill [nonexistent] not found');
+
+        $this->registry->findOrFail('nonexistent');
+    }
+
+    public function test_has_returns_false_for_nonexistent_skill(): void
+    {
+        $this->assertFalse($this->registry->has('nonexistent'));
+    }
+
+    public function test_count_returns_correct_number(): void
+    {
+        $this->assertEquals(0, $this->registry->count());
+
+        $skill1 = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+        $this->registry->register($skill1);
+
+        $this->assertEquals(1, $this->registry->count());
+
+        $skill2 = $this->loader->load(__DIR__.'/Fixtures/order-fulfillment');
+        $this->registry->register($skill2);
+
+        $this->assertEquals(2, $this->registry->count());
+    }
+
+    public function test_to_prompt_generates_xml_for_all_skills(): void
+    {
+        $skill1 = $this->loader->load(__DIR__.'/Fixtures/customer-support');
+        $skill2 = $this->loader->load(__DIR__.'/Fixtures/order-fulfillment');
+
+        $this->registry->register($skill1);
+        $this->registry->register($skill2);
+
+        $prompt = $this->registry->toPrompt();
+
+        $this->assertStringContainsString('<available_skills>', $prompt);
+        $this->assertStringContainsString('</available_skills>', $prompt);
+        $this->assertStringContainsString('customer-support', $prompt);
+        $this->assertStringContainsString('order-fulfillment', $prompt);
+        $this->assertStringContainsString('<skill>', $prompt);
+        $this->assertStringContainsString('</skill>', $prompt);
+    }
+
+    public function test_to_prompt_returns_empty_string_for_no_skills(): void
+    {
+        $prompt = $this->registry->toPrompt();
+
+        $this->assertEquals('', $prompt);
+    }
+
+    public function test_from_directory_loads_all_skills(): void
+    {
+        $registry = SkillRegistry::fromDirectory(__DIR__.'/Fixtures');
+
+        $this->assertCount(2, $registry->all());
+        $this->assertTrue($registry->has('customer-support'));
+        $this->assertTrue($registry->has('order-fulfillment'));
+    }
+}


### PR DESCRIPTION
Skills let you give your agent specialized knowledge using plain markdown files. A customer support agent could activate a skill that knows your escalation policies. A product agent could pull in feature documentation on demand. The format is flexible enough to describe anything your agent might need to know, without stuffing it all into the system prompt upfront.

Adds support for the [Agent Skills](https://agentskills.io) open standard, enabling agents to discover, activate, and read skill resources through a three-layer progressive disclosure model.

**Discovery**: `SkillLoader` parses `SKILL.md` files (YAML frontmatter + markdown body). `SkillRegistry` holds loaded skills and generates an `<available_skills>` XML block for the system prompt containing only names and descriptions.

**Activation**: `ActivateSkillTool` implements the `Tool` contract so the LLM can call `activate_skill` to retrieve a skill's full instructions on demand. If the skill has files in `scripts/`, `references/`, or `assets/`, the response includes an `<available_resources>` listing.

**Resource reading**: `ReadSkillResourceTool` lets the LLM read individual resource files from an activated skill by relative path, with path traversal protection.

All frontmatter fields from the spec are supported: `name`, `description`, `license`, `compatibility`, `allowed-tools`, and `metadata`.

**Note:** Test fixtures in `tests/Feature/Skills/Fixtures/` contain `SKILL.md` files. These are test data only.

<img width="375" height="221" alt="image" src="https://github.com/user-attachments/assets/d9e390a9-4c60-4024-963e-3e2e697f7c49" />

```
<?php
$registry = SkillRegistry::fromDirectory(base_path('skills'));

// In your agent's instructions()
$registry->toPrompt();

// In your agent's tools()
new ActivateSkillTool($registry);
new ReadSkillResourceTool($registry);
```