### PR TITLE
fix: handle nullable usage in stream end events

### DIFF
--- a/src/Gateway/Prism/PrismUsage.php
+++ b/src/Gateway/Prism/PrismUsage.php
@@ -10,14 +10,14 @@ class PrismUsage
     /**
      * Convert the Prism usage value object to a Laravel AI SDK usage object.
      */
-    public static function toLaravelUsage(PrismUsageValueObject $usage): Usage
+    public static function toLaravelUsage(?PrismUsageValueObject $usage): Usage
     {
         return new Usage(
-            $usage->promptTokens ?: 0,
-            $usage->completionTokens ?: 0,
-            $usage->cacheWriteInputTokens ?: 0,
-            $usage->cacheReadInputTokens ?: 0,
-            $usage->thoughtTokens ?: 0,
+            $usage?->promptTokens ?: 0,
+            $usage?->completionTokens ?: 0,
+            $usage?->cacheWriteInputTokens ?: 0,
+            $usage?->cacheReadInputTokens ?: 0,
+            $usage?->thoughtTokens ?: 0,
         );
     }
 }

--- a/tests/Unit/Gateway/Prism/PrismUsageTest.php
+++ b/tests/Unit/Gateway/Prism/PrismUsageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use Laravel\Ai\Gateway\Prism\PrismUsage;
+use Laravel\Ai\Responses\Data\Usage;
+use PHPUnit\Framework\TestCase;
+use Prism\Prism\ValueObjects\Usage as PrismUsageValueObject;
+
+class PrismUsageTest extends TestCase
+{
+    public function test_converts_prism_usage_to_laravel_usage(): void
+    {
+        $prismUsage = new PrismUsageValueObject(
+            promptTokens: 100,
+            completionTokens: 50,
+            cacheWriteInputTokens: 10,
+            cacheReadInputTokens: 5,
+            thoughtTokens: 20,
+        );
+
+        $usage = PrismUsage::toLaravelUsage($prismUsage);
+
+        $this->assertInstanceOf(Usage::class, $usage);
+        $this->assertEquals(100, $usage->promptTokens);
+        $this->assertEquals(50, $usage->completionTokens);
+        $this->assertEquals(10, $usage->cacheWriteInputTokens);
+        $this->assertEquals(5, $usage->cacheReadInputTokens);
+        $this->assertEquals(20, $usage->reasoningTokens);
+    }
+
+    public function test_handles_null_usage(): void
+    {
+        $usage = PrismUsage::toLaravelUsage(null);
+
+        $this->assertInstanceOf(Usage::class, $usage);
+        $this->assertEquals(0, $usage->promptTokens);
+        $this->assertEquals(0, $usage->completionTokens);
+        $this->assertEquals(0, $usage->cacheWriteInputTokens);
+        $this->assertEquals(0, $usage->cacheReadInputTokens);
+        $this->assertEquals(0, $usage->reasoningTokens);
+    }
+}


### PR DESCRIPTION
### Problem

Prism's `StreamEndEvent` declares usage as nullable:

```php
// prism-php/prism StreamEndEvent
public ?Usage $usage = null,
```

But `PrismUsage::toLaravelUsage()` expects a non-nullable `Usage`:

```php
public static function toLaravelUsage(PrismUsageValueObject $usage): Usage
```

Prism intentionally makes usage nullable on `StreamEndEvent` because not all providers guarantee usage data in every streaming chunk (e.g. OpenRouter sends usage in a separate chunk after the finish chunk, which may not always be captured). When the stream ends without usage data, this causes:

```
TypeError: Laravel\Ai\Gateway\Prism\PrismUsage::toLaravelUsage():
Argument #1 ($usage) must be of type Prism\Prism\ValueObjects\Usage, null given
```

### Fix

Accept nullable usage and use null-safe operators:

```diff
- public static function toLaravelUsage(PrismUsageValueObject $usage): Usage
+ public static function toLaravelUsage(?PrismUsageValueObject $usage): Usage
  {
      return new Usage(
-         $usage->promptTokens ?: 0,
-         $usage->completionTokens ?: 0,
-         $usage->cacheWriteInputTokens ?: 0,
-         $usage->cacheReadInputTokens ?: 0,
-         $usage->thoughtTokens ?: 0,
+         $usage?->promptTokens ?: 0,
+         $usage?->completionTokens ?: 0,
+         $usage?->cacheWriteInputTokens ?: 0,
+         $usage?->cacheReadInputTokens ?: 0,
+         $usage?->thoughtTokens ?: 0,
      );
  }
```

When usage is null, returns a zero-value `Usage` instance. All existing non-null callers continue to work identically.
