### PR TITLE
fix: add missing arguments fallback in PrismTool object code paths

### DIFF
--- a/src/Gateway/Prism/PrismTool.php
+++ b/src/Gateway/Prism/PrismTool.php
@@ -50,10 +50,12 @@ class PrismTool extends Tool
             );
         }
 
+        $arguments = $toolCall->arguments();
+
         return new ToolCall(
             $toolCall->id,
             $toolCall->name,
-            static::normalizeArguments($toolCall->arguments()['schema_definition'] ?? []),
+            static::normalizeArguments($arguments['schema_definition'] ?? $arguments),
             $toolCall->resultId,
             $toolCall->reasoningId,
             $toolCall->reasoningSummary,
@@ -78,7 +80,7 @@ class PrismTool extends Tool
         return new ToolResult(
             $toolResult->toolCallId,
             $toolResult->toolName,
-            static::normalizeArguments($toolResult->args['schema_definition'] ?? []),
+            static::normalizeArguments($toolResult->args['schema_definition'] ?? $toolResult->args),
             $toolResult->result,
             $toolResult->toolCallResultId,
         );

--- a/tests/Unit/Gateway/Prism/PrismToolTest.php
+++ b/tests/Unit/Gateway/Prism/PrismToolTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use Laravel\Ai\Gateway\Prism\PrismTool;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use PHPUnit\Framework\TestCase;
+use Prism\Prism\ValueObjects\ToolCall as PrismToolCall;
+use Prism\Prism\ValueObjects\ToolResult as PrismToolResult;
+
+class PrismToolTest extends TestCase
+{
+    public function test_to_laravel_tool_call_from_array_unwraps_schema_definition(): void
+    {
+        $result = PrismTool::toLaravelToolCall([
+            'id' => 'call_1',
+            'name' => 'search',
+            'arguments' => ['schema_definition' => ['query' => 'test']],
+        ]);
+
+        $this->assertInstanceOf(ToolCall::class, $result);
+        $this->assertSame('call_1', $result->id);
+        $this->assertSame('search', $result->name);
+        $this->assertSame(['query' => 'test'], $result->arguments);
+    }
+
+    public function test_to_laravel_tool_call_from_array_uses_raw_arguments_when_schema_definition_is_missing(): void
+    {
+        $result = PrismTool::toLaravelToolCall([
+            'id' => 'call_2',
+            'name' => 'search',
+            'arguments' => ['query' => 'test'],
+        ]);
+
+        $this->assertInstanceOf(ToolCall::class, $result);
+        $this->assertSame(['query' => 'test'], $result->arguments);
+    }
+
+    public function test_to_laravel_tool_call_from_object_unwraps_schema_definition(): void
+    {
+        $prismToolCall = new PrismToolCall(
+            id: 'call_3',
+            name: 'search',
+            arguments: ['schema_definition' => ['query' => 'test']],
+            resultId: 'res_1',
+            reasoningId: 'reason_1',
+            reasoningSummary: ['summary'],
+        );
+
+        $result = PrismTool::toLaravelToolCall($prismToolCall);
+
+        $this->assertInstanceOf(ToolCall::class, $result);
+        $this->assertSame('call_3', $result->id);
+        $this->assertSame('search', $result->name);
+        $this->assertSame(['query' => 'test'], $result->arguments);
+        $this->assertSame('res_1', $result->resultId);
+        $this->assertSame('reason_1', $result->reasoningId);
+        $this->assertSame(['summary'], $result->reasoningSummary);
+    }
+
+    public function test_to_laravel_tool_call_from_object_uses_raw_arguments_when_schema_definition_is_missing(): void
+    {
+        $prismToolCall = new PrismToolCall(
+            id: 'call_4',
+            name: 'search',
+            arguments: ['query' => 'test', 'limit' => 10],
+        );
+
+        $result = PrismTool::toLaravelToolCall($prismToolCall);
+
+        $this->assertInstanceOf(ToolCall::class, $result);
+        $this->assertSame(['query' => 'test', 'limit' => 10], $result->arguments);
+    }
+
+    public function test_to_laravel_tool_result_from_array_unwraps_schema_definition(): void
+    {
+        $result = PrismTool::toLaravelToolResult([
+            'toolCallId' => 'call_1',
+            'toolName' => 'search',
+            'args' => ['schema_definition' => ['query' => 'test']],
+            'result' => 'found it',
+        ]);
+
+        $this->assertInstanceOf(ToolResult::class, $result);
+        $this->assertSame('call_1', $result->id);
+        $this->assertSame('search', $result->name);
+        $this->assertSame(['query' => 'test'], $result->arguments);
+        $this->assertSame('found it', $result->result);
+    }
+
+    public function test_to_laravel_tool_result_from_array_uses_raw_args_when_schema_definition_is_missing(): void
+    {
+        $result = PrismTool::toLaravelToolResult([
+            'toolCallId' => 'call_2',
+            'toolName' => 'search',
+            'args' => ['query' => 'test'],
+            'result' => 'found it',
+        ]);
+
+        $this->assertInstanceOf(ToolResult::class, $result);
+        $this->assertSame(['query' => 'test'], $result->arguments);
+    }
+
+    public function test_to_laravel_tool_result_from_object_unwraps_schema_definition(): void
+    {
+        $prismToolResult = new PrismToolResult(
+            toolCallId: 'call_3',
+            toolName: 'search',
+            args: ['schema_definition' => ['query' => 'test']],
+            result: 'found it',
+            toolCallResultId: 'res_1',
+        );
+
+        $result = PrismTool::toLaravelToolResult($prismToolResult);
+
+        $this->assertInstanceOf(ToolResult::class, $result);
+        $this->assertSame('call_3', $result->id);
+        $this->assertSame('search', $result->name);
+        $this->assertSame(['query' => 'test'], $result->arguments);
+        $this->assertSame('found it', $result->result);
+        $this->assertSame('res_1', $result->resultId);
+    }
+
+    public function test_to_laravel_tool_result_from_object_uses_raw_args_when_schema_definition_is_missing(): void
+    {
+        $prismToolResult = new PrismToolResult(
+            toolCallId: 'call_4',
+            toolName: 'search',
+            args: ['query' => 'test', 'limit' => 10],
+            result: 'found it',
+        );
+
+        $result = PrismTool::toLaravelToolResult($prismToolResult);
+
+        $this->assertInstanceOf(ToolResult::class, $result);
+        $this->assertSame(['query' => 'test', 'limit' => 10], $result->arguments);
+    }
+}


### PR DESCRIPTION
`PrismTool::toLaravelToolCall()` and `PrismTool::toLaravelToolResult()` had inconsistent fallback logic between their array and object code paths, causing tool arguments to silently become empty arrays when `schema_definition` wrapping is not present in the LLM response.

## Root Cause

The SDK wraps tool parameters in `ObjectSchema(name='schema_definition')`, so LLM responses typically return arguments as `{"schema_definition": {...actual args}}`. Both methods correctly unwrap this on the array path:

```php
$toolCall['arguments']['schema_definition'] ?? $toolCall['arguments'] ?? []
```

But the object path only had:

```php
$toolCall->arguments()['schema_definition'] ?? []
```

When a provider doesn't send the `schema_definition` wrapper name to the LLM (e.g. `SanitizedObjectSchema` strips it for compatible endpoints), the LLM returns raw arguments without the wrapper. The missing intermediate fallback causes **all arguments to be silently replaced with an empty array**.

Standard OpenAI/Anthropic providers don't trigger this because they preserve the `schema_definition` name in the schema — but any provider that omits it (or any LLM that ignores parameter names) will hit this bug.

## Fix

**`toLaravelToolCall()`** — Added `$toolCall->arguments()` as intermediate fallback. Extracted into a local variable to avoid redundant JSON decoding (`arguments()` is a method, not a property):

```php
$arguments = $toolCall->arguments();
static::normalizeArguments($arguments['schema_definition'] ?? $arguments),
```

**`toLaravelToolResult()`** — Added `$toolResult->args` as intermediate fallback. No local variable needed (`args` is a readonly property):

```php
static::normalizeArguments($toolResult->args['schema_definition'] ?? $toolResult->args),
```

## Changes

- `src/Gateway/Prism/PrismTool.php` — 2 lines fixed
- `tests/Unit/Gateway/Prism/PrismToolTest.php` — **new**, 8 test methods

## Test Coverage

| Method | Input | Scenario |
|---|---|---|
| `toLaravelToolCall` | array | with `schema_definition` — unwraps ✅ |
| `toLaravelToolCall` | array | without `schema_definition` — uses raw arguments ✅ |
| `toLaravelToolCall` | object | with `schema_definition` — unwraps ✅ |
| `toLaravelToolCall` | object | without `schema_definition` — uses raw arguments ✅ |
| `toLaravelToolResult` | array | with `schema_definition` — unwraps ✅ |
| `toLaravelToolResult` | array | without `schema_definition` — uses raw args ✅ |
| `toLaravelToolResult` | object | with `schema_definition` — unwraps ✅ |
| `toLaravelToolResult` | object | without `schema_definition` — uses raw args ✅ |

All 17 unit tests pass (9 existing + 8 new), Pint clean.
