### PR TITLE
[0.x] Ensure StreamEvent broadcast doesn't double prefix private channels

### DIFF
--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -3,8 +3,6 @@
 namespace Laravel\Ai\Streaming\Events;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Broadcast;
 
 abstract class StreamEvent

--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -17,9 +17,7 @@ abstract class StreamEvent
     public function broadcast(Channel|array $channels, bool $now = false): void
     {
         foreach (Arr::wrap($channels) as $channel) {
-            $event = $channel instanceof PrivateChannel
-                ? Broadcast::private((string) $channel)
-                : Broadcast::on((string) $channel);
+            $event = Broadcast::on((string) $channel);
 
             $event->as($this->type())
                 ->with($this->toArray())

--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -16,13 +16,10 @@ abstract class StreamEvent
      */
     public function broadcast(Channel|array $channels, bool $now = false): void
     {
-        foreach (Arr::wrap($channels) as $channel) {
-            $event = Broadcast::on((string) $channel);
-
-            $event->as($this->type())
-                ->with($this->toArray())
-                ->{$now ? 'sendNow' : 'send'}();
-        }
+        Broadcast::on($channels)
+            ->as($this->type())
+            ->with($this->toArray())
+            ->{$now ? 'sendNow' : 'send'}();
     }
 
     /**


### PR DESCRIPTION
Currently if the channel is a Private channel, it's causing a double prefix because it's being re-passed into to the BroadcastManager private method - which creates a new instance - causing a double prefix

```php 
$stream = (new SalesCoach)->stream('Analyze this sales transcript...');
 
foreach ($stream as $event) {
    $event->broadcast(new PrivateChannel('user')); // appears as private-private-user currently, rather than private-user
}
```

This PR simplifies it a lot as the [BroadcastManager](https://github.com/laravel/framework/blob/bc483f7c55c7cafbb1079f585166b1a873435099/src/Illuminate/Broadcasting/BroadcastManager.php#L140), already handles all of this for us (it can handle array, or Channel) from having a poke..

Thanks.

Closes https://github.com/laravel/ai/issues/146 if merged 🫡 