### PR TITLE
fix(tests): AddsToolsToPrismRequestsTest method

### DIFF
--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -49,7 +49,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -98,7 +98,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -147,7 +147,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }


### PR DESCRIPTION
fix(tests): align method name with call in AddsToolsToPrismRequestsTest

Rename test_invoke_tool to testInvokeTool in anonymous class so it matches the call site and resolves "Call to undefined method testInvokeTool()".