### PR TITLE
Add support for anonymous users

### DIFF
--- a/src/Contracts/ConversationStore.php
+++ b/src/Contracts/ConversationStore.php
@@ -16,17 +16,17 @@ interface ConversationStore
     /**
      * Store a new conversation and return its ID.
      */
-    public function storeConversation(string|int $userId, string $title): string;
+    public function storeConversation(string|int|null $userId, string $title): string;
 
     /**
      * Store a new user message for the given conversation and return its ID.
      */
-    public function storeUserMessage(string $conversationId, string|int $userId, AgentPrompt $prompt): string;
+    public function storeUserMessage(string $conversationId, string|int|null $userId, AgentPrompt $prompt): string;
 
     /**
      * Store a new assistant message for the given conversation and return its ID.
      */
-    public function storeAssistantMessage(string $conversationId, string|int $userId, AgentPrompt $prompt, AgentResponse $response): string;
+    public function storeAssistantMessage(string $conversationId, string|int|null $userId, AgentPrompt $prompt, AgentResponse $response): string;
 
     /**
      * Get the latest messages for the given conversation.

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -31,7 +31,7 @@ class RememberConversation
             // Create conversation if necessary...
             if (! $agent->currentConversation()) {
                 $conversationId = $this->store->storeConversation(
-                    $agent->conversationParticipant()->id,
+                    $agent->conversationParticipant()?->id,
                     $this->generateTitle($prompt->prompt)
                 );
 
@@ -44,14 +44,14 @@ class RememberConversation
             // Record user message...
             $this->store->storeUserMessage(
                 $agent->currentConversation(),
-                $agent->conversationParticipant()->id,
+                $agent->conversationParticipant()?->id,
                 $prompt
             );
 
             // Record assistant message...
             $this->store->storeAssistantMessage(
                 $agent->currentConversation(),
-                $agent->conversationParticipant()->id,
+                $agent->conversationParticipant()?->id,
                 $prompt,
                 $response
             );

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -26,7 +26,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Store a new conversation and return its ID.
      */
-    public function storeConversation(string|int $userId, string $title): string
+    public function storeConversation(string|int|null $userId, string $title): string
     {
         $conversationId = (string) Str::uuid7();
 
@@ -44,7 +44,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Store a new user message for the given conversation and return its ID.
      */
-    public function storeUserMessage(string $conversationId, string|int $userId, AgentPrompt $prompt): string
+    public function storeUserMessage(string $conversationId, string|int|null $userId, AgentPrompt $prompt): string
     {
         $messageId = (string) Str::uuid7();
 
@@ -70,7 +70,7 @@ class DatabaseConversationStore implements ConversationStore
     /**
      * Store a new assistant message for the given conversation and return its ID.
      */
-    public function storeAssistantMessage(string $conversationId, string|int $userId, AgentPrompt $prompt, AgentResponse $response): string
+    public function storeAssistantMessage(string $conversationId, string|int|null $userId, AgentPrompt $prompt, AgentResponse $response): string
     {
         $messageId = (string) Str::uuid7();
 


### PR DESCRIPTION
This adds support for anonymous users by allowing the `userId` to be null.

`latestConversationId` still requries a user ID as it stands, but if you feel this should also allow `null` as a value, then I'd be happy to make the change.

As it stands, I've also left the migration as requiring a `user_id`, but if you think it would be best to update/add a new migration, then I can make that change as well (we will potentially want to make this change as the `RemembersConversations` trait allows `conversationParticipant` to return `null`)

#76 