### PR TITLE
feat: implement Azure OpenAI deployment routing to map logical model

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -62,6 +62,11 @@ return [
             'api_version' => env('AZURE_OPENAI_API_VERSION', '2024-10-21'),
             'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
             'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+            'deployments' => [
+                'gpt-4o' => env('AZURE_OPENAI_GPT_4O_DEPLOYMENT', 'gpt-4o'),
+                'gpt-4o-mini' => env('AZURE_OPENAI_GPT_4O_MINI_DEPLOYMENT', 'gpt-4o-mini'),
+                'text-embedding-3-small' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+            ],
         ],
 
         'cohere' => [

--- a/src/Contracts/Providers/Azure/DeploymentRouter.php
+++ b/src/Contracts/Providers/Azure/DeploymentRouter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Providers\Azure;
+
+interface DeploymentRouter
+{
+    /**
+     * Map the given model to an Azure OpenAI deployment name.
+     */
+    public function route(string $model): string;
+}

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -74,6 +74,21 @@ class AgentPrompt extends Prompt
     }
 
     /**
+     * Set the model for the prompt, returning a new prompt instance.
+     */
+    public function withModel(string $model): AgentPrompt
+    {
+        return new static(
+            $this->agent,
+            $this->prompt,
+            $this->attachments,
+            $this->provider,
+            $model,
+            $this->timeout,
+        );
+    }
+
+    /**
      * Add new attachment to the prompt, returning a new prompt instance.
      */
     public function withAttachments(Collection|array $attachments): AgentPrompt

--- a/src/Providers/Azure/MapDeploymentRouter.php
+++ b/src/Providers/Azure/MapDeploymentRouter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Ai\Providers\Azure;
+
+use Laravel\Ai\Contracts\Providers\Azure\DeploymentRouter;
+
+class MapDeploymentRouter implements DeploymentRouter
+{
+    /**
+     * Create a new map deployment router instance.
+     */
+    public function __construct(protected array $map) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function route(string $model): string
+    {
+        return $this->map[$model] ?? $model;
+    }
+}

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -5,13 +5,82 @@ namespace Laravel\Ai\Providers;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 
+use Laravel\Ai\Contracts\Providers\Azure\DeploymentRouter;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Providers\Azure\MapDeploymentRouter;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+
 class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextProvider
 {
-    use Concerns\GeneratesEmbeddings;
-    use Concerns\GeneratesText;
+    use Concerns\GeneratesEmbeddings {
+        embeddings as traitEmbeddings;
+    }
+    use Concerns\GeneratesText {
+        prompt as traitPrompt;
+        stream as traitStream;
+    }
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
+
+    /**
+     * The deployment router instance.
+     */
+    protected ?DeploymentRouter $router = null;
+
+    /**
+     * Invoke the given agent.
+     */
+    public function prompt(AgentPrompt $prompt): AgentResponse
+    {
+        return $this->traitPrompt(
+            $prompt->withModel($this->deploymentRouter()->route($prompt->model))
+        );
+    }
+
+    /**
+     * Stream the response from the given agent.
+     */
+    public function stream(AgentPrompt $prompt): StreamableAgentResponse
+    {
+        return $this->traitStream(
+            $prompt->withModel($this->deploymentRouter()->route($prompt->model))
+        );
+    }
+
+    /**
+     * Get embedding vectors representing the given inputs.
+     *
+     * @param  string[]  $input
+     */
+    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null): EmbeddingsResponse
+    {
+        return $this->traitEmbeddings(
+            $inputs,
+            $dimensions,
+            $this->deploymentRouter()->route($model ?? $this->defaultEmbeddingsModel())
+        );
+    }
+
+    /**
+     * Get the deployment router instance.
+     */
+    public function deploymentRouter(): DeploymentRouter
+    {
+        return $this->router ??= new MapDeploymentRouter($this->config['deployments'] ?? []);
+    }
+
+    /**
+     * Set the deployment router instance.
+     */
+    public function useDeploymentRouter(DeploymentRouter $router): self
+    {
+        $this->router = $router;
+
+        return $this;
+    }
 
     /**
      * Get the credentials for the AI provider.

--- a/tests/Feature/AzureDeploymentRoutingTest.php
+++ b/tests/Feature/AzureDeploymentRoutingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Providers\AzureOpenAiProvider;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\TestCase;
+
+class AzureDeploymentRoutingTest extends TestCase
+{
+    public function test_it_routes_text_generation_models_to_deployments()
+    {
+        config(['ai.default' => 'azure']);
+        config(['ai.providers.azure' => [
+            'driver' => 'azure',
+            'key' => 'test-key',
+            'url' => 'https://test.openai.azure.com',
+            'deployments' => [
+                'gpt-4o' => 'my-gpt4o-deployment',
+                'gpt-4o-mini' => 'my-mini-deployment',
+            ],
+        ]]);
+
+        AssistantAgent::fake();
+
+        (new AssistantAgent)->prompt('Hello', model: 'gpt-4o');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->model === 'my-gpt4o-deployment';
+        });
+
+        (new AssistantAgent)->prompt('Hello', model: 'gpt-4o-mini');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->model === 'my-mini-deployment';
+        });
+
+        (new AssistantAgent)->prompt('Hello', model: 'unknown-model');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->model === 'unknown-model';
+        });
+    }
+
+    public function test_it_routes_embeddings_models_to_deployments()
+    {
+        config(['ai.providers.azure' => [
+            'driver' => 'azure',
+            'key' => 'test-key',
+            'url' => 'https://test.openai.azure.com',
+            'deployments' => [
+                'text-embedding-3-small' => 'my-embedding-deployment',
+            ],
+        ]]);
+
+        /** @var AzureOpenAiProvider $provider */
+        $provider = Ai::embeddingProvider('azure');
+
+        // We can't easily check the final call to the gateway without deep mocking,
+        // but we can verify the router logic is accessible and works.
+        $this->assertEquals('my-embedding-deployment', $provider->deploymentRouter()->route('text-embedding-3-small'));
+    }
+}


### PR DESCRIPTION
# Azure OpenAI Deployment-Based Router

In Azure OpenAI Service, each model is deployed as a separate "Deployment" with its own unique name (e.g., `my-gpt-4o-deployment`). This structure differs from standard OpenAI, where model names are universal.

The **Deployment-Based Router** allows you to map logical, unified model names to specific Azure deployment names dynamically. This is essential for large-scale projects where you want to switch models without changing code or hardcoded deployment names.