### PR TITLE
Add optional Prism Relay MCP server integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.6"
     },
+    "suggest": {
+        "prism-php/relay": "Adds MCP tool calling support through Prism Relay (remote HTTP and local STDIO servers)."
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {

--- a/src/Providers/Tools/McpServer.php
+++ b/src/Providers/Tools/McpServer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Providers\Tools;
+
+class McpServer extends ProviderTool
+{
+    /**
+     * @param  array<string, mixed>|null  $config
+     */
+    public function __construct(
+        public string $name,
+        public ?array $config = null,
+    ) {}
+}

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -49,7 +49,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -98,7 +98,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -147,7 +147,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }

--- a/tests/Unit/Gateway/Prism/McpServerToolIntegrationTest.php
+++ b/tests/Unit/Gateway/Prism/McpServerToolIntegrationTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Tools\McpServer;
+use PHPUnit\Framework\TestCase;
+use Prism\Prism\Enums\ToolChoice;
+use Prism\Prism\Tool as PrismToolDefinition;
+use RuntimeException;
+
+class McpServerToolIntegrationTest extends TestCase
+{
+    public function test_add_tools_passes_through_prism_tools(): void
+    {
+        $tool = (new PrismToolDefinition)
+            ->as('lookup')
+            ->for('Lookup data')
+            ->using(fn (): string => 'ok');
+
+        $request = new class
+        {
+            public array $tools = [];
+
+            public mixed $toolChoice = null;
+
+            public mixed $maxSteps = null;
+
+            public function withTools(array $tools): self
+            {
+                $this->tools = $tools;
+
+                return $this;
+            }
+
+            public function withToolChoice($toolChoice): self
+            {
+                $this->toolChoice = $toolChoice;
+
+                return $this;
+            }
+
+            public function withMaxSteps($maxSteps): self
+            {
+                $this->maxSteps = $maxSteps;
+
+                return $this;
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function test_add_tools($request, array $tools, ?TextGenerationOptions $options = null): mixed
+            {
+                return $this->addTools($request, $tools, $options);
+            }
+        };
+
+        $handler->test_add_tools($request, [$tool]);
+
+        $this->assertSame([$tool], $request->tools);
+        $this->assertSame(ToolChoice::Auto, $request->toolChoice);
+        $this->assertSame(2.0, $request->maxSteps);
+    }
+
+    public function test_mcp_server_tool_throws_helpful_exception_without_relay_package(): void
+    {
+        if (class_exists(\Prism\Relay\RelayFactory::class)) {
+            $this->markTestSkipped('Relay is installed in this environment.');
+        }
+
+        $request = new class
+        {
+            public function withTools(array $tools): self
+            {
+                return $this;
+            }
+
+            public function withToolChoice($toolChoice): self
+            {
+                return $this;
+            }
+
+            public function withMaxSteps($maxSteps): self
+            {
+                return $this;
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function test_add_tools($request, array $tools, ?TextGenerationOptions $options = null): mixed
+            {
+                return $this->addTools($request, $tools, $options);
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('MCP tools require the optional "prism-php/relay" package.');
+
+        $handler->test_add_tools($request, [new McpServer('github')]);
+    }
+
+    public function test_mcp_server_expansion_is_used_for_default_max_steps(): void
+    {
+        $request = new class
+        {
+            public array $tools = [];
+
+            public mixed $maxSteps = null;
+
+            public function withTools(array $tools): self
+            {
+                $this->tools = $tools;
+
+                return $this;
+            }
+
+            public function withToolChoice($toolChoice): self
+            {
+                return $this;
+            }
+
+            public function withMaxSteps($maxSteps): self
+            {
+                $this->maxSteps = $maxSteps;
+
+                return $this;
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function test_add_tools($request, array $tools, ?TextGenerationOptions $options = null): mixed
+            {
+                return $this->addTools($request, $tools, $options);
+            }
+
+            protected function resolveRelayTools(McpServer $server): array
+            {
+                return [
+                    (new PrismToolDefinition)->as('first')->for('first')->using(fn (): string => 'ok'),
+                    (new PrismToolDefinition)->as('second')->for('second')->using(fn (): string => 'ok'),
+                ];
+            }
+        };
+
+        $handler->test_add_tools($request, [new McpServer('github')]);
+
+        $this->assertCount(2, $request->tools);
+        $this->assertSame(3.0, $request->maxSteps);
+    }
+}


### PR DESCRIPTION
This PR adds first-party, optional MCP tool integration via Prism Relay without coupling Laravel AI to a required extra package.

### What’s included

- New `McpServer` tool (`Laravel\Ai\Providers\Tools\McpServer`) to represent an MCP server in an agent’s `tools()`.
- Prism gateway tool resolution now supports:
  - Laravel AI tools (`Laravel\Ai\Contracts\Tool`)
  - Provider tools (`ProviderTool`)
  - Native Prism tools (`Prism\Prism\Tool`) as pass-through
  - `McpServer`, resolved via `Prism\Relay\RelayFactory::tools(...)`
- Clear runtime exception if `prism-php/relay` is not installed and `McpServer` is used.
- `composer.json` now includes a `suggest` entry for `prism-php/relay`.

## Why

Current provider-tool mapping is provider-specific. MCP should be provider-agnostic and composable.

## Usage example

```php
use Laravel\Ai\Providers\Tools\McpServer;

public function tools(): iterable
{
    return [
        new McpServer('github'), // uses config/relay.php
    ];
}
```

Inline custom server config (remote HTTP example):

```php
use Laravel\Ai\Providers\Tools\McpServer;
use Prism\Relay\Enums\Transport;

new McpServer('github', [
    'url' => env('RELAY_GITHUB_SERVER_URL'),
    'api_key' => env('RELAY_GITHUB_SERVER_API_KEY'),
    'timeout' => 30,
    'transport' => Transport::Http,
]);
```

You can also pass native Prism tools directly (including Relay-generated tools), which enables fully custom MCP calling flows.

## How to test

1. Install optional dependency:
   - `composer require prism-php/relay`
2. Publish Relay config:
   - `php artisan vendor:publish --tag=relay-config`
3. Configure at least one MCP server in `config/relay.php` (HTTP or STDIO).
4. Add `new McpServer('<server-name>')` to an agent’s `tools()`.
5. Prompt the agent and confirm MCP tools are callable.

## Notes

We are still missing proper Streamable HTTP ([PR](https://github.com/prism-php/relay/pull/31)) and OAuth support in the upstream package.