### PR TITLE
Flexible Unique Identifier Strategy

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -42,6 +42,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure how the AI SDK stores data in the database.
+    | The "id_generator" option controls the strategy used to generate
+    | unique identifiers for conversations, messages, and invocations.
+    |
+    | Supported generators:
+    |   - UuidV7Generator (default) — Time-ordered, sortable. Best for most apps.
+    |   - UuidV4Generator — Random. Widely compatible but not sortable.
+    |   - UlidGenerator — Time-ordered, compact (26 chars). Good alternative.
+    |   - RandomHexGenerator — 32-char hex string. Simple and fast.
+    |
+    | The "id_column_type" option controls the database column type used
+    | for identifier columns. Both store fixed 36-character strings:
+    |   - "string" (VARCHAR) — Variable-length. Slightly more storage overhead
+    |     but universally supported and flexible.
+    |   - "char" (CHAR) — Fixed-length. Marginally faster lookups on some
+    |     databases (MySQL/MariaDB) due to predictable row sizes.
+    |
+    */
+
+    'database' => [
+        'id_generator' => Laravel\Ai\Support\Generators\UuidV7Generator::class,
+        'id_column_type' => 'string',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | AI Providers
     |--------------------------------------------------------------------------
     |

--- a/config/ai.php
+++ b/config/ai.php
@@ -49,16 +49,18 @@ return [
     | The "id_generator" option controls the strategy used to generate
     | unique identifiers for conversations, messages, and invocations.
     |
+    | Each generator defines its own length, which is used automatically
+    | by migrations to size the database columns appropriately.
+    |
     | Supported generators:
-    |   - UuidV7Generator (default) — Time-ordered, sortable. Best for most apps.
-    |   - UuidV4Generator — Random. Widely compatible but not sortable.
-    |   - UlidGenerator — Time-ordered, compact (26 chars). Good alternative.
-    |   - RandomHexGenerator — 32-char hex string. Simple and fast.
+    |   - UuidV7Generator (default) — Time-ordered, sortable. 36 chars.
+    |   - UuidV4Generator — Random. Widely compatible but not sortable. 36 chars.
+    |   - UlidGenerator — Time-ordered, compact. 26 chars.
+    |   - RandomHexGenerator — Simple and fast. 32 chars.
     |
     | The "id_column_type" option controls the database column type used
-    | for identifier columns. Both store fixed 36-character strings:
-    |   - "string" (VARCHAR) — Variable-length. Slightly more storage overhead
-    |     but universally supported and flexible.
+    | for identifier columns:
+    |   - "string" (VARCHAR) — Variable-length. Universally supported.
     |   - "char" (CHAR) — Fixed-length. Marginally faster lookups on some
     |     databases (MySQL/MariaDB) due to predictable row sizes.
     |

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Migrations\AiMigration;
 
 return new class extends AiMigration
@@ -12,9 +13,10 @@ return new class extends AiMigration
     public function up(): void
     {
         $columnType = config('ai.database.id_column_type', 'string');
+        $idLength = resolve(UniqueIdentifierGenerator::class)->length();
 
-        Schema::create('agent_conversations', function (Blueprint $table) use ($columnType) {
-            $table->{$columnType}('id', 36)->primary();
+        Schema::create('agent_conversations', function (Blueprint $table) use ($columnType, $idLength) {
+            $table->{$columnType}('id', $idLength)->primary();
             $table->foreignId('user_id');
             $table->string('title');
             $table->timestamps();
@@ -22,9 +24,9 @@ return new class extends AiMigration
             $table->index(['user_id', 'updated_at']);
         });
 
-        Schema::create('agent_conversation_messages', function (Blueprint $table) use ($columnType) {
-            $table->{$columnType}('id', 36)->primary();
-            $table->{$columnType}('conversation_id', 36)->index();
+        Schema::create('agent_conversation_messages', function (Blueprint $table) use ($columnType, $idLength) {
+            $table->{$columnType}('id', $idLength)->primary();
+            $table->{$columnType}('conversation_id', $idLength)->index();
             $table->foreignId('user_id');
             $table->string('agent');
             $table->string('role', 25);

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -11,8 +11,10 @@ return new class extends AiMigration
      */
     public function up(): void
     {
-        Schema::create('agent_conversations', function (Blueprint $table) {
-            $table->string('id', 36)->primary();
+        $columnType = config('ai.database.id_column_type', 'string');
+
+        Schema::create('agent_conversations', function (Blueprint $table) use ($columnType) {
+            $table->{$columnType}('id', 36)->primary();
             $table->foreignId('user_id');
             $table->string('title');
             $table->timestamps();
@@ -20,9 +22,9 @@ return new class extends AiMigration
             $table->index(['user_id', 'updated_at']);
         });
 
-        Schema::create('agent_conversation_messages', function (Blueprint $table) {
-            $table->string('id', 36)->primary();
-            $table->string('conversation_id', 36)->index();
+        Schema::create('agent_conversation_messages', function (Blueprint $table) use ($columnType) {
+            $table->{$columnType}('id', 36)->primary();
+            $table->{$columnType}('conversation_id', 36)->index();
             $table->foreignId('user_id');
             $table->string('agent');
             $table->string('role', 25);

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 
 class AiServiceProvider extends ServiceProvider
@@ -23,6 +24,10 @@ class AiServiceProvider extends ServiceProvider
     {
         $this->app->scoped(AiManager::class, fn ($app): AiManager => new AiManager($app));
         $this->app->singleton(ConversationStore::class, DatabaseConversationStore::class);
+        $this->app->singleton(
+            UniqueIdentifierGenerator::class,
+            fn ($app) => new ($app['config']['ai.database.id_generator'] ?? \Laravel\Ai\Support\Generators\UuidV7Generator::class)()
+        );
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');
     }

--- a/src/Contracts/UniqueIdentifierGenerator.php
+++ b/src/Contracts/UniqueIdentifierGenerator.php
@@ -11,4 +11,11 @@ interface UniqueIdentifierGenerator
      * Generate a unique identifier string.
      */
     public function generate(): string;
+
+    /**
+     * The length of identifiers produced by this generator.
+     *
+     * Used by migrations to size database columns appropriately.
+     */
+    public function length(): int;
 }

--- a/src/Contracts/UniqueIdentifierGenerator.php
+++ b/src/Contracts/UniqueIdentifierGenerator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+/**
+ * Contract for generating unique identifiers.
+ */
+interface UniqueIdentifierGenerator
+{
+    /**
+     * Generate a unique identifier string.
+     */
+    public function generate(): string;
+}

--- a/src/Providers/Concerns/GeneratesAudio.php
+++ b/src/Providers/Concerns/GeneratesAudio.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\AudioGenerated;
 use Laravel\Ai\Events\GeneratingAudio;
 use Laravel\Ai\Prompts\AudioPrompt;
@@ -20,7 +20,7 @@ trait GeneratesAudio
         ?string $instructions = null,
         ?string $model = null,
     ): AudioResponse {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $model ??= $this->defaultAudioModel();
 

--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\EmbeddingsGenerated;
 use Laravel\Ai\Events\GeneratingEmbeddings;
 use Laravel\Ai\Prompts\EmbeddingsPrompt;
@@ -23,7 +23,7 @@ trait GeneratesEmbeddings
             throw new InvalidArgumentException('Dimensions must be provided when model is specified.');
         }
 
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $model ??= $this->defaultEmbeddingsModel();
         $dimensions ??= $this->defaultEmbeddingsDimensions();

--- a/src/Providers/Concerns/GeneratesImages.php
+++ b/src/Providers/Concerns/GeneratesImages.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\GeneratingImage;
 use Laravel\Ai\Events\ImageGenerated;
 use Laravel\Ai\Prompts\ImagePrompt;
@@ -26,7 +26,7 @@ trait GeneratesImages
         ?string $model = null,
         ?int $timeout = null,
     ): ImageResponse {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $model ??= $this->defaultImageModel();
 

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -4,7 +4,6 @@ namespace Laravel\Ai\Providers\Concerns;
 
 use Closure;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
@@ -14,6 +13,7 @@ use Laravel\Ai\Contracts\HasMiddleware;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
@@ -36,7 +36,7 @@ trait GeneratesText
      */
     public function prompt(AgentPrompt $prompt): AgentResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $processedPrompt = null;
 
@@ -111,7 +111,7 @@ trait GeneratesText
     {
         $this->textGateway()->onToolInvocation(
             invoking: function (Tool $tool, array $arguments) use ($invocationId, $agent) {
-                $this->currentToolInvocationId = (string) Str::uuid7();
+                $this->currentToolInvocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
                 $this->events->dispatch(new InvokingTool(
                     $invocationId, $this->currentToolInvocationId, $agent, $tool, $arguments

--- a/src/Providers/Concerns/GeneratesTranscriptions.php
+++ b/src/Providers/Concerns/GeneratesTranscriptions.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\GeneratingTranscription;
 use Laravel\Ai\Events\TranscriptionGenerated;
 use Laravel\Ai\Prompts\TranscriptionPrompt;
@@ -21,7 +21,7 @@ trait GeneratesTranscriptions
         bool $diarize = false,
         ?string $model = null,
     ): TranscriptionResponse {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $model ??= $this->defaultTranscriptionModel();
 

--- a/src/Providers/Concerns/ManagesFiles.php
+++ b/src/Providers/Concerns/ManagesFiles.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\FileDeleted;
 use Laravel\Ai\Events\FileStored;
 use Laravel\Ai\Events\StoringFile;
@@ -26,7 +26,7 @@ trait ManagesFiles
      */
     public function putFile(StorableFile $file): StoredFileResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         if (Ai::filesAreFaked()) {
             Ai::recordFileUpload($file);
@@ -51,7 +51,7 @@ trait ManagesFiles
      */
     public function deleteFile(string $fileId): void
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         if (Ai::filesAreFaked()) {
             Ai::recordFileDeletion($fileId);

--- a/src/Providers/Concerns/ManagesStores.php
+++ b/src/Providers/Concerns/ManagesStores.php
@@ -4,9 +4,9 @@ namespace Laravel\Ai\Providers\Concerns;
 
 use DateInterval;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Contracts\Files\HasProviderId;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\AddingFileToStore;
 use Laravel\Ai\Events\CreatingStore;
 use Laravel\Ai\Events\FileAddedToStore;
@@ -35,7 +35,7 @@ trait ManagesStores
         ?Collection $fileIds = null,
         ?DateInterval $expiresWhenIdleFor = null,
     ): Store {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $fileIds ??= new Collection;
 
@@ -62,7 +62,7 @@ trait ManagesStores
      */
     public function addFileToStore(string $storeId, HasProviderId $file, array $metadata = []): string
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $this->events->dispatch(new AddingFileToStore(
             $invocationId, $this, $storeId, $file->id()
@@ -83,7 +83,7 @@ trait ManagesStores
      */
     public function removeFileFromStore(string $storeId, HasProviderId|string $documentId): bool
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $documentId = $documentId instanceof HasProviderId ? $documentId->id() : $documentId;
 
@@ -110,7 +110,7 @@ trait ManagesStores
      */
     public function deleteStore(string $storeId): bool
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         if (Ai::storesAreFaked()) {
             Ai::recordStoreDeletion($storeId);

--- a/src/Providers/Concerns/Reranks.php
+++ b/src/Providers/Concerns/Reranks.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\Reranked;
 use Laravel\Ai\Events\Reranking;
 use Laravel\Ai\Prompts\RerankingPrompt;
@@ -18,7 +18,7 @@ trait Reranks
      */
     public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null): RerankingResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $model ??= $this->defaultRerankingModel();
 

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Ai\Providers\Concerns;
 
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -25,7 +25,7 @@ trait StreamsText
      */
     public function stream(AgentPrompt $prompt): StreamableAgentResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         $processedPrompt = null;
 

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -4,8 +4,8 @@ namespace Laravel\Ai\Storage;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
@@ -28,7 +28,7 @@ class DatabaseConversationStore implements ConversationStore
      */
     public function storeConversation(string|int $userId, string $title): string
     {
-        $conversationId = (string) Str::uuid7();
+        $conversationId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         DB::table('agent_conversations')->insert([
             'id' => $conversationId,
@@ -46,7 +46,7 @@ class DatabaseConversationStore implements ConversationStore
      */
     public function storeUserMessage(string $conversationId, string|int $userId, AgentPrompt $prompt): string
     {
-        $messageId = (string) Str::uuid7();
+        $messageId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         DB::table('agent_conversation_messages')->insert([
             'id' => $messageId,
@@ -72,7 +72,7 @@ class DatabaseConversationStore implements ConversationStore
      */
     public function storeAssistantMessage(string $conversationId, string|int $userId, AgentPrompt $prompt, AgentResponse $response): string
     {
-        $messageId = (string) Str::uuid7();
+        $messageId = resolve(UniqueIdentifierGenerator::class)->generate();
 
         DB::table('agent_conversation_messages')->insert([
             'id' => $messageId,

--- a/src/Support/Generators/RandomHexGenerator.php
+++ b/src/Support/Generators/RandomHexGenerator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ai\Support\Generators;
+
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
+
+/**
+ * Random hex generator (32 characters).
+ */
+class RandomHexGenerator implements UniqueIdentifierGenerator
+{
+    public function generate(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+}

--- a/src/Support/Generators/RandomHexGenerator.php
+++ b/src/Support/Generators/RandomHexGenerator.php
@@ -13,4 +13,9 @@ class RandomHexGenerator implements UniqueIdentifierGenerator
     {
         return bin2hex(random_bytes(16));
     }
+
+    public function length(): int
+    {
+        return 32;
+    }
 }

--- a/src/Support/Generators/UlidGenerator.php
+++ b/src/Support/Generators/UlidGenerator.php
@@ -14,4 +14,9 @@ class UlidGenerator implements UniqueIdentifierGenerator
     {
         return strtolower((string) Str::ulid());
     }
+
+    public function length(): int
+    {
+        return 26;
+    }
 }

--- a/src/Support/Generators/UlidGenerator.php
+++ b/src/Support/Generators/UlidGenerator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Support\Generators;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
+
+/**
+ * ULID generator.
+ */
+class UlidGenerator implements UniqueIdentifierGenerator
+{
+    public function generate(): string
+    {
+        return strtolower((string) Str::ulid());
+    }
+}

--- a/src/Support/Generators/UuidV4Generator.php
+++ b/src/Support/Generators/UuidV4Generator.php
@@ -14,4 +14,9 @@ class UuidV4Generator implements UniqueIdentifierGenerator
     {
         return (string) Str::uuid();
     }
+
+    public function length(): int
+    {
+        return 36;
+    }
 }

--- a/src/Support/Generators/UuidV4Generator.php
+++ b/src/Support/Generators/UuidV4Generator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Support\Generators;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
+
+/**
+ * UUID v4 generator.
+ */
+class UuidV4Generator implements UniqueIdentifierGenerator
+{
+    public function generate(): string
+    {
+        return (string) Str::uuid();
+    }
+}

--- a/src/Support/Generators/UuidV7Generator.php
+++ b/src/Support/Generators/UuidV7Generator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Support\Generators;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
+
+/**
+ * UUID v7 generator.
+ */
+class UuidV7Generator implements UniqueIdentifierGenerator
+{
+    public function generate(): string
+    {
+        return (string) Str::uuid7();
+    }
+}

--- a/src/Support/Generators/UuidV7Generator.php
+++ b/src/Support/Generators/UuidV7Generator.php
@@ -14,4 +14,9 @@ class UuidV7Generator implements UniqueIdentifierGenerator
     {
         return (string) Str::uuid7();
     }
+
+    public function length(): int
+    {
+        return 36;
+    }
 }

--- a/tests/Feature/UniqueIdentifierStrategyTest.php
+++ b/tests/Feature/UniqueIdentifierStrategyTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Contracts\UniqueIdentifierGenerator;
+use Laravel\Ai\Support\Generators\RandomHexGenerator;
+use Laravel\Ai\Support\Generators\UlidGenerator;
+use Laravel\Ai\Support\Generators\UuidV4Generator;
+use Laravel\Ai\Support\Generators\UuidV7Generator;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\TestCase;
+
+class UniqueIdentifierStrategyTest extends TestCase
+{
+    public function test_default_generator_is_uuid_v7(): void
+    {
+        $generator = resolve(UniqueIdentifierGenerator::class);
+        $this->assertInstanceOf(UuidV7Generator::class, $generator);
+    }
+
+    public function test_generator_can_be_configured_to_uuid_v4(): void
+    {
+        config(['ai.database.id_generator' => UuidV4Generator::class]);
+        $this->app->singleton(UniqueIdentifierGenerator::class, fn ($app) => new ($app['config']['ai.database.id_generator'])());
+
+        $generator = resolve(UniqueIdentifierGenerator::class);
+        $this->assertInstanceOf(UuidV4Generator::class, $generator);
+
+        $id = $generator->generate();
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $id);
+    }
+
+    public function test_generator_can_be_configured_to_ulid(): void
+    {
+        config(['ai.database.id_generator' => UlidGenerator::class]);
+        $this->app->singleton(UniqueIdentifierGenerator::class, fn ($app) => new ($app['config']['ai.database.id_generator'])());
+
+        $generator = resolve(UniqueIdentifierGenerator::class);
+        $this->assertInstanceOf(UlidGenerator::class, $generator);
+
+        $id = $generator->generate();
+        $this->assertEquals(26, strlen($id));
+        $this->assertMatchesRegularExpression('/^[0-9a-z]{26}$/', $id);
+    }
+
+    public function test_generator_can_be_configured_to_random_hex(): void
+    {
+        config(['ai.database.id_generator' => RandomHexGenerator::class]);
+        $this->app->singleton(UniqueIdentifierGenerator::class, fn ($app) => new ($app['config']['ai.database.id_generator'])());
+
+        $generator = resolve(UniqueIdentifierGenerator::class);
+        $this->assertInstanceOf(RandomHexGenerator::class, $generator);
+
+        $id = $generator->generate();
+        $this->assertEquals(32, strlen($id));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $id);
+    }
+
+    public function test_agent_invocation_uses_configured_generator(): void
+    {
+        config(['ai.database.id_generator' => UlidGenerator::class]);
+        $this->app->singleton(UniqueIdentifierGenerator::class, fn ($app) => new ($app['config']['ai.database.id_generator'])());
+
+        AssistantAgent::fake(['response']);
+
+        $response = (new AssistantAgent)->prompt('test');
+
+        // ULID is 26 chars lowercase
+        $this->assertEquals(26, strlen($response->invocationId));
+        $this->assertMatchesRegularExpression('/^[0-9a-z]{26}$/', $response->invocationId);
+    }
+
+    public function test_agent_invocation_uses_random_hex_generator(): void
+    {
+        config(['ai.database.id_generator' => RandomHexGenerator::class]);
+        $this->app->singleton(UniqueIdentifierGenerator::class, fn ($app) => new ($app['config']['ai.database.id_generator'])());
+
+        AssistantAgent::fake(['response']);
+
+        $response = (new AssistantAgent)->prompt('test');
+
+        // RandomHex is 32 hex chars
+        $this->assertEquals(32, strlen($response->invocationId));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $response->invocationId);
+    }
+
+    public function test_default_uuid_v7_produces_uuid_format_invocation_ids(): void
+    {
+        AssistantAgent::fake(['response']);
+
+        $response = (new AssistantAgent)->prompt('test');
+
+        $this->assertEquals(36, strlen($response->invocationId));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $response->invocationId);
+    }
+
+    public function test_generator_is_resolved_as_singleton(): void
+    {
+        $generator1 = resolve(UniqueIdentifierGenerator::class);
+        $generator2 = resolve(UniqueIdentifierGenerator::class);
+
+        $this->assertSame($generator1, $generator2);
+    }
+}

--- a/tests/Feature/UniqueIdentifierStrategyTest.php
+++ b/tests/Feature/UniqueIdentifierStrategyTest.php
@@ -101,4 +101,21 @@ class UniqueIdentifierStrategyTest extends TestCase
 
         $this->assertSame($generator1, $generator2);
     }
+
+    public function test_generator_length_matches_generated_output(): void
+    {
+        $generators = [
+            UuidV7Generator::class,
+            UuidV4Generator::class,
+            UlidGenerator::class,
+            RandomHexGenerator::class,
+        ];
+
+        foreach ($generators as $generatorClass) {
+            $generator = new $generatorClass;
+            $id = $generator->generate();
+
+            $this->assertEquals($generator->length(), strlen($id), "{$generatorClass}::length() does not match actual output length.");
+        }
+    }
 }

--- a/tests/Unit/Support/GeneratorsTest.php
+++ b/tests/Unit/Support/GeneratorsTest.php
@@ -24,6 +24,7 @@ class GeneratorsTest extends TestCase
         $result = $generator->generate();
 
         $this->assertEquals(36, strlen($result));
+        $this->assertEquals(36, $generator->length());
     }
 
     public function test_uuid_v7_has_correct_format(): void
@@ -57,6 +58,7 @@ class GeneratorsTest extends TestCase
         $result = $generator->generate();
 
         $this->assertEquals(36, strlen($result));
+        $this->assertEquals(36, $generator->length());
     }
 
     public function test_uuid_v4_has_correct_format(): void
@@ -90,6 +92,7 @@ class GeneratorsTest extends TestCase
         $result = $generator->generate();
 
         $this->assertEquals(26, strlen($result));
+        $this->assertEquals(26, $generator->length());
     }
 
     public function test_ulid_has_correct_format(): void
@@ -123,6 +126,7 @@ class GeneratorsTest extends TestCase
         $result = $generator->generate();
 
         $this->assertEquals(32, strlen($result));
+        $this->assertEquals(32, $generator->length());
     }
 
     public function test_random_hex_has_correct_format(): void

--- a/tests/Unit/Support/GeneratorsTest.php
+++ b/tests/Unit/Support/GeneratorsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Laravel\Ai\Support\Generators\RandomHexGenerator;
+use Laravel\Ai\Support\Generators\UlidGenerator;
+use Laravel\Ai\Support\Generators\UuidV4Generator;
+use Laravel\Ai\Support\Generators\UuidV7Generator;
+use PHPUnit\Framework\TestCase;
+
+class GeneratorsTest extends TestCase
+{
+    public function test_uuid_v7_returns_string(): void
+    {
+        $generator = new UuidV7Generator;
+        $result = $generator->generate();
+
+        $this->assertIsString($result);
+    }
+
+    public function test_uuid_v7_has_correct_length(): void
+    {
+        $generator = new UuidV7Generator;
+        $result = $generator->generate();
+
+        $this->assertEquals(36, strlen($result));
+    }
+
+    public function test_uuid_v7_has_correct_format(): void
+    {
+        $generator = new UuidV7Generator;
+        $result = $generator->generate();
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $result);
+    }
+
+    public function test_uuid_v7_generates_unique_values(): void
+    {
+        $generator = new UuidV7Generator;
+        $result1 = $generator->generate();
+        $result2 = $generator->generate();
+
+        $this->assertNotEquals($result1, $result2);
+    }
+
+    public function test_uuid_v4_returns_string(): void
+    {
+        $generator = new UuidV4Generator;
+        $result = $generator->generate();
+
+        $this->assertIsString($result);
+    }
+
+    public function test_uuid_v4_has_correct_length(): void
+    {
+        $generator = new UuidV4Generator;
+        $result = $generator->generate();
+
+        $this->assertEquals(36, strlen($result));
+    }
+
+    public function test_uuid_v4_has_correct_format(): void
+    {
+        $generator = new UuidV4Generator;
+        $result = $generator->generate();
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $result);
+    }
+
+    public function test_uuid_v4_generates_unique_values(): void
+    {
+        $generator = new UuidV4Generator;
+        $result1 = $generator->generate();
+        $result2 = $generator->generate();
+
+        $this->assertNotEquals($result1, $result2);
+    }
+
+    public function test_ulid_returns_string(): void
+    {
+        $generator = new UlidGenerator;
+        $result = $generator->generate();
+
+        $this->assertIsString($result);
+    }
+
+    public function test_ulid_has_correct_length(): void
+    {
+        $generator = new UlidGenerator;
+        $result = $generator->generate();
+
+        $this->assertEquals(26, strlen($result));
+    }
+
+    public function test_ulid_has_correct_format(): void
+    {
+        $generator = new UlidGenerator;
+        $result = $generator->generate();
+
+        $this->assertMatchesRegularExpression('/^[0-9a-z]{26}$/', $result);
+    }
+
+    public function test_ulid_generates_unique_values(): void
+    {
+        $generator = new UlidGenerator;
+        $result1 = $generator->generate();
+        $result2 = $generator->generate();
+
+        $this->assertNotEquals($result1, $result2);
+    }
+
+    public function test_random_hex_returns_string(): void
+    {
+        $generator = new RandomHexGenerator;
+        $result = $generator->generate();
+
+        $this->assertIsString($result);
+    }
+
+    public function test_random_hex_has_correct_length(): void
+    {
+        $generator = new RandomHexGenerator;
+        $result = $generator->generate();
+
+        $this->assertEquals(32, strlen($result));
+    }
+
+    public function test_random_hex_has_correct_format(): void
+    {
+        $generator = new RandomHexGenerator;
+        $result = $generator->generate();
+
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $result);
+    }
+
+    public function test_random_hex_generates_unique_values(): void
+    {
+        $generator = new RandomHexGenerator;
+        $result1 = $generator->generate();
+        $result2 = $generator->generate();
+
+        $this->assertNotEquals($result1, $result2);
+    }
+}


### PR DESCRIPTION
This PR introduces a contract-based strategy for generating unique identifiers across the Laravel AI SDK. It allows developers to choose their preferred ID format (UUID v7, UUID v4, ULID, or Random Hex) via configuration, replacing the hardcoded `Str::uuid7()` implementation.

### Key Changes
- **New Contract**: `UniqueIdentifierGenerator` with `generate()` and `length()` methods.
- **4 Generators Included**:
  - `UuidV7Generator` (Default) — 36 chars, time-ordered.
  - `UuidV4Generator` — 36 chars, random.
  - `UlidGenerator` — 26 chars, time-ordered, compact.
  - `RandomHexGenerator` — 32 chars, simple/fast.
- **Configurable Database Columns**: The migration now respects the configured generator's length and allows choosing between `string` (VARCHAR) or `char` (CHAR) column types.
- **Unified Generation**: All internal ID generation (conversations, messages, invocations) now uses the resolved generator singleton.

### Configuration
New options in `config/ai.php`:

```php
'database' => [
    'id_generator' => \Laravel\Ai\Support\Generators\UuidV7Generator::class, // or UlidGenerator::class, etc.
    'id_column_type' => 'string', // 'string' or 'char'
],
```

### Migration Impact
The `agent_conversations` and `agent_conversation_messages` tables now dynamically size their ID columns based on the selected generator's `length()` method:
- UUIDs: 36 characters
- ULID: 26 characters
- RandomHex: 32 characters

### Backward Compatibility
- Default behavior remains unchanged (UUID v7).
- Existing applications using the default config will see no functional difference.
