### PR TITLE
[0.x] Forward dimensions to Prism embedding requests

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -330,6 +330,10 @@ class PrismGateway implements Gateway
             fn ($prism) => $this->configure($prism, $provider, $model)
         );
 
+        $request->withProviderOptions(
+            $this->dimensionsProviderOptions($provider, $dimensions)
+        );
+
         (new Collection($inputs))->each($request->fromInput(...));
 
         $response = $request->asEmbeddings();
@@ -339,6 +343,18 @@ class PrismGateway implements Gateway
             $response->usage->tokens,
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Map the dimensions parameter to provider-specific options.
+     */
+    protected function dimensionsProviderOptions(EmbeddingProvider $provider, int $dimensions): array
+    {
+        return match ($provider->driver()) {
+            'gemini' => ['outputDimensionality' => $dimensions],
+            'openai' => ['dimensions' => $dimensions],
+            default => [],
+        };
     }
 
     /**

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -330,9 +330,11 @@ class PrismGateway implements Gateway
             fn ($prism) => $this->configure($prism, $provider, $model)
         );
 
-        $request->withProviderOptions(
-            $this->dimensionsProviderOptions($provider, $dimensions)
-        );
+        $request->withProviderOptions(match ($provider->driver()) {
+            'gemini' => ['outputDimensionality' => $dimensions],
+            'openai' => ['dimensions' => $dimensions],
+            default => [],
+        });
 
         (new Collection($inputs))->each($request->fromInput(...));
 
@@ -343,18 +345,6 @@ class PrismGateway implements Gateway
             $response->usage->tokens,
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Map the dimensions parameter to provider-specific options.
-     */
-    protected function dimensionsProviderOptions(EmbeddingProvider $provider, int $dimensions): array
-    {
-        return match ($provider->driver()) {
-            'gemini' => ['outputDimensionality' => $dimensions],
-            'openai' => ['dimensions' => $dimensions],
-            default => [],
-        };
     }
 
     /**

--- a/tests/Feature/EmbeddingsIntegrationTest.php
+++ b/tests/Feature/EmbeddingsIntegrationTest.php
@@ -24,4 +24,14 @@ class EmbeddingsIntegrationTest extends TestCase
         Event::assertDispatched(GeneratingEmbeddings::class);
         Event::assertDispatched(EmbeddingsGenerated::class);
     }
+
+    public function test_embeddings_can_be_generated_with_custom_dimensions(): void
+    {
+        $response = Embeddings::for(['test text'])
+            ->dimensions(256)
+            ->generate();
+
+        $this->assertInstanceOf(EmbeddingsResponse::class, $response);
+        $this->assertEquals(256, count($response->embeddings[0]));
+    }
 }


### PR DESCRIPTION
**Summary**

This PR fixes an issue where the dimensions() setting for embeddings was ignored for all Prism-backed providers (Gemini, OpenAI, Anthropic).

Although `PrismGateway::generateEmbeddings()` received the $dimensions value, it was never passed to Prism’s embedding request. As a result, calls like:

```php
Embeddings::for(['text'])
    ->dimensions(768)
    ->generate('gemini', 'gemini-embedding-001');
```

always returned the provider’s default size (e.g. Gemini returning `3072` instead of `768`), causing failures in vector stores that require a fixed dimension size.


**Root Cause**

The `$dimensions` parameter was accepted but never used. Prism already supports custom dimensions via provider options, but those options were not being set. Each provider uses a different option name (e.g. outputDimensionality for Gemini, dimensions for OpenAI).


**Changes**
- Pass dimensions to Prism via withProviderOptions()
- Add provider-specific mapping for dimension options
- Preserve existing behavior for providers that don’t support custom dimensions

```php
$request->withProviderOptions(
    $this->dimensionsProviderOptions($provider, $dimensions)
);
```

Ref: https://github.com/laravel/ai/issues/93