### PR TITLE
Add Traceable trait with log and Langfuse tracing drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /tmp
 /vendor
 CLAUDE.md
+.env

--- a/config/ai.php
+++ b/config/ai.php
@@ -40,6 +40,37 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Tracing
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure tracing for AI agent invocations. When an
+    | agent uses the Traceable trait, trace data will be sent to the
+    | configured driver. The Langfuse driver dispatches queued jobs.
+    |
+    */
+
+    'tracing' => [
+        'default' => env('AI_TRACING_DRIVER', 'log'),
+
+        'drivers' => [
+            'log' => [
+                'driver' => 'log',
+                'channel' => env('AI_TRACING_LOG_CHANNEL'),
+                'level' => 'info',
+            ],
+
+            'langfuse' => [
+                'driver' => 'langfuse',
+                'url' => env('LANGFUSE_URL', 'https://cloud.langfuse.com'),
+                'public_key' => env('LANGFUSE_PUBLIC_KEY'),
+                'secret_key' => env('LANGFUSE_SECRET_KEY'),
+                'queue' => env('AI_TRACING_QUEUE', 'default'),
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | AI Providers
     |--------------------------------------------------------------------------
     |

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -11,6 +11,7 @@ use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Laravel\Ai\Tracing\TracingManager;
 
 class AiServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,7 @@ class AiServiceProvider extends ServiceProvider
     {
         $this->app->scoped(AiManager::class, fn ($app): AiManager => new AiManager($app));
         $this->app->singleton(ConversationStore::class, DatabaseConversationStore::class);
+        $this->app->singleton(TracingManager::class, fn ($app) => new TracingManager($app));
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');
     }

--- a/src/Concerns/Traceable.php
+++ b/src/Concerns/Traceable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ai\Concerns;
+
+trait Traceable
+{
+    /**
+     * Get the tracing driver to use for this agent.
+     *
+     * Return null to use the default configured driver.
+     */
+    public function tracingDriver(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Contracts/TracingDriver.php
+++ b/src/Contracts/TracingDriver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+interface TracingDriver
+{
+    /**
+     * Register event listeners for the given agent invocation.
+     */
+    public function registerListeners(string $invocationId, Agent $agent, Dispatcher $events): void;
+}

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Providers\Concerns;
 
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Laravel\Ai\Concerns\Traceable;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
@@ -26,6 +27,8 @@ trait StreamsText
     public function stream(AgentPrompt $prompt): StreamableAgentResponse
     {
         $invocationId = (string) Str::uuid7();
+
+        $this->registerTracingListeners($invocationId, $prompt->agent);
 
         $processedPrompt = null;
 

--- a/src/Tracing/Drivers/LangfuseDriver.php
+++ b/src/Tracing/Drivers/LangfuseDriver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Ai\Tracing\Drivers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\TracingDriver;
+use Laravel\Ai\Events\AgentFailedOver;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Tracing\Jobs\SendLangfuseTrace;
+use Laravel\Ai\Tracing\LangfusePayloadBuilder;
+
+class LangfuseDriver implements TracingDriver
+{
+    /**
+     * Create a new Langfuse driver instance.
+     */
+    public function __construct(protected array $config) {}
+
+    /**
+     * Register event listeners for the given agent invocation.
+     */
+    public function registerListeners(string $invocationId, Agent $agent, Dispatcher $events): void
+    {
+        $builder = new LangfusePayloadBuilder($invocationId, $agent);
+
+        $events->listen(InvokingTool::class, function (InvokingTool $event) use ($invocationId, $builder) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $builder->recordToolInvoking($event);
+        });
+
+        $events->listen(ToolInvoked::class, function (ToolInvoked $event) use ($invocationId, $builder) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $builder->recordToolInvoked($event);
+        });
+
+        $events->listen(AgentFailedOver::class, function (AgentFailedOver $event) use ($agent, $builder) {
+            if ($event->agent !== $agent) {
+                return;
+            }
+
+            $builder->recordFailover($event);
+        });
+
+        $events->listen(AgentPrompted::class, function (AgentPrompted $event) use ($invocationId, $builder) {
+            if ($event->invocationId !== $invocationId || $event instanceof AgentStreamed) {
+                return;
+            }
+
+            $this->dispatchTrace($builder->build($event));
+        });
+
+        $events->listen(AgentStreamed::class, function (AgentStreamed $event) use ($invocationId, $builder) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $this->dispatchTrace($builder->build($event));
+        });
+    }
+
+    /**
+     * Dispatch the trace payload as a queued job.
+     */
+    protected function dispatchTrace(array $payload): void
+    {
+        SendLangfuseTrace::dispatch(
+            $payload,
+            $this->config['url'],
+            $this->config['public_key'],
+            $this->config['secret_key'],
+        )->onQueue($this->config['queue'] ?? 'default');
+    }
+}

--- a/src/Tracing/Drivers/LogDriver.php
+++ b/src/Tracing/Drivers/LogDriver.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Laravel\Ai\Tracing\Drivers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\TracingDriver;
+use Laravel\Ai\Events\AgentFailedOver;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\ToolInvoked;
+
+class LogDriver implements TracingDriver
+{
+    /**
+     * Create a new log driver instance.
+     */
+    public function __construct(protected array $config) {}
+
+    /**
+     * Register event listeners for the given agent invocation.
+     */
+    public function registerListeners(string $invocationId, Agent $agent, Dispatcher $events): void
+    {
+        $events->listen(PromptingAgent::class, function (PromptingAgent $event) use ($invocationId) {
+            if ($event->invocationId !== $invocationId || $event instanceof \Laravel\Ai\Events\StreamingAgent) {
+                return;
+            }
+
+            $this->log('Agent prompting', [
+                'invocation_id' => $event->invocationId,
+                'agent' => $event->prompt->agent::class,
+                'model' => $event->prompt->model,
+            ]);
+        });
+
+        $events->listen(\Laravel\Ai\Events\StreamingAgent::class, function (\Laravel\Ai\Events\StreamingAgent $event) use ($invocationId) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $this->log('Agent streaming', [
+                'invocation_id' => $event->invocationId,
+                'agent' => $event->prompt->agent::class,
+                'model' => $event->prompt->model,
+            ]);
+        });
+
+        $events->listen(InvokingTool::class, function (InvokingTool $event) use ($invocationId) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $this->log('Invoking tool', [
+                'invocation_id' => $event->invocationId,
+                'tool_invocation_id' => $event->toolInvocationId,
+                'agent' => $event->agent::class,
+                'tool' => $event->tool::class,
+            ]);
+        });
+
+        $events->listen(ToolInvoked::class, function (ToolInvoked $event) use ($invocationId) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $this->log('Tool invoked', [
+                'invocation_id' => $event->invocationId,
+                'tool_invocation_id' => $event->toolInvocationId,
+                'agent' => $event->agent::class,
+                'tool' => $event->tool::class,
+            ]);
+        });
+
+        $events->listen(AgentPrompted::class, function (AgentPrompted $event) use ($invocationId) {
+            if ($event->invocationId !== $invocationId || $event instanceof AgentStreamed) {
+                return;
+            }
+
+            $this->log('Agent prompted', [
+                'invocation_id' => $event->invocationId,
+                'agent' => $event->prompt->agent::class,
+                'model' => $event->response->meta->model,
+                'provider' => $event->response->meta->provider,
+                'usage' => $event->response->usage->toArray(),
+            ]);
+        });
+
+        $events->listen(AgentStreamed::class, function (AgentStreamed $event) use ($invocationId) {
+            if ($event->invocationId !== $invocationId) {
+                return;
+            }
+
+            $this->log('Agent streamed', [
+                'invocation_id' => $event->invocationId,
+                'agent' => $event->prompt->agent::class,
+                'model' => $event->response->meta->model,
+                'provider' => $event->response->meta->provider,
+                'usage' => $event->response->usage->toArray(),
+            ]);
+        });
+
+        $events->listen(AgentFailedOver::class, function (AgentFailedOver $event) use ($invocationId, $agent) {
+            if ($event->agent !== $agent) {
+                return;
+            }
+
+            $this->log('Agent failed over', [
+                'invocation_id' => $invocationId,
+                'agent' => $event->agent::class,
+                'provider' => $event->provider::class,
+                'model' => $event->model,
+                'exception' => $event->exception->getMessage(),
+            ]);
+        });
+    }
+
+    /**
+     * Write a log entry.
+     */
+    protected function log(string $message, array $context): void
+    {
+        $logger = $this->config['channel']
+            ? Log::channel($this->config['channel'])
+            : Log::getFacadeRoot();
+
+        $level = $this->config['level'] ?? 'info';
+
+        $logger->{$level}("[AI Tracing] {$message}", $context);
+    }
+}

--- a/src/Tracing/Drivers/NullDriver.php
+++ b/src/Tracing/Drivers/NullDriver.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Tracing\Drivers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\TracingDriver;
+
+class NullDriver implements TracingDriver
+{
+    /**
+     * Register event listeners for the given agent invocation.
+     */
+    public function registerListeners(string $invocationId, Agent $agent, Dispatcher $events): void
+    {
+        //
+    }
+}

--- a/src/Tracing/Jobs/SendLangfuseTrace.php
+++ b/src/Tracing/Jobs/SendLangfuseTrace.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Ai\Tracing\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Http;
+
+class SendLangfuseTrace implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    /**
+     * The backoff strategy for retries (in seconds).
+     *
+     * @var array<int, int>
+     */
+    public array $backoff = [5, 30, 120];
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public array $payload,
+        public string $url,
+        public string $publicKey,
+        public string $secretKey,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        Http::withBasicAuth($this->publicKey, $this->secretKey)
+            ->post(rtrim($this->url, '/').'/api/public/ingestion', $this->payload)
+            ->throw();
+    }
+}

--- a/src/Tracing/LangfusePayloadBuilder.php
+++ b/src/Tracing/LangfusePayloadBuilder.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Laravel\Ai\Tracing;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Events\AgentFailedOver;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
+
+class LangfusePayloadBuilder
+{
+    /**
+     * The trace ID for the current invocation.
+     */
+    protected string $traceId;
+
+    /**
+     * The generation span ID.
+     */
+    protected string $generationId;
+
+    /**
+     * The start time of the invocation.
+     */
+    protected string $startTime;
+
+    /**
+     * Collected tool span data keyed by tool invocation ID.
+     *
+     * @var array<string, array>
+     */
+    protected array $toolSpans = [];
+
+    /**
+     * Collected failover events.
+     *
+     * @var array<int, array>
+     */
+    protected array $failoverEvents = [];
+
+    /**
+     * Create a new payload builder instance.
+     */
+    public function __construct(
+        protected string $invocationId,
+        protected Agent $agent,
+    ) {
+        $this->traceId = $this->invocationId;
+        $this->generationId = (string) Str::uuid7();
+        $this->startTime = now()->toIso8601ZuluString();
+    }
+
+    /**
+     * Record a tool invocation starting.
+     */
+    public function recordToolInvoking(InvokingTool $event): void
+    {
+        $this->toolSpans[$event->toolInvocationId] = [
+            'id' => $event->toolInvocationId,
+            'name' => class_basename($event->tool),
+            'start_time' => now()->toIso8601ZuluString(),
+            'input' => $event->arguments,
+        ];
+    }
+
+    /**
+     * Record a tool invocation completing.
+     */
+    public function recordToolInvoked(ToolInvoked $event): void
+    {
+        if (isset($this->toolSpans[$event->toolInvocationId])) {
+            $this->toolSpans[$event->toolInvocationId]['end_time'] = now()->toIso8601ZuluString();
+            $this->toolSpans[$event->toolInvocationId]['output'] = is_string($event->result)
+                ? $event->result
+                : json_encode($event->result);
+        }
+    }
+
+    /**
+     * Record a failover event.
+     */
+    public function recordFailover(AgentFailedOver $event): void
+    {
+        $this->failoverEvents[] = [
+            'provider' => $event->provider::class,
+            'model' => $event->model,
+            'exception' => $event->exception->getMessage(),
+            'time' => now()->toIso8601ZuluString(),
+        ];
+    }
+
+    /**
+     * Build the final Langfuse batch ingestion payload.
+     */
+    public function build(AgentPrompted $event): array
+    {
+        $endTime = now()->toIso8601ZuluString();
+        $batch = [];
+
+        // Trace
+        $batch[] = [
+            'id' => (string) Str::uuid7(),
+            'type' => 'trace-create',
+            'timestamp' => $this->startTime,
+            'body' => [
+                'id' => $this->traceId,
+                'name' => class_basename($this->agent),
+                'input' => $event->prompt->prompt,
+                'output' => $event->response->text,
+                'metadata' => [
+                    'agent_class' => $this->agent::class,
+                    'invocation_id' => $this->invocationId,
+                ],
+            ],
+        ];
+
+        // Generation span for the LLM call
+        $batch[] = [
+            'id' => (string) Str::uuid7(),
+            'type' => 'generation-create',
+            'timestamp' => $this->startTime,
+            'body' => [
+                'id' => $this->generationId,
+                'traceId' => $this->traceId,
+                'name' => 'llm-generation',
+                'startTime' => $this->startTime,
+                'endTime' => $endTime,
+                'model' => $event->response->meta->model,
+                'input' => $event->prompt->prompt,
+                'output' => $event->response->text,
+                'usage' => [
+                    'promptTokens' => $event->response->usage->promptTokens,
+                    'completionTokens' => $event->response->usage->completionTokens,
+                ],
+                'metadata' => [
+                    'provider' => $event->response->meta->provider,
+                ],
+            ],
+        ];
+
+        // Tool spans
+        foreach ($this->toolSpans as $toolSpan) {
+            $batch[] = [
+                'id' => (string) Str::uuid7(),
+                'type' => 'span-create',
+                'timestamp' => $toolSpan['start_time'],
+                'body' => [
+                    'id' => $toolSpan['id'],
+                    'traceId' => $this->traceId,
+                    'parentObservationId' => $this->generationId,
+                    'name' => $toolSpan['name'],
+                    'startTime' => $toolSpan['start_time'],
+                    'endTime' => $toolSpan['end_time'] ?? $endTime,
+                    'input' => $toolSpan['input'],
+                    'output' => $toolSpan['output'] ?? null,
+                ],
+            ];
+        }
+
+        // Failover events
+        foreach ($this->failoverEvents as $failover) {
+            $batch[] = [
+                'id' => (string) Str::uuid7(),
+                'type' => 'event-create',
+                'timestamp' => $failover['time'],
+                'body' => [
+                    'id' => (string) Str::uuid7(),
+                    'traceId' => $this->traceId,
+                    'name' => 'failover',
+                    'metadata' => [
+                        'provider' => $failover['provider'],
+                        'model' => $failover['model'],
+                        'exception' => $failover['exception'],
+                    ],
+                ],
+            ];
+        }
+
+        return ['batch' => $batch];
+    }
+}

--- a/src/Tracing/TracingManager.php
+++ b/src/Tracing/TracingManager.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Ai\Tracing;
+
+use Illuminate\Contracts\Foundation\Application;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\TracingDriver;
+use Laravel\Ai\Tracing\Drivers\LangfuseDriver;
+use Laravel\Ai\Tracing\Drivers\LogDriver;
+use Laravel\Ai\Tracing\Drivers\NullDriver;
+
+class TracingManager
+{
+    /**
+     * The resolved driver instances.
+     *
+     * @var array<string, TracingDriver>
+     */
+    protected array $drivers = [];
+
+    /**
+     * Create a new tracing manager instance.
+     */
+    public function __construct(protected Application $app) {}
+
+    /**
+     * Get a tracing driver instance by name.
+     */
+    public function driver(?string $name = null): TracingDriver
+    {
+        $name = $name ?? $this->getDefaultDriver();
+
+        return $this->drivers[$name] ??= $this->resolve($name);
+    }
+
+    /**
+     * Get the default driver name.
+     */
+    public function getDefaultDriver(): string
+    {
+        return $this->app['config']['ai.tracing.default'] ?? 'log';
+    }
+
+    /**
+     * Resolve the given driver.
+     */
+    protected function resolve(string $name): TracingDriver
+    {
+        $config = $this->app['config']["ai.tracing.drivers.{$name}"] ?? null;
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Tracing driver [{$name}] is not defined.");
+        }
+
+        return match ($config['driver'] ?? $name) {
+            'log' => new LogDriver($config),
+            'langfuse' => new LangfuseDriver($config),
+            'null' => new NullDriver,
+            default => throw new InvalidArgumentException("Unsupported tracing driver [{$config['driver']}]."),
+        };
+    }
+}

--- a/tests/Feature/Agents/TraceableAgent.php
+++ b/tests/Feature/Agents/TraceableAgent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Concerns\Traceable;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+class TraceableAgent implements Agent
+{
+    use Promptable, Traceable;
+
+    protected ?string $driver = null;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function tracingDriver(): ?string
+    {
+        return $this->driver;
+    }
+
+    public function useTracingDriver(string $driver): self
+    {
+        $this->driver = $driver;
+
+        return $this;
+    }
+}

--- a/tests/Feature/TracingIntegrationTest.php
+++ b/tests/Feature/TracingIntegrationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Tracing\Jobs\SendLangfuseTrace;
+use Tests\Feature\Agents\TraceableAgent;
+use Tests\TestCase;
+
+class TracingIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! env('ANTHROPIC_API_KEY') || ! env('LANGFUSE_PUBLIC_KEY') || ! env('LANGFUSE_SECRET_KEY')) {
+            $this->markTestSkipped('Anthropic and Langfuse credentials are required.');
+        }
+
+        $this->app['config']->set('ai.providers.anthropic.key', env('ANTHROPIC_API_KEY'));
+        $this->app['config']->set('ai.tracing.default', 'langfuse');
+        $this->app['config']->set('ai.tracing.drivers.langfuse', [
+            'driver' => 'langfuse',
+            'url' => env('LANGFUSE_BASE_URL', env('LANGFUSE_URL', 'https://cloud.langfuse.com')),
+            'public_key' => env('LANGFUSE_PUBLIC_KEY'),
+            'secret_key' => env('LANGFUSE_SECRET_KEY'),
+            'queue' => 'sync',
+        ]);
+    }
+
+    public function test_real_agent_prompt_sends_trace_to_langfuse(): void
+    {
+        $agent = new TraceableAgent;
+
+        $response = $agent->prompt(
+            'What is 2 + 2? Reply with just the number.',
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+        );
+
+        $this->assertNotEmpty($response->text);
+        $this->assertGreaterThan(0, $response->usage->promptTokens);
+        $this->assertGreaterThan(0, $response->usage->completionTokens);
+
+        // If we reach here without exceptions, the trace was sent successfully.
+        // Check your Langfuse dashboard to see the trace.
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_real_agent_prompt_sends_correct_payload_structure(): void
+    {
+        Http::fake([
+            '*/api/public/ingestion' => Http::response(['successes' => [], 'errors' => []], 200),
+        ]);
+
+        $agent = new TraceableAgent;
+
+        $response = $agent->prompt(
+            'What is 2 + 2? Reply with just the number.',
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+        );
+
+        Http::assertSent(function ($request) use ($response) {
+            $body = $request->data();
+
+            if (! isset($body['batch']) || count($body['batch']) < 2) {
+                return false;
+            }
+
+            $trace = collect($body['batch'])->firstWhere('type', 'trace-create');
+            $generation = collect($body['batch'])->firstWhere('type', 'generation-create');
+
+            // Verify trace structure
+            if (! $trace || $trace['body']['name'] !== 'TraceableAgent') {
+                return false;
+            }
+
+            if ($trace['body']['metadata']['agent_class'] !== TraceableAgent::class) {
+                return false;
+            }
+
+            // Verify generation structure
+            if (! $generation || $generation['body']['model'] !== 'claude-sonnet-4-5-20250929') {
+                return false;
+            }
+
+            if ($generation['body']['usage']['promptTokens'] <= 0) {
+                return false;
+            }
+
+            // Verify auth header (basic auth with public:secret)
+            $authHeader = $request->header('Authorization')[0] ?? '';
+            if (! str_starts_with($authHeader, 'Basic ')) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    public function test_real_agent_stream_sends_trace_to_langfuse(): void
+    {
+        $agent = new TraceableAgent;
+
+        $response = $agent->stream(
+            'What is 2 + 2? Reply with just the number.',
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+        );
+
+        $text = '';
+        $response->each(function () use (&$text) {
+            // consume the stream
+        });
+
+        $this->assertNotEmpty($response->text);
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Feature/TracingTest.php
+++ b/tests/Feature/TracingTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+use InvalidArgumentException;
+use Laravel\Ai\Tracing\Drivers\LangfuseDriver;
+use Laravel\Ai\Tracing\Drivers\LogDriver;
+use Laravel\Ai\Tracing\Drivers\NullDriver;
+use Laravel\Ai\Tracing\Jobs\SendLangfuseTrace;
+use Laravel\Ai\Tracing\TracingManager;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\TraceableAgent;
+use Tests\TestCase;
+
+class TracingTest extends TestCase
+{
+    public function test_tracing_manager_resolves_log_driver(): void
+    {
+        $manager = $this->app->make(TracingManager::class);
+
+        $this->assertInstanceOf(LogDriver::class, $manager->driver('log'));
+    }
+
+    public function test_tracing_manager_resolves_langfuse_driver(): void
+    {
+        $manager = $this->app->make(TracingManager::class);
+
+        $this->assertInstanceOf(LangfuseDriver::class, $manager->driver('langfuse'));
+    }
+
+    public function test_tracing_manager_resolves_default_driver(): void
+    {
+        $this->app['config']->set('ai.tracing.default', 'log');
+
+        $manager = $this->app->make(TracingManager::class);
+
+        $this->assertInstanceOf(LogDriver::class, $manager->driver());
+    }
+
+    public function test_tracing_manager_throws_for_undefined_driver(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tracing driver [nonexistent] is not defined.');
+
+        $this->app->make(TracingManager::class)->driver('nonexistent');
+    }
+
+    public function test_tracing_manager_caches_resolved_drivers(): void
+    {
+        $manager = $this->app->make(TracingManager::class);
+
+        $first = $manager->driver('log');
+        $second = $manager->driver('log');
+
+        $this->assertSame($first, $second);
+    }
+
+    public function test_null_driver_can_be_configured(): void
+    {
+        $this->app['config']->set('ai.tracing.drivers.null', [
+            'driver' => 'null',
+        ]);
+
+        $manager = $this->app->make(TracingManager::class);
+
+        $this->assertInstanceOf(NullDriver::class, $manager->driver('null'));
+    }
+
+    public function test_agents_without_traceable_trait_are_unaffected(): void
+    {
+        Log::spy();
+
+        AssistantAgent::fake(['Response']);
+
+        (new AssistantAgent)->prompt('Test prompt');
+
+        Log::shouldNotHaveReceived('channel');
+    }
+
+    public function test_log_driver_logs_prompt_and_completion(): void
+    {
+        $this->app['config']->set('ai.tracing.default', 'log');
+
+        $log = Log::spy();
+
+        TraceableAgent::fake(['Response']);
+
+        (new TraceableAgent)->prompt('Test prompt');
+
+        Log::shouldHaveReceived('info')->atLeast()->once();
+    }
+
+    public function test_log_driver_logs_to_configured_channel(): void
+    {
+        $this->app['config']->set('ai.tracing.default', 'log');
+        $this->app['config']->set('ai.tracing.drivers.log.channel', 'stderr');
+
+        $channelLog = Log::partialMock();
+        $channelLog->shouldReceive('channel')
+            ->with('stderr')
+            ->andReturnSelf()
+            ->atLeast()->once();
+        $channelLog->shouldReceive('info')->atLeast()->once();
+
+        TraceableAgent::fake(['Response']);
+
+        (new TraceableAgent)->prompt('Test prompt');
+    }
+
+    public function test_log_driver_logs_streaming(): void
+    {
+        $this->app['config']->set('ai.tracing.default', 'log');
+
+        Log::spy();
+
+        TraceableAgent::fake(['Streamed response']);
+
+        $response = (new TraceableAgent)->stream('Test prompt');
+        $response->each(fn () => true);
+
+        Log::shouldHaveReceived('info')->atLeast()->once();
+    }
+
+    public function test_agent_can_override_tracing_driver(): void
+    {
+        $this->app['config']->set('ai.tracing.default', 'log');
+        $this->app['config']->set('ai.tracing.drivers.null', [
+            'driver' => 'null',
+        ]);
+
+        Log::spy();
+
+        TraceableAgent::fake(['Response']);
+
+        (new TraceableAgent)->useTracingDriver('null')->prompt('Test prompt');
+
+        Log::shouldNotHaveReceived('info');
+    }
+
+    public function test_langfuse_driver_dispatches_queued_job_on_prompt(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('ai.tracing.default', 'langfuse');
+        $this->app['config']->set('ai.tracing.drivers.langfuse', [
+            'driver' => 'langfuse',
+            'url' => 'https://cloud.langfuse.com',
+            'public_key' => 'pk-test',
+            'secret_key' => 'sk-test',
+            'queue' => 'tracing',
+        ]);
+
+        TraceableAgent::fake(['Response']);
+
+        (new TraceableAgent)->prompt('Test prompt');
+
+        Queue::assertPushed(SendLangfuseTrace::class, function (SendLangfuseTrace $job) {
+            return $job->url === 'https://cloud.langfuse.com'
+                && $job->publicKey === 'pk-test'
+                && $job->secretKey === 'sk-test'
+                && $job->queue === 'tracing'
+                && isset($job->payload['batch'])
+                && count($job->payload['batch']) >= 2;
+        });
+    }
+
+    public function test_langfuse_driver_dispatches_queued_job_on_stream(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('ai.tracing.default', 'langfuse');
+        $this->app['config']->set('ai.tracing.drivers.langfuse', [
+            'driver' => 'langfuse',
+            'url' => 'https://cloud.langfuse.com',
+            'public_key' => 'pk-test',
+            'secret_key' => 'sk-test',
+            'queue' => 'default',
+        ]);
+
+        TraceableAgent::fake(['Streamed response']);
+
+        $response = (new TraceableAgent)->stream('Test prompt');
+        $response->each(fn () => true);
+
+        Queue::assertPushed(SendLangfuseTrace::class);
+    }
+
+    public function test_langfuse_payload_contains_trace_and_generation(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('ai.tracing.default', 'langfuse');
+        $this->app['config']->set('ai.tracing.drivers.langfuse', [
+            'driver' => 'langfuse',
+            'url' => 'https://cloud.langfuse.com',
+            'public_key' => 'pk-test',
+            'secret_key' => 'sk-test',
+            'queue' => 'default',
+        ]);
+
+        TraceableAgent::fake(['Response']);
+
+        (new TraceableAgent)->prompt('Test prompt');
+
+        Queue::assertPushed(SendLangfuseTrace::class, function (SendLangfuseTrace $job) {
+            $batch = $job->payload['batch'];
+            $types = array_column($batch, 'type');
+
+            return in_array('trace-create', $types)
+                && in_array('generation-create', $types);
+        });
+    }
+
+    public function test_langfuse_trace_contains_agent_metadata(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('ai.tracing.default', 'langfuse');
+        $this->app['config']->set('ai.tracing.drivers.langfuse', [
+            'driver' => 'langfuse',
+            'url' => 'https://cloud.langfuse.com',
+            'public_key' => 'pk-test',
+            'secret_key' => 'sk-test',
+            'queue' => 'default',
+        ]);
+
+        TraceableAgent::fake(['Response']);
+
+        (new TraceableAgent)->prompt('Test prompt');
+
+        Queue::assertPushed(SendLangfuseTrace::class, function (SendLangfuseTrace $job) {
+            $trace = collect($job->payload['batch'])->firstWhere('type', 'trace-create');
+
+            return $trace['body']['name'] === 'TraceableAgent'
+                && $trace['body']['input'] === 'Test prompt'
+                && $trace['body']['output'] === 'Response'
+                && $trace['body']['metadata']['agent_class'] === TraceableAgent::class;
+        });
+    }
+
+    public function test_langfuse_job_is_not_dispatched_for_non_traceable_agents(): void
+    {
+        Queue::fake();
+
+        $this->app['config']->set('ai.tracing.default', 'langfuse');
+
+        AssistantAgent::fake(['Response']);
+
+        (new AssistantAgent)->prompt('Test prompt');
+
+        Queue::assertNotPushed(SendLangfuseTrace::class);
+    }
+}


### PR DESCRIPTION
 I've been building with Laravel AI and one thing I kept running into is that there's no way to see what your agents are actually doing. When something goes wrong or even when things go right; I'm flying blind. There's no observability into the prompts being sent, the tools being called, or the tokens being used.

This PR adds a Traceable trait that gives you that visibility, with support for logging to a Laravel log channel or sending traces to Langfuse or others. 

Maybe you will find it useful.

## Summary

- Adds an opt-in `Traceable` trait that agents can use (like `RemembersConversations`) to send trace data to a configured backend during invocations
- Includes two drivers: **Log** (writes structured entries to a Laravel log channel) and **Langfuse** (dispatches queued jobs to the Langfuse batch ingestion API)
- Includes a **Null** driver for testing or explicitly disabling tracing
- Agents can override the default driver via `tracingDriver()` method

### How it works

When `GeneratesText::prompt()` or `StreamsText::stream()` detects the `Traceable` trait (via `class_uses_recursive`, same pattern as `RemembersConversations`), it registers scoped event listeners for that invocation's ID. These listeners collect data from `PromptingAgent`, `InvokingTool`, `ToolInvoked`, `AgentPrompted`, `AgentStreamed`, and `AgentFailedOver` events.

### New files

| File | Purpose |
|------|---------|
| `src/Concerns/Traceable.php` | Marker trait with optional `tracingDriver()` override |
| `src/Contracts/TracingDriver.php` | Driver interface |
| `src/Tracing/TracingManager.php` | Driver factory (singleton) |
| `src/Tracing/Drivers/LogDriver.php` | Log channel backend |
| `src/Tracing/Drivers/LangfuseDriver.php` | Langfuse backend |
| `src/Tracing/Drivers/NullDriver.php` | No-op driver |
| `src/Tracing/LangfusePayloadBuilder.php` | Builds Langfuse batch ingestion payload |
| `src/Tracing/Jobs/SendLangfuseTrace.php` | Queued job for Langfuse API |

### Usage

```php
class MyAgent implements Agent
{
    use Promptable, Traceable;

    public function instructions(): string { return '...'; }

    // Optional: override the default tracing driver
    public function tracingDriver(): ?string { return 'langfuse'; }
}
```

### Configuration

```php
// config/ai.php
'tracing' => [
    'default' => env('AI_TRACING_DRIVER', 'log'),
    'drivers' => [
        'log' => [
            'driver' => 'log',
            'channel' => env('AI_TRACING_LOG_CHANNEL'),
            'level' => 'info',
        ],
        'langfuse' => [
            'driver' => 'langfuse',
            'url' => env('LANGFUSE_URL', 'https://cloud.langfuse.com'),
            'public_key' => env('LANGFUSE_PUBLIC_KEY'),
            'secret_key' => env('LANGFUSE_SECRET_KEY'),
            'queue' => env('AI_TRACING_QUEUE', 'default'),
        ],
    ],
],
```

## Test plan

- [x] 16 unit tests covering TracingManager, all drivers, trait detection, and driver override
- [x] 3 integration tests with real Anthropic API calls verifying Langfuse payload structure and end-to-end trace delivery
- [x] Verified agents without `Traceable` trait are completely unaffected
- [x] All 112 existing tests continue to pass