### PR TITLE
[0.x] Adjust assertEquals order

### DIFF
--- a/tests/Feature/AgentIntegrationTest.php
+++ b/tests/Feature/AgentIntegrationTest.php
@@ -48,8 +48,8 @@ class AgentIntegrationTest extends TestCase
         $this->assertTrue(str_contains($response->text, 'Laravel'));
         $this->assertTrue(Str::isUuid($response->invocationId, 7));
         $this->assertTrue($response->messages->count() > 0);
-        $this->assertEquals($response->meta->provider, 'groq');
-        $this->assertEquals($response->meta->model, 'openai/gpt-oss-20b');
+        $this->assertEquals('groq', $response->meta->provider);
+        $this->assertEquals('openai/gpt-oss-20b', $response->meta->model);
         $this->assertTrue($response->steps->count() > 0);
 
         Event::assertDispatched(PromptingAgent::class);

--- a/tests/Feature/EmbeddingsIntegrationTest.php
+++ b/tests/Feature/EmbeddingsIntegrationTest.php
@@ -19,7 +19,7 @@ class EmbeddingsIntegrationTest extends TestCase
 
         $this->assertInstanceOf(EmbeddingsResponse::class, $response);
         $this->assertTrue(count($response->embeddings[0]) === 1536);
-        $this->assertEquals($response->meta->provider, 'openai');
+        $this->assertEquals('openai', $response->meta->provider);
 
         Event::assertDispatched(GeneratingEmbeddings::class);
         Event::assertDispatched(EmbeddingsGenerated::class);

--- a/tests/Feature/ImageIntegrationTest.php
+++ b/tests/Feature/ImageIntegrationTest.php
@@ -11,6 +11,6 @@ class ImageIntegrationTest extends TestCase
     {
         $response = Image::of('Donut sitting on a kitchen counter.')->generate(provider: ['xai']);
 
-        $this->assertEquals($response->meta->provider, 'xai');
+        $this->assertEquals('xai', $response->meta->provider);
     }
 }


### PR DESCRIPTION
Adjusts the ordering in a few tests. The expectation should be the first argument.

🫡 