### PR TITLE
Fix streaming generators under Octane

### DIFF
--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -26,7 +26,7 @@ trait CanStreamUsingVercelProtocol
             public ?array $lastStreamEndEvent = null;
         };
 
-        return response()->stream(function () use ($state) {
+        $stream = function () use ($state): iterable {
             $lastStreamEndEvent = null;
 
             foreach ($this as $event) {
@@ -69,6 +69,28 @@ trait CanStreamUsingVercelProtocol
             }
 
             yield "data: [DONE]\n\n";
+        };
+
+        return response()->stream(function () use ($stream): void {
+            $result = $stream();
+
+            if (! is_iterable($result)) {
+                return;
+            }
+
+            foreach ($result as $message) {
+                if (connection_aborted()) {
+                    return;
+                }
+
+                echo (string) $message;
+
+                if (ob_get_level() > 0) {
+                    ob_flush();
+                }
+
+                flush();
+            }
         }, headers: [
             'Cache-Control' => 'no-cache, no-transform',
             'Content-Type' => 'text/event-stream',

--- a/tests/Feature/StreamableAgentResponseStreamingTest.php
+++ b/tests/Feature/StreamableAgentResponseStreamingTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Testing\TestResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Tests\TestCase;
+
+class StreamableAgentResponseStreamingTest extends TestCase
+{
+    public function test_streamable_agent_response_streams_under_octane(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = '1';
+
+        try {
+            $invocationId = 'invocation-1';
+
+            $response = new StreamableAgentResponse(
+                $invocationId,
+                function () use ($invocationId): iterable {
+                    yield (new TextDelta('event-1', 'message-1', 'Hello', 123))
+                        ->withInvocationId($invocationId);
+
+                    yield (new StreamEnd('event-2', 'stop', new Usage, 124))
+                        ->withInvocationId($invocationId);
+                },
+                new Meta('test', 'model'),
+            );
+
+            $streamedResponse = $response->toResponse(request());
+
+            $testResponse = TestResponse::fromBaseResponse($streamedResponse);
+            $content = $testResponse->streamedContent();
+
+            $this->assertStringContainsString(
+                'data: {"id":"event-1","invocation_id":"invocation-1","type":"text_delta","message_id":"message-1","delta":"Hello","timestamp":123}',
+                $content
+            );
+            $this->assertStringContainsString('data: [DONE]', $content);
+        } finally {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+    }
+
+    public function test_streamable_agent_response_streams_vercel_protocol_under_octane(): void
+    {
+        $_SERVER['LARAVEL_OCTANE'] = '1';
+
+        try {
+            $invocationId = 'invocation-2';
+
+            $response = (new StreamableAgentResponse(
+                $invocationId,
+                function () use ($invocationId): iterable {
+                    yield (new StreamStart('stream-1', 'test', 'model', 123))
+                        ->withInvocationId($invocationId);
+
+                    yield (new TextDelta('event-1', 'message-1', 'Hello', 124))
+                        ->withInvocationId($invocationId);
+
+                    yield (new StreamEnd('event-2', 'stop', new Usage, 125))
+                        ->withInvocationId($invocationId);
+                },
+                new Meta('test', 'model'),
+            ))->usingVercelDataProtocol();
+
+            $streamedResponse = $response->toResponse(request());
+
+            $testResponse = TestResponse::fromBaseResponse($streamedResponse);
+            $content = $testResponse->streamedContent();
+
+            $this->assertStringContainsString(
+                'data: {"type":"start","messageId":"stream-1"}',
+                $content
+            );
+            $this->assertStringContainsString(
+                'data: {"type":"text-delta","id":"message-1","delta":"Hello"}',
+                $content
+            );
+            $this->assertStringContainsString('data: {"type":"finish"}', $content);
+            $this->assertStringContainsString('data: [DONE]', $content);
+        } finally {
+            unset($_SERVER['LARAVEL_OCTANE']);
+        }
+    }
+}

--- a/tests/Feature/StreamableAgentResponseStreamingTest.php
+++ b/tests/Feature/StreamableAgentResponseStreamingTest.php
@@ -35,12 +35,14 @@ class StreamableAgentResponseStreamingTest extends TestCase
             $streamedResponse = $response->toResponse(request());
 
             $testResponse = TestResponse::fromBaseResponse($streamedResponse);
+
             $content = $testResponse->streamedContent();
 
             $this->assertStringContainsString(
                 'data: {"id":"event-1","invocation_id":"invocation-1","type":"text_delta","message_id":"message-1","delta":"Hello","timestamp":123}',
                 $content
             );
+
             $this->assertStringContainsString('data: [DONE]', $content);
         } finally {
             unset($_SERVER['LARAVEL_OCTANE']);
@@ -70,7 +72,6 @@ class StreamableAgentResponseStreamingTest extends TestCase
             ))->usingVercelDataProtocol();
 
             $streamedResponse = $response->toResponse(request());
-
             $testResponse = TestResponse::fromBaseResponse($streamedResponse);
             $content = $testResponse->streamedContent();
 
@@ -78,10 +79,12 @@ class StreamableAgentResponseStreamingTest extends TestCase
                 'data: {"type":"start","messageId":"stream-1"}',
                 $content
             );
+
             $this->assertStringContainsString(
                 'data: {"type":"text-delta","id":"message-1","delta":"Hello"}',
                 $content
             );
+
             $this->assertStringContainsString('data: {"type":"finish"}', $content);
             $this->assertStringContainsString('data: [DONE]', $content);
         } finally {


### PR DESCRIPTION
Hello,

This PR fixes generator-returning stream callbacks under Octane being ignored, which results in an empty response body. In Laravel’s `Illuminate\Routing\ResponseFactory::stream()`, when `$_SERVER['LARAVEL_OCTANE']` is set and the callback is a generator, the callback is attached directly to `StreamedResponse` without a wrapper that iterates it. Octane doesn’t iterate the generator, so no chunks are echoed. Our fix in `StreamableAgentResponse::toResponse()` and `CanStreamUsingVercelProtocol::toVercelProtocolResponse()` consumes any iterable returned by the stream callback and echoes each chunk (with flushing), so streaming works consistently under both Octane and non-Octane runtimes. It also exits early on `connection_aborted()` to avoid unnecessary work. This mirrors the sibling PR https://github.com/laravel/mcp/pull/148.

Here’s the Octane-specific branch in laravel/framework that triggers the issue (from `src/Illuminate/Routing/ResponseFactory.php`, method stream()):

```php
if (! is_null($callback) && (new ReflectionFunction($callback))->isGenerator()) {
    if (isset($_SERVER['LARAVEL_OCTANE'])) {
        return (new StreamedResponse(
            null, $status, array_merge($headers, ['X-Accel-Buffering' => 'no'])
        ))->setCallback($callback);
    }
    return new StreamedResponse(function () use ($callback) {
        foreach ($callback() as $chunk) {
            echo $chunk;
            when(ob_get_level() > 0, fn () => ob_flush());
            flush();
        }
    }, $status, array_merge($headers, ['X-Accel-Buffering' => 'no']));
}
```

I've also included my own trait I wrote to resolve this issue in my own project to resolve this issue.

**User benefits**

- Streaming responses work under Octane when callbacks return generators/iterables.
- Behavior matches non-Octane runtimes without changing user-facing APIs.
- Applies to both the default SSE stream and the Vercel protocol stream.

**Safety**
- Only affects stream callbacks that return an iterable/generator.
- Callbacks that echo directly are unchanged; they are not wrapped or double-emitted (unless a callback both echoes and returns an iterable, which is undefined usage).

**Tests**
- Added coverage for generator return values when `$_SERVER['LARAVEL_OCTANE']` is set (default SSE).
- Added coverage for generator return values when `$_SERVER['LARAVEL_OCTANE']` is set (Vercel protocol).
- `./vendor/bin/phpunit --filter StreamableAgentResponseStreamingTest` (filtered because I think a lot of test requires a token for a service provider?)

**Other options**

We could change laravel/octane to iterate generator callbacks in `ResponseFactory::stream()`, but that’s a broader framework behavior change. This PR keeps the fix local to this transport.

**AI**

I used GPT-Codex to triage this issue and work on a fix.

```php
<?php

declare(strict_types=1);

namespace App\Concerns;

use Laravel\Ai\Responses\StreamableAgentResponse;
use Symfony\Component\HttpFoundation\StreamedResponse;

/**
 * Converts a StreamableAgentResponse into an echo-based StreamedResponse.
 *
 * StreamableAgentResponse::toResponse() produces a generator-based callback
 * that is never iterated under Octane, resulting in an empty response body.
 * This trait manually iterates the stream and echoes each SSE event, which
 * works correctly under both Octane and non-Octane environments.
 */
trait StreamsAgentResponses
{
    protected function toStreamedResponse(StreamableAgentResponse $stream): StreamedResponse
    {
        return response()->stream(function () use ($stream): void {
            foreach ($stream as $event) {
                echo 'data: '.($event)."\n\n";
                if (ob_get_level() > 0) {
                    ob_flush();
                }
                flush();
            }
            echo "data: [DONE]\n\n";
            if (ob_get_level() > 0) {
                ob_flush();
            }
            flush();
        }, 200, [
            'Content-Type' => 'text/event-stream',
        ]);
    }
}
```