### PR TITLE
Fix message ordering to use created_at

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -102,7 +102,7 @@ class DatabaseConversationStore implements ConversationStore
     {
         return DB::table('agent_conversation_messages')
             ->where('conversation_id', $conversationId)
-            ->orderByDesc('id')
+            ->latest()
             ->limit($limit)
             ->get()
             ->reverse()


### PR DESCRIPTION
Fix message ordering to use created_at instead of UUID string column

The getLatestConversationMessages method was ordering by the id column, which stores UUID7 values as string(36). While UUID7 is time-ordered, lexicographic string comparison may produce incorrect results depending on the database engine or collation. Use Laravel's latest() to order by created_at instead, consistent with how latestConversationId already orders by timestamp.