### PR TITLE
Fix invalid Message role and null response in HandlesRateLimiting

### DIFF
--- a/src/Gateway/Concerns/HandlesRateLimiting.php
+++ b/src/Gateway/Concerns/HandlesRateLimiting.php
@@ -21,7 +21,7 @@ trait HandlesRateLimiting
         try {
             return $callback();
         } catch (RequestException $e) {
-            if ($e->response->status() === 429) {
+            if ($e->response !== null && $e->response->status() === 429) {
                 throw RateLimitedException::forProvider(
                     $providerName, $e->getCode(), $e
                 );

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -25,7 +25,7 @@ class Message
 
         $this->role = $role instanceof MessageRole
             ? $role
-            : MessageRole::tryFrom($role) ?? throw new InvalidArgumentException('Invalid message role.');
+            : (MessageRole::tryFrom($role) ?? throw new InvalidArgumentException('Invalid message role.'));
     }
 
     /**

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -25,7 +25,7 @@ class Message
 
         $this->role = $role instanceof MessageRole
             ? $role
-            : MessageRole::tryFrom($role);
+            : MessageRole::tryFrom($role) ?? throw new InvalidArgumentException('Invalid message role.');
     }
 
     /**

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -158,7 +158,7 @@ trait Promptable
     }
 
     /**
-     * Get the providers and models array given the given initial provider and model values.
+     * Get the providers and models array for the given initial provider and model values.
      */
     protected function getProvidersAndModels(array|string|null $provider, ?string $model): array
     {

--- a/src/Providers/Concerns/GeneratesTranscriptions.php
+++ b/src/Providers/Concerns/GeneratesTranscriptions.php
@@ -13,7 +13,7 @@ use Laravel\Ai\Responses\TranscriptionResponse;
 trait GeneratesTranscriptions
 {
     /**
-     * Generate audio from the given text.
+     * Transcribe the given audio to text.
      */
     public function transcribe(
         TranscribableAudio $audio,


### PR DESCRIPTION
## Changes

- **Message.php:** When a string is passed as `$role` that doesn't match any `MessageRole` enum case, `MessageRole::tryFrom($role)` returns null and was assigned to the non-nullable `$role` property, causing a TypeError. Now throws `InvalidArgumentException('Invalid message role.')` with a clear message.

- **HandlesRateLimiting.php:** `RequestException` can have a null `response` when the request never completed (e.g. connection timeout, DNS failure). Accessing `$e->response->status()` without a check could cause a null dereference. Now checks `$e->response !== null` before reading `->status()`.