### PR TITLE
[0.x] Add return type annotations to interfaces

### DIFF
--- a/src/Contracts/Conversational.php
+++ b/src/Contracts/Conversational.php
@@ -6,6 +6,8 @@ interface Conversational
 {
     /**
      * Get the list of messages comprising the conversation so far.
+     *
+     * @return \Laravel\Ai\Messages\Message[]
      */
     public function messages(): iterable;
 }

--- a/src/Contracts/Gateway/TextGateway.php
+++ b/src/Contracts/Gateway/TextGateway.php
@@ -13,6 +13,8 @@ interface TextGateway
     /**
      * Generate text representing the next message in a conversation.
      *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     * @param  \Laravel\Ai\Contracts\Tool[]  $tools
      * @param  array<string, \Illuminate\JsonSchema\Types\Type>|null  $schema
      */
     public function generateText(
@@ -29,6 +31,8 @@ interface TextGateway
     /**
      * Stream text representing the next message in a conversation.
      *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     * @param  \Laravel\Ai\Contracts\Tool[]  $tools
      * @param  array<string, \Illuminate\JsonSchema\Types\Type>|null  $schema
      */
     public function streamText(

--- a/src/Contracts/HasStructuredOutput.php
+++ b/src/Contracts/HasStructuredOutput.php
@@ -8,6 +8,8 @@ interface HasStructuredOutput
 {
     /**
      * Get the agent's structured output schema definition.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
      */
     public function schema(JsonSchema $schema): array;
 }

--- a/src/Contracts/Tool.php
+++ b/src/Contracts/Tool.php
@@ -21,7 +21,7 @@ interface Tool
     /**
      * Get the tool's schema definition.
      *
-     * @return array<string, mixed>
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
      */
     public function schema(JsonSchema $schema): array;
 }

--- a/src/Contracts/Tool.php
+++ b/src/Contracts/Tool.php
@@ -20,6 +20,8 @@ interface Tool
 
     /**
      * Get the tool's schema definition.
+     *
+     * @return array<string, mixed>
      */
     public function schema(JsonSchema $schema): array;
 }


### PR DESCRIPTION
Adds more precise return types to some interfaces.

The `\Laravel\Ai\Contracts\HasTools::tools` returns a list of Tool interfaces. Should the `\Laravel\Ai\Contracts\Conversational::messages` also return a list of interfaces or is the concrete `\Laravel\Ai\Messages\Message` fine? Do you expect users to implement their own Message or just extend it?