### PR TITLE
Add string representation to Provider to prevent fatal error in unsupported provider path

### DIFF
--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -62,4 +62,12 @@ abstract class Provider
                 : [$key => $value]; // Provider name and model name...
         })->all();
     }
+    
+    /**
+     * Convert the provider to its string representation.
+     */
+    public function __toString(): string
+    {
+        return $this->driver();
+    }
 }


### PR DESCRIPTION
Fixes  https://github.com/laravel/ai/issues/112

Prevents a fatal error when an unsupported provider is encountered (for example `OpenAi` instead of `openai`).  
The provider instance is concatenated into the exception message, and without `__toString()` PHP throws “Object of class … could not be converted to string”, masking the intended `InvalidArgumentException`.

https://github.com/laravel/ai/blob/df3e8e0efb4ea9012723787032dbaccf047b8f59/src/Gateway/Prism/PrismGateway.php#L375

This change allows the provider to be safely rendered in that message.

