### PR TITLE
Fix undefined array key error in queued agent assertions

### DIFF
--- a/src/Concerns/InteractsWithFakeAgents.php
+++ b/src/Concerns/InteractsWithFakeAgents.php
@@ -105,7 +105,7 @@ trait InteractsWithFakeAgents
         return $this->assertAgentWasPrompted(
             $agent,
             $callback,
-            $this->recordedQueuedPrompts[$agent],
+            $this->recordedQueuedPrompts[$agent] ?? [],
             'An expected queued prompt was not received.'
         );
     }
@@ -141,7 +141,7 @@ trait InteractsWithFakeAgents
         return $this->assertAgentNotPrompted(
             $agent,
             $callback,
-            $this->recordedQueuedPrompts[$agent],
+            $this->recordedQueuedPrompts[$agent] ?? [],
             'An unexpected queued prompt was received.'
         );
     }

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -164,6 +164,27 @@ class AgentFakeTest extends TestCase
         AssistantAgent::assertNeverQueued();
     }
 
+    public function test_assert_queued_does_not_throw_undefined_key_when_agent_was_never_queued()
+    {
+        AssistantAgent::fake();
+
+        // Should fail the assertion gracefully, not throw an undefined array key error.
+        try {
+            AssistantAgent::assertQueued('Some prompt');
+            $this->fail('Expected assertion to fail.');
+        } catch (\PHPUnit\Framework\AssertionFailedError $e) {
+            $this->assertStringContainsString('An expected queued prompt was not received.', $e->getMessage());
+        }
+    }
+
+    public function test_assert_not_queued_does_not_throw_undefined_key_when_agent_was_never_queued()
+    {
+        AssistantAgent::fake();
+
+        // Should pass gracefully since the agent was never queued.
+        AssistantAgent::assertNotQueued('Some prompt');
+    }
+
     public function test_fake_closures_can_throw_exceptions()
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Both assertAgentWasQueued and assertAgentNotQueued accessed $this->recordedQueuedPrompts[$agent] without checking if the key exists, causing an "Undefined array key" error when the agent was never queued. 

This PR adds the ?? [] fallback to match the pattern already used by the other assertion methods.