### PR TITLE
Fix: Read timeout from provider config as fallback

### DIFF
--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -224,7 +224,35 @@ trait Promptable
             return $attributes[0]->newInstance()->value;
         }
 
+        $providerName = $this->getDefaultProvider();
+
+        if ($providerName) {
+            $providerTimeout = config("ai.providers.{$providerName}.timeout");
+
+            if (! is_null($providerTimeout)) {
+                return (int) $providerTimeout;
+            }
+        }
+
         return 60;
+    }
+
+    /**
+     * Get the default provider name for this agent.
+     */
+    protected function getDefaultProvider(): ?string
+    {
+        if (method_exists($this, 'provider')) {
+            return $this->provider();
+        }
+
+        $attributes = (new ReflectionClass($this))->getAttributes(ProviderAttribute::class);
+
+        if (! empty($attributes)) {
+            return $attributes[0]->newInstance()->value;
+        }
+
+        return config('ai.default');
     }
 
     /**

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -251,11 +251,11 @@ class AgentFakeTest extends TestCase
     public function test_provider_config_timeout_works_with_stream(): void
     {
         config(['ai.providers.openai.timeout' => 133]);
-        
+
         AssistantAgent::fake();
-        
+
         (new AssistantAgent)->stream('Test prompt');
-        
+
         AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
             return $prompt->timeout === 133;
         });

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -233,4 +233,31 @@ class AgentFakeTest extends TestCase
         $this->assertEquals(150, $revised->timeout);
         $this->assertEquals('Revised prompt', $revised->prompt);
     }
+
+    public function test_timeout_from_provider_config_is_used(): void
+    {
+        config(['ai.providers.openai.timeout' => 233]);
+
+        AssistantAgent::fake();
+
+        (new AssistantAgent)->prompt('Test prompt');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->prompt === 'Test prompt'
+                && $prompt->timeout === 233;
+        });
+    }
+
+    public function test_provider_config_timeout_works_with_stream(): void
+    {
+        config(['ai.providers.openai.timeout' => 133]);
+        
+        AssistantAgent::fake();
+        
+        (new AssistantAgent)->stream('Test prompt');
+        
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->timeout === 133;
+        });
+    }
 }


### PR DESCRIPTION
## Problem
Setting `timeout` in provider config has no effect. Example:
```php
'anthropic' => [
    'driver' => 'anthropic',
    'key' => env('ANTHROPIC_API_KEY'),
    'timeout' => 180, // silently ignored
],
```

The timeout always defaults to 60 seconds regardless of this config value.

## Root Cause
The `getTimeout()` method never checked the provider config. It only checked:
1. Explicit parameter
2. `timeout()` method
3. `#[Timeout]` attribute
4. Then jumped straight to hardcoded `60`

## Solution
Added provider config as a fallback before the hardcoded default.

Now checks `config("ai.providers.{provider}.timeout")` and uses it if present.

## Testing
Added two tests confirming provider config timeout works for both `prompt()` and `stream()` methods.

Fixes #104