### PR TITLE
Add Murf AI Provider support

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -94,6 +94,11 @@ return [
             'key' => env('JINA_API_KEY'),
         ],
 
+        'murf' => [
+            'driver' => 'murf',
+            'key' => env('MURF_API_KEY'),
+        ],
+
         'mistral' => [
             'driver' => 'mistral',
             'key' => env('MISTRAL_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -24,6 +24,7 @@ use Laravel\Ai\Providers\GeminiProvider;
 use Laravel\Ai\Providers\GroqProvider;
 use Laravel\Ai\Providers\JinaProvider;
 use Laravel\Ai\Providers\MistralProvider;
+use Laravel\Ai\Providers\MurfProvider;
 use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\OpenRouterProvider;
@@ -57,7 +58,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof AudioProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support audio generation.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support audio generation.');
             }
         });
     }
@@ -81,7 +82,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof EmbeddingProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support embedding generation.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support embedding generation.');
             }
         });
     }
@@ -105,7 +106,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof RerankingProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support reranking.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support reranking.');
             }
         });
     }
@@ -129,7 +130,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof ImageProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support image generation.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support image generation.');
             }
         });
     }
@@ -153,7 +154,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof TextProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support text generation.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support text generation.');
             }
         });
     }
@@ -177,7 +178,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof TranscriptionProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support transcription generation.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support transcription generation.');
             }
         });
     }
@@ -201,7 +202,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof FileProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support file management.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support file management.');
             }
         });
     }
@@ -225,7 +226,7 @@ class AiManager extends MultipleInstanceManager
     {
         return tap($this->instance($name), function ($instance) {
             if (! $instance instanceof StoreProvider) {
-                throw new LogicException('Provider ['.$instance::class.'] does not support store management.');
+                throw new LogicException('Provider [' . $instance::class . '] does not support store management.');
             }
         });
     }
@@ -336,6 +337,17 @@ class AiManager extends MultipleInstanceManager
     }
 
     /**
+     * Create a Murf AI powered instance.
+     */
+    public function createMurfDriver(array $config): MurfProvider
+    {
+        return new MurfProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
      * Create a Mistral AI powered instance.
      */
     public function createMistralDriver(array $config): MistralProvider
@@ -439,7 +451,8 @@ class AiManager extends MultipleInstanceManager
     public function getInstanceConfig($name)
     {
         $config = $this->app['config']->get(
-            'ai.providers.'.$name, ['driver' => $name],
+            'ai.providers.' . $name,
+            ['driver' => $name],
         );
 
         if ($config['driver'] instanceof Lab) {

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -13,6 +13,7 @@ enum Lab: string
     case Groq = 'groq';
     case Jina = 'jina';
     case Mistral = 'mistral';
+    case Murf = 'murf';
     case Ollama = 'ollama';
     case OpenAI = 'openai';
     case OpenRouter = 'openrouter';

--- a/src/Gateway/MurfGateway.php
+++ b/src/Gateway/MurfGateway.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\Data\Meta;
+
+class MurfGateway implements AudioGateway
+{
+    use Concerns\HandlesRateLimiting;
+
+    /**
+     * Base URL for the Murf API.
+     */
+    protected string $baseUrl = 'https://api.murf.ai/v1';
+
+    /**
+     * Generate audio from the given text.
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+    ): AudioResponse {
+        $voiceId = $this->resolveVoiceId($voice);
+
+        $response = $this->withRateLimitHandling($provider->name(), fn() => Http::withHeaders([
+            'api-key' => $provider->providerCredentials()['key'],
+            'Content-Type' => 'application/json',
+        ])->post($this->baseUrl . '/speech/generate', [
+            'text' => $text,
+            'voiceId' => $voiceId,
+            'format' => 'MP3',
+            'encodeAsBase64' => true,
+            'modelVersion' => $model,
+        ])->throw());
+
+        $body = $response->json();
+        $encodedAudio = $body['encodedAudio'] ?? '';
+
+        return new AudioResponse(
+            $encodedAudio,
+            new Meta($provider->name(), $model),
+            'audio/mpeg',
+        );
+    }
+
+    /**
+     * Resolve the Murf voice ID from the given voice name or identifier.
+     */
+    protected function resolveVoiceId(string $voice): string
+    {
+        return match ($voice) {
+            'default-male' => 'en-US-george',
+            'default-female' => 'en-US-natalie',
+            default => $voice,
+        };
+    }
+}

--- a/src/Providers/MurfProvider.php
+++ b/src/Providers/MurfProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Gateway\MurfGateway;
+
+class MurfProvider extends Provider implements AudioProvider
+{
+    use Concerns\GeneratesAudio;
+    use Concerns\HasAudioGateway;
+
+    public function __construct(
+        protected array $config,
+        protected Dispatcher $events,
+    ) {}
+
+    /**
+     * Get the provider's audio gateway.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ?? new MurfGateway;
+    }
+
+    /**
+     * Get the name of the default audio (TTS) model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return 'GEN2';
+    }
+}


### PR DESCRIPTION
Added Murf AI as a provider option for text-to-speech (TTS). Uses a dedicated gateway that calls Murf's `/v1/speech/generate` endpoint

**Supports:**

- Audio generation (text-to-speech)
- Default voice mapping 

**Configuration**

```env
MURF_API_KEY=
```
