### PR TITLE
Adds missing Tool import to stubs

### DIFF
--- a/stubs/agent.stub
+++ b/stubs/agent.stub
@@ -5,6 +5,7 @@ namespace {{ namespace }};
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Promptable;
 use Stringable;
 

--- a/stubs/structured-agent.stub
+++ b/stubs/structured-agent.stub
@@ -7,6 +7,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Promptable;
 use Stringable;
 


### PR DESCRIPTION
Adds the missing `Tool` import to the stubs, which is referenced in the phpdoc of `tools()`.