### PR TITLE
[0.x] Add `agent()` method to the `\Laravel\Ai\Tools\Request` class

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -64,6 +65,7 @@ class PrismGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?Agent $agent = null,
     ): TextResponse {
         [$request, $structured] = [
             $this->createPrismTextRequest($provider, $model, $schema, $options, $timeout),
@@ -75,7 +77,7 @@ class PrismGateway implements Gateway
         }
 
         if (count($tools) > 0) {
-            $this->addTools($request, $tools, $options);
+            $this->addTools($request, $tools, $options, $agent);
             $this->addProviderTools($provider, $request, $tools, $options);
         }
 
@@ -123,6 +125,7 @@ class PrismGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?Agent $agent = null,
     ): Generator {
         [$request, $structured] = [
             $this->createPrismTextRequest($provider, $model, $schema, $options, $timeout),
@@ -134,7 +137,7 @@ class PrismGateway implements Gateway
         }
 
         if (count($tools) > 0) {
-            $this->addTools($request, $tools, $options);
+            $this->addTools($request, $tools, $options, $agent);
             $this->addProviderTools($provider, $request, $tools, $options);
         }
 

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -65,6 +65,7 @@ trait GeneratesText
                     $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null,
                     TextGenerationOptions::forAgent($agent),
                     $prompt->timeout,
+                    $agent,
                 );
 
                 return $agent instanceof HasStructuredOutput

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -64,6 +64,7 @@ trait StreamsText
                             null,
                             TextGenerationOptions::forAgent($agent),
                             $prompt->timeout,
+                            $agent,
                         );
                     },
                     $meta,

--- a/src/Tools/Request.php
+++ b/src/Tools/Request.php
@@ -7,12 +7,24 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
+use Laravel\Ai\Contracts\Agent;
 
 class Request implements Arrayable, ArrayAccess
 {
     use Conditionable, InteractsWithData, Macroable;
 
-    public function __construct(protected array $arguments = []) {}
+    public function __construct(
+        protected array $arguments = [],
+        protected ?Agent $agent = null
+    ) {}
+
+    /**
+     * Get the agent that is invoking the tool.
+     */
+    public function agent(): ?Agent
+    {
+        return $this->agent;
+    }
 
     /**
      * @param  array<array-key, string>|array-key|null  $keys

--- a/tests/Feature/Agents/ToolUsingNonStructuredOutputAgent.php
+++ b/tests/Feature/Agents/ToolUsingNonStructuredOutputAgent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Feature\Tools\RandomNumberGenerator;
+
+class ToolUsingNonStructuredOutputAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function __construct(public bool $fixed = false, public bool $toolThrowsException = false) {}
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that generates random numbers using the tool available to you. Always use the tool to get a cryptographically secure random number.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     *
+     * @return Tool[]
+     */
+    public function tools(): iterable
+    {
+        return [
+            $this->fixed
+                ? new FixedNumberGenerator($this->toolThrowsException)
+                : new RandomNumberGenerator($this->toolThrowsException),
+        ];
+    }
+}

--- a/tests/Feature/Tools/FixedNumberGenerator.php
+++ b/tests/Feature/Tools/FixedNumberGenerator.php
@@ -8,6 +8,8 @@ use Laravel\Ai\Tools\Request;
 
 class FixedNumberGenerator implements Tool
 {
+    public static $usedAgent;
+
     public function __construct(public bool $throwsException = false) {}
 
     /**
@@ -23,6 +25,8 @@ class FixedNumberGenerator implements Tool
      */
     public function handle(Request $request): string
     {
+        static::$usedAgent = $request->agent();
+
         if ($this->throwsException) {
             throw new \Exception('Forced to throw exception.');
         }

--- a/tests/Feature/Tools/RandomNumberGenerator.php
+++ b/tests/Feature/Tools/RandomNumberGenerator.php
@@ -8,6 +8,8 @@ use Laravel\Ai\Tools\Request;
 
 class RandomNumberGenerator implements Tool
 {
+    public static $usedAgent;
+
     public function __construct(public bool $throwsException = false) {}
 
     /**
@@ -23,6 +25,8 @@ class RandomNumberGenerator implements Tool
      */
     public function handle(Request $request): string
     {
+        static::$usedAgent = $request->agent();
+
         if ($this->throwsException) {
             throw new \Exception('Forced to throw exception.');
         }


### PR DESCRIPTION
I wanted to create a tool that returns data that is limited to what the user of the current conversation can see. Currently, there is no way to do that as the tool does not have access to the agent object.

This PR fixes that by adding an `agent()` method to the `\Laravel\Ai\Tools\Request` class. I chose to give the request access to the entire agent object and not just passing the value of the `conversationUser` property on the `RemembersConversations` trait, because an agent might have other properties that you want to access in a tool.

```php
class GetBookingsByStatus implements Tool
{
    public function handle(Request $request): Stringable|string
    {
		return Booking::query()
			->where('status', $request->string('status'))
			->where('user_id', $request->agent()->conversationParticipant()->id)
			->get()
			->toJson();
	}
}
```
