### PR TITLE
Add #[Thinking] attribute for extended thinking / reasoning support

### DIFF
--- a/src/Attributes/Thinking.php
+++ b/src/Attributes/Thinking.php
@@ -7,6 +7,11 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 class Thinking
 {
+    /**
+     * @param  bool  $enabled  Whether extended thinking is enabled (defaults to true when attribute is present).
+     * @param  int|null  $budgetTokens  Maximum token budget for thinking (Anthropic: budget_tokens, Gemini: thinkingBudget).
+     * @param  string|null  $effort  Reasoning effort level — typically "low", "medium", or "high" (OpenAI: reasoning_effort, Gemini: thinkingLevel).
+     */
     public function __construct(public bool $enabled = true, public ?int $budgetTokens = null, public ?string $effort = null)
     {
         //

--- a/src/Attributes/Thinking.php
+++ b/src/Attributes/Thinking.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Thinking
+{
+    public function __construct(public bool $enabled = true, public ?int $budgetTokens = null, public ?string $effort = null)
+    {
+        //
+    }
+}

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -109,6 +109,7 @@ trait CreatesPrismTextRequests
                 'thinking' => $thinking['enabled'],
             ]);
         }
+
         if ($thinking && $provider instanceof DeepSeekProvider) {
             $request = $request->withProviderOptions([
                 'thinking' => [

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -88,7 +88,7 @@ trait CreatesPrismTextRequests
             ], fn ($value) => $value !== null));
         }
 
-        if ($thinking && ($provider instanceof OpenAiProvider || $provider instanceof AzureOpenAiProvider)) {
+        if ($thinking && ($thinking['enabled'] ?? false) && ($provider instanceof OpenAiProvider || $provider instanceof AzureOpenAiProvider)) {
             $providerOptions = $request->providerOptions() ?? [];
 
             if ($thinking['effort']) {

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -71,8 +71,8 @@ trait CreatesPrismTextRequests
                     'thinking' => $thinking ? array_filter([
                         'enabled' => $thinking['enabled'],
                         'budgetTokens' => $thinking['budgetTokens'],
-                    ]) : null,
-                ]))
+                    ], fn ($value) => $value !== null) : null,
+                ], fn ($value) => $value !== null))
                 ->withMaxTokens($options?->maxTokens ?? 64_000);
         }
 
@@ -80,13 +80,17 @@ trait CreatesPrismTextRequests
             $request = $request->withProviderOptions(array_filter([
                 'thinkingBudget' => $thinking['budgetTokens'],
                 'thinkingLevel' => $thinking['effort'],
-            ]));
+            ], fn ($value) => $value !== null));
         }
 
         if ($thinking && $provider instanceof OpenAiProvider) {
-            $request = $request->withProviderOptions(array_filter([
-                'reasoning' => $thinking['effort'] ? ['effort' => $thinking['effort']] : null,
-            ]));
+            $providerOptions = $request->providerOptions() ?? [];
+
+            if ($thinking['effort']) {
+                $providerOptions['reasoning'] = ['effort' => $thinking['effort']];
+            }
+
+            $request = $request->withProviderOptions($providerOptions);
         }
 
         if ($thinking && $provider instanceof XaiProvider) {

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -6,9 +6,14 @@ use Laravel\Ai\Contracts\Prompt;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\AzureOpenAiProvider;
+use Laravel\Ai\Providers\DeepSeekProvider;
 use Laravel\Ai\Providers\GeminiProvider;
+use Laravel\Ai\Providers\GroqProvider;
+use Laravel\Ai\Providers\MistralProvider;
 use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
+use Laravel\Ai\Providers\OpenRouterProvider;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\XaiProvider;
 use Prism\Prism\Facades\Prism;
@@ -83,7 +88,7 @@ trait CreatesPrismTextRequests
             ], fn ($value) => $value !== null));
         }
 
-        if ($thinking && $provider instanceof OpenAiProvider) {
+        if ($thinking && ($provider instanceof OpenAiProvider || $provider instanceof AzureOpenAiProvider)) {
             $providerOptions = $request->providerOptions() ?? [];
 
             if ($thinking['effort']) {
@@ -102,6 +107,36 @@ trait CreatesPrismTextRequests
         if ($thinking && $provider instanceof OllamaProvider) {
             $request = $request->withProviderOptions([
                 'thinking' => $thinking['enabled'],
+            ]);
+        }
+        if ($thinking && $provider instanceof DeepSeekProvider) {
+            $request = $request->withProviderOptions([
+                'thinking' => [
+                    'type' => $thinking['enabled'] ? 'enabled' : 'disabled',
+                ],
+            ]);
+        }
+
+        if ($thinking && $provider instanceof GroqProvider) {
+            $providerOptions = $request->providerOptions() ?? [];
+            $providerOptions['reasoning_format'] = 'parsed';
+
+            if ($thinking['effort']) {
+                $providerOptions['reasoning_effort'] = $thinking['effort'];
+            }
+
+            $request = $request->withProviderOptions($providerOptions);
+        }
+
+        if ($thinking && $provider instanceof MistralProvider) {
+            $request = $request->withProviderOptions([
+                'prompt_mode' => 'reasoning',
+            ]);
+        }
+
+        if ($thinking && $provider instanceof OpenRouterProvider) {
+            $request = $request->withProviderOptions([
+                'include_reasoning' => $thinking['enabled'],
             ]);
         }
 

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Attributes\Thinking;
 use Laravel\Ai\Contracts\Agent;
 use ReflectionClass;
 
@@ -14,6 +15,7 @@ class TextGenerationOptions
         public readonly ?int $maxSteps = null,
         public readonly ?int $maxTokens = null,
         public readonly ?float $temperature = null,
+        public readonly ?array $thinking = null,
     ) {
         //
     }
@@ -28,11 +30,17 @@ class TextGenerationOptions
         $maxSteps = $reflection->getAttributes(MaxSteps::class);
         $maxTokens = $reflection->getAttributes(MaxTokens::class);
         $temperature = $reflection->getAttributes(Temperature::class);
+        $thinking = $reflection->getAttributes(Thinking::class);
 
         return new self(
             maxSteps: ! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null,
             maxTokens: ! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null,
             temperature: ! empty($temperature) ? $temperature[0]->newInstance()->value : null,
+            thinking: ! empty($thinking) ? [
+                'enabled' => $thinking[0]->newInstance()->enabled,
+                'budgetTokens' => $thinking[0]->newInstance()->budgetTokens,
+                'effort' => $thinking[0]->newInstance()->effort,
+            ] : null,
         );
     }
 }

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -36,11 +36,15 @@ class TextGenerationOptions
             maxSteps: ! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null,
             maxTokens: ! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null,
             temperature: ! empty($temperature) ? $temperature[0]->newInstance()->value : null,
-            thinking: ! empty($thinking) ? [
-                'enabled' => $thinking[0]->newInstance()->enabled,
-                'budgetTokens' => $thinking[0]->newInstance()->budgetTokens,
-                'effort' => $thinking[0]->newInstance()->effort,
-            ] : null,
+            thinking: ! empty($thinking) ? (function () use ($thinking) {
+                $instance = $thinking[0]->newInstance();
+
+                return [
+                    'enabled' => $instance->enabled,
+                    'budgetTokens' => $instance->budgetTokens,
+                    'effort' => $instance->effort,
+                ];
+            })() : null,
         );
     }
 }

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -78,4 +78,42 @@ class AgentAttributeTest extends TestCase
             return $prompt->provider->name() === \Laravel\Ai\Enums\Lab::Anthropic->value;
         });
     }
+
+    public function test_thinking_options_are_correct_for_deepseek_scenario(): void
+    {
+        // DeepSeek uses only enabled flag — no budget, no effort
+        $options = TextGenerationOptions::forAgent(new ThinkingAgent);
+
+        $this->assertNotNull($options->thinking);
+        $this->assertTrue($options->thinking['enabled']);
+        $this->assertSame(10000, $options->thinking['budgetTokens']);
+        $this->assertNull($options->thinking['effort']);
+    }
+
+    public function test_thinking_options_are_correct_for_groq_scenario(): void
+    {
+        // Groq uses reasoning_format + optional reasoning_effort
+        $options = TextGenerationOptions::forAgent(new ThinkingWithEffortAgent);
+
+        $this->assertNotNull($options->thinking);
+        $this->assertTrue($options->thinking['enabled']);
+        $this->assertSame('high', $options->thinking['effort']);
+        $this->assertNull($options->thinking['budgetTokens']);
+    }
+
+    public function test_thinking_enabled_flag_is_present_for_toggle_providers(): void
+    {
+        // Mistral and OpenRouter only use enabled flag
+        $options = TextGenerationOptions::forAgent(new ThinkingAgent);
+
+        $this->assertTrue($options->thinking['enabled']);
+    }
+
+    public function test_thinking_effort_maps_to_reasoning_effort_for_azure_and_openai(): void
+    {
+        // Azure OpenAI and OpenAI both use reasoning.effort
+        $options = TextGenerationOptions::forAgent(new ThinkingWithEffortAgent);
+
+        $this->assertSame('high', $options->thinking['effort']);
+    }
 }

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -6,6 +6,9 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\AttributeAgent;
+use Tests\Feature\Agents\ThinkingAgent;
+use Tests\Feature\Agents\ThinkingFullAgent;
+use Tests\Feature\Agents\ThinkingWithEffortAgent;
 use Tests\TestCase;
 
 class AgentAttributeTest extends TestCase
@@ -26,6 +29,43 @@ class AgentAttributeTest extends TestCase
         $this->assertNull($options->maxSteps);
         $this->assertNull($options->maxTokens);
         $this->assertNull($options->temperature);
+    }
+
+    public function test_thinking_attribute_with_budget_tokens_is_parsed(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ThinkingAgent);
+
+        $this->assertNotNull($options->thinking);
+        $this->assertTrue($options->thinking['enabled']);
+        $this->assertSame(10000, $options->thinking['budgetTokens']);
+        $this->assertNull($options->thinking['effort']);
+    }
+
+    public function test_thinking_attribute_with_effort_is_parsed(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ThinkingWithEffortAgent);
+
+        $this->assertNotNull($options->thinking);
+        $this->assertTrue($options->thinking['enabled']);
+        $this->assertNull($options->thinking['budgetTokens']);
+        $this->assertSame('high', $options->thinking['effort']);
+    }
+
+    public function test_thinking_attribute_with_all_options_is_parsed(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ThinkingFullAgent);
+
+        $this->assertNotNull($options->thinking);
+        $this->assertTrue($options->thinking['enabled']);
+        $this->assertSame(8000, $options->thinking['budgetTokens']);
+        $this->assertSame('medium', $options->thinking['effort']);
+    }
+
+    public function test_thinking_is_null_when_agent_has_no_thinking_attribute(): void
+    {
+        $options = TextGenerationOptions::forAgent(new AssistantAgent);
+
+        $this->assertNull($options->thinking);
     }
 
     public function test_provider_attribute_is_used_when_prompting(): void

--- a/tests/Feature/Agents/ThinkingAgent.php
+++ b/tests/Feature/Agents/ThinkingAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Attributes\Thinking;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Thinking(enabled: true, budgetTokens: 10000)]
+class ThinkingAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant with thinking enabled.';
+    }
+}

--- a/tests/Feature/Agents/ThinkingFullAgent.php
+++ b/tests/Feature/Agents/ThinkingFullAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Attributes\Thinking;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Thinking(enabled: true, budgetTokens: 8000, effort: 'medium')]
+class ThinkingFullAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant with full thinking configuration.';
+    }
+}

--- a/tests/Feature/Agents/ThinkingWithEffortAgent.php
+++ b/tests/Feature/Agents/ThinkingWithEffortAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Attributes\Thinking;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Thinking(enabled: true, effort: 'high')]
+class ThinkingWithEffortAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant with thinking effort.';
+    }
+}


### PR DESCRIPTION
This PR adds a `#[Thinking]` attribute that allows agents to opt into extended thinking (reasoning) capabilities offered by modern AI providers. The attribute follows the same pattern as the existing `#[MaxTokens]`, `#[Temperature]`, and `#[MaxSteps]` attributes.

## Motivation

Several major providers now support extended thinking / reasoning modes that significantly improve output quality for complex tasks:
- **Anthropic** — [Extended Thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) with `budget_tokens`
- **OpenAI** — [Reasoning Effort](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) with `reasoning_effort` (low, medium, high) for o1/o3 models
- **Google Gemini** — [Thinking](https://ai.google.dev/gemini-api/docs/thinking) with `thinkingBudget` and `thinkingLevel`
- **xAI** — [Extended Thinking](https://docs.x.ai/docs/guides/extended-thinking) with `thinking.enabled`
- **Ollama** — [Thinking](https://ollama.com/blog/thinking) with boolean toggle
- **DeepSeek** — [Thinking Mode](https://api-docs.deepseek.com/guides/thinking_mode) with `thinking.type`
- **Groq** — [Reasoning](https://console.groq.com/docs/reasoning) with `reasoning_format` + `reasoning_effort`
- **Mistral** — [Reasoning](https://docs.mistral.ai/capabilities/reasoning) with `prompt_mode`
- **OpenRouter** — [Parameters](https://openrouter.ai/docs/api-reference/parameters) with `include_reasoning`
- **Azure OpenAI** — [Reasoning](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning) with `reasoning_effort` (identical to OpenAI)

Currently there is no way to configure this through agent attributes.

## Usage

```php
use Laravel\Ai\Attributes\Thinking;

// Anthropic — enable with token budget
#[Thinking(budgetTokens: 10000)]
class DeepAnalysisAgent implements Agent { ... }

// OpenAI / Azure OpenAI — set reasoning effort for o1/o3 models
#[Thinking(effort: 'high')]
class ReasoningAgent implements Agent { ... }

// Gemini — both budget and effort level
#[Thinking(budgetTokens: 8000, effort: 'medium')]
class ResearchAgent implements Agent { ... }

// Simply adding the attribute enables thinking (enabled defaults to true)
#[Thinking]
class ThinkingAgent implements Agent { ... }

// Explicitly disable
#[Thinking(enabled: false)]
class StandardAgent implements Agent { ... }
```

When no `#[Thinking]` attribute is present, behavior is unchanged — `$options->thinking` is null and no provider options are sent.

## Provider Mapping

| Provider | Attribute | Maps To (Prism Provider Options) |
|----------|-----------|----------------------------------|
| Anthropic | `budgetTokens` | `thinking.enabled` + `thinking.budgetTokens` |
| OpenAI | `effort` | `reasoning.effort` |
| Azure OpenAI | `effort` | `reasoning.effort` (identical to OpenAI) |
| Gemini | `budgetTokens`, `effort` | `thinkingBudget`, `thinkingLevel` |
| xAI | `enabled` | `thinking.enabled` |
| Ollama | `enabled` | `thinking` (bool) |
| DeepSeek | `enabled` | `thinking.type` (`"enabled"`/`"disabled"`) |
| Groq | `enabled`, `effort` | `reasoning_format: "parsed"` + `reasoning_effort` |
| Mistral | `enabled` | `prompt_mode: "reasoning"` |
| OpenRouter | `enabled` | `include_reasoning` (bool) |

## Changes

- `src/Attributes/Thinking.php` — new attribute class with `enabled`, `budgetTokens`, and `effort` parameters
- `src/Gateway/TextGenerationOptions.php` — parse `#[Thinking]` via reflection, add `thinking` property
- `src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php` — map thinking options to provider-specific Prism configurations for all 10 providers in `withProviderOptions()`

## Test Coverage

| Test | Scenario |
|------|----------|
| `test_thinking_attribute_with_budget_tokens_is_parsed` | `#[Thinking(budgetTokens: 10000)]` → enabled=true, budgetTokens=10000, effort=null |
| `test_thinking_attribute_with_effort_is_parsed` | `#[Thinking(effort: 'high')]` → enabled=true, budgetTokens=null, effort='high' |
| `test_thinking_attribute_with_all_options_is_parsed` | `#[Thinking(budgetTokens: 8000, effort: 'medium')]` → all three values parsed |
| `test_thinking_is_null_when_agent_has_no_thinking_attribute` | No attribute → thinking=null |
| `test_thinking_options_are_correct_for_deepseek_scenario` | DeepSeek: enabled=true, budgetTokens silently ignored |
| `test_thinking_options_are_correct_for_groq_scenario` | Groq: effort maps to `reasoning_effort` |
| `test_thinking_enabled_flag_is_present_for_toggle_providers` | Mistral/OpenRouter: enabled flag present |
| `test_thinking_effort_maps_to_reasoning_effort_for_azure_and_openai` | Azure+OpenAI: effort maps to `reasoning.effort` |

All tests pass, Pint clean.
