### PR TITLE
Add Bedrock provider support and related tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "laravel/serializable-closure": "^2.0",
         "prism-php/prism": "^0.99.0"
     },
+    "suggest": {
+        "prism-php/bedrock": "Required for AWS Bedrock provider support (^1.8)."
+    },
     "require-dev": {
         "laravel/pint": "^1.26",
         "mockery/mockery": "^1.6.12",

--- a/config/ai.php
+++ b/config/ai.php
@@ -55,6 +55,14 @@ return [
             'key' => env('ANTHROPIC_API_KEY'),
         ],
 
+        'bedrock' => [
+            'driver' => 'bedrock',
+            'access_key' => env('AWS_ACCESS_KEY_ID'),
+            'secret_key' => env('AWS_SECRET_ACCESS_KEY'),
+            'session_token' => env('AWS_SESSION_TOKEN'),
+            'region' => env('AWS_BEDROCK_REGION', env('AWS_DEFAULT_REGION', 'us-east-1')),
+        ],
+
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\BedrockProvider;
 use Laravel\Ai\Providers\CohereProvider;
 use Laravel\Ai\Providers\DeepSeekProvider;
 use Laravel\Ai\Providers\ElevenLabsProvider;
@@ -246,6 +247,18 @@ class AiManager extends MultipleInstanceManager
     public function createAnthropicDriver(array $config): AnthropicProvider
     {
         return new AnthropicProvider(
+            new PrismGateway($this->app['events']),
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a Bedrock powered instance.
+     */
+    public function createBedrockDriver(array $config): BedrockProvider
+    {
+        return new BedrockProvider(
             new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -359,10 +359,11 @@ class PrismGateway implements Gateway
     /**
      * Map the given Laravel AI provider to a Prism provider.
      */
-    protected static function toPrismProvider(Provider $provider): PrismProvider
+    protected static function toPrismProvider(Provider $provider): PrismProvider|string
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
+            'bedrock' => 'bedrock',
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
             'groq' => PrismProvider::Groq,

--- a/src/Providers/BedrockProvider.php
+++ b/src/Providers/BedrockProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+
+class BedrockProvider extends Provider implements EmbeddingProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    /**
+     * Get the credentials for the underlying AI provider.
+     *
+     * The prism-php/bedrock package expects `api_key` (AWS access key ID)
+     * and `api_secret` (AWS secret access key) for signing requests.
+     */
+    public function providerCredentials(): array
+    {
+        return [
+            'key' => $this->config['access_key'] ?? null,
+        ];
+    }
+
+    /**
+     * Get the provider connection configuration other than the driver, key, and name.
+     *
+     * Passes AWS-specific configuration that the Bedrock Prism provider needs:
+     * api_secret, session_token, region, and use_default_credential_provider.
+     */
+    public function additionalConfiguration(): array
+    {
+        return array_filter([
+            'api_secret' => $this->config['secret_key'] ?? null,
+            'session_token' => $this->config['session_token'] ?? null,
+            'region' => $this->config['region'] ?? 'us-east-1',
+            'use_default_credential_provider' => $this->useDefaultCredentialProvider(),
+        ]);
+    }
+
+    /**
+     * Determine if the default AWS credential provider chain should be used.
+     */
+    protected function useDefaultCredentialProvider(): bool
+    {
+        return empty($this->config['access_key']) && empty($this->config['secret_key']);
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return 'anthropic.claude-sonnet-4-5-20250929-v1:0';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return 'anthropic.claude-haiku-4-5-20251001-v1:0';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return 'anthropic.claude-opus-4-6-v1:0';
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return 'amazon.titan-embed-text-v2:0';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return 1024;
+    }
+}

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -3,15 +3,32 @@
 namespace Tests\Feature;
 
 use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\BedrockProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use LogicException;
 use Tests\TestCase;
 
 class AiManagerTest extends TestCase
 {
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('ai.providers.bedrock', [
+            'driver' => 'bedrock',
+            'name' => 'bedrock',
+            'access_key' => 'test-access-key',
+            'secret_key' => 'test-secret-key',
+            'region' => 'us-west-2',
+        ]);
+    }
+
     public function test_can_get_an_openai_provider_instance(): void
     {
         $this->assertInstanceOf(OpenAiProvider::class, Ai::textProvider('openai'));
+    }
+
+    public function test_can_get_a_bedrock_provider_instance(): void
+    {
+        $this->assertInstanceOf(BedrockProvider::class, Ai::textProvider('bedrock'));
     }
 
     public function test_provider_type_is_ensured(): void
@@ -19,5 +36,26 @@ class AiManagerTest extends TestCase
         $this->expectException(LogicException::class);
 
         Ai::audioProvider('anthropic');
+    }
+
+    public function test_bedrock_does_not_support_audio(): void
+    {
+        $this->expectException(LogicException::class);
+
+        Ai::audioProvider('bedrock');
+    }
+
+    public function test_bedrock_does_not_support_images(): void
+    {
+        $this->expectException(LogicException::class);
+
+        Ai::imageProvider('bedrock');
+    }
+
+    public function test_bedrock_does_not_support_transcription(): void
+    {
+        $this->expectException(LogicException::class);
+
+        Ai::transcriptionProvider('bedrock');
     }
 }

--- a/tests/Feature/BedrockProviderTest.php
+++ b/tests/Feature/BedrockProviderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Ai;
+use Tests\TestCase;
+
+class BedrockProviderTest extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('ai.providers.bedrock', [
+            'driver' => 'bedrock',
+            'name' => 'bedrock',
+            'access_key' => 'test-access-key',
+            'secret_key' => 'test-secret-key',
+            'session_token' => 'test-session-token',
+            'region' => 'us-west-2',
+        ]);
+    }
+
+    public function test_provider_credentials_returns_access_key(): void
+    {
+        $provider = Ai::textProvider('bedrock');
+
+        $credentials = $provider->providerCredentials();
+
+        $this->assertEquals('test-access-key', $credentials['key']);
+    }
+
+    public function test_additional_configuration_returns_aws_config(): void
+    {
+        $provider = Ai::textProvider('bedrock');
+
+        $config = $provider->additionalConfiguration();
+
+        $this->assertEquals('test-secret-key', $config['api_secret']);
+        $this->assertEquals('test-session-token', $config['session_token']);
+        $this->assertEquals('us-west-2', $config['region']);
+        $this->assertArrayNotHasKey('use_default_credential_provider', $config);
+    }
+
+    public function test_uses_default_credential_provider_when_keys_are_empty(): void
+    {
+        $this->app['config']->set('ai.providers.bedrock', [
+            'driver' => 'bedrock',
+            'name' => 'bedrock',
+            'access_key' => null,
+            'secret_key' => null,
+            'region' => 'us-east-1',
+        ]);
+
+        $provider = Ai::textProvider('bedrock');
+        $config = $provider->additionalConfiguration();
+
+        $this->assertTrue($config['use_default_credential_provider']);
+    }
+
+    public function test_does_not_use_default_credential_provider_when_keys_set(): void
+    {
+        $provider = Ai::textProvider('bedrock');
+        $config = $provider->additionalConfiguration();
+
+        $this->assertArrayNotHasKey('use_default_credential_provider', $config);
+    }
+
+    public function test_default_text_model(): void
+    {
+        $provider = Ai::textProvider('bedrock');
+
+        $this->assertEquals('anthropic.claude-sonnet-4-5-20250929-v1:0', $provider->defaultTextModel());
+    }
+
+    public function test_cheapest_text_model(): void
+    {
+        $provider = Ai::textProvider('bedrock');
+
+        $this->assertEquals('anthropic.claude-haiku-4-5-20251001-v1:0', $provider->cheapestTextModel());
+    }
+
+    public function test_smartest_text_model(): void
+    {
+        $provider = Ai::textProvider('bedrock');
+
+        $this->assertEquals('anthropic.claude-opus-4-6-v1:0', $provider->smartestTextModel());
+    }
+
+    public function test_default_embeddings_model(): void
+    {
+        $provider = Ai::embeddingProvider('bedrock');
+
+        $this->assertEquals('amazon.titan-embed-text-v2:0', $provider->defaultEmbeddingsModel());
+    }
+
+    public function test_default_embeddings_dimensions(): void
+    {
+        $provider = Ai::embeddingProvider('bedrock');
+
+        $this->assertEquals(1024, $provider->defaultEmbeddingsDimensions());
+    }
+
+    public function test_region_defaults_to_us_east_1(): void
+    {
+        $this->app['config']->set('ai.providers.bedrock', [
+            'driver' => 'bedrock',
+            'name' => 'bedrock',
+            'access_key' => 'key',
+            'secret_key' => 'secret',
+        ]);
+
+        $provider = Ai::textProvider('bedrock');
+        $config = $provider->additionalConfiguration();
+
+        $this->assertEquals('us-east-1', $config['region']);
+    }
+}


### PR DESCRIPTION
This pull request adds support for AWS Bedrock as an AI provider. It introduces a new `BedrockProvider` class, updates configuration and provider resolution to support Bedrock, and includes comprehensive tests to ensure correct integration and behavior. The changes also update dependencies and provider mapping to accommodate the new provider.

**Bedrock Provider Integration:**

* Added a new `BedrockProvider` class implementing text and embedding capabilities, with support for AWS-specific credentials and model selection. (`src/Providers/BedrockProvider.php`)
* Registered the Bedrock provider in the manager, including a `createBedrockDriver` method and required imports. (`src/AiManager.php`) [[1]](diffhunk://#diff-beecb4f7e98a80c2357fe3dce7bc76d2673d9f2caa42a082c93b2ec162ac931aR18) [[2]](diffhunk://#diff-beecb4f7e98a80c2357fe3dce7bc76d2673d9f2caa42a082c93b2ec162ac931aR256-R267)
* Updated the provider mapping in `PrismGateway` to recognize the Bedrock driver. (`src/Gateway/Prism/PrismGateway.php`)

**Configuration and Dependency Updates:**

* Added Bedrock configuration options to the AI provider config file. (`config/ai.php`)
* Updated `composer.json` to suggest the `prism-php/bedrock` package for Bedrock support. (`composer.json`)

**Testing:**

* Added a dedicated test suite for `BedrockProvider`, covering credentials, configuration, model selection, and default region logic. (`tests/Feature/BedrockProviderTest.php`)
* Updated `AiManagerTest` to include Bedrock provider tests and ensure unsupported features throw exceptions. (`tests/Feature/AiManagerTest.php`)

If anyone has suggestions, feedback, or enhancement ideas, they are very welcome.