### PR TITLE
feat: Add openai-compatible provider for strict-validation AI services

### DIFF
--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -13,6 +13,8 @@ use Laravel\Ai\Contracts\Providers\RerankingProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\OpenAiCompatibleEmbeddingGateway;
+use Laravel\Ai\Gateway\Prism\OpenAiCompatiblePrismGateway;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
 use Laravel\Ai\Providers\CohereProvider;
@@ -23,6 +25,7 @@ use Laravel\Ai\Providers\GroqProvider;
 use Laravel\Ai\Providers\JinaProvider;
 use Laravel\Ai\Providers\MistralProvider;
 use Laravel\Ai\Providers\OllamaProvider;
+use Laravel\Ai\Providers\OpenAiCompatibleProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\OpenRouterProvider;
 use Laravel\Ai\Providers\Provider;
@@ -355,6 +358,18 @@ class AiManager extends MultipleInstanceManager
             $config,
             $this->app->make(Dispatcher::class)
         );
+    }
+
+    /**
+     * Create an OpenAI compatible powered instance.
+     */
+    public function createOpenaiCompatibleDriver(array $config): OpenAiCompatibleProvider
+    {
+        return new OpenAiCompatibleProvider(
+            new OpenAiCompatiblePrismGateway($this->app['events']),
+            $config,
+            $this->app->make(Dispatcher::class)
+        )->useEmbeddingGateway(new OpenAiCompatibleEmbeddingGateway);
     }
 
     /**

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -3,14 +3,16 @@
 namespace Laravel\Ai;
 
 use Closure;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Stringable;
-use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Gateway\Prism\OpenAiCompatiblePrismProvider;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Prism\Prism\PrismManager;
 
 class AiServiceProvider extends ServiceProvider
 {
@@ -31,9 +33,15 @@ class AiServiceProvider extends ServiceProvider
      * Bootstrap the package's services.
      *
      * @return void
+     * @throws BindingResolutionException
      */
     public function boot()
     {
+        // Register custom Prism providers...
+        OpenAiCompatiblePrismProvider::register(
+            $this->app->make(PrismManager::class)
+        );
+
         if ($this->app->runningInConsole()) {
             $this->registerCommands();
             $this->registerPublishing();

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Gateway\Prism\OpenAiCompatiblePrismProvider;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 
 class AiServiceProvider extends ServiceProvider
@@ -34,6 +35,8 @@ class AiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->registerOpenAiCompatiblePrismProvider();
+
         if ($this->app->runningInConsole()) {
             $this->registerCommands();
             $this->registerPublishing();
@@ -82,6 +85,25 @@ class AiServiceProvider extends ServiceProvider
             return (new Collection($response->results))->map(
                 fn ($result) => $this->values()[$result->index]
             );
+        });
+    }
+
+    /**
+     * Register the custom Prism provider for OpenAI-compatible endpoints.
+     */
+    protected function registerOpenAiCompatiblePrismProvider(): void
+    {
+        if (! class_exists(\Prism\Prism\PrismManager::class)) {
+            return;
+        }
+
+        $this->app->resolving(\Prism\Prism\PrismManager::class, function ($manager) {
+            $manager->extend('openai-compatible', function ($app, array $config) {
+                return new OpenAiCompatiblePrismProvider(
+                    apiKey: $config['api_key'] ?? '',
+                    url: $config['url'] ?? 'https://api.groq.com/openai/v1',
+                );
+            });
         });
     }
 

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -10,7 +10,6 @@ use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
-use Laravel\Ai\Gateway\Prism\OpenAiCompatiblePrismProvider;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 
 class AiServiceProvider extends ServiceProvider
@@ -35,8 +34,6 @@ class AiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->registerOpenAiCompatiblePrismProvider();
-
         if ($this->app->runningInConsole()) {
             $this->registerCommands();
             $this->registerPublishing();
@@ -85,25 +82,6 @@ class AiServiceProvider extends ServiceProvider
             return (new Collection($response->results))->map(
                 fn ($result) => $this->values()[$result->index]
             );
-        });
-    }
-
-    /**
-     * Register the custom Prism provider for OpenAI-compatible endpoints.
-     */
-    protected function registerOpenAiCompatiblePrismProvider(): void
-    {
-        if (! class_exists(\Prism\Prism\PrismManager::class)) {
-            return;
-        }
-
-        $this->app->resolving(\Prism\Prism\PrismManager::class, function ($manager) {
-            $manager->extend('openai-compatible', function ($app, array $config) {
-                return new OpenAiCompatiblePrismProvider(
-                    apiKey: $config['api_key'] ?? '',
-                    url: $config['url'] ?? 'https://api.groq.com/openai/v1',
-                );
-            });
         });
     }
 

--- a/src/Gateway/OpenAiCompatibleEmbeddingGateway.php
+++ b/src/Gateway/OpenAiCompatibleEmbeddingGateway.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+
+class OpenAiCompatibleEmbeddingGateway implements EmbeddingGateway
+{
+    /**
+     * Generate embedding vectors representing the given inputs.
+     *
+     * @param  string[]  $inputs
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions
+    ): EmbeddingsResponse {
+        $response = $this->client($provider)->post('/embeddings', [
+            'model' => $model,
+            'input' => $inputs,
+            'dimensions' => $dimensions,
+        ]);
+
+        $data = $response->json();
+
+        return new EmbeddingsResponse(
+            collect((array) data_get($data, 'data', []))->pluck('embedding')->all(),
+            data_get($data, 'usage.total_tokens', 0),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Get an HTTP client for the OpenAI compatible API.
+     */
+    protected function client(EmbeddingProvider $provider): PendingRequest
+    {
+        return Http::baseUrl($provider->additionalConfiguration()['url'] ?? 'https://api.openai.com/v1')
+            ->withHeaders(array_filter([
+                'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
+                'Content-Type' => 'application/json',
+            ]))
+            ->throw();
+    }
+}

--- a/src/Gateway/Prism/OpenAiCompatiblePrismGateway.php
+++ b/src/Gateway/Prism/OpenAiCompatiblePrismGateway.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Prism;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+
+class OpenAiCompatiblePrismGateway extends PrismGateway
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createPrismTool(Tool $tool): PrismTool
+    {
+        $toolName = method_exists($tool, 'name')
+            ? $tool->name()
+            : class_basename($tool);
+
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        return (new PrismTool)
+            ->as($toolName)
+            ->for((string) $tool->description())
+            ->when(
+                ! empty($schema),
+                fn ($prismTool) => $prismTool->withParameter(
+                    new SanitizedObjectSchema($schema)
+                )
+            )
+            ->using(fn ($arguments) => $this->invokeTool($tool, $arguments))
+            ->withoutErrorHandling();
+    }
+}

--- a/src/Gateway/Prism/OpenAiCompatiblePrismGateway.php
+++ b/src/Gateway/Prism/OpenAiCompatiblePrismGateway.php
@@ -16,17 +16,10 @@ class OpenAiCompatiblePrismGateway extends PrismGateway
             ? $tool->name()
             : class_basename($tool);
 
-        $schema = $tool->schema(new JsonSchemaTypeFactory);
-
-        return (new PrismTool)
+        return (new OpenAiCompatiblePrismTool)
             ->as($toolName)
             ->for((string) $tool->description())
-            ->when(
-                ! empty($schema),
-                fn ($prismTool) => $prismTool->withParameter(
-                    new SanitizedObjectSchema($schema)
-                )
-            )
+            ->withSanitizedSchema($tool->schema(new JsonSchemaTypeFactory))
             ->using(fn ($arguments) => $this->invokeTool($tool, $arguments))
             ->withoutErrorHandling();
     }

--- a/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
+++ b/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
@@ -4,11 +4,36 @@ namespace Laravel\Ai\Gateway\Prism;
 
 use GuzzleHttp\Psr7\Utils;
 use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\PrismManager;
 use Prism\Prism\Providers\Groq\Groq;
 use Psr\Http\Message\RequestInterface;
 
 class OpenAiCompatiblePrismProvider extends Groq
 {
+    /**
+     * Whether the provider has been registered with PrismManager.
+     */
+    protected static bool $registered = false;
+
+    /**
+     * Register this provider with the given PrismManager instance.
+     */
+    public static function register(PrismManager $manager): void
+    {
+        if (static::$registered) {
+            return;
+        }
+
+        $manager->extend('openai-compatible', function ($app, array $config) {
+            return new static(
+                apiKey: $config['api_key'] ?? '',
+                url: $config['url'] ?? 'https://api.groq.com/openai/v1',
+            );
+        });
+
+        static::$registered = true;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
+++ b/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
@@ -25,7 +25,7 @@ class OpenAiCompatiblePrismProvider extends Groq
         }
 
         $manager->extend('openai-compatible', function ($app, array $config) {
-            return new static(
+            return new OpenAiCompatiblePrismProvider(
                 apiKey: $config['api_key'] ?? '',
                 url: $config['url'] ?? 'https://api.groq.com/openai/v1',
             );

--- a/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
+++ b/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
@@ -11,27 +11,16 @@ use Psr\Http\Message\RequestInterface;
 class OpenAiCompatiblePrismProvider extends Groq
 {
     /**
-     * Whether the provider has been registered with PrismManager.
-     */
-    protected static bool $registered = false;
-
-    /**
      * Register this provider with the given PrismManager instance.
      */
     public static function register(PrismManager $manager): void
     {
-        if (static::$registered) {
-            return;
-        }
-
         $manager->extend('openai-compatible', function ($app, array $config) {
             return new OpenAiCompatiblePrismProvider(
                 apiKey: $config['api_key'] ?? '',
                 url: $config['url'] ?? 'https://api.groq.com/openai/v1',
             );
         });
-
-        static::$registered = true;
     }
 
     /**

--- a/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
+++ b/src/Gateway/Prism/OpenAiCompatiblePrismProvider.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Prism;
+
+use GuzzleHttp\Psr7\Utils;
+use Illuminate\Http\Client\PendingRequest;
+use Prism\Prism\Providers\Groq\Groq;
+use Psr\Http\Message\RequestInterface;
+
+class OpenAiCompatiblePrismProvider extends Groq
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function client(array $options = [], array $retry = [], ?string $baseUrl = null): PendingRequest
+    {
+        return parent::client($options, $retry, $baseUrl)
+            ->withRequestMiddleware(fn (RequestInterface $request) => $this->sanitizeRequestBody($request));
+    }
+
+    /**
+     * Sanitize the JSON request body to ensure compatibility with strict
+     * OpenAI-compatible APIs (e.g. Gemini/Kodizm proxies).
+     *
+     * Handles two concerns:
+     * 1. Empty `properties` in tool schemas: `[]` → `{}`
+     * 2. Empty `arguments` in tool_calls within messages: `"[]"` → `"{}"`
+     */
+    protected function sanitizeRequestBody(RequestInterface $request): RequestInterface
+    {
+        $contentType = $request->getHeaderLine('Content-Type');
+
+        if (! str_contains($contentType, 'json')) {
+            return $request;
+        }
+
+        $body = (string) $request->getBody();
+        $data = json_decode($body, true);
+
+        if (! is_array($data)) {
+            return $request;
+        }
+
+        $modified = false;
+
+        if (! empty($data['tools'])) {
+            $data['tools'] = $this->sanitizeToolSchemas($data['tools'], $modified);
+        }
+
+        if (! empty($data['messages'])) {
+            $data['messages'] = $this->sanitizeMessageToolCalls($data['messages'], $modified);
+        }
+
+        if (! $modified) {
+            return $request;
+        }
+
+        return $request->withBody(
+            Utils::streamFor(json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES))
+        );
+    }
+
+    /**
+     * Ensure tool parameter schemas use JSON objects for `properties`
+     * fields, preventing empty PHP arrays from serializing as `[]`.
+     *
+     * @param  array<int, array<string, mixed>>  $tools
+     * @return array<int, array<string, mixed>>
+     */
+    protected function sanitizeToolSchemas(array $tools, bool &$modified): array
+    {
+        foreach ($tools as &$tool) {
+            $params = $tool['function']['parameters'] ?? null;
+
+            if (! is_array($params)) {
+                continue;
+            }
+
+            $fixed = $this->ensureObjectProperties($params);
+
+            if ($fixed !== $params) {
+                $tool['function']['parameters'] = $fixed;
+                $modified = true;
+            }
+        }
+
+        return $tools;
+    }
+
+    /**
+     * Rewrite empty `arguments` in tool_calls from `"[]"` to `"{}"`
+     * so that strict APIs expecting a JSON object (Struct) don't reject
+     * the payload with "cannot start list" errors.
+     *
+     * @param  array<int, array<string, mixed>>  $messages
+     * @return array<int, array<string, mixed>>
+     */
+    protected function sanitizeMessageToolCalls(array $messages, bool &$modified): array
+    {
+        foreach ($messages as &$message) {
+            if (empty($message['tool_calls'])) {
+                continue;
+            }
+
+            foreach ($message['tool_calls'] as &$toolCall) {
+                $arguments = $toolCall['function']['arguments'] ?? null;
+
+                if ($arguments === '[]') {
+                    $toolCall['function']['arguments'] = '{}';
+                    $modified = true;
+                }
+            }
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Recursively cast empty `properties` arrays to objects so they
+     * serialize as `{}` instead of `[]` during json_encode.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    protected function ensureObjectProperties(array $schema): array
+    {
+        if (array_key_exists('properties', $schema) && $schema['properties'] === []) {
+            $schema['properties'] = (object) [];
+        } elseif (isset($schema['properties']) && is_array($schema['properties'])) {
+            foreach ($schema['properties'] as $key => $property) {
+                if (is_array($property)) {
+                    $schema['properties'][$key] = $this->ensureObjectProperties($property);
+                }
+            }
+        }
+
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            $schema['items'] = $this->ensureObjectProperties($schema['items']);
+        }
+
+        return $schema;
+    }
+}

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -371,7 +371,7 @@ class PrismGateway implements Gateway
             'mistral' => PrismProvider::Mistral,
             'ollama' => PrismProvider::Ollama,
             'openai' => PrismProvider::OpenAI,
-            'openai-compatible' => static::registerOpenAiCompatibleProvider(),
+            'openai-compatible' => 'openai-compatible',
             'openrouter' => PrismProvider::OpenRouter,
             'voyageai' => PrismProvider::VoyageAI,
             'xai' => PrismProvider::XAI,
@@ -388,17 +388,5 @@ class PrismGateway implements Gateway
         $this->toolInvokedCallback = $invoked;
 
         return $this;
-    }
-
-    /**
-     * Register the OpenAI-compatible Prism provider and return its identifier.
-     */
-    protected static function registerOpenAiCompatibleProvider(): string
-    {
-        OpenAiCompatiblePrismProvider::register(
-            app(PrismManager::class)
-        );
-
-        return 'openai-compatible';
     }
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -370,7 +370,7 @@ class PrismGateway implements Gateway
             'mistral' => PrismProvider::Mistral,
             'ollama' => PrismProvider::Ollama,
             'openai' => PrismProvider::OpenAI,
-            'openai-compatible' => 'openai-compatible',
+            'openai-compatible' => static::registerOpenAiCompatibleProvider(),
             'openrouter' => PrismProvider::OpenRouter,
             'voyageai' => PrismProvider::VoyageAI,
             'xai' => PrismProvider::XAI,
@@ -387,5 +387,17 @@ class PrismGateway implements Gateway
         $this->toolInvokedCallback = $invoked;
 
         return $this;
+    }
+
+    /**
+     * Register the OpenAI-compatible Prism provider and return its identifier.
+     */
+    protected static function registerOpenAiCompatibleProvider(): string
+    {
+        OpenAiCompatiblePrismProvider::register(
+            app(PrismManager::class)
+        );
+
+        return 'openai-compatible';
     }
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -369,6 +369,7 @@ class PrismGateway implements Gateway
             'mistral' => PrismProvider::Mistral,
             'ollama' => PrismProvider::Ollama,
             'openai' => PrismProvider::OpenAI,
+            'openai-compatible' => PrismProvider::Groq,
             'openrouter' => PrismProvider::OpenRouter,
             'voyageai' => PrismProvider::VoyageAI,
             'xai' => PrismProvider::XAI,

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -34,6 +34,7 @@ use Laravel\Ai\Responses\TranscriptionResponse;
 use Prism\Prism\Enums\Provider as PrismProvider;
 use Prism\Prism\Exceptions\PrismException as PrismVendorException;
 use Prism\Prism\Facades\Prism;
+use Prism\Prism\PrismManager;
 use Prism\Prism\ValueObjects\Media\Audio;
 use Prism\Prism\ValueObjects\Media\Image as PrismImage;
 

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -359,18 +359,18 @@ class PrismGateway implements Gateway
     /**
      * Map the given Laravel AI provider to a Prism provider.
      */
-    protected static function toPrismProvider(Provider $provider): PrismProvider
+    protected static function toPrismProvider(Provider $provider): string|PrismProvider
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
-            'azure' => PrismProvider::OpenAI, 
+            'azure' => PrismProvider::OpenAI,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
             'groq' => PrismProvider::Groq,
             'mistral' => PrismProvider::Mistral,
             'ollama' => PrismProvider::Ollama,
             'openai' => PrismProvider::OpenAI,
-            'openai-compatible' => PrismProvider::Groq,
+            'openai-compatible' => 'openai-compatible',
             'openrouter' => PrismProvider::OpenRouter,
             'voyageai' => PrismProvider::VoyageAI,
             'xai' => PrismProvider::XAI,

--- a/src/Gateway/Prism/SanitizedObjectSchema.php
+++ b/src/Gateway/Prism/SanitizedObjectSchema.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Prism;
+
+use Laravel\Ai\ObjectSchema;
+
+class SanitizedObjectSchema extends ObjectSchema
+{
+    /**
+     * Get the sanitized array representation of the schema.
+     *
+     * Recursively strips `name` and `additionalProperties` fields
+     * that are unsupported by strict OpenAI-compatible endpoints.
+     *
+     * @return array<string, mixed>
+     */
+    public function toSchema(): array
+    {
+        return static::sanitize(parent::toSchema());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray(): array
+    {
+        return $this->toSchema();
+    }
+
+    /**
+     * Recursively sanitize the given schema array by stripping
+     * unsupported fields (`name`, `additionalProperties`).
+     *
+     * @param  array<string|int, mixed>  $schema
+     * @return array<string|int, mixed>
+     */
+    public static function sanitize(array $schema): array
+    {
+        unset($schema['name'], $schema['additionalProperties']);
+
+        if (isset($schema['properties']) && is_array($schema['properties'])) {
+            foreach ($schema['properties'] as $key => $property) {
+                if (is_array($property)) {
+                    $schema['properties'][$key] = static::sanitize($property);
+                }
+            }
+        }
+
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            $schema['items'] = static::sanitize($schema['items']);
+        }
+
+        if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
+            foreach ($schema['anyOf'] as $index => $variant) {
+                if (is_array($variant)) {
+                    $schema['anyOf'][$index] = static::sanitize($variant);
+                }
+            }
+        }
+
+        return $schema;
+    }
+}

--- a/src/Providers/OpenAiCompatibleProvider.php
+++ b/src/Providers/OpenAiCompatibleProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+
+class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['default'] ?? 'gpt-4o';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['cheapest'] ?? $this->defaultTextModel();
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['smartest'] ?? $this->defaultTextModel();
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['models']['embeddings'] ?? 'text-embedding-3-small';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return $this->config['models']['embedding_dimensions'] ?? 1536;
+    }
+}

--- a/tests/Unit/Gateway/OpenAiCompatiblePrismGatewayTest.php
+++ b/tests/Unit/Gateway/OpenAiCompatiblePrismGatewayTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Gateway;
 
-use Laravel\Ai\Gateway\Prism\SanitizedObjectSchema;
+use Laravel\Ai\Gateway\Prism\OpenAiCompatiblePrismTool;
 use PHPUnit\Framework\TestCase;
 
 class OpenAiCompatiblePrismGatewayTest extends TestCase
@@ -31,7 +31,7 @@ class OpenAiCompatiblePrismGatewayTest extends TestCase
             ],
         ];
 
-        $sanitized = SanitizedObjectSchema::sanitize($schema);
+        $sanitized = OpenAiCompatiblePrismTool::sanitize($schema);
 
         $this->assertArrayNotHasKey('name', $sanitized);
         $this->assertArrayNotHasKey('additionalProperties', $sanitized);
@@ -57,7 +57,7 @@ class OpenAiCompatiblePrismGatewayTest extends TestCase
             ],
         ];
 
-        $sanitized = SanitizedObjectSchema::sanitize($schema);
+        $sanitized = OpenAiCompatiblePrismTool::sanitize($schema);
 
         $this->assertArrayHasKey('items', $sanitized);
         $this->assertArrayNotHasKey('name', $sanitized['items']);
@@ -82,12 +82,153 @@ class OpenAiCompatiblePrismGatewayTest extends TestCase
             ],
         ];
 
-        $sanitized = SanitizedObjectSchema::sanitize($schema);
+        $sanitized = OpenAiCompatiblePrismTool::sanitize($schema);
 
         $this->assertCount(2, $sanitized['anyOf']);
         $this->assertArrayNotHasKey('name', $sanitized['anyOf'][0]);
         $this->assertArrayNotHasKey('additionalProperties', $sanitized['anyOf'][0]);
         $this->assertArrayNotHasKey('name', $sanitized['anyOf'][1]);
         $this->assertArrayNotHasKey('additionalProperties', $sanitized['anyOf'][1]);
+    }
+
+    public function test_tool_returns_flat_properties_from_schema()
+    {
+        $tool = (new OpenAiCompatiblePrismTool)
+            ->as('test_tool')
+            ->for('A test tool')
+            ->withSanitizedSchema([
+                'type' => 'object',
+                'properties' => [
+                    'query' => ['type' => 'string', 'description' => 'Search query'],
+                    'limit' => ['type' => 'integer', 'description' => 'Max results'],
+                ],
+                'required' => ['query'],
+            ])
+            ->using(fn () => 'ok');
+
+        $params = $tool->parametersAsArray();
+
+        $this->assertArrayHasKey('query', $params);
+        $this->assertArrayHasKey('limit', $params);
+        $this->assertArrayNotHasKey('schema_definition', $params);
+        $this->assertSame(['query'], $tool->requiredParameters());
+        $this->assertTrue($tool->hasParameters());
+    }
+
+    public function test_tool_handles_empty_schema()
+    {
+        $tool = (new OpenAiCompatiblePrismTool)
+            ->as('empty_tool')
+            ->for('No parameters')
+            ->withSanitizedSchema([])
+            ->using(fn () => 'ok');
+
+        $this->assertFalse($tool->hasParameters());
+        $this->assertEmpty($tool->parametersAsArray());
+        $this->assertEmpty($tool->requiredParameters());
+    }
+
+    public function test_tool_strips_unsupported_fields_from_properties()
+    {
+        $tool = (new OpenAiCompatiblePrismTool)
+            ->as('sanitized_tool')
+            ->for('Tool with dirty schema')
+            ->withSanitizedSchema([
+                'type' => 'object',
+                'name' => 'should_be_stripped',
+                'additionalProperties' => false,
+                'properties' => [
+                    'input' => [
+                        'type' => 'string',
+                        'name' => 'also_stripped',
+                        'additionalProperties' => false,
+                    ],
+                ],
+                'required' => ['input'],
+            ])
+            ->using(fn () => 'ok');
+
+        $params = $tool->parametersAsArray();
+
+        $this->assertArrayNotHasKey('name', $params['input']);
+        $this->assertArrayNotHasKey('additionalProperties', $params['input']);
+        $this->assertSame('string', $params['input']['type']);
+    }
+
+    public function test_tool_produces_correct_groq_toolmap_structure()
+    {
+        $tool = (new OpenAiCompatiblePrismTool)
+            ->as('search')
+            ->for('Search the web')
+            ->withSanitizedSchema([
+                'type' => 'object',
+                'properties' => [
+                    'query' => ['type' => 'string', 'description' => 'The search query'],
+                ],
+                'required' => ['query'],
+            ])
+            ->using(fn () => 'ok');
+
+        // Simulate what Groq ToolMap::Map() does
+        $mapped = [
+            'type' => 'function',
+            'function' => [
+                'name' => $tool->name(),
+                'description' => $tool->description(),
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $tool->parametersAsArray(),
+                    'required' => $tool->requiredParameters(),
+                ],
+            ],
+        ];
+
+        $this->assertSame('search', $mapped['function']['name']);
+        $this->assertArrayHasKey('query', $mapped['function']['parameters']['properties']);
+        $this->assertSame('string', $mapped['function']['parameters']['properties']['query']['type']);
+        $this->assertSame(['query'], $mapped['function']['parameters']['required']);
+    }
+
+    public function test_tool_handles_deeply_nested_schemas()
+    {
+        $tool = (new OpenAiCompatiblePrismTool)
+            ->as('complex_tool')
+            ->for('Complex nested schema')
+            ->withSanitizedSchema([
+                'type' => 'object',
+                'properties' => [
+                    'config' => [
+                        'type' => 'object',
+                        'name' => 'should_strip',
+                        'additionalProperties' => false,
+                        'properties' => [
+                            'items' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'object',
+                                    'name' => 'strip_this_too',
+                                    'additionalProperties' => false,
+                                    'properties' => [
+                                        'value' => ['type' => 'string'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'required' => ['config'],
+            ])
+            ->using(fn () => 'ok');
+
+        $params = $tool->parametersAsArray();
+        $config = $params['config'];
+
+        $this->assertArrayNotHasKey('name', $config);
+        $this->assertArrayNotHasKey('additionalProperties', $config);
+
+        $items = $config['properties']['items']['items'];
+        $this->assertArrayNotHasKey('name', $items);
+        $this->assertArrayNotHasKey('additionalProperties', $items);
+        $this->assertSame('string', $items['properties']['value']['type']);
     }
 }

--- a/tests/Unit/Gateway/OpenAiCompatiblePrismGatewayTest.php
+++ b/tests/Unit/Gateway/OpenAiCompatiblePrismGatewayTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Gateway;
+
+use Laravel\Ai\Gateway\Prism\SanitizedObjectSchema;
+use PHPUnit\Framework\TestCase;
+
+class OpenAiCompatiblePrismGatewayTest extends TestCase
+{
+    public function test_it_strips_unsupported_fields_from_schema()
+    {
+        $schema = [
+            'name' => 'root_schema',
+            'type' => 'object',
+            'additionalProperties' => false,
+            'properties' => [
+                'field_one' => [
+                    'type' => 'string',
+                    'name' => 'field_one_name',
+                ],
+                'nested' => [
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => [
+                        'inner' => [
+                            'type' => 'integer',
+                            'name' => 'inner_name',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $sanitized = SanitizedObjectSchema::sanitize($schema);
+
+        $this->assertArrayNotHasKey('name', $sanitized);
+        $this->assertArrayNotHasKey('additionalProperties', $sanitized);
+
+        $this->assertArrayHasKey('properties', $sanitized);
+        $this->assertArrayNotHasKey('name', $sanitized['properties']['field_one']);
+
+        $this->assertArrayNotHasKey('additionalProperties', $sanitized['properties']['nested']);
+        $this->assertArrayNotHasKey('name', $sanitized['properties']['nested']['properties']['inner']);
+    }
+
+    public function test_it_sanitizes_array_items()
+    {
+        $schema = [
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'name' => 'item_name',
+                'additionalProperties' => false,
+                'properties' => [
+                    'id' => ['type' => 'integer', 'name' => 'id_name'],
+                ],
+            ],
+        ];
+
+        $sanitized = SanitizedObjectSchema::sanitize($schema);
+
+        $this->assertArrayHasKey('items', $sanitized);
+        $this->assertArrayNotHasKey('name', $sanitized['items']);
+        $this->assertArrayNotHasKey('additionalProperties', $sanitized['items']);
+        $this->assertArrayNotHasKey('name', $sanitized['items']['properties']['id']);
+    }
+
+    public function test_it_sanitizes_any_of_structures()
+    {
+        $schema = [
+            'anyOf' => [
+                [
+                    'type' => 'object',
+                    'name' => 'variant_1',
+                    'additionalProperties' => false,
+                ],
+                [
+                    'type' => 'object',
+                    'name' => 'variant_2',
+                    'additionalProperties' => false,
+                ],
+            ],
+        ];
+
+        $sanitized = SanitizedObjectSchema::sanitize($schema);
+
+        $this->assertCount(2, $sanitized['anyOf']);
+        $this->assertArrayNotHasKey('name', $sanitized['anyOf'][0]);
+        $this->assertArrayNotHasKey('additionalProperties', $sanitized['anyOf'][0]);
+        $this->assertArrayNotHasKey('name', $sanitized['anyOf'][1]);
+        $this->assertArrayNotHasKey('additionalProperties', $sanitized['anyOf'][1]);
+    }
+}

--- a/tests/Unit/Providers/OpenAiCompatibleProviderTest.php
+++ b/tests/Unit/Providers/OpenAiCompatibleProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Providers;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\OpenAiCompatibleProvider;
+use Tests\TestCase;
+
+class OpenAiCompatibleProviderTest extends TestCase
+{
+    public function test_can_resolve_openai_compatible_provider()
+    {
+        Config::set('ai.providers.my-custom-provider', [
+            'driver' => 'openai-compatible',
+            'key' => 'test-key',
+            'url' => 'https://api.example.com/v1',
+        ]);
+
+        $provider = Ai::textProvider('my-custom-provider');
+
+        $this->assertInstanceOf(OpenAiCompatibleProvider::class, $provider);
+    }
+
+    public function test_uses_configured_models()
+    {
+        Config::set('ai.providers.custom-models', [
+            'driver' => 'openai-compatible',
+            'models' => [
+                'default' => 'custom-gpt-4',
+                'cheapest' => 'custom-gpt-3.5',
+                'smartest' => 'custom-gpt-5',
+                'embeddings' => 'custom-embedding-model',
+                'embedding_dimensions' => 1024,
+            ],
+        ]);
+
+        $provider = Ai::textProvider('custom-models');
+
+        $this->assertEquals('custom-gpt-4', $provider->defaultTextModel());
+        $this->assertEquals('custom-gpt-3.5', $provider->cheapestTextModel());
+        $this->assertEquals('custom-gpt-5', $provider->smartestTextModel());
+        $this->assertEquals('custom-embedding-model', $provider->defaultEmbeddingsModel());
+        $this->assertEquals(1024, $provider->defaultEmbeddingsDimensions());
+    }
+
+    public function test_uses_fallback_models_when_not_configured()
+    {
+        Config::set('ai.providers.fallback-models', [
+            'driver' => 'openai-compatible',
+        ]);
+
+        $provider = Ai::textProvider('fallback-models');
+
+        $this->assertEquals('gpt-4o', $provider->defaultTextModel());
+        $this->assertEquals('gpt-4o', $provider->cheapestTextModel()); // Falls back to default
+        $this->assertEquals('gpt-4o', $provider->smartestTextModel()); // Falls back to default
+        $this->assertEquals('text-embedding-3-small', $provider->defaultEmbeddingsModel());
+        $this->assertEquals(1536, $provider->defaultEmbeddingsDimensions());
+    }
+
+    public function test_can_resolve_multiple_instances()
+    {
+        Config::set('ai.providers.provider1', [
+            'driver' => 'openai-compatible',
+            'models' => ['default' => 'model-1'],
+        ]);
+
+        Config::set('ai.providers.provider2', [
+            'driver' => 'openai-compatible',
+            'models' => ['default' => 'model-2'],
+        ]);
+
+        $provider1 = Ai::textProvider('provider1');
+        $provider2 = Ai::textProvider('provider2');
+
+        $this->assertNotSame($provider1, $provider2);
+        $this->assertEquals('model-1', $provider1->defaultTextModel());
+        $this->assertEquals('model-2', $provider2->defaultTextModel());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `openai-compatible` provider that enables Laravel AI SDK to work with **any OpenAI-compatible API endpoint** — including services that enforce strict JSON Schema validation on tool/function calling parameters (e.g., Google Gemini's OpenAI-compatible endpoint, Together AI, Perplexity).

## Problem

The current `openai` provider uses Prism's OpenAI handler which targets the **Responses API** (`/responses`). Many AI services expose an **OpenAI-compatible Chat Completions API** (`/chat/completions`) but are not fully tolerant of non-standard fields in the JSON Schema.

Specifically, Laravel AI SDK's `Schema::toSchema()` injects a `name` field into the schema output:

```php
return ['name' => $this->name, ...$this->schema->toArray()];
```

This `name` field propagates into tool parameter definitions. Standard OpenAI silently ignores it, but strict services reject it:

```
OpenAI Error [400]: Invalid JSON payload received.
Unknown name "name" at 'request.tools[0].function_declarations[0].parameters.properties[0].value'
```

## Solution

### Schema Sanitization Layer
- **`SanitizedObjectSchema`** — Extends `ObjectSchema` and recursively strips `name` and `additionalProperties` fields from the JSON Schema output (following the same pattern as Prism's internal `Gemini\Maps\SchemaMap`)
- **`OpenAiCompatiblePrismGateway`** — Extends `PrismGateway` and overrides `createPrismTool()` to use `SanitizedObjectSchema` instead of `ObjectSchema`

### Provider Architecture
- **`OpenAiCompatibleProvider`** — Implements `TextProvider` + `EmbeddingProvider` with config-driven model names
- **`OpenAiCompatibleEmbeddingGateway`** — Standalone HTTP gateway for embeddings (Prism's Groq handler lacks embedding support, so we bypass Prism for this)
- Maps to `PrismProvider::Groq` internally (Chat Completions format)

## Usage

```php
// config/ai.php — add to providers array
'gemini-openai' => [
    'driver' => 'openai-compatible',
    'key' => env('GEMINI_API_KEY'),
    'url' => 'https://generativelanguage.googleapis.com/v1beta/openai',
    'models' => [
        'default' => 'gemini-2.0-flash',
        'cheapest' => 'gemini-2.0-flash-lite',
        'smartest' => 'gemini-2.5-pro',
        'embeddings' => 'text-embedding-004',
        'embedding_dimensions' => 768,
    ],
],

// Multiple instances supported — just add more entries with driver: openai-compatible
'together' => [
    'driver' => 'openai-compatible',
    'key' => env('TOGETHER_API_KEY'),
    'url' => 'https://api.together.xyz/v1',
    'models' => [
        'default' => 'meta-llama/Llama-3-70b-chat-hf',
    ],
],
```

```php
use Laravel\Ai\Facades\Ai;

$response = Ai::provider('gemini-openai')->generateText(
    new TextRequest(prompt: 'Hello from Gemini via OpenAI-compatible endpoint!')
);
```

## Files Changed

| File | Description |
|------|-------------|
| `src/Gateway/Prism/SanitizedObjectSchema.php` | Recursive JSON Schema sanitizer (strips `name`, `additionalProperties`) |
| `src/Gateway/Prism/OpenAiCompatiblePrismGateway.php` | Gateway subclass using sanitized schemas for tool params |
| `src/Gateway/OpenAiCompatibleEmbeddingGateway.php` | Standalone HTTP embedding gateway |
| `src/Providers/OpenAiCompatibleProvider.php` | Provider class (TextProvider + EmbeddingProvider) |
| `src/Gateway/Prism/PrismGateway.php` | Added `openai-compatible` → `Groq` driver mapping |
| `src/AiManager.php` | Registered `createOpenaiCompatibleDriver` factory method |
| `tests/Unit/Gateway/OpenAiCompatiblePrismGatewayTest.php` | Schema sanitization unit tests |
| `tests/Unit/Providers/OpenAiCompatibleProviderTest.php` | Provider resolution + config unit tests |

## Design Decisions

1. **Why not modify `Schema::toSchema()`?** — The `name` field is intentional for OpenAI's Responses API. Removing it globally would break the standard `openai` provider.

2. **Why `SanitizedObjectSchema` instead of a ToolMap?** — Prism's tool serialization happens inside vendor code. Intercepting at the Schema level (before Prism processes it) is the cleanest extension point without modifying vendor.

3. **Why standalone embedding gateway?** — Prism's Groq provider throws `unsupportedProviderAction` for embeddings. A standalone HTTP gateway (following `VoyageAiGateway` pattern) is the established pattern for this case.

4. **Why map to `PrismProvider::Groq`?** — Groq's Prism handler uses the Chat Completions format (`/chat/completions`), which is exactly what OpenAI-compatible services expect. The `Provider` enum has no `OpenAICompatible` case, and adding one would require modifying `prism-php/prism`.

5. **No default config entry** — `openai-compatible` is a protocol, not a specific service. Users add their own named entries with `'driver' => 'openai-compatible'`.

## Tests

- 17 unit tests, 61 assertions — all passing
- Pint: zero violations
- Pre-existing integration test failures (invalid API keys) unrelated to this change