### PR TITLE
Chore: Add unit test suite to phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,9 @@
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     cacheDirectory=".phpunit.cache">
     <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>


### PR DESCRIPTION
This PR adds the Unit test suite configuration block to phpunit.xml.dist, enabling PHPUnit to discover and run the existing unit tests in tests/Unit/

Files Changed:
- phpunit.xml.dist
