### PR TITLE
Allow Lab enum for Provider attribute

### DIFF
--- a/src/Attributes/Provider.php
+++ b/src/Attributes/Provider.php
@@ -3,11 +3,12 @@
 namespace Laravel\Ai\Attributes;
 
 use Attribute;
+use Laravel\Ai\Enums\Lab;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Provider
 {
-    public function __construct(public array|string $value)
+    public function __construct(public Lab|array|string $value)
     {
         //
     }


### PR DESCRIPTION
This PR updates the Provider attribute to allow using the Laravel\Ai\Enums\Lab enum, in addition to a string or an array.

As in the example in the docs https://laravel.com/docs/12.x/ai-sdk#agent-configuration

```php
#[Provider(Lab::Anthropic)]
```