### PR TITLE
[0.x] Add recursive character text splitter

### DIFF
--- a/src/Concerns/SplitsText.php
+++ b/src/Concerns/SplitsText.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Ai\Concerns;
+
+use Laravel\Ai\Contracts\Splitter;
+use Laravel\Ai\Splitters\RecursiveCharacterTextSplitter;
+use RuntimeException;
+
+trait SplitsText
+{
+    /**
+     * Split a document's text content using the default recursive character splitter.
+     *
+     * @param  array<int, string>  $separators
+     * @return array<int, string>
+     */
+    public function splitText(
+        int $chunkSize = 1000,
+        int $chunkOverlap = 200,
+        array $separators = RecursiveCharacterTextSplitter::DEFAULT_SEPARATORS,
+    ): array {
+        return $this->split(new RecursiveCharacterTextSplitter(
+            chunkSize: $chunkSize,
+            chunkOverlap: $chunkOverlap,
+            separators: $separators,
+        ));
+    }
+
+    /**
+     * Split a document's text content using a custom splitter implementation.
+     *
+     * @return array<int, string>
+     */
+    public function split(Splitter $splitter): array
+    {
+        return $splitter->split($this->splittableContent());
+    }
+
+    /**
+     * Split a document's text content using a custom splitter implementation.
+     *
+     * @return array<int, string>
+     */
+    public function splitWith(Splitter $splitter): array
+    {
+        return $this->split($splitter);
+    }
+
+    protected function splittableContent(): string
+    {
+        if (! method_exists($this, 'content')) {
+            throw new RuntimeException('Unable to split text for ['.static::class.'] because content() is unavailable.');
+        }
+
+        /** @var callable(): string $resolver */
+        $resolver = [$this, 'content'];
+
+        return $resolver();
+    }
+}

--- a/src/Contracts/Splitter.php
+++ b/src/Contracts/Splitter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Ai\Contracts;
+
+interface Splitter
+{
+    /**
+     * Split a text payload into chunks.
+     *
+     * @return array<int, string>
+     */
+    public function split(string $text): array;
+}

--- a/src/Files/Document.php
+++ b/src/Files/Document.php
@@ -1,11 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravel\Ai\Files;
 
 use Illuminate\Http\UploadedFile;
+use Laravel\Ai\Concerns\SplitsText;
 
 abstract class Document extends File
 {
+    use SplitsText;
+
     /**
      * Create a new document from a string.
      */

--- a/src/Splitters/RecursiveCharacterTextSplitter.php
+++ b/src/Splitters/RecursiveCharacterTextSplitter.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Ai\Splitters;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\Splitter;
+
+class RecursiveCharacterTextSplitter implements Splitter
+{
+    /**
+     * @var array<int, string>
+     */
+    public const DEFAULT_SEPARATORS = ["\n\n", "\n", ' ', ''];
+
+    /**
+     * @param  array<int, string>  $separators
+     */
+    public function __construct(
+        protected readonly int $chunkSize = 1000,
+        protected readonly int $chunkOverlap = 200,
+        protected readonly array $separators = self::DEFAULT_SEPARATORS,
+    ) {
+        if ($chunkSize < 1) {
+            throw new InvalidArgumentException('Chunk size must be at least 1.');
+        }
+
+        if ($chunkOverlap < 0) {
+            throw new InvalidArgumentException('Chunk overlap cannot be negative.');
+        }
+
+        if ($chunkOverlap >= $chunkSize) {
+            throw new InvalidArgumentException('Chunk overlap must be smaller than chunk size.');
+        }
+
+        if ($separators === []) {
+            throw new InvalidArgumentException('At least one separator is required.');
+        }
+
+        foreach ($separators as $separator) {
+            if (! is_string($separator)) {
+                throw new InvalidArgumentException('Separators must be strings.');
+            }
+        }
+    }
+
+    /**
+     * Split a text payload into chunks.
+     *
+     * @return array<int, string>
+     */
+    public function split(string $text): array
+    {
+        if ($text === '') {
+            return [];
+        }
+
+        $segments = $this->splitRecursively($text, $this->separators);
+
+        return $this->mergeWithOverlap($segments);
+    }
+
+    /**
+     * Split a text payload into chunks.
+     *
+     * @return array<int, string>
+     */
+    public function splitText(string $text): array
+    {
+        return $this->split($text);
+    }
+
+    /**
+     * @param  array<int, string>  $separators
+     * @return array<int, string>
+     */
+    protected function splitRecursively(string $text, array $separators): array
+    {
+        if ($text === '') {
+            return [];
+        }
+
+        if (Str::length($text) <= $this->chunkSize) {
+            return [$text];
+        }
+
+        [$separator, $nextSeparators] = $this->selectSeparator($text, $separators);
+
+        $segments = [];
+
+        foreach ($this->splitOnSeparator($text, $separator) as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+
+            if (Str::length($segment) <= $this->chunkSize) {
+                $segments[] = $segment;
+
+                continue;
+            }
+
+            if ($nextSeparators !== []) {
+                $segments = [
+                    ...$segments,
+                    ...$this->splitRecursively($segment, $nextSeparators),
+                ];
+
+                continue;
+            }
+
+            $segments = [
+                ...$segments,
+                ...$this->hardWrap($segment),
+            ];
+        }
+
+        return array_values(array_filter($segments, static fn (string $segment): bool => $segment !== ''));
+    }
+
+    /**
+     * @param  array<int, string>  $separators
+     * @return array{0: string, 1: array<int, string>}
+     */
+    protected function selectSeparator(string $text, array $separators): array
+    {
+        $separator = $separators[array_key_last($separators)] ?? '';
+        $separatorIndex = array_key_last($separators) ?? 0;
+
+        foreach ($separators as $index => $candidate) {
+            if ($candidate === '' || str_contains($text, $candidate)) {
+                $separator = $candidate;
+                $separatorIndex = $index;
+
+                break;
+            }
+        }
+
+        return [$separator, array_values(array_slice($separators, $separatorIndex + 1))];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function splitOnSeparator(string $text, string $separator): array
+    {
+        if ($separator === '') {
+            return $this->splitByCharacter($text);
+        }
+
+        $parts = explode($separator, $text);
+
+        if (count($parts) === 1) {
+            return [$text];
+        }
+
+        $segments = [];
+        $lastPartIndex = count($parts) - 1;
+
+        foreach ($parts as $index => $part) {
+            if ($part !== '') {
+                $segments[] = $part;
+            }
+
+            if ($index < $lastPartIndex) {
+                $segments[] = $separator;
+            }
+        }
+
+        return $segments === [] ? [$text] : $segments;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function splitByCharacter(string $text): array
+    {
+        $segments = [];
+        $length = Str::length($text);
+
+        for ($index = 0; $index < $length; $index++) {
+            $segments[] = Str::substr($text, $index, 1);
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param  array<int, string>  $segments
+     * @return array<int, string>
+     */
+    protected function mergeWithOverlap(array $segments): array
+    {
+        $chunks = [];
+        $currentChunk = '';
+        $currentHasNewContent = false;
+
+        foreach ($segments as $segment) {
+            $pending = $segment;
+
+            while ($pending !== '') {
+                $pendingLength = Str::length($pending);
+                $remainingSpace = $this->chunkSize - Str::length($currentChunk);
+
+                if ($remainingSpace <= 0) {
+                    $chunks[] = $currentChunk;
+                    $currentChunk = $this->overlapTail($currentChunk);
+                    $currentHasNewContent = false;
+
+                    continue;
+                }
+
+                if (
+                    $pendingLength > $remainingSpace &&
+                    $currentChunk !== '' &&
+                    $currentHasNewContent
+                ) {
+                    $chunks[] = $currentChunk;
+                    $currentChunk = $this->overlapTail($currentChunk);
+                    $currentHasNewContent = false;
+
+                    continue;
+                }
+
+                $slice = $pendingLength <= $remainingSpace
+                    ? $pending
+                    : Str::substr($pending, 0, $remainingSpace);
+
+                if ($slice === '') {
+                    break;
+                }
+
+                $currentChunk .= $slice;
+                $currentHasNewContent = true;
+                $pending = Str::substr($pending, Str::length($slice));
+
+                if (Str::length($currentChunk) === $this->chunkSize) {
+                    $chunks[] = $currentChunk;
+                    $currentChunk = $this->overlapTail($currentChunk);
+                    $currentHasNewContent = false;
+                }
+            }
+        }
+
+        if ($currentHasNewContent && $currentChunk !== '') {
+            $chunks[] = $currentChunk;
+        }
+
+        return $chunks;
+    }
+
+    protected function overlapTail(string $chunk): string
+    {
+        if ($this->chunkOverlap === 0) {
+            return '';
+        }
+
+        $length = Str::length($chunk);
+
+        if ($length <= $this->chunkOverlap) {
+            return $chunk;
+        }
+
+        return Str::substr($chunk, $length - $this->chunkOverlap);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function hardWrap(string $text): array
+    {
+        $chunks = [];
+        $length = Str::length($text);
+
+        for ($offset = 0; $offset < $length; $offset += $this->chunkSize) {
+            $chunks[] = Str::substr($text, $offset, $this->chunkSize);
+        }
+
+        return array_values(array_filter($chunks, static fn (string $chunk): bool => $chunk !== ''));
+    }
+}

--- a/tests/Unit/Files/DocumentSplitTest.php
+++ b/tests/Unit/Files/DocumentSplitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Files;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Splitter;
+use Laravel\Ai\Files\Document;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DocumentSplitTest extends TestCase
+{
+    public function test_document_from_string_can_be_split_with_default_splitter(): void
+    {
+        $text = 'Alpha beta gamma delta epsilon zeta eta theta';
+
+        $chunks = Document::fromString($text, 'text/plain')->splitText(
+            chunkSize: 12,
+            chunkOverlap: 2,
+            separators: [' ', ''],
+        );
+
+        $this->assertNotEmpty($chunks);
+
+        foreach ($chunks as $chunk) {
+            $this->assertLessThanOrEqual(12, Str::length($chunk));
+        }
+
+        $this->assertSame($text, $this->reconstructFromOverlap($chunks, 2));
+    }
+
+    public function test_document_can_split_with_custom_splitter_implementation(): void
+    {
+        $document = Document::fromString('Hello world', 'text/plain');
+
+        $splitter = new class implements Splitter
+        {
+            /**
+             * @return array<int, string>
+             */
+            public function split(string $text): array
+            {
+                return ['custom', $text];
+            }
+        };
+
+        $this->assertSame(['custom', 'Hello world'], $document->split($splitter));
+    }
+
+    public function test_provider_documents_throw_when_content_is_unavailable(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('content() is unavailable');
+
+        Document::fromId('doc_123')->splitText();
+    }
+
+    /**
+     * @param  array<int, string>  $chunks
+     */
+    private function reconstructFromOverlap(array $chunks, int $chunkOverlap): string
+    {
+        $reconstructed = $chunks[0] ?? '';
+
+        foreach ($chunks as $index => $chunk) {
+            if ($index === 0) {
+                continue;
+            }
+
+            $reconstructed .= Str::substr($chunk, $chunkOverlap);
+        }
+
+        return $reconstructed;
+    }
+}

--- a/tests/Unit/Splitters/RecursiveCharacterTextSplitterTest.php
+++ b/tests/Unit/Splitters/RecursiveCharacterTextSplitterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Splitters;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Splitters\RecursiveCharacterTextSplitter;
+use PHPUnit\Framework\TestCase;
+
+class RecursiveCharacterTextSplitterTest extends TestCase
+{
+    public function test_it_splits_simple_text_by_length(): void
+    {
+        $splitter = new RecursiveCharacterTextSplitter(
+            chunkSize: 5,
+            chunkOverlap: 0,
+            separators: [''],
+        );
+
+        $chunks = $splitter->split('abcdefghijklmnopqrstuvwxyz');
+
+        $this->assertSame(['abcde', 'fghij', 'klmno', 'pqrst', 'uvwxy', 'z'], $chunks);
+    }
+
+    public function test_it_respects_paragraph_separators(): void
+    {
+        $splitter = new RecursiveCharacterTextSplitter(
+            chunkSize: 20,
+            chunkOverlap: 0,
+            separators: ["\n\n", "\n", ' ', ''],
+        );
+
+        $text = "Paragraph one.\n\nParagraph two.\n\nParagraph three.";
+        $chunks = $splitter->split($text);
+
+        $this->assertSame([
+            "Paragraph one.\n\n",
+            "Paragraph two.\n\n",
+            'Paragraph three.',
+        ], $chunks);
+    }
+
+    public function test_it_maintains_overlap_between_chunks(): void
+    {
+        $splitter = new RecursiveCharacterTextSplitter(
+            chunkSize: 10,
+            chunkOverlap: 3,
+            separators: [''],
+        );
+
+        $chunks = $splitter->split('abcdefghijklmnopqrstuvwxyz');
+
+        $this->assertGreaterThan(1, count($chunks));
+        $this->assertChunksWithinLimit($chunks, 10);
+        $this->assertOverlaps($chunks, 3);
+        $this->assertSame('abcdefghijklmnopqrstuvwxyz', $this->reconstructFromOverlap($chunks, 3));
+    }
+
+    public function test_it_handles_text_smaller_than_chunk_size(): void
+    {
+        $splitter = new RecursiveCharacterTextSplitter(
+            chunkSize: 100,
+            chunkOverlap: 0,
+            separators: ["\n\n", "\n", ' ', ''],
+        );
+
+        $text = 'Short text.';
+        $chunks = $splitter->split($text);
+
+        $this->assertSame([$text], $chunks);
+    }
+
+    /**
+     * @param  array<int, string>  $chunks
+     */
+    private function assertChunksWithinLimit(array $chunks, int $chunkSize): void
+    {
+        foreach ($chunks as $chunk) {
+            $this->assertLessThanOrEqual($chunkSize, Str::length($chunk));
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $chunks
+     */
+    private function assertOverlaps(array $chunks, int $chunkOverlap): void
+    {
+        foreach (array_keys($chunks) as $index) {
+            if (! isset($chunks[$index + 1])) {
+                continue;
+            }
+
+            $this->assertSame(
+                Str::substr($chunks[$index], -$chunkOverlap),
+                Str::substr($chunks[$index + 1], 0, $chunkOverlap),
+            );
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $chunks
+     */
+    private function reconstructFromOverlap(array $chunks, int $chunkOverlap): string
+    {
+        $reconstructed = $chunks[0] ?? '';
+
+        foreach ($chunks as $index => $chunk) {
+            if ($index === 0) {
+                continue;
+            }
+
+            $reconstructed .= Str::substr($chunk, $chunkOverlap);
+        }
+
+        return $reconstructed;
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds first-party text chunking support to the Laravel AI SDK by introducing a recursive character splitter and wiring it into `Document`.

## Why

Issue #71 reports failures and poor retrieval quality when large documents are embedded without chunking. This change adds a built-in, UTF-8-safe splitter so long text can be chunked predictably before embedding/RAG workflows.

## Changes

- Add `Laravel\Ai\Contracts\Splitter`
- Add `Laravel\Ai\Splitters\RecursiveCharacterTextSplitter`
  - Configurable `chunkSize`, `chunkOverlap`, and `separators`
  - Recursive separator fallback (`"\n\n"`, `"\n"`, `' '`, then character level)
  - Overlap-aware merge pass
  - UTF-8-safe length/substr handling via `Illuminate\Support\Str`
- Add `Laravel\Ai\Concerns\SplitsText`
  - `splitText(...)` convenience method
  - `split(Splitter $splitter)` for custom splitter implementations
- Update `Laravel\Ai\Files\Document` to use `SplitsText`
- Add unit tests for splitter behavior and `Document` integration

## Testing

- `./vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/Splitters/RecursiveCharacterTextSplitterTest.php tests/Unit/Files/DocumentSplitTest.php`
- `./vendor/bin/pint --test src/Contracts/Splitter.php src/Splitters/RecursiveCharacterTextSplitter.php src/Concerns/SplitsText.php src/Files/Document.php tests/Unit/Splitters/RecursiveCharacterTextSplitterTest.php tests/Unit/Files/DocumentSplitTest.php`

Fixes #71.
