### PR TITLE
Allow customization of conversation title prompt

### DIFF
--- a/src/Concerns/RemembersConversations.php
+++ b/src/Concerns/RemembersConversations.php
@@ -69,6 +69,14 @@ trait RemembersConversations
     }
 
     /**
+     * Get the prompt used to generate conversation titles.
+     */
+    public function conversationTitlePrompt(): string
+    {
+        return 'Generate a concise 3-5 word title for a conversation that starts with the following message. Respond with only the title, no quotes or punctuation.';
+    }
+
+    /**
      * Get the UUID for the current conversation, if applicable.
      */
     public function currentConversation(): ?string

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -32,7 +32,7 @@ class RememberConversation
             if (! $agent->currentConversation()) {
                 $conversationId = $this->store->storeConversation(
                     $agent->conversationParticipant()?->id,
-                    $this->generateTitle($prompt->prompt)
+                    $this->generateTitle($prompt->prompt, $agent)
                 );
 
                 $agent->continue(
@@ -66,13 +66,17 @@ class RememberConversation
     /**
      * Generate a title for the conversation.
      */
-    protected function generateTitle(string $prompt): string
+    protected function generateTitle(string $prompt, $agent): string
     {
+        $titlePrompt = method_exists($agent, 'conversationTitlePrompt')
+            ? $agent->conversationTitlePrompt()
+            : 'Generate a concise 3-5 word title for a conversation that starts with the following message. Respond with only the title, no quotes or punctuation.';
+
         try {
             $response = $this->provider->textGateway()->generateText(
                 $this->provider,
                 $this->provider->cheapestTextModel(),
-                'Generate a concise 3-5 word title for a conversation that starts with the following message. Respond with only the title, no quotes or punctuation.',
+                $titlePrompt,
                 [new UserMessage(Str::limit($prompt, 500))],
             );
 


### PR DESCRIPTION
The `RememberConversation` middleware has the title generation prompt hardcoded in English (line 75), so there's no way to customize it. Not through config, not through method override.

If the app runs in another language, the only option right now is to work around the SDK and handle title generation separately, which kind of defeats the purpose of `RemembersConversations`.

This PR adds a `conversationTitlePrompt()` method to the `RemembersConversations` trait so developers can override it per agent, the same way `maxConversationMessages()` already works. Since it lives in the agent, each one can have its own prompt independently.
```php
public function conversationTitlePrompt(): string
{
    return 'Your custom prompt in any language...';
}
```

The middleware checks for the method with `method_exists()` and falls back to the current default, so nothing breaks for existing implementations.