### PR TITLE
Fix AgentPrompted event null prompt when middleware short-circuits

### DIFF
--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -77,7 +77,7 @@ trait GeneratesText
             });
 
         $this->events->dispatch(
-            new AgentPrompted($invocationId, $processedPrompt, $response)
+            new AgentPrompted($invocationId, $processedPrompt ?? $prompt, $response)
         );
 
         return $response;


### PR DESCRIPTION
When middleware short-circuits the pipeline (returns without calling `$next`), the `AgentPrompted` event was dispatched with a `null` prompt, causing a `TypeError`                                   

The fix is to fall back to the original prompt when the processed prompt is not set
                                                                                                      
I Added a test for short-circuiting middleware dispatching `AgentPrompted` with the correct prompt
