### PR TITLE
Add cache response middleware for text generation

### DIFF
--- a/src/Middleware/CacheResponse.php
+++ b/src/Middleware/CacheResponse.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Laravel\Ai\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Responses\StructuredAgentResponse;
+
+class CacheResponse
+{
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct(
+        protected ?int $seconds = 3600,
+        protected ?string $store = null,
+    ) {}
+
+    /**
+     * Handle the incoming prompt.
+     */
+    public function handle(AgentPrompt $prompt, Closure $next)
+    {
+        $key = $this->cacheKey($prompt);
+
+        $cached = $this->cache()->get($key);
+
+        if ($cached !== null) {
+            return $this->restoreResponse($cached);
+        }
+
+        $response = $next($prompt);
+
+        if ($response instanceof StreamableAgentResponse) {
+            return $response;
+        }
+
+        $this->cache()->put(
+            $key, $this->serializeResponse($response), $this->seconds
+        );
+
+        return $response;
+    }
+
+    /**
+     * Generate a deterministic cache key for the given prompt.
+     */
+    protected function cacheKey(AgentPrompt $prompt): string
+    {
+        $hash = hash('sha256', implode('|', [
+            get_class($prompt->agent),
+            $prompt->provider->name(),
+            $prompt->model,
+            (string) $prompt->agent->instructions(),
+            $prompt->prompt,
+        ]));
+
+        return "ai:text:{$hash}";
+    }
+
+    /**
+     * Serialize an agent response for caching.
+     */
+    protected function serializeResponse(AgentResponse $response): array
+    {
+        $data = [
+            'text' => $response->text,
+            'usage' => $response->usage->toArray(),
+            'meta' => [
+                'provider' => $response->meta->provider,
+                'model' => $response->meta->model,
+            ],
+        ];
+
+        if ($response instanceof StructuredAgentResponse) {
+            return [...$data, 'type' => 'structured', 'structured' => $response->structured];
+        }
+
+        return [...$data, 'type' => 'text'];
+    }
+
+    /**
+     * Restore an agent response from cached data.
+     */
+    protected function restoreResponse(array $data): AgentResponse
+    {
+        $usage = new Usage(
+            $data['usage']['prompt_tokens'],
+            $data['usage']['completion_tokens'],
+            $data['usage']['cache_write_input_tokens'],
+            $data['usage']['cache_read_input_tokens'],
+            $data['usage']['reasoning_tokens'],
+        );
+
+        $meta = new Meta(
+            $data['meta']['provider'],
+            $data['meta']['model'],
+        );
+
+        $invocationId = (string) Str::uuid7();
+
+        if ($data['type'] === 'structured') {
+            return new StructuredAgentResponse(
+                $invocationId, $data['structured'], $data['text'], $usage, $meta
+            );
+        }
+
+        return new AgentResponse($invocationId, $data['text'], $usage, $meta);
+    }
+
+    /**
+     * Get the cache store instance.
+     */
+    protected function cache()
+    {
+        return Cache::store($this->store);
+    }
+}

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -77,7 +77,7 @@ trait GeneratesText
             });
 
         $this->events->dispatch(
-            new AgentPrompted($invocationId, $processedPrompt, $response)
+            new AgentPrompted($invocationId, $processedPrompt ?? $prompt, $response)
         );
 
         return $response;

--- a/tests/Feature/Agents/StructuredAgent.php
+++ b/tests/Feature/Agents/StructuredAgent.php
@@ -4,12 +4,27 @@ namespace Tests\Feature\Agents;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasMiddleware;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 
-class StructuredAgent implements Agent, HasStructuredOutput
+class StructuredAgent implements Agent, HasMiddleware, HasStructuredOutput
 {
     use Promptable;
+
+    protected $middleware = [];
+
+    public function middleware(): array
+    {
+        return $this->middleware;
+    }
+
+    public function withMiddleware(array $middleware): self
+    {
+        $this->middleware = $middleware;
+
+        return $this;
+    }
 
     /**
      * Get the instructions that the agent should follow.

--- a/tests/Feature/CacheResponseMiddlewareTest.php
+++ b/tests/Feature/CacheResponseMiddlewareTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Cache;
+use Laravel\Ai\Middleware\CacheResponse;
+use Laravel\Ai\Responses\StructuredAgentResponse;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\StructuredAgent;
+use Tests\TestCase;
+
+class CacheResponseMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::store('array')->flush();
+    }
+
+    public function test_response_is_cached_and_returned_on_subsequent_calls(): void
+    {
+        AssistantAgent::fake([
+            'First response',
+            'Second response',
+        ]);
+
+        $agent = (new AssistantAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $first = $agent->prompt('Hello');
+        $second = $agent->prompt('Hello');
+
+        $this->assertEquals('First response', $first->text);
+        $this->assertEquals('First response', $second->text);
+    }
+
+    public function test_different_prompts_are_cached_separately(): void
+    {
+        AssistantAgent::fake([
+            'Response A',
+            'Response B',
+        ]);
+
+        $agent = (new AssistantAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $first = $agent->prompt('Prompt A');
+        $second = $agent->prompt('Prompt B');
+
+        $this->assertEquals('Response A', $first->text);
+        $this->assertEquals('Response B', $second->text);
+    }
+
+    public function test_cached_response_has_fresh_invocation_id(): void
+    {
+        AssistantAgent::fake([
+            'Cached response',
+        ]);
+
+        $agent = (new AssistantAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $first = $agent->prompt('Hello');
+        $second = $agent->prompt('Hello');
+
+        $this->assertNotEquals($first->invocationId, $second->invocationId);
+    }
+
+    public function test_cached_response_preserves_usage_and_meta(): void
+    {
+        AssistantAgent::fake([
+            'Response',
+        ]);
+
+        $agent = (new AssistantAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $first = $agent->prompt('Hello');
+        $second = $agent->prompt('Hello');
+
+        $this->assertEquals($first->usage->toArray(), $second->usage->toArray());
+        $this->assertEquals($first->meta->provider, $second->meta->provider);
+        $this->assertEquals($first->meta->model, $second->meta->model);
+    }
+
+    public function test_streaming_responses_are_not_cached(): void
+    {
+        AssistantAgent::fake([
+            'First stream',
+            'Second stream',
+        ]);
+
+        $agent = (new AssistantAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $first = $agent->stream('Hello');
+        $first->each(fn () => true);
+
+        $second = $agent->stream('Hello');
+        $second->each(fn () => true);
+
+        $this->assertEquals('First stream', $first->text);
+        $this->assertEquals('Second stream', $second->text);
+    }
+
+    public function test_structured_responses_are_cached(): void
+    {
+        StructuredAgent::fake([
+            ['symbol' => 'Au'],
+            ['symbol' => 'Ag'],
+        ]);
+
+        $agent = (new StructuredAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $first = $agent->prompt('What is gold?');
+        $second = $agent->prompt('What is gold?');
+
+        $this->assertInstanceOf(StructuredAgentResponse::class, $first);
+        $this->assertInstanceOf(StructuredAgentResponse::class, $second);
+        $this->assertEquals('Au', $first['symbol']);
+        $this->assertEquals('Au', $second['symbol']);
+    }
+
+    public function test_then_callback_works_on_cached_response(): void
+    {
+        AssistantAgent::fake([
+            'Response',
+        ]);
+
+        $agent = (new AssistantAgent)->withMiddleware([new CacheResponse(store: 'array')]);
+
+        $callbackText = null;
+
+        $agent->prompt('Hello')->then(function ($response) use (&$callbackText) {
+            $callbackText = $response->text;
+        });
+
+        $this->assertEquals('Response', $callbackText);
+
+        $cachedCallbackText = null;
+
+        $agent->prompt('Hello')->then(function ($response) use (&$cachedCallbackText) {
+            $cachedCallbackText = $response->text;
+        });
+
+        $this->assertEquals('Response', $cachedCallbackText);
+    }
+}


### PR DESCRIPTION
This PR adds a `CacheResponse` middleware that caches `AgentResponse` and `StructuredAgentResponse` 
  objects, avoiding redundant API calls for identical prompts. Similar to the existing embeddings     
  caching, but implemented as opt-in middleware per agent following the existing middleware pattern.  
                                                                                                      
  ```php                                                                                              
  class MyAgent implements Agent, HasMiddleware                                                       
  {
      use Promptable;

      public function middleware(): array
      {
          return [
              new CacheResponse(seconds: 3600, store: 'redis'),
          ];
      }
  }
  ```

  Cache keys are deterministic SHA256 hashes of the agent class, provider, model, instructions, and
  prompt text. Streaming responses pass through uncached. Cached responses are restored with a fresh
  invocation ID.

  This PR also includes the fix from #100 as it is required for short-circuiting middleware to work
  correctly.
