### PR TITLE
Allow stream provider failover

### DIFF
--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -31,7 +31,7 @@ interface Agent
     public function stream(
         string $prompt,
         array $attachments = [],
-        ?string $provider = null,
+        array|string|null $provider = null,
         ?string $model = null
     ): StreamableAgentResponse;
 

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -65,7 +65,7 @@ trait Promptable
     public function stream(
         string $prompt,
         array $attachments = [],
-        ?string $provider = null,
+        array|string|null $provider = null,
         ?string $model = null,
         ?int $timeout = null): StreamableAgentResponse
     {


### PR DESCRIPTION
`stream()` accepts `array|string|null $provider`, matching the prompt method and enabling model failover during streams. This aligns the API and uses the existing `withModelFailover()` behavior.