### PR TITLE
fix: fall back to raw arguments when schema_definition key is missing

### DIFF
--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -68,7 +68,7 @@ trait AddsToolsToPrismRequests
      */
     protected function invokeTool(Tool $tool, array $arguments): string
     {
-        $arguments = $arguments['schema_definition'] ?? [];
+        $arguments = $arguments['schema_definition'] ?? $arguments;
 
         call_user_func($this->invokingToolCallback, $tool, $arguments);
 

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests;
+use Laravel\Ai\Tools\Request;
+use PHPUnit\Framework\TestCase;
+use Stringable;
+
+class AddsToolsToPrismRequestsTest extends TestCase
+{
+    public function test_invoke_tool_unwraps_schema_definition(): void
+    {
+        $tool = new class implements Tool
+        {
+            public array $receivedArguments = [];
+
+            public function description(): Stringable|string
+            {
+                return 'Test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                $this->receivedArguments = $request->all();
+
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function testInvokeTool(Tool $tool, array $arguments): string
+            {
+                return $this->invokeTool($tool, $arguments);
+            }
+        };
+
+        $handler->testInvokeTool($tool, ['schema_definition' => ['query' => 'test']]);
+
+        $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
+    }
+
+    public function test_invoke_tool_falls_back_to_raw_arguments_when_schema_definition_is_missing(): void
+    {
+        $tool = new class implements Tool
+        {
+            public array $receivedArguments = [];
+
+            public function description(): Stringable|string
+            {
+                return 'Test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                $this->receivedArguments = $request->all();
+
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function testInvokeTool(Tool $tool, array $arguments): string
+            {
+                return $this->invokeTool($tool, $arguments);
+            }
+        };
+
+        $handler->testInvokeTool($tool, ['query' => 'test']);
+
+        $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
+    }
+
+    public function test_invoke_tool_handles_empty_arguments(): void
+    {
+        $tool = new class implements Tool
+        {
+            public array $receivedArguments = [];
+
+            public function description(): Stringable|string
+            {
+                return 'Test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                $this->receivedArguments = $request->all();
+
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function testInvokeTool(Tool $tool, array $arguments): string
+            {
+                return $this->invokeTool($tool, $arguments);
+            }
+        };
+
+        $handler->testInvokeTool($tool, []);
+
+        $this->assertEquals([], $tool->receivedArguments);
+    }
+}


### PR DESCRIPTION
### Problem

During multi-step tool calling, `invokeTool()` in `AddsToolsToPrismRequests` unwraps arguments from the `schema_definition` key with a fallback to an empty array:

```php
$arguments = $arguments['schema_definition'] ?? [];
```

`ObjectSchema` wraps tool parameters under a `schema_definition` key, so the model is expected to send `{"schema_definition": {"query": "..."}}`. However, models don't always strictly follow the JSON schema wrapper — they sometimes send arguments directly: `{"query": "..."}`. When this happens, the `?? []` fallback silently discards all arguments, and the tool fails with:

```
Undefined array key "query"
```

Note: `PrismTool::toLaravelToolCall()` already handles this case with the same defensive pattern:

```php
$toolCall['arguments']['schema_definition'] ?? $toolCall['arguments'] ?? []
```

This PR aligns `invokeTool()` with that same approach.

### Fix

```diff
- $arguments = $arguments['schema_definition'] ?? [];
+ $arguments = $arguments['schema_definition'] ?? $arguments;
```
