### PR TITLE
Fix typos in AiManager DocBlocks

### DIFF
--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -276,7 +276,7 @@ class AiManager extends MultipleInstanceManager
     }
 
     /**
-     * Create an Eleven Labs powered instance.
+     * Create an ElevenLabs powered instance.
      */
     public function createElevenDriver(array $config): ElevenLabsProvider
     {
@@ -287,7 +287,7 @@ class AiManager extends MultipleInstanceManager
     }
 
     /**
-     * Create an Gemini powered instance.
+     * Create a Gemini powered instance.
      */
     public function createGeminiDriver(array $config): GeminiProvider
     {
@@ -299,7 +299,7 @@ class AiManager extends MultipleInstanceManager
     }
 
     /**
-     * Create an Groq powered instance.
+     * Create a Groq powered instance.
      */
     public function createGroqDriver(array $config): GroqProvider
     {


### PR DESCRIPTION
## 📝 Summary

This PR fixes minor grammatical and naming issues in the DocBlock comments in `src/AiManager.php`.

It corrects the usage of the indefinite article before provider names and aligns the ElevenLabs name with its official casing.

## 🛠️ Changes

- **src/AiManager.php**
  - Line 279: Changed `Create an Eleven Labs powered instance.` to `Create an ElevenLabs powered instance.`
  - Line 290: Changed `Create an Gemini powered instance.` to `Create a Gemini powered instance.`
  - Line 302: Changed `Create an Groq powered instance.` to `Create a Groq powered instance.`

## 🔗 Related Issue

N/A (documentation-only fix)

## 📋 Checklist

- [x] I have read the contribution guidelines.
- [x] I have verified that my changes are documentation-only and introduce no functional changes.
- [x] I have ensured the comments follow the project’s coding standards.
