### PR TITLE
feat: add Agent Skills system

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -117,4 +117,23 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | AI Skills
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure your AI skills. Skills are atomic units of
+    | functionality that can be used by AI agents to perform tasks.
+    |
+    | Supported Modes: "none", "lite", "full"
+    |
+    */
+
+    'skills' => [
+        'default_mode' => 'lite',
+        'paths' => [
+            resource_path('skills'),
+        ],
+    ],
+
 ];

--- a/src/Console/Commands/MakeSkillCommand.php
+++ b/src/Console/Commands/MakeSkillCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Ai\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class MakeSkillCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:skill {name : The name of the skill} {--force : Overwrite the skill if it already exists}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new AI skill';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $name = Str::kebab($this->argument('name'));
+        $directory = resource_path("skills/{$name}");
+        $path = "{$directory}/SKILL.md";
+
+        if (File::exists($path) && ! $this->option('force')) {
+            $this->error("Skill [{$name}] already exists!");
+
+            return 1;
+        }
+
+        if (! File::isDirectory($directory)) {
+            File::makeDirectory($directory, 0755, true);
+        }
+
+        $stub = File::get(__DIR__.'/../../../stubs/skill.stub');
+
+        $content = str_replace(
+            ['{{ name }}', '{{ slug }}'],
+            [Str::headline($name), $name],
+            $stub
+        );
+
+        File::put($path, $content);
+
+        $this->info("Skill [{$name}] created successfully.");
+
+        return 0;
+    }
+}

--- a/src/Console/Commands/SkillsListCommand.php
+++ b/src/Console/Commands/SkillsListCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Ai\Console\Commands;
+
+use Illuminate\Console\Command;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillDiscovery;
+
+class SkillsListCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'skill:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all available AI skills';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(SkillDiscovery $discovery): int
+    {
+        $skills = $discovery->discover();
+
+        if ($skills->isEmpty()) {
+            $this->info('No skills found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Name', 'Description', 'Source'],
+            $skills->map(fn (Skill $s) => [$s->name, $s->description, $s->source])
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -15,19 +15,27 @@ class AgentPrompt extends Prompt
 
     public readonly ?int $timeout;
 
+    public readonly array $tools;
+
+    public readonly ?string $instructions;
+
     public function __construct(
         Agent $agent,
         string $prompt,
         Collection|array $attachments,
         TextProvider $provider,
         string $model,
-        ?int $timeout = null
+        ?int $timeout = null,
+        array $tools = [],
+        ?string $instructions = null
     ) {
         parent::__construct($prompt, $provider, $model);
 
         $this->agent = $agent;
         $this->attachments = Collection::make($attachments);
         $this->timeout = $timeout;
+        $this->tools = $tools;
+        $this->instructions = $instructions;
     }
 
     /**
@@ -70,6 +78,8 @@ class AgentPrompt extends Prompt
             $this->provider,
             $this->model,
             $this->timeout,
+            $this->tools,
+            $this->instructions,
         );
     }
 

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -12,7 +12,6 @@ use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Contracts\HasMiddleware;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\InvokingTool;
@@ -59,9 +58,9 @@ trait GeneratesText
                 $response = $this->textGateway()->generateText(
                     $this,
                     $prompt->model,
-                    (string) $agent->instructions(),
+                    $prompt->instructions ?? (string) $agent->instructions(),
                     $messages,
-                    $agent instanceof HasTools ? $agent->tools() : [],
+                    $prompt->tools,
                     $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null,
                     TextGenerationOptions::forAgent($agent),
                     $prompt->timeout,

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasStructuredOutput;
-use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -58,9 +57,9 @@ trait StreamsText
                             $invocationId,
                             $this,
                             $prompt->model,
-                            (string) $agent->instructions(),
+                            $prompt->instructions ?? (string) $agent->instructions(),
                             $messages,
-                            $agent instanceof HasTools ? $agent->tools() : [],
+                            $prompt->tools,
                             null,
                             TextGenerationOptions::forAgent($agent),
                             $prompt->timeout,

--- a/src/Skillable.php
+++ b/src/Skillable.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Laravel\Ai;
+
+use Laravel\Ai\Skills\SkillMode;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Skills\Tools\ListSkills;
+use Laravel\Ai\Skills\Tools\SkillLoader;
+use Laravel\Ai\Skills\Tools\SkillReferenceReader;
+
+trait Skillable
+{
+    /**
+     * The skill registry instance.
+     */
+    protected ?SkillRegistry $skillRegistry = null;
+
+    /**
+     * Get the skills assigned to the agent.
+     */
+    public function skills(): iterable
+    {
+        return [];
+    }
+
+    /**
+     * Get the instructions provided by the agent's skills.
+     */
+    public function skillInstructions(SkillMode|string|null $mode = null): string
+    {
+        $this->bootSkillsIfNeeded();
+
+        return $this->skillRegistry->instructions($mode);
+    }
+
+    /**
+     * Get the meta-tools for skill management.
+     *
+     * @return array<int, object>
+     */
+    public function skillTools(): array
+    {
+        $this->bootSkillsIfNeeded();
+
+        return [
+            app(ListSkills::class),
+            app(SkillLoader::class),
+            app(SkillReferenceReader::class),
+        ];
+    }
+
+    /**
+     * Boot the skill registry if it has not already been initialized.
+     */
+    protected function bootSkillsIfNeeded(): void
+    {
+        if ($this->skillRegistry !== null) {
+            return;
+        }
+
+        $this->skillRegistry = app(SkillRegistry::class);
+
+        foreach ($this->skills() as $key => $value) {
+            $name = is_int($key) ? $value : $key;
+            $mode = is_int($key) ? null : $value;
+
+            $this->skillRegistry->load($name, $mode);
+        }
+    }
+}

--- a/src/Skills/Skill.php
+++ b/src/Skills/Skill.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+final readonly class Skill
+{
+    /**
+     * Create a new skill instance.
+     */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public string $instructions,
+        public string $source = 'local',
+        public ?string $basePath = null,
+    ) {}
+
+    /**
+     * Get the URL-friendly slug for the skill name.
+     */
+    public function slug(): string
+    {
+        return Str::slug($this->name);
+    }
+
+    /**
+     * Get the reference files available in the skill's base directory.
+     *
+     * @return array<int, string>
+     */
+    public function referenceFiles(): array
+    {
+        if (! $this->basePath || ! is_dir($this->basePath)) {
+            return [];
+        }
+
+        $finder = (new Finder)
+            ->files()
+            ->followLinks()
+            ->in($this->basePath)
+            ->name(['*.md', '*.txt', '*.yaml', '*.yml', '*.json'])
+            ->notName('SKILL.md');
+
+        return collect($finder)
+            ->map(fn (SplFileInfo $file) => $file->getRelativePathname())
+            ->values()
+            ->all();
+    }
+}

--- a/src/Skills/SkillDiscovery.php
+++ b/src/Skills/SkillDiscovery.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Support\Collection;
+use Symfony\Component\Finder\Finder;
+
+class SkillDiscovery
+{
+    /**
+     * Create a new skill discovery instance.
+     *
+     * @param  array<int, string>  $paths
+     */
+    public function __construct(
+        protected array $paths
+    ) {}
+
+    /**
+     * Discover all available skills from configured paths.
+     */
+    public function discover(): Collection
+    {
+        return $this->scanLocal();
+    }
+
+    /**
+     * Resolve a single skill by its name.
+     */
+    public function resolve(string $name): ?Skill
+    {
+        return $this->discover()->first(fn (Skill $skill) => $skill->name === $name);
+    }
+
+    /**
+     * Scan the local filesystem for skill definitions.
+     */
+    protected function scanLocal(): Collection
+    {
+        $skills = collect();
+
+        if (empty($this->paths)) {
+            return $skills;
+        }
+
+        $existingPaths = array_filter($this->paths, 'is_dir');
+
+        if (empty($existingPaths)) {
+            return $skills;
+        }
+
+        $finder = new Finder;
+        $finder->files()
+            ->followLinks()
+            ->in($existingPaths)
+            ->name('SKILL.md')
+            ->depth('== 1');
+
+        foreach ($finder as $file) {
+            $skill = SkillParser::parse(
+                $file->getContents(),
+                'local',
+                $file->getPath()
+            );
+
+            if ($skill) {
+                $skills->push($skill);
+            }
+        }
+
+        return $skills;
+    }
+}

--- a/src/Skills/SkillMode.php
+++ b/src/Skills/SkillMode.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+enum SkillMode: string
+{
+    case None = 'none';
+    case Lite = 'lite';
+    case Full = 'full';
+
+    /**
+     * Resolve a skill mode from a string or enum instance.
+     */
+    public static function fromValue(string|self $value): self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        return self::from(strtolower($value));
+    }
+}

--- a/src/Skills/SkillParser.php
+++ b/src/Skills/SkillParser.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class SkillParser
+{
+    /**
+     * Parse a skill definition from its raw Markdown content.
+     */
+    public static function parse(string $content, string $source = 'local', ?string $basePath = null): ?Skill
+    {
+        if (! str_starts_with($content, '---')) {
+            Log::warning('Skill content must start with YAML frontmatter.');
+
+            return null;
+        }
+
+        $parts = explode('---', $content, 3);
+
+        if (count($parts) < 3) {
+            Log::warning('Skill content must contain YAML frontmatter and Markdown body.');
+
+            return null;
+        }
+
+        try {
+            $frontmatter = Yaml::parse($parts[1]);
+        } catch (ParseException $e) {
+            Log::warning('Failed to parse skill frontmatter: '.$e->getMessage());
+
+            return null;
+        }
+
+        $body = trim($parts[2]);
+
+        if (! isset($frontmatter['name']) || ! isset($frontmatter['description'])) {
+            Log::warning('Skill frontmatter must contain "name" and "description".');
+
+            return null;
+        }
+
+        return new Skill(
+            name: $frontmatter['name'],
+            description: $frontmatter['description'],
+            instructions: $body,
+            source: $source,
+            basePath: $basePath,
+        );
+    }
+}

--- a/src/Skills/SkillRegistry.php
+++ b/src/Skills/SkillRegistry.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Laravel\Ai\Skills;
+
+use Illuminate\Support\Collection;
+
+class SkillRegistry
+{
+    /**
+     * The loaded skills.
+     *
+     * @var array<string, Skill>
+     */
+    protected array $skills = [];
+
+    /**
+     * The modes for the loaded skills.
+     *
+     * @var array<string, SkillMode>
+     */
+    protected array $skillModes = [];
+
+    public function __construct(
+        protected SkillDiscovery $discovery
+    ) {}
+
+    /**
+     * Load a skill by name with an optional discovery mode.
+     */
+    public function load(string $name, SkillMode|string|null $mode = null): ?Skill
+    {
+        $skill = $this->discovery->resolve($name);
+
+        if ($skill) {
+            $this->skills[$skill->name] = $skill;
+
+            if ($mode) {
+                $this->skillModes[$skill->name] = $mode instanceof SkillMode ? $mode : SkillMode::fromValue($mode);
+            }
+        }
+
+        return $skill;
+    }
+
+    /**
+     * Determine if a skill is currently loaded.
+     */
+    public function isLoaded(string $name): bool
+    {
+        return isset($this->skills[$name]);
+    }
+
+    /**
+     * Get a loaded skill by name.
+     */
+    public function get(string $name): ?Skill
+    {
+        return $this->skills[$name] ?? null;
+    }
+
+    /**
+     * @return array<string, Skill>
+     */
+    public function getLoaded(): array
+    {
+        return $this->skills;
+    }
+
+    /**
+     * Discover all available skills.
+     */
+    public function discover(): Collection
+    {
+        return $this->discovery->discover();
+    }
+
+    /**
+     * Get the aggregated instructions for all loaded skills.
+     */
+    public function instructions(SkillMode|string|null $mode = null): string
+    {
+        $globalMode = $mode instanceof SkillMode
+            ? $mode
+            : SkillMode::fromValue($mode ?? config('ai.skills.default_mode', 'full'));
+
+        return collect($this->skills)
+            ->map(function (Skill $skill) use ($globalMode) {
+                $skillMode = $this->skillModes[$skill->name] ?? $globalMode;
+
+                if ($skillMode === SkillMode::Full) {
+                    return sprintf(
+                        '<skill name="%s">%s%s%s</skill>',
+                        htmlspecialchars($skill->name, ENT_QUOTES | ENT_XML1),
+                        PHP_EOL,
+                        $skill->instructions,
+                        PHP_EOL
+                    );
+                }
+
+                if ($skillMode === SkillMode::Lite) {
+                    return sprintf(
+                        '<skill name="%s" description="%s" />',
+                        htmlspecialchars($skill->name, ENT_QUOTES | ENT_XML1),
+                        htmlspecialchars($skill->description, ENT_QUOTES | ENT_XML1)
+                    );
+                }
+
+                return '';
+            })
+            ->filter()
+            ->implode(PHP_EOL);
+    }
+}

--- a/src/Skills/Tools/ListSkills.php
+++ b/src/Skills/Tools/ListSkills.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Laravel\Ai\Skills\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Stringable;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Tools\Request;
+
+class ListSkills implements Tool
+{
+    /**
+     * The memoized description of the tool.
+     */
+    private ?string $memoizedDescription = null;
+
+    /**
+     * Create a new tool instance.
+     */
+    public function __construct(
+        protected SkillRegistry $registry
+    ) {}
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return 'skill_list';
+    }
+
+    /**
+     * Get the description of the tool.
+     */
+    public function description(): Stringable|string
+    {
+        if ($this->memoizedDescription) {
+            return $this->memoizedDescription;
+        }
+
+        $skills = $this->registry->discover();
+
+        $xml = $skills->map(fn ($skill) => sprintf(
+            '  <skill name="%s" description="%s" />',
+            htmlspecialchars($skill->name, ENT_QUOTES | ENT_XML1),
+            htmlspecialchars($skill->description, ENT_QUOTES | ENT_XML1),
+        ))->implode("\n");
+
+        return $this->memoizedDescription = <<<XML
+List the available skills that can be loaded.
+Available skills:
+<available_skills>
+$xml
+</available_skills>
+XML;
+    }
+
+    /**
+     * Run the tool.
+     */
+    public function handle(Request $request): Stringable|string
+    {
+        $skills = $this->registry->discover();
+
+        if ($skills->isEmpty()) {
+            return 'No skills found.';
+        }
+
+        $header = "| Name | Description | Source | Status |\n|---|---|---|---|\n";
+
+        $rows = $skills->map(function ($skill) {
+            $status = $this->registry->isLoaded($skill->name) ? 'Loaded' : 'Available';
+
+            return sprintf(
+                '| %s | %s | %s | %s |',
+                $skill->name,
+                $skill->description,
+                $skill->source,
+                $status
+            );
+        })->implode("\n");
+
+        return $header.$rows;
+    }
+
+    /**
+     * Get the parameter schema for the tool.
+     *
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/src/Skills/Tools/SkillLoader.php
+++ b/src/Skills/Tools/SkillLoader.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Laravel\Ai\Skills\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Stringable;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Skills\SkillMode;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Tools\Request;
+
+class SkillLoader implements Tool
+{
+    /**
+     * Create a new tool instance.
+     */
+    public function __construct(
+        protected SkillRegistry $registry
+    ) {}
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return 'skill_load';
+    }
+
+    /**
+     * Get the description of the tool.
+     */
+    public function description(): Stringable|string
+    {
+        return 'Load a skill into the conversation context.';
+    }
+
+    /**
+     * Run the tool.
+     */
+    public function handle(Request $request): Stringable|string
+    {
+        $name = (string) $request->string('skill');
+
+        $skill = $this->registry->load($name, SkillMode::Full);
+
+        if (! $skill) {
+            return "Skill '{$name}' not found.";
+        }
+
+        $escapedName = htmlspecialchars($skill->name, ENT_QUOTES | ENT_XML1);
+
+        $references = '';
+        $files = $skill->referenceFiles();
+
+        if (! empty($files)) {
+            $fileList = implode(', ', $files);
+            $references = <<<XML
+
+<skill_references>
+Available files: $fileList
+Use the `skill_read` tool with skill="{$escapedName}" and file="<filename>" to read these.
+</skill_references>
+XML;
+        }
+
+        return <<<XML
+<skill name="{$escapedName}">
+<instructions>
+{$skill->instructions}
+</instructions>$references
+</skill>
+XML;
+    }
+
+    /**
+     * Get the parameter schema for the tool.
+     *
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'skill' => $schema->string()
+                ->description('The name of the skill to load')
+                ->required(),
+        ];
+    }
+}

--- a/src/Skills/Tools/SkillReferenceReader.php
+++ b/src/Skills/Tools/SkillReferenceReader.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Laravel\Ai\Skills\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Stringable;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Tools\Request;
+
+class SkillReferenceReader implements Tool
+{
+    /**
+     * Create a new tool instance.
+     */
+    public function __construct(
+        protected SkillRegistry $registry
+    ) {}
+
+    /**
+     * Get the name of the tool.
+     */
+    public function name(): string
+    {
+        return 'skill_read';
+    }
+
+    /**
+     * Get the description of the tool.
+     */
+    public function description(): Stringable|string
+    {
+        return 'Reads a file from a skill\'s directory.';
+    }
+
+    /**
+     * Run the tool.
+     */
+    public function handle(Request $request): Stringable|string
+    {
+        $skillName = (string) $request->string('skill');
+        $fileName = (string) $request->string('file');
+
+        $skill = $this->registry->get($skillName);
+
+        if (! $skill) {
+            return sprintf("Skill '%s' not loaded or not found.", $skillName);
+        }
+
+        if (! $skill->basePath) {
+            return sprintf("Skill '%s' does not have a base path.", $skillName);
+        }
+
+        // Security check: block absolute path attempts
+        if (str_starts_with($fileName, '/')) {
+            return 'Access denied: Cannot read outside skill directory.';
+        }
+
+        $filePath = $skill->basePath.'/'.$fileName;
+
+        if (! file_exists($filePath)) {
+            return sprintf("File '%s' not found in skill directory.", $fileName);
+        }
+
+        // Whitelist check: Ensure file is in allowed reference files
+        if (! in_array($fileName, $skill->referenceFiles(), true)) {
+            return sprintf("File '%s' is not in the allowed reference files list.", $fileName);
+        }
+
+        $path = realpath($filePath);
+        $basePath = realpath($skill->basePath);
+
+        // Double-check resolved path stays within skill directory (with trailing slash)
+        if (! $path || ! $basePath) {
+            return 'Access denied: Cannot read outside skill directory.';
+        }
+
+        $basePath = rtrim($basePath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        if (! str_starts_with($path, $basePath)) {
+            return 'Access denied: Cannot read outside skill directory.';
+        }
+
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            return sprintf("Failed to read file '%s'.", $fileName);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Get the parameter schema for the tool.
+     *
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'skill' => $schema->string()
+                ->description('The name of the skill')
+                ->required(),
+            'file' => $schema->string()
+                ->description('The relative path to the file within the skill directory')
+                ->required(),
+        ];
+    }
+}

--- a/stubs/skill.stub
+++ b/stubs/skill.stub
@@ -1,0 +1,8 @@
+---
+name: {{ name }}
+description: A skill for {{ slug }}.
+---
+
+# {{ name }}
+
+Write the skill instructions here.

--- a/tests/Feature/Console/MakeSkillCommandTest.php
+++ b/tests/Feature/Console/MakeSkillCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class MakeSkillCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (File::exists(resource_path('skills/test-skill'))) {
+            File::deleteDirectory(resource_path('skills/test-skill'));
+        }
+    }
+
+    public function test_can_create_a_skill_file(): void
+    {
+        $this->artisan('make:skill', [
+            'name' => 'test-skill',
+        ])->assertExitCode(0);
+
+        $this->assertFileExists(resource_path('skills/test-skill/SKILL.md'));
+
+        $content = File::get(resource_path('skills/test-skill/SKILL.md'));
+        $this->assertStringContainsString('name: Test Skill', $content);
+    }
+
+    public function test_can_create_a_skill_with_force_option(): void
+    {
+        File::makeDirectory(resource_path('skills/test-skill'), 0755, true);
+        File::put(resource_path('skills/test-skill/SKILL.md'), 'old content');
+
+        $this->artisan('make:skill', [
+            'name' => 'test-skill',
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $content = File::get(resource_path('skills/test-skill/SKILL.md'));
+        $this->assertStringContainsString('name: Test Skill', $content);
+        $this->assertStringNotContainsString('old content', $content);
+    }
+}

--- a/tests/Feature/Console/SkillsListCommandTest.php
+++ b/tests/Feature/Console/SkillsListCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Laravel\Ai\Console\Commands\SkillsListCommand;
+use Tests\TestCase;
+
+class SkillsListCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::registerCommand($this->app->make(SkillsListCommand::class));
+    }
+
+    public function test_shows_message_when_no_skills_found(): void
+    {
+        $this->app['config']->set('ai.skills.paths', []);
+
+        $this->artisan('skill:list')
+            ->expectsOutputToContain('No skills found.')
+            ->assertExitCode(0);
+    }
+
+    public function test_lists_discovered_skills_as_table(): void
+    {
+        $tmpDir = sys_get_temp_dir().'/laravel-ai-test-skills/test-skill';
+
+        File::makeDirectory($tmpDir, 0755, true, true);
+        File::put($tmpDir.'/SKILL.md', <<<'MD'
+---
+name: Test Skill
+description: A test skill
+---
+Some instructions here.
+MD);
+
+        $this->app['config']->set('ai.skills.paths', [dirname($tmpDir)]);
+
+        $this->artisan('skill:list')
+            ->expectsOutputToContain('Test Skill')
+            ->assertExitCode(0);
+
+        File::deleteDirectory(dirname($tmpDir));
+    }
+}

--- a/tests/Feature/Skills/ConfigTest.php
+++ b/tests/Feature/Skills/ConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Orchestra\Testbench\TestCase;
+
+class ConfigTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return ['Laravel\Ai\AiServiceProvider'];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('ai', require __DIR__.'/../../../config/ai.php');
+    }
+
+    public function test_config_values_are_retrievable()
+    {
+        $this->assertEquals('lite', config('ai.skills.default_mode'));
+        $this->assertIsArray(config('ai.skills.paths'));
+        $this->assertContains(resource_path('skills'), config('ai.skills.paths'));
+    }
+}

--- a/tests/Feature/Skills/IntegrationTest.php
+++ b/tests/Feature/Skills/IntegrationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Stringable;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Skillable;
+use Laravel\Ai\Skills\SkillMode;
+use Tests\TestCase;
+
+class TestSkillAgent implements Agent
+{
+    use Promptable;
+    use Skillable;
+
+    public function skills(): iterable
+    {
+        return ['test-skill' => SkillMode::Full];
+    }
+
+    public function tools(): iterable
+    {
+        return [];
+    }
+
+    public function instructions(): Stringable|string
+    {
+        return 'Base instructions';
+    }
+}
+
+class IntegrationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $path = resource_path('skills/test-skill');
+        if (File::exists($path)) {
+            File::deleteDirectory($path);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_end_to_end_skill_flow()
+    {
+        $path = resource_path('skills/test-skill');
+        if (File::exists($path)) {
+            File::deleteDirectory($path);
+        }
+
+        // 1. Create a new skill using the artisan command
+        $this->artisan('make:skill', ['name' => 'test-skill'])
+            ->assertExitCode(0);
+
+        // Verify the file exists
+        $skillPath = resource_path('skills/test-skill/SKILL.md');
+        $this->assertFileExists($skillPath);
+
+        // Customize the skill content for testing
+        $skillContent = <<<'EOT'
+---
+name: test-skill
+description: A test skill for integration testing
+---
+You are a helpful test assistant.
+Always respond with "Test Successful".
+EOT;
+        File::put($skillPath, $skillContent);
+
+        // 2. Fake the AI response
+        TestSkillAgent::fake([
+            'Test Successful',
+        ]);
+
+        // 3. Instantiate the concrete agent class
+        $agent = new TestSkillAgent;
+
+        // 4. Prompt the agent
+        $response = $agent->prompt('Check for test-skill');
+
+        // 5. Verify the output
+        $this->assertEquals('Test Successful', $response->text);
+
+        // 6. Verify the skill was injected correctly
+        TestSkillAgent::assertPrompted(function ($prompt) {
+            // Check that instructions contain the skill instructions
+            $instructions = (string) $prompt->instructions;
+
+            // The skill content "You are a helpful test assistant." should be present if the skill was loaded.
+            return str_contains($instructions, 'You are a helpful test assistant');
+        });
+
+    }
+}

--- a/tests/Feature/Skills/PromptableSkillsTest.php
+++ b/tests/Feature/Skills/PromptableSkillsTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Stringable;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Skillable;
+use Laravel\Ai\Skills\SkillMode;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Tools\Request;
+use Mockery;
+use Tests\TestCase;
+
+class PromptableSkillsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_it_appends_skill_instructions_when_prompting()
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')->with('test-skill', SkillMode::Full)->once();
+        $registry->shouldReceive('instructions')->with(null)->andReturn('Skill instructions');
+
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $agent = new class implements Agent
+        {
+            use Promptable, Skillable;
+
+            public function skills(): iterable
+            {
+                return ['test-skill' => SkillMode::Full];
+            }
+
+            public function instructions(): Stringable|string
+            {
+                return 'Base instructions';
+            }
+        };
+
+        $agent::fake(['response']);
+
+        $agent->prompt('hello');
+
+        $agent::assertPrompted(function ($prompt) {
+            return str_contains($prompt->instructions, 'Base instructions')
+                && str_contains($prompt->instructions, 'Skill instructions');
+        });
+    }
+
+    public function test_get_tools_returns_tools_when_agent_defines_them()
+    {
+        $toolA = new class implements Tool
+        {
+            public function name(): string
+            {
+                return 'tool_a';
+            }
+
+            public function description(): string
+            {
+                return 'Tool A';
+            }
+
+            public function handle(Request $request): string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+        $toolB = new class implements Tool
+        {
+            public function name(): string
+            {
+                return 'tool_b';
+            }
+
+            public function description(): string
+            {
+                return 'Tool B';
+            }
+
+            public function handle(Request $request): string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $agent = new class($toolA, $toolB) implements Agent
+        {
+            use Promptable;
+
+            private object $toolA;
+
+            private object $toolB;
+
+            public function __construct(object $toolA, object $toolB)
+            {
+                $this->toolA = $toolA;
+                $this->toolB = $toolB;
+            }
+
+            public function tools(): array
+            {
+                return [$this->toolA, $this->toolB];
+            }
+
+            public function instructions(): string
+            {
+                return 'Test instructions';
+            }
+        };
+
+        $agent::fake(['response']);
+
+        $agent->prompt('hello');
+
+        $agent::assertPrompted(function ($prompt) use ($toolA, $toolB) {
+            return $prompt->tools === [$toolA, $toolB];
+        });
+    }
+
+    public function test_get_tools_returns_empty_array_when_agent_has_no_tools()
+    {
+        $agent = new class implements Agent
+        {
+            use Promptable;
+
+            public function instructions(): string
+            {
+                return 'No tools agent';
+            }
+        };
+
+        $agent::fake(['response']);
+
+        $agent->prompt('hello');
+
+        $agent::assertPrompted(function ($prompt) {
+            return $prompt->tools === [];
+        });
+    }
+
+    public function test_get_tools_merges_skill_tools_with_agent_tools()
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')->once();
+        $registry->shouldReceive('instructions')->with(null)->andReturn('');
+
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $agent = new class implements Agent
+        {
+            use Promptable, Skillable;
+
+            public function skills(): iterable
+            {
+                return ['test-skill' => SkillMode::Full];
+            }
+
+            public function tools(): iterable
+            {
+                return [];
+            }
+
+            public function instructions(): string
+            {
+                return 'Test';
+            }
+        };
+
+        $agent::fake(['response']);
+
+        $agent->prompt('hello');
+
+        $agent::assertPrompted(function ($prompt) {
+            $toolNames = array_map(fn ($t) => $t->name(), $prompt->tools);
+
+            return in_array('skill_list', $toolNames)
+                && in_array('skill_load', $toolNames)
+                && in_array('skill_read', $toolNames);
+        });
+    }
+}

--- a/tests/Feature/Skills/SkillDiscoveryTest.php
+++ b/tests/Feature/Skills/SkillDiscoveryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillDiscovery;
+use Tests\TestCase;
+
+class SkillDiscoveryTest extends TestCase
+{
+    protected string $tempPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempPath = sys_get_temp_dir().'/ai_sdk_test_'.uniqid();
+        File::makeDirectory($this->tempPath, 0755, true, true);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->tempPath);
+        parent::tearDown();
+    }
+
+    public function test_it_discovers_skills_in_given_paths()
+    {
+        $skillDir = $this->tempPath.'/test-skill';
+        File::makeDirectory($skillDir);
+        File::put($skillDir.'/SKILL.md', <<<'MD'
+---
+name: Test Skill
+description: A test skill description
+---
+Test instructions
+MD
+        );
+
+        $discovery = new SkillDiscovery([$this->tempPath]);
+        $skills = $discovery->discover();
+
+        $this->assertCount(1, $skills);
+        $this->assertInstanceOf(Skill::class, $skills->first());
+        $this->assertEquals('Test Skill', $skills->first()->name);
+    }
+
+    public function test_it_rescans_on_every_discover_call()
+    {
+        $skillDir = $this->tempPath.'/test-skill';
+        File::makeDirectory($skillDir);
+        File::put($skillDir.'/SKILL.md', '---
+name: Initial Skill
+description: Description
+---
+Body');
+
+        $discovery = new SkillDiscovery([$this->tempPath]);
+
+        $this->assertEquals('Initial Skill', $discovery->discover()->first()->name);
+
+        File::put($skillDir.'/SKILL.md', '---
+name: Updated Skill
+description: Description
+---
+Body');
+
+        $this->assertEquals('Updated Skill', $discovery->discover()->first()->name);
+    }
+
+    public function test_resolve_finds_skill_by_name()
+    {
+        $skillDir = $this->tempPath.'/test-skill';
+        File::makeDirectory($skillDir);
+        File::put($skillDir.'/SKILL.md', '---
+name: Target Skill
+description: Description
+---
+Body');
+
+        $discovery = new SkillDiscovery([$this->tempPath]);
+
+        $skill = $discovery->resolve('Target Skill');
+        $this->assertNotNull($skill);
+        $this->assertEquals('Target Skill', $skill->name);
+
+        $this->assertNull($discovery->resolve('Non Existent'));
+    }
+
+    public function test_returns_empty_collection_for_empty_paths()
+    {
+        $discovery = new SkillDiscovery([]);
+
+        $this->assertTrue($discovery->discover()->isEmpty());
+    }
+
+    public function test_it_follows_symlinks_when_discovering_skills()
+    {
+        $targetDir = $this->tempPath.'/actual-skill';
+        File::makeDirectory($targetDir);
+        File::put($targetDir.'/SKILL.md', '---
+name: Symlinked Skill
+description: A symlinked skill
+---
+Instructions');
+
+        $linksDir = sys_get_temp_dir().'/ai_sdk_links_'.uniqid();
+        File::makeDirectory($linksDir);
+        symlink($targetDir, $linksDir.'/linked-skill');
+
+        $discovery = new SkillDiscovery([$linksDir]);
+        $skills = $discovery->discover();
+
+        $this->assertCount(1, $skills);
+        $this->assertEquals('Symlinked Skill', $skills->first()->name);
+
+        unlink($linksDir.'/linked-skill');
+        File::deleteDirectory($linksDir);
+    }
+}

--- a/tests/Feature/Skills/SkillModeTest.php
+++ b/tests/Feature/Skills/SkillModeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skills\SkillMode;
+use PHPUnit\Framework\TestCase;
+use ValueError;
+
+class SkillModeTest extends TestCase
+{
+    public function test_it_has_expected_cases(): void
+    {
+        $this->assertEquals('none', SkillMode::None->value);
+        $this->assertEquals('lite', SkillMode::Lite->value);
+        $this->assertEquals('full', SkillMode::Full->value);
+    }
+
+    public function test_from_value_handles_strings(): void
+    {
+        $this->assertEquals(SkillMode::None, SkillMode::fromValue('none'));
+        $this->assertEquals(SkillMode::Lite, SkillMode::fromValue('lite'));
+        $this->assertEquals(SkillMode::Full, SkillMode::fromValue('full'));
+    }
+
+    public function test_from_value_is_case_insensitive(): void
+    {
+        $this->assertEquals(SkillMode::None, SkillMode::fromValue('NONE'));
+        $this->assertEquals(SkillMode::Lite, SkillMode::fromValue('Lite'));
+        $this->assertEquals(SkillMode::Full, SkillMode::fromValue('fULL'));
+    }
+
+    public function test_from_value_handles_enum_instance(): void
+    {
+        $this->assertEquals(SkillMode::Lite, SkillMode::fromValue(SkillMode::Lite));
+    }
+
+    public function test_from_value_throws_exception_for_invalid_value(): void
+    {
+        $this->expectException(ValueError::class);
+        SkillMode::fromValue('invalid');
+    }
+}

--- a/tests/Feature/Skills/SkillParserTest.php
+++ b/tests/Feature/Skills/SkillParserTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skills\SkillParser;
+use Tests\TestCase;
+
+class SkillParserTest extends TestCase
+{
+    public function test_parses_valid_skill_md()
+    {
+        $markdown = <<<'MD'
+---
+name: my-skill
+description: A useful skill
+---
+# Instructions
+Do something.
+MD;
+
+        $skill = SkillParser::parse($markdown, 'remote', '/base');
+
+        $this->assertNotNull($skill);
+        $this->assertSame('my-skill', $skill->name);
+        $this->assertSame('A useful skill', $skill->description);
+        $this->assertSame('remote', $skill->source);
+        $this->assertSame('/base', $skill->basePath);
+        $this->assertSame('# Instructions'.PHP_EOL.'Do something.', $skill->instructions);
+    }
+
+    public function test_returns_null_for_missing_name()
+    {
+        $markdown = <<<'MD'
+---
+description: Missing name
+---
+Body
+MD;
+
+        $this->assertNull(SkillParser::parse($markdown));
+    }
+
+    public function test_returns_null_for_missing_description()
+    {
+        $markdown = <<<'MD'
+---
+name: Missing description
+---
+Body
+MD;
+
+        $this->assertNull(SkillParser::parse($markdown));
+    }
+
+    public function test_returns_null_for_invalid_yaml()
+    {
+        $markdown = <<<'MD'
+---
+name: invalid: [yaml
+---
+Body
+MD;
+
+        $this->assertNull(SkillParser::parse($markdown));
+    }
+
+    public function test_handles_minimal_frontmatter()
+    {
+        $markdown = <<<'MD'
+---
+name: simple
+description: simple desc
+---
+body
+MD;
+
+        $skill = SkillParser::parse($markdown);
+
+        $this->assertNotNull($skill);
+        $this->assertSame('simple', $skill->name);
+        $this->assertSame('simple desc', $skill->description);
+        $this->assertSame('local', $skill->source);
+        $this->assertNull($skill->basePath);
+    }
+
+    public function test_preserves_markdown_instructions()
+    {
+        $markdown = <<<'MD'
+---
+name: md
+description: md desc
+---
+# Header
+- list item
+MD;
+
+        $skill = SkillParser::parse($markdown);
+
+        $this->assertSame('# Header'.PHP_EOL.'- list item', $skill->instructions);
+    }
+
+    public function test_returns_null_for_content_without_frontmatter()
+    {
+        $markdown = <<<'MD'
+# Just Markdown
+No frontmatter here at all.
+MD;
+
+        $this->assertNull(SkillParser::parse($markdown));
+    }
+}

--- a/tests/Feature/Skills/SkillRegistryTest.php
+++ b/tests/Feature/Skills/SkillRegistryTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillMode;
+use Laravel\Ai\Skills\SkillRegistry;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class SkillRegistryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function test_it_can_load_a_skill()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $skill = new Skill('test-skill', 'Description', 'Instructions');
+
+        $discovery->shouldReceive('resolve')->with('test-skill')->once()->andReturn($skill);
+
+        $registry = new SkillRegistry($discovery);
+
+        $this->assertFalse($registry->isLoaded('test-skill'));
+
+        $loadedSkill = $registry->load('test-skill');
+
+        $this->assertSame($skill, $loadedSkill);
+        $this->assertTrue($registry->isLoaded('test-skill'));
+        $this->assertSame($skill, $registry->get('test-skill'));
+    }
+
+    public function test_it_returns_null_when_skill_cannot_be_resolved()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $discovery->shouldReceive('resolve')->with('unknown')->once()->andReturn(null);
+
+        $registry = new SkillRegistry($discovery);
+
+        $this->assertNull($registry->load('unknown'));
+        $this->assertFalse($registry->isLoaded('unknown'));
+    }
+
+    public function test_it_can_get_all_loaded_skills()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $skill1 = new Skill('skill-1', 'Desc 1', 'Instr 1');
+        $skill2 = new Skill('skill-2', 'Desc 2', 'Instr 2');
+
+        $discovery->shouldReceive('resolve')->with('skill-1')->andReturn($skill1);
+        $discovery->shouldReceive('resolve')->with('skill-2')->andReturn($skill2);
+
+        $registry = new SkillRegistry($discovery);
+        $registry->load('skill-1');
+        $registry->load('skill-2');
+
+        $loaded = $registry->getLoaded();
+
+        $this->assertCount(2, $loaded);
+        $this->assertArrayHasKey('skill-1', $loaded);
+        $this->assertArrayHasKey('skill-2', $loaded);
+    }
+
+    public function test_it_generates_instructions_xml_in_full_mode()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $skill = new Skill('test-skill', 'Description', 'Instructions');
+
+        $discovery->shouldReceive('resolve')->with('test-skill')->andReturn($skill);
+
+        $registry = new SkillRegistry($discovery);
+        $registry->load('test-skill');
+
+        $expected = '<skill name="test-skill">'.PHP_EOL.'Instructions'.PHP_EOL.'</skill>';
+        $this->assertEquals($expected, $registry->instructions('full'));
+    }
+
+    public function test_it_generates_instructions_xml_in_lite_mode()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $skill = new Skill('test-skill', 'Description', 'Instructions');
+
+        $discovery->shouldReceive('resolve')->with('test-skill')->andReturn($skill);
+
+        $registry = new SkillRegistry($discovery);
+        $registry->load('test-skill');
+
+        $expected = '<skill name="test-skill" description="Description" />';
+        $this->assertEquals($expected, $registry->instructions('lite'));
+    }
+
+    public function test_it_prioritizes_specific_skill_mode_over_global_mode()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $fullSkill = new Skill('full-skill', 'Full Desc', 'Full Instr');
+        $liteSkill = new Skill('lite-skill', 'Lite Desc', 'Lite Instr');
+        $defaultSkill = new Skill('default-skill', 'Default Desc', 'Default Instr');
+
+        $discovery->shouldReceive('resolve')->with('full-skill')->andReturn($fullSkill);
+        $discovery->shouldReceive('resolve')->with('lite-skill')->andReturn($liteSkill);
+        $discovery->shouldReceive('resolve')->with('default-skill')->andReturn($defaultSkill);
+
+        $registry = new SkillRegistry($discovery);
+
+        // Load with specific modes
+        $registry->load('full-skill', 'full');
+        $registry->load('lite-skill', 'lite');
+        // Load without specific mode
+        $registry->load('default-skill');
+
+        // Request global mode as 'lite'
+        // full-skill should stay full
+        // lite-skill should stay lite
+        // default-skill should be lite (from global)
+        $xml = $registry->instructions('lite');
+
+        $this->assertStringContainsString('<skill name="full-skill">'.PHP_EOL.'Full Instr'.PHP_EOL.'</skill>', $xml);
+        $this->assertStringContainsString('<skill name="lite-skill" description="Lite Desc" />', $xml);
+        $this->assertStringContainsString('<skill name="default-skill" description="Default Desc" />', $xml);
+
+        // Request global mode as 'full'
+        // full-skill should stay full
+        // lite-skill should stay lite
+        // default-skill should be full (from global)
+        $xmlFull = $registry->instructions('full');
+
+        $this->assertStringContainsString('<skill name="full-skill">'.PHP_EOL.'Full Instr'.PHP_EOL.'</skill>', $xmlFull);
+        $this->assertStringContainsString('<skill name="lite-skill" description="Lite Desc" />', $xmlFull);
+        $this->assertStringContainsString('<skill name="default-skill">'.PHP_EOL.'Default Instr'.PHP_EOL.'</skill>', $xmlFull);
+    }
+
+    public function test_none_mode_returns_empty_string()
+    {
+        $discovery = Mockery::mock('Laravel\Ai\Skills\SkillDiscovery');
+        $skill = new Skill('test-skill', 'Description', 'Instructions');
+
+        $discovery->shouldReceive('resolve')->with('test-skill')->andReturn($skill);
+
+        $registry = new SkillRegistry($discovery);
+        $registry->load('test-skill');
+
+        $this->assertSame('', $registry->instructions(SkillMode::None));
+    }
+}

--- a/tests/Feature/Skills/SkillTest.php
+++ b/tests/Feature/Skills/SkillTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skills\Skill;
+use ReflectionClass;
+use Tests\TestCase;
+
+class SkillTest extends TestCase
+{
+    public function test_skill_slug_generation()
+    {
+        $skill = new Skill(
+            name: 'My Coding Skill',
+            description: 'Desc',
+            instructions: 'Inst'
+        );
+
+        $this->assertSame('my-coding-skill', $skill->slug());
+    }
+
+    public function test_skill_is_immutable()
+    {
+        $this->assertTrue((new ReflectionClass(Skill::class))->isReadOnly());
+    }
+
+    public function test_reference_files_returns_supported_files_excluding_skill_md()
+    {
+        $tempPath = sys_get_temp_dir().'/skill-ref-test-'.uniqid();
+        mkdir($tempPath);
+
+        file_put_contents($tempPath.'/SKILL.md', 'skip');
+        file_put_contents($tempPath.'/guide.md', 'content');
+        file_put_contents($tempPath.'/config.yaml', 'content');
+        file_put_contents($tempPath.'/data.json', 'content');
+        file_put_contents($tempPath.'/notes.txt', 'content');
+        file_put_contents($tempPath.'/image.png', 'content');
+
+        $skill = new Skill(
+            name: 'test',
+            description: 'd',
+            instructions: 'i',
+            basePath: $tempPath
+        );
+
+        $files = $skill->referenceFiles();
+
+        $this->assertContains('guide.md', $files);
+        $this->assertContains('config.yaml', $files);
+        $this->assertContains('data.json', $files);
+        $this->assertContains('notes.txt', $files);
+        $this->assertNotContains('SKILL.md', $files);
+        $this->assertNotContains('image.png', $files);
+
+        array_map('unlink', glob($tempPath.'/*'));
+        rmdir($tempPath);
+    }
+
+    public function test_reference_files_returns_empty_when_no_base_path()
+    {
+        $skill = new Skill(name: 'test', description: 'd', instructions: 'i');
+
+        $this->assertSame([], $skill->referenceFiles());
+    }
+
+    public function test_reference_files_returns_empty_when_directory_missing()
+    {
+        $skill = new Skill(
+            name: 'test',
+            description: 'd',
+            instructions: 'i',
+            basePath: '/nonexistent/path/'.uniqid()
+        );
+
+        $this->assertSame([], $skill->referenceFiles());
+    }
+
+    public function test_reference_files_discovers_files_in_subdirectories()
+    {
+        $tempPath = sys_get_temp_dir().'/skill-ref-subdir-'.uniqid();
+        mkdir($tempPath);
+        mkdir($tempPath.'/references');
+
+        file_put_contents($tempPath.'/SKILL.md', 'skip');
+        file_put_contents($tempPath.'/guide.md', 'root file');
+        file_put_contents($tempPath.'/references/utilities.md', 'content');
+        file_put_contents($tempPath.'/references/theme.md', 'content');
+
+        $skill = new Skill(
+            name: 'test',
+            description: 'd',
+            instructions: 'i',
+            basePath: $tempPath
+        );
+
+        $files = $skill->referenceFiles();
+
+        $this->assertContains('guide.md', $files);
+        $this->assertContains('references/utilities.md', $files);
+        $this->assertContains('references/theme.md', $files);
+        $this->assertNotContains('SKILL.md', $files);
+
+        array_map('unlink', glob($tempPath.'/references/*'));
+        rmdir($tempPath.'/references');
+        array_map('unlink', glob($tempPath.'/*'));
+        rmdir($tempPath);
+    }
+}

--- a/tests/Feature/Skills/SkillableTest.php
+++ b/tests/Feature/Skills/SkillableTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature\Skills;
+
+use Laravel\Ai\Skillable;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillMode;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Skills\Tools\ListSkills;
+use Laravel\Ai\Skills\Tools\SkillLoader;
+use Laravel\Ai\Skills\Tools\SkillReferenceReader;
+use Mockery;
+use Tests\TestCase;
+
+class SkillableTest extends TestCase
+{
+    public function test_it_can_resolve_skills_from_array()
+    {
+        $skillable = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [
+                    'coach',
+                    '/path/to/skill',
+                    'writer' => SkillMode::Full,
+                    'editor' => 'lite',
+                ];
+            }
+        };
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $registry->shouldReceive('load')->with('coach', null)->once()->andReturn(new Skill('coach', 'desc', 'instr'));
+        $registry->shouldReceive('load')->with('/path/to/skill', null)->once()->andReturn(new Skill('path-skill', 'desc', 'instr'));
+        $registry->shouldReceive('load')->with('writer', SkillMode::Full)->once()->andReturn(new Skill('writer', 'desc', 'instr'));
+        $registry->shouldReceive('load')->with('editor', 'lite')->once()->andReturn(new Skill('editor', 'desc', 'instr'));
+        $registry->shouldReceive('instructions')->with(null)->once()->andReturn('');
+
+        // Trigger lazy loading
+        $skillable->skillInstructions();
+    }
+
+    public function test_it_returns_skill_instructions()
+    {
+        $skillable = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return ['coach'];
+            }
+        };
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $registry->shouldReceive('load')->with('coach', null)->once();
+
+        // Default mode is Lite if not specified, but usually we pass it
+        $registry->shouldReceive('instructions')->with(SkillMode::Full)->once()->andReturn('full instructions');
+        $registry->shouldReceive('instructions')->with(SkillMode::Lite)->once()->andReturn('lite instructions');
+
+        $this->assertEquals('full instructions', $skillable->skillInstructions(SkillMode::Full));
+        $this->assertEquals('lite instructions', $skillable->skillInstructions(SkillMode::Lite));
+    }
+
+    public function test_it_boots_skills_only_once()
+    {
+        $skillable = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return ['coach'];
+            }
+        };
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $registry->shouldReceive('load')->with('coach', null)->once();
+        $registry->shouldReceive('instructions')->twice()->andReturn('instructions');
+
+        $skillable->skillInstructions();
+        $skillable->skillInstructions();
+    }
+
+    public function test_it_returns_empty_with_no_skills()
+    {
+        $skillable = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [];
+            }
+        };
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $registry->shouldReceive('load')->never();
+        $registry->shouldReceive('instructions')->once()->andReturn('');
+
+        $this->assertSame('', $skillable->skillInstructions());
+    }
+
+    public function test_skill_tools_returns_three_meta_tools()
+    {
+        $skillable = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [];
+            }
+        };
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $registry->shouldReceive('load')->never();
+
+        $tools = $skillable->skillTools();
+
+        $this->assertCount(3, $tools);
+        $this->assertInstanceOf(ListSkills::class, $tools[0]);
+        $this->assertInstanceOf(SkillLoader::class, $tools[1]);
+        $this->assertInstanceOf(SkillReferenceReader::class, $tools[2]);
+    }
+
+    public function test_skill_tools_boots_skills_before_returning()
+    {
+        $skillable = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return ['coach', 'writer' => SkillMode::Full];
+            }
+        };
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $this->app->instance(SkillRegistry::class, $registry);
+
+        $registry->shouldReceive('load')->with('coach', null)->once();
+        $registry->shouldReceive('load')->with('writer', SkillMode::Full)->once();
+
+        $tools = $skillable->skillTools();
+
+        $this->assertCount(3, $tools);
+    }
+}

--- a/tests/Feature/Skills/Tools/ListSkillsTest.php
+++ b/tests/Feature/Skills/Tools/ListSkillsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Skills\Tools;
+
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Skills\Tools\ListSkills;
+use Laravel\Ai\Tools\Request;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class ListSkillsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function test_description_contains_available_skills_xml_block(): void
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('discover')->once()->andReturn(collect([
+            new Skill(
+                name: 'git-master',
+                description: 'Advanced git operations',
+                instructions: '...',
+                source: 'local',
+            ),
+            new Skill(
+                name: 'playwright',
+                description: 'Browser automation via Playwright',
+                instructions: '...',
+                source: 'community',
+            ),
+        ]));
+
+        $tool = new ListSkills($registry);
+
+        $description = (string) $tool->description();
+
+        $this->assertStringContainsString('<available_skills>', $description);
+        $this->assertStringContainsString('</available_skills>', $description);
+        $this->assertStringContainsString('git-master', $description);
+        $this->assertStringContainsString('Advanced git operations', $description);
+        $this->assertStringContainsString('playwright', $description);
+        $this->assertStringContainsString('Browser automation via Playwright', $description);
+    }
+
+    public function test_description_is_memoized(): void
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('discover')->once()->andReturn(collect([
+            new Skill(
+                name: 'test-skill',
+                description: 'A test skill',
+                instructions: '...',
+            ),
+        ]));
+
+        $tool = new ListSkills($registry);
+
+        $first = $tool->description();
+        $second = $tool->description();
+
+        $this->assertSame((string) $first, (string) $second);
+    }
+
+    public function test_description_with_no_skills_still_valid(): void
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('discover')->once()->andReturn(collect());
+
+        $tool = new ListSkills($registry);
+
+        $description = (string) $tool->description();
+
+        $this->assertStringContainsString('<available_skills>', $description);
+        $this->assertStringContainsString('</available_skills>', $description);
+    }
+
+    public function test_handle_returns_markdown_table_with_status(): void
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('discover')->andReturn(collect([
+            new Skill(
+                name: 'loaded-skill',
+                description: 'A loaded skill',
+                instructions: '...',
+                source: 'local',
+            ),
+            new Skill(
+                name: 'available-skill',
+                description: 'An available skill',
+                instructions: '...',
+                source: 'community',
+            ),
+        ]));
+
+        $registry->shouldReceive('isLoaded')
+            ->with('loaded-skill')
+            ->andReturn(true);
+
+        $registry->shouldReceive('isLoaded')
+            ->with('available-skill')
+            ->andReturn(false);
+
+        $tool = new ListSkills($registry);
+
+        $result = (string) $tool->handle(new Request([]));
+
+        $this->assertStringContainsString('| Name |', $result);
+        $this->assertStringContainsString('| Description |', $result);
+        $this->assertStringContainsString('| Source |', $result);
+        $this->assertStringContainsString('| Status |', $result);
+        $this->assertStringContainsString('|---', $result);
+        $this->assertStringContainsString('loaded-skill', $result);
+        $this->assertStringContainsString('available-skill', $result);
+        $this->assertStringContainsString('Loaded', $result);
+        $this->assertStringContainsString('Available', $result);
+    }
+}

--- a/tests/Feature/Skills/Tools/MetaToolsTest.php
+++ b/tests/Feature/Skills/Tools/MetaToolsTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature\Skills\Tools;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Skills\Tools\ListSkills;
+use Laravel\Ai\Skills\Tools\SkillLoader;
+use Laravel\Ai\Skills\Tools\SkillReferenceReader;
+use Laravel\Ai\Tools\Request;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+
+class MetaToolsTest extends TestCase
+{
+    private string $tempPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempPath = sys_get_temp_dir().'/ai_sdk_test_'.uniqid();
+
+        if (! is_dir($this->tempPath)) {
+            mkdir($this->tempPath, 0777, true);
+        }
+
+        file_put_contents($this->tempPath.'/test.txt', 'secret content');
+        file_put_contents($this->tempPath.'/outside.txt', 'forbidden content');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempPath)) {
+            File::deleteDirectory($this->tempPath);
+        }
+
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_list_skills_returns_all_available_skills()
+    {
+        $skills = collect([
+            new Skill(
+                name: 'test-skill',
+                description: 'A test skill',
+                instructions: 'Do things',
+                source: 'local'
+            ),
+            new Skill(
+                name: 'another-skill',
+                description: 'Another skill',
+                instructions: 'Do other things',
+                source: 'community'
+            ),
+        ]);
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('discover')->andReturn($skills);
+        $registry->shouldReceive('isLoaded')->andReturn(false);
+
+        $tool = new ListSkills($registry);
+
+        $result = $tool->handle(new Request([]));
+
+        $this->assertStringContainsString('test-skill', (string) $result);
+        $this->assertStringContainsString('A test skill', (string) $result);
+        $this->assertStringContainsString('another-skill', (string) $result);
+        $this->assertStringContainsString('local', (string) $result);
+        $this->assertStringContainsString('community', (string) $result);
+    }
+
+    public function test_skill_loader_loads_specific_skill()
+    {
+        $skill = new Skill(
+            name: 'target-skill',
+            description: 'Target skill',
+            instructions: 'Target instructions',
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')
+            ->with('target-skill', Mockery::any())
+            ->andReturn($skill);
+
+        $tool = new SkillLoader($registry);
+
+        $result = $tool->handle(new Request(['skill' => 'target-skill']));
+
+        $this->assertStringContainsString('<skill name="target-skill">', (string) $result);
+        $this->assertStringContainsString('Target instructions', (string) $result);
+        $this->assertStringContainsString('<instructions>', (string) $result);
+    }
+
+    public function test_skill_loader_returns_error_if_skill_not_found()
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')
+            ->with('missing-skill', Mockery::any())
+            ->andReturn(null);
+
+        $tool = new SkillLoader($registry);
+
+        $result = $tool->handle(new Request(['skill' => 'missing-skill']));
+
+        $this->assertStringContainsString('not found', (string) $result);
+    }
+
+    public function test_skill_reference_reader_reads_file_within_skill_path()
+    {
+        $skill = new Skill(
+            name: 'fs-skill',
+            description: 'FS Skill',
+            instructions: '...',
+            basePath: $this->tempPath
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('fs-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'fs-skill',
+            'file' => 'test.txt',
+        ]));
+
+        $this->assertEquals('secret content', (string) $result);
+    }
+
+    public function test_skill_reference_reader_blocks_path_traversal()
+    {
+        $skill = new Skill(
+            name: 'fs-skill',
+            description: 'FS Skill',
+            instructions: '...',
+            basePath: $this->tempPath
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('fs-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'fs-skill',
+            'file' => '../outside.txt',
+        ]));
+
+        $this->assertStringContainsString('not found', (string) $result);
+    }
+
+    public function test_skill_reference_reader_handles_missing_files()
+    {
+        $skill = new Skill(
+            name: 'fs-skill',
+            description: 'FS Skill',
+            instructions: '...',
+            basePath: $this->tempPath
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('fs-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'fs-skill',
+            'file' => 'does_not_exist.txt',
+        ]));
+
+        $this->assertStringContainsString('not found', (string) $result);
+    }
+}

--- a/tests/Feature/Skills/Tools/SkillLoaderTest.php
+++ b/tests/Feature/Skills/Tools/SkillLoaderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature\Skills\Tools;
+
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Skills\Tools\SkillLoader;
+use Laravel\Ai\Tools\Request;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class SkillLoaderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function test_handle_returns_xml_structured_output(): void
+    {
+        $skill = new Skill(
+            name: 'git-master',
+            description: 'Advanced git operations',
+            instructions: 'Use git commands wisely.',
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')->with('git-master', Mockery::any())->once()->andReturn($skill);
+
+        $tool = new SkillLoader($registry);
+
+        $result = (string) $tool->handle(new Request(['skill' => 'git-master']));
+
+        $this->assertStringContainsString('<skill name="git-master">', $result);
+        $this->assertStringContainsString('<instructions>', $result);
+        $this->assertStringContainsString('Use git commands wisely.', $result);
+        $this->assertStringContainsString('</instructions>', $result);
+        $this->assertStringContainsString('</skill>', $result);
+    }
+
+    public function test_handle_includes_reference_files_with_skill_read_guidance(): void
+    {
+        $tempPath = sys_get_temp_dir().'/skill-loader-test-'.uniqid();
+        mkdir($tempPath, 0777, true);
+
+        file_put_contents($tempPath.'/guide.md', '# Guide');
+        file_put_contents($tempPath.'/config.yaml', 'key: value');
+
+        $skill = new Skill(
+            name: 'my-skill',
+            description: 'A skill with references',
+            instructions: 'Follow the guide.',
+            basePath: $tempPath,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')->with('my-skill', Mockery::any())->once()->andReturn($skill);
+
+        $tool = new SkillLoader($registry);
+
+        $result = (string) $tool->handle(new Request(['skill' => 'my-skill']));
+
+        $this->assertStringContainsString('<skill_references>', $result);
+        $this->assertStringContainsString('</skill_references>', $result);
+        $this->assertStringContainsString('guide.md', $result);
+        $this->assertStringContainsString('config.yaml', $result);
+        $this->assertStringContainsString('skill_read', $result);
+
+        array_map('unlink', glob($tempPath.'/*'));
+        rmdir($tempPath);
+    }
+
+    public function test_handle_omits_references_block_when_no_files(): void
+    {
+        $skill = new Skill(
+            name: 'simple-skill',
+            description: 'No references',
+            instructions: 'Just do it.',
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')->with('simple-skill', Mockery::any())->once()->andReturn($skill);
+
+        $tool = new SkillLoader($registry);
+
+        $result = (string) $tool->handle(new Request(['skill' => 'simple-skill']));
+
+        $this->assertStringContainsString('<skill name="simple-skill">', $result);
+        $this->assertStringContainsString('Just do it.', $result);
+        $this->assertStringNotContainsString('<skill_references>', $result);
+        $this->assertStringNotContainsString('</skill_references>', $result);
+    }
+
+    public function test_handle_returns_not_found_for_unknown_skill(): void
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('load')->with('nonexistent', Mockery::any())->once()->andReturn(null);
+
+        $tool = new SkillLoader($registry);
+
+        $result = (string) $tool->handle(new Request(['skill' => 'nonexistent']));
+
+        $this->assertSame("Skill 'nonexistent' not found.", $result);
+    }
+}

--- a/tests/Feature/Skills/Tools/SkillReferenceReaderTest.php
+++ b/tests/Feature/Skills/Tools/SkillReferenceReaderTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature\Skills\Tools;
+
+use FilesystemIterator;
+use Laravel\Ai\Skills\Skill;
+use Laravel\Ai\Skills\SkillRegistry;
+use Laravel\Ai\Skills\Tools\SkillReferenceReader;
+use Laravel\Ai\Tools\Request;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class SkillReferenceReaderTest extends TestCase
+{
+    private string $tempPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempPath = sys_get_temp_dir().'/ai_sdk_test_'.uniqid();
+        if (! is_dir($this->tempPath)) {
+            mkdir($this->tempPath);
+        }
+        file_put_contents($this->tempPath.'/test.txt', 'Test content');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempPath)) {
+            $this->deleteDirectory($this->tempPath);
+        }
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function deleteDirectory(string $dir): void
+    {
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+
+    public function test_reads_valid_file_within_skill_directory(): void
+    {
+        $skill = new Skill(
+            name: 'valid-skill',
+            description: 'Valid',
+            instructions: 'Instructions',
+            basePath: $this->tempPath,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('valid-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'valid-skill',
+            'file' => 'test.txt',
+        ]));
+
+        $this->assertSame('Test content', (string) $result);
+    }
+
+    public function test_blocks_directory_traversal(): void
+    {
+        $skill = new Skill(
+            name: 'valid-skill',
+            description: 'Valid',
+            instructions: 'Instructions',
+            basePath: $this->tempPath,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('valid-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'valid-skill',
+            'file' => '../outside.txt',
+        ]));
+
+        $this->assertStringContainsString('not found', (string) $result);
+    }
+
+    public function test_returns_error_for_unloaded_skill(): void
+    {
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('unknown-skill')->andReturn(null);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'unknown-skill',
+            'file' => 'test.txt',
+        ]));
+
+        $this->assertStringContainsString('Skill \'unknown-skill\' not loaded', (string) $result);
+    }
+
+    public function test_returns_error_for_skill_without_base_path(): void
+    {
+        $skill = new Skill(
+            name: 'no-path-skill',
+            description: 'No Path',
+            instructions: 'Instructions',
+            basePath: null,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('no-path-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'no-path-skill',
+            'file' => 'test.txt',
+        ]));
+
+        $this->assertStringContainsString('does not have a base path', (string) $result);
+    }
+
+    public function test_returns_error_for_nonexistent_file(): void
+    {
+        $skill = new Skill(
+            name: 'valid-skill',
+            description: 'Valid',
+            instructions: 'Instructions',
+            basePath: $this->tempPath,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('valid-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'valid-skill',
+            'file' => 'does_not_exist.txt',
+        ]));
+
+        $this->assertStringContainsString('not found', (string) $result);
+    }
+
+    public function test_blocks_reading_non_reference_files(): void
+    {
+        // Use .log extension which is not in the allowed list (md, txt, yaml, yml, json)
+        file_put_contents($this->tempPath.'/secret.log', 'Log content');
+
+        $skill = new Skill(
+            name: 'valid-skill',
+            description: 'Valid',
+            instructions: 'Instructions',
+            basePath: $this->tempPath,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('valid-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'valid-skill',
+            'file' => 'secret.log',
+        ]));
+        $this->assertStringContainsString('not in the allowed reference files list', (string) $result);
+    }
+
+    public function test_reads_files_from_subdirectories(): void
+    {
+        mkdir($this->tempPath.'/references');
+        file_put_contents($this->tempPath.'/references/utilities.md', 'Utility reference content');
+
+        $skill = new Skill(
+            name: 'valid-skill',
+            description: 'Valid',
+            instructions: 'Instructions',
+            basePath: $this->tempPath,
+        );
+
+        $registry = Mockery::mock(SkillRegistry::class);
+        $registry->shouldReceive('get')->with('valid-skill')->andReturn($skill);
+
+        $tool = new SkillReferenceReader($registry);
+
+        $result = $tool->handle(new Request([
+            'skill' => 'valid-skill',
+            'file' => 'references/utilities.md',
+        ]));
+
+        $this->assertSame('Utility reference content', (string) $result);
+    }
+}


### PR DESCRIPTION
This PR adds a complete Skills system to the Laravel AI SDK, allowing AI agents to dynamically discover, load, and use skill-based instructions and reference files at runtime.

## Motivation

AI agents often need specialized knowledge — coding standards, API documentation, design patterns — that goes beyond their base training. Currently, developers must hardcode all instructions into agent classes. Skills solve this by providing a file-based, discoverable system where domain knowledge is packaged as Markdown files with optional reference materials, and agents can opt-in to skill support via a simple trait.

## How It Works

A skill is a directory containing a `SKILL.md` file with YAML front matter (name, description) and Markdown instructions. Any additional `.md`, `.txt`, `.yaml`, `.yml`, or `.json` files in the directory (or subdirectories) are automatically discovered as reference files:

```
resources/skills/
└── wind-ui/
    ├── SKILL.md
    ├── components.md
    └── references/
        └── utilities.md
```

Agents opt-in to skills by using the `Skillable` trait:

```php
class DesignAgent extends Agent
{
    use Skillable;

    public function skills(): iterable
    {
        return [
            'wind-ui',                // uses default mode from config
            'tailwind' => 'lite',     // per-skill mode override
        ];
    }
}
```

The LLM can also discover and load skills dynamically via three meta-tools: `skill_list`, `skill_load`, and `skill_read`.

## New Features

- **Skill DTO & Parser** — Parses `SKILL.md` files with YAML front matter into structured `Skill` objects
- **SkillDiscovery** — Filesystem-based discovery across configurable paths, with symlink support
- **SkillRegistry** — Manages loaded skills and aggregates instructions by mode (full/lite/none)
- **Skillable trait** — Opt-in trait for agents, merges skill tools and instructions into the prompt
- **Meta-tools** — `skill_list` (discover available skills), `skill_load` (load full instructions), `skill_read` (read reference files with path traversal protection)
- **Artisan commands** — `make:skill` scaffolding and `skill:list` for discovery
- **Config** — `ai.skills.paths` and `ai.skills.default_mode` in `config/ai.php`

## Core Changes (Minimal & Surgical)

The existing codebase required small fixes for skills to function correctly:

- **`AgentPrompt`** — Added `tools` and `instructions` properties so the prompt carries pre-resolved data
- **`Promptable`** — Added `getTools()` and `getInstructions()` methods that merge agent tools with skill tools before prompt creation
- **`GeneratesText` / `StreamsText`** — Changed to use `$prompt->tools` and `$prompt->instructions` instead of re-calling `$agent->tools()` / `$agent->instructions()`. This was a bug — the original code bypassed any tool/instruction enrichment done during prompt construction

## Security

`SkillReferenceReader` enforces three layers of protection against path traversal:

1. **Absolute path block** — Rejects filenames starting with `/`
2. **Whitelist check** — Only files listed in `referenceFiles()` are accessible
3. **Realpath validation** — Resolved path must stay within the skill's base directory

## Tests

65 new tests covering all functionality:

- Skill parsing, discovery, and registry
- Skillable trait integration with agents
- All three meta-tools (including security edge cases)
- Artisan commands
- Configuration
- End-to-end integration

All existing tests continue to pass.

## Breaking Changes

None. Skills are entirely opt-in. Agents without the `Skillable` trait behave exactly as before.

## Attribution

This feature was inspired by [laravel-ai-sdk-skills](https://github.com/anilcancakir/laravel-ai-sdk-skills), a standalone plugin that demonstrated the concept of file-based skill discovery for Laravel AI agents.
