### PR TITLE
Fix: Ensure API keys from config are passed to Prism gateway for media generation

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -181,7 +181,10 @@ class PrismGateway implements Gateway
     ): ImageResponse {
         try {
             $response = Prism::image()
-                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
+                ->using(static::toPrismProvider($provider), $model, array_merge(
+                    $provider->additionalConfiguration(),
+                    array_filter(['api_key' => $provider->providerCredentials()['key']])
+                ))
                 ->withPrompt($prompt, $this->toPrismImageAttachments($attachments))
                 ->withProviderOptions($provider->defaultImageOptions($size, $quality))
                 ->withClientOptions([
@@ -246,7 +249,10 @@ class PrismGateway implements Gateway
 
         try {
             $response = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
+                ->using(static::toPrismProvider($provider), $model, array_merge(
+                    $provider->additionalConfiguration(),
+                    array_filter(['api_key' => $provider->providerCredentials()['key']])
+                ))
                 ->withInput($text)
                 ->withVoice($voice)
                 ->withProviderOptions(array_filter([
@@ -281,7 +287,10 @@ class PrismGateway implements Gateway
             }
 
             $request = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
+                ->using(static::toPrismProvider($provider), $model, array_merge(
+                    $provider->additionalConfiguration(),
+                    array_filter(['api_key' => $provider->providerCredentials()['key']])
+                ))
                 ->withInput(match (true) {
                     $audio instanceof TranscribableAudio => Audio::fromBase64(
                         base64_encode($audio->content()), $audio->mimeType()


### PR DESCRIPTION
The package currently fails to pass the API key defined in the `ai.php` config to the underlying Prism instance for image, audio, and transcription generation.

This forces users to rely on Prism's default `.env` lookup, breaking applications that inject keys via config (e.g., from secrets managers or cached config) or use custom environment variable names.

## The Fix

**Images, Audio, & Transcription**: Updated `src/Gateway/Prism/PrismGateway.php` to explicitly add the `api_key` to the configuration array passed to Prism. This is necessary because `$provider->additionalConfiguration()` intentionally strips the key to avoid duplication, but it was not being re-added for these media types causing the underlying Prism library to fall back to environment variables.
