### PR TITLE
Add API key to provider configuration in image and audio generation

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -181,7 +181,10 @@ class PrismGateway implements Gateway
     ): ImageResponse {
         try {
             $response = Prism::image()
-                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
+                ->using(static::toPrismProvider($provider), $model, array_filter([
+                    ...$provider->additionalConfiguration(),
+                    'api_key' => $provider->providerCredentials()['key'],
+                ]))
                 ->withPrompt($prompt, $this->toPrismImageAttachments($attachments))
                 ->withProviderOptions($provider->defaultImageOptions($size, $quality))
                 ->withClientOptions([
@@ -246,7 +249,10 @@ class PrismGateway implements Gateway
 
         try {
             $response = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
+                ->using(static::toPrismProvider($provider), $model, array_filter([
+                    ...$provider->additionalConfiguration(),
+                    'api_key' => $provider->providerCredentials()['key'],
+                ]))
                 ->withInput($text)
                 ->withVoice($voice)
                 ->withProviderOptions(array_filter([
@@ -281,7 +287,10 @@ class PrismGateway implements Gateway
             }
 
             $request = Prism::audio()
-                ->using(static::toPrismProvider($provider), $model, $provider->additionalConfiguration())
+                ->using(static::toPrismProvider($provider), $model, array_filter([
+                    ...$provider->additionalConfiguration(),
+                    'api_key' => $provider->providerCredentials()['key'],
+                ]))
                 ->withInput(match (true) {
                     $audio instanceof TranscribableAudio => Audio::fromBase64(
                         base64_encode($audio->content()), $audio->mimeType()


### PR DESCRIPTION
# Fix: Support custom API keys for Image, Audio, and Transcription generation

## Problem

When using custom provider configurations with hardcoded API keys (instead of environment variables), the Image, Audio, and Transcription generation methods were failing with authentication errors.

**Example configuration that wasn't working:**
```php
// config/ai.php
'providers' => [
    'custom-openai' => [
        'driver' => 'openai',
        'key' => 'sk-proj-custom-key-here',  // Hardcoded key
    ],
]
```

```php
// Usage
Image::of('a cat')->generate('custom-openai');
// Error: OpenAI Error [401]: Missing bearer or basic authentication in header
```

The same configuration would only work if the key was set via `env('OPENAI_API_KEY')`.

## Root Cause

The `generateImage`, `generateAudio`, and `generateTranscription` methods in `PrismGateway` were only passing `$provider->additionalConfiguration()` to Prism, which doesn't include the API key. 

In contrast, the `generateText` method (via `CreatesPrismTextRequests::configure()`) was correctly passing the API key explicitly:

```php
// Text generation (working correctly)
'api_key' => $provider->providerCredentials()['key']
```

## Solution

Added explicit API key passing to all three methods, consistent with how text generation handles it:

```php
->using(static::toPrismProvider($provider), $model, array_filter([
    ...$provider->additionalConfiguration(),
    'api_key' => $provider->providerCredentials()['key'],  // ← Added this
]))
```

## Changes Made

- **PrismGateway::generateImage()**: Added explicit API key to Prism configuration
- **PrismGateway::generateAudio()**: Added explicit API key to Prism configuration  
- **PrismGateway::generateTranscription()**: Added explicit API key to Prism configuration

## Impact

This change allows users to:
1. Define multiple provider configurations using the same driver but different API keys
2. Use hardcoded API keys in configuration without relying on environment variables
3. Have consistent behavior across all generation types (text, image, audio, transcription)

**Example now working:**
```php
'providers' => [
    'openai' => [
        'driver' => 'openai',
        'key' => env('OPENAI_API_KEY'),
    ],
    'openai-project-a' => [
        'driver' => 'openai',
        'key' => 'sk-proj-key-for-project-a',
    ],
    'openai-project-b' => [
        'driver' => 'openai', 
        'key' => 'sk-proj-key-for-project-b',
    ],
]
```

```php
Image::of('prompt')->generate('openai-project-a');  // Uses project A key
Audio::of('text')->generate('openai-project-b');    // Uses project B key
```

## Backwards Compatibility

✅ Fully backwards compatible. Existing configurations using `env()` continue to work as before.
