### PR TITLE
[0.x] Add support for configuring provider options on agents

### DIFF
--- a/src/Contracts/HasProviderOptions.php
+++ b/src/Contracts/HasProviderOptions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+interface HasProviderOptions
+{
+    /**
+     * Get the provider-specific options to be passed to Prism.
+     *
+     * @return array<string, mixed>
+     */
+    public function providerOptions(): array;
+}

--- a/src/Contracts/HasProviderOptions.php
+++ b/src/Contracts/HasProviderOptions.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Ai\Contracts;
 
+use Laravel\Ai\Enums\Lab;
+
 interface HasProviderOptions
 {
     /**
@@ -9,5 +11,5 @@ interface HasProviderOptions
      *
      * @return array<string, mixed>
      */
-    public function providerOptions(): array;
+    public function providerOptions(Lab|string $provider): array;
 }

--- a/src/Contracts/HasProviderOptions.php
+++ b/src/Contracts/HasProviderOptions.php
@@ -7,7 +7,7 @@ use Laravel\Ai\Enums\Lab;
 interface HasProviderOptions
 {
     /**
-     * Get the provider-specific options to be passed to Prism.
+     * Get the provider-specific options to be passed to the provider.
      *
      * @return array<string, mixed>
      */

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -60,11 +60,23 @@ trait CreatesPrismTextRequests
     protected function withProviderOptions($request, Provider $provider, ?array $schema, ?TextGenerationOptions $options)
     {
         if ($provider instanceof AnthropicProvider) {
+            $providerOptions = array_filter([
+                'use_tool_calling' => $schema ? true : null,
+            ]);
+
+            // Merge agent provider options (agent options can override defaults)
+            if (! is_null($options?->providerOptions)) {
+                $providerOptions = array_merge($providerOptions, $options->providerOptions);
+            }
+
             return $request
-                ->withProviderOptions(array_filter([
-                    'use_tool_calling' => $schema ? true : null,
-                ]))
+                ->withProviderOptions($providerOptions)
                 ->withMaxTokens($options?->maxTokens ?? 64_000);
+        }
+
+        // For non-Anthropic providers, apply agent provider options if available
+        if (! is_null($options?->providerOptions)) {
+            $request = $request->withProviderOptions($options->providerOptions);
         }
 
         if (! is_null($options?->maxTokens)) {

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -69,7 +69,7 @@ trait CreatesPrismTextRequests
                 'use_tool_calling' => $schema ? true : null,
             ]);
 
-            // Merge agent provider options (agent options can override defaults)
+            // Merge agent provider options (agent options can override defaults)...
             if (! is_null($agentProviderOptions)) {
                 $providerOptions = array_merge($providerOptions, $agentProviderOptions);
             }
@@ -79,7 +79,7 @@ trait CreatesPrismTextRequests
                 ->withMaxTokens($options?->maxTokens ?? 64_000);
         }
 
-        // For non-Anthropic providers, apply agent provider options if available
+        // For non-Anthropic providers, apply agent provider options if available...
         if (! is_null($agentProviderOptions)) {
             $request = $request->withProviderOptions($agentProviderOptions);
         }

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -7,6 +7,7 @@ use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
 use ReflectionClass;
 
 class TextGenerationOptions
@@ -15,9 +16,23 @@ class TextGenerationOptions
         public readonly ?int $maxSteps = null,
         public readonly ?int $maxTokens = null,
         public readonly ?float $temperature = null,
-        public readonly ?array $providerOptions = null,
+        public readonly ?Agent $agent = null,
     ) {
         //
+    }
+
+    /**
+     * Get the provider-specific options for the given provider.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function providerOptions(Lab|string $provider): ?array
+    {
+        if ($this->agent instanceof HasProviderOptions) {
+            return $this->agent->providerOptions($provider);
+        }
+
+        return null;
     }
 
     /**
@@ -31,15 +46,11 @@ class TextGenerationOptions
         $maxTokens = $reflection->getAttributes(MaxTokens::class);
         $temperature = $reflection->getAttributes(Temperature::class);
 
-        $providerOptions = $agent instanceof HasProviderOptions
-            ? $agent->providerOptions()
-            : null;
-
         return new self(
             maxSteps: ! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null,
             maxTokens: ! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null,
             temperature: ! empty($temperature) ? $temperature[0]->newInstance()->value : null,
-            providerOptions: $providerOptions,
+            agent: $agent,
         );
     }
 }

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
 use ReflectionClass;
 
 class TextGenerationOptions
@@ -14,6 +15,7 @@ class TextGenerationOptions
         public readonly ?int $maxSteps = null,
         public readonly ?int $maxTokens = null,
         public readonly ?float $temperature = null,
+        public readonly ?array $providerOptions = null,
     ) {
         //
     }
@@ -29,10 +31,15 @@ class TextGenerationOptions
         $maxTokens = $reflection->getAttributes(MaxTokens::class);
         $temperature = $reflection->getAttributes(Temperature::class);
 
+        $providerOptions = $agent instanceof HasProviderOptions
+            ? $agent->providerOptions()
+            : null;
+
         return new self(
             maxSteps: ! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null,
             maxTokens: ! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null,
             temperature: ! empty($temperature) ? $temperature[0]->newInstance()->value : null,
+            providerOptions: $providerOptions,
         );
     }
 }

--- a/tests/Feature/AgentProviderOptionsTest.php
+++ b/tests/Feature/AgentProviderOptionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Tests\Feature\Agents\AssistantAgent;
@@ -10,26 +11,68 @@ use Tests\TestCase;
 
 class AgentProviderOptionsTest extends TestCase
 {
-    public function test_text_generation_options_can_be_created_from_agent_with_provider_options(): void
+    public function test_text_generation_options_can_extract_provider_options_for_openai(): void
     {
         $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
 
-        $this->assertNotNull($options->providerOptions);
-        $this->assertIsArray($options->providerOptions);
+        $providerOptions = $options->providerOptions(Lab::OpenAI);
+
+        $this->assertNotNull($providerOptions);
+        $this->assertIsArray($providerOptions);
         $this->assertEquals([
             'reasoning' => [
                 'effort' => 'high',
             ],
             'frequency_penalty' => 0.5,
             'presence_penalty' => 0.3,
-        ], $options->providerOptions);
+        ], $providerOptions);
+    }
+
+    public function test_text_generation_options_can_extract_provider_options_for_anthropic(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+        $providerOptions = $options->providerOptions(Lab::Anthropic);
+
+        $this->assertNotNull($providerOptions);
+        $this->assertEquals([
+            'thinking' => [
+                'type' => 'enabled',
+                'budget_tokens' => 10000,
+            ],
+        ], $providerOptions);
+    }
+
+    public function test_text_generation_options_accept_string_provider(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+        $providerOptions = $options->providerOptions('openai');
+
+        $this->assertNotNull($providerOptions);
+        $this->assertEquals([
+            'reasoning' => [
+                'effort' => 'high',
+            ],
+            'frequency_penalty' => 0.5,
+            'presence_penalty' => 0.3,
+        ], $providerOptions);
+    }
+
+    public function test_text_generation_options_return_empty_array_for_unknown_provider(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+        $providerOptions = $options->providerOptions(Lab::Gemini);
+
+        $this->assertEquals([], $providerOptions);
     }
 
     public function test_text_generation_options_have_null_provider_options_when_agent_does_not_implement_interface(): void
     {
         $options = TextGenerationOptions::forAgent(new AssistantAgent);
 
-        $this->assertNull($options->providerOptions);
+        $this->assertNull($options->providerOptions(Lab::OpenAI));
     }
 
     public function test_provider_options_are_passed_through_when_prompting(): void
@@ -39,7 +82,9 @@ class AgentProviderOptionsTest extends TestCase
         (new ProviderOptionsAgent)->prompt('Hello');
 
         ProviderOptionsAgent::assertPrompted(function (AgentPrompt $prompt) {
-            return $prompt->options->providerOptions === [
+            $options = TextGenerationOptions::forAgent($prompt->agent);
+
+            return $options->providerOptions(Lab::OpenAI) === [
                 'reasoning' => [
                     'effort' => 'high',
                 ],
@@ -56,7 +101,9 @@ class AgentProviderOptionsTest extends TestCase
         (new AssistantAgent)->prompt('Hello');
 
         AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
-            return $prompt->options->providerOptions === null;
+            $options = TextGenerationOptions::forAgent($prompt->agent);
+
+            return $options->providerOptions(Lab::OpenAI) === null;
         });
     }
 }

--- a/tests/Feature/AgentProviderOptionsTest.php
+++ b/tests/Feature/AgentProviderOptionsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\TestCase;
+
+class AgentProviderOptionsTest extends TestCase
+{
+    public function test_text_generation_options_can_be_created_from_agent_with_provider_options(): void
+    {
+        $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+        $this->assertNotNull($options->providerOptions);
+        $this->assertIsArray($options->providerOptions);
+        $this->assertEquals([
+            'reasoning' => [
+                'effort' => 'high',
+            ],
+            'frequency_penalty' => 0.5,
+            'presence_penalty' => 0.3,
+        ], $options->providerOptions);
+    }
+
+    public function test_text_generation_options_have_null_provider_options_when_agent_does_not_implement_interface(): void
+    {
+        $options = TextGenerationOptions::forAgent(new AssistantAgent);
+
+        $this->assertNull($options->providerOptions);
+    }
+
+    public function test_provider_options_are_passed_through_when_prompting(): void
+    {
+        ProviderOptionsAgent::fake();
+
+        (new ProviderOptionsAgent)->prompt('Hello');
+
+        ProviderOptionsAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->options->providerOptions === [
+                'reasoning' => [
+                    'effort' => 'high',
+                ],
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
+            ];
+        });
+    }
+
+    public function test_provider_options_default_to_null_when_not_provided(): void
+    {
+        AssistantAgent::fake();
+
+        (new AssistantAgent)->prompt('Hello');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->options->providerOptions === null;
+        });
+    }
+}

--- a/tests/Feature/AgentProviderOptionsTest.php
+++ b/tests/Feature/AgentProviderOptionsTest.php
@@ -19,6 +19,7 @@ class AgentProviderOptionsTest extends TestCase
 
         $this->assertNotNull($providerOptions);
         $this->assertIsArray($providerOptions);
+
         $this->assertEquals([
             'reasoning' => [
                 'effort' => 'high',
@@ -35,6 +36,7 @@ class AgentProviderOptionsTest extends TestCase
         $providerOptions = $options->providerOptions(Lab::Anthropic);
 
         $this->assertNotNull($providerOptions);
+
         $this->assertEquals([
             'thinking' => [
                 'type' => 'enabled',
@@ -50,6 +52,7 @@ class AgentProviderOptionsTest extends TestCase
         $providerOptions = $options->providerOptions('openai');
 
         $this->assertNotNull($providerOptions);
+
         $this->assertEquals([
             'reasoning' => [
                 'effort' => 'high',

--- a/tests/Feature/Agents/ProviderOptionsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsAgent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Promptable;
+
+class ProviderOptionsAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function providerOptions(): array
+    {
+        return [
+            'reasoning' => [
+                'effort' => 'high',
+            ],
+            'frequency_penalty' => 0.5,
+            'presence_penalty' => 0.3,
+        ];
+    }
+}

--- a/tests/Feature/Agents/ProviderOptionsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 class ProviderOptionsAgent implements Agent, HasProviderOptions
@@ -15,14 +16,25 @@ class ProviderOptionsAgent implements Agent, HasProviderOptions
         return 'You are a helpful assistant.';
     }
 
-    public function providerOptions(): array
+    public function providerOptions(Lab|string $provider): array
     {
-        return [
-            'reasoning' => [
-                'effort' => 'high',
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::OpenAI => [
+                'reasoning' => [
+                    'effort' => 'high',
+                ],
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
             ],
-            'frequency_penalty' => 0.5,
-            'presence_penalty' => 0.3,
-        ];
+            Lab::Anthropic => [
+                'thinking' => [
+                    'type' => 'enabled',
+                    'budget_tokens' => 10000,
+                ],
+            ],
+            default => [],
+        };
     }
 }


### PR DESCRIPTION
This PR adds a HasProviderOptions interface that allows agents to specify provider-specific options (e.g., OpenAI's reasoning.effort, frequency_penalty, presence_penalty) that get passed through to Prism's withProviderOptions().

**Problem**

The SDK currently has no way for agents to configure provider-specific options. TextGenerationOptions only supports maxSteps, maxTokens, and temperature via attributes.

This is a practical blocker for OpenAI's reasoning models, where reasoning.effort defaults to "medium" when omitted — burning unnecessary tokens for simple tasks like classification or extraction. Other provider options like frequency_penalty and presence_penalty are also inaccessible.

**Solution**

A new HasProviderOptions interface that agents can implement:

```
use Laravel\Ai\Contracts\Agent;
use Laravel\Ai\Contracts\HasProviderOptions;

class MyAgent implements Agent, HasProviderOptions
{
    use Promptable;

    public function instructions(): string
    {
        return 'You are a helpful assistant.';
    }

    public function providerOptions(): array
    {
        return [
            'reasoning' => ['effort' => 'low'],
            'frequency_penalty' => 0.5,
            'presence_penalty' => 0.3,
        ];
    }
}
```

Why an interface over attributes?

• Provider options are diverse and provider-specific — attributes would proliferate quickly
• An interface allows dynamic options based on runtime context
• Aligns with existing patterns (HasTools, HasMiddleware, HasStructuredOutput)
• Community consensus in #82 favored this approach
Changes

• Add Laravel\Ai\Contracts\HasProviderOptions interface
• Modify TextGenerationOptions — extract provider options from agent via interface check
• Modify CreatesPrismTextRequests — merge agent's provider options with existing provider-specific defaults (agent options override)
• Add tests and test agent
Backward Compatibility

✅ Fully backward compatible. Existing agents without HasProviderOptions continue to work unchanged — providerOptions defaults to null and no additional options are passed.

Testing

• Provider options correctly extracted from agent implementing HasProviderOptions
• Options are null for agents without the interface
• Options passed through when prompting
• Options default to null when not provided
Fixes #82.