### PR TITLE
Add `#ReasoningEffort[]` Attribute

### DIFF
--- a/src/Attributes/ReasoningEffort.php
+++ b/src/Attributes/ReasoningEffort.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ReasoningEffort
+{
+    public function __construct(public string $value = 'medium')
+    {
+        //
+    }
+}

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -71,6 +71,12 @@ trait CreatesPrismTextRequests
             $request = $request->withMaxTokens($options->maxTokens);
         }
 
+        if (! is_null($options?->reasoningEffort) && $provider instanceof OpenAiProvider) {
+            $request = $request->withProviderOptions([
+                'reasoning' => ['effort' => $options->reasoningEffort],
+            ]);
+        }
+
         return $request;
     }
 

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -71,7 +71,7 @@ trait CreatesPrismTextRequests
             $request = $request->withMaxTokens($options->maxTokens);
         }
 
-        if (! is_null($options?->reasoningEffort) && $provider instanceof OpenAiProvider) {
+        if (! is_null($options?->reasoningEffort)) {
             $request = $request->withProviderOptions([
                 'reasoning' => ['effort' => $options->reasoningEffort],
             ]);

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway;
 
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\ReasoningEffort;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use ReflectionClass;
@@ -14,6 +15,7 @@ class TextGenerationOptions
         public readonly ?int $maxSteps = null,
         public readonly ?int $maxTokens = null,
         public readonly ?float $temperature = null,
+        public readonly ?string $reasoningEffort = null,
     ) {
         //
     }
@@ -28,11 +30,13 @@ class TextGenerationOptions
         $maxSteps = $reflection->getAttributes(MaxSteps::class);
         $maxTokens = $reflection->getAttributes(MaxTokens::class);
         $temperature = $reflection->getAttributes(Temperature::class);
+        $reasoningEffort = $reflection->getAttributes(ReasoningEffort::class);
 
         return new self(
             maxSteps: ! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null,
             maxTokens: ! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null,
             temperature: ! empty($temperature) ? $temperature[0]->newInstance()->value : null,
+            reasoningEffort: ! empty($reasoningEffort) ? $reasoningEffort[0]->newInstance()->value : null,
         );
     }
 }

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -17,6 +17,7 @@ class AgentAttributeTest extends TestCase
         $this->assertSame(10, $options->maxSteps);
         $this->assertSame(4096, $options->maxTokens);
         $this->assertSame(0.7, $options->temperature);
+        $this->assertSame('minimal', $options->reasoningEffort);
     }
 
     public function test_text_generation_options_are_null_when_agent_has_no_attributes(): void
@@ -26,6 +27,7 @@ class AgentAttributeTest extends TestCase
         $this->assertNull($options->maxSteps);
         $this->assertNull($options->maxTokens);
         $this->assertNull($options->temperature);
+        $this->assertNull($options->reasoningEffort);
     }
 
     public function test_provider_attribute_is_used_when_prompting(): void

--- a/tests/Feature/Agents/AttributeAgent.php
+++ b/tests/Feature/Agents/AttributeAgent.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Agents;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Attributes\ReasoningEffort;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Promptable;
@@ -12,6 +13,7 @@ use Laravel\Ai\Promptable;
 #[MaxSteps(10)]
 #[MaxTokens(4096)]
 #[Temperature(0.7)]
+#[ReasoningEffort('minimal')]
 #[Provider('anthropic')]
 class AttributeAgent implements Agent
 {


### PR DESCRIPTION
I recently updated my app to use `gpt-5-nano` in some places and then immediately realised how slow it was.

I forgot that they're reasoning models, which is the reason for the slowness. 

This PR adds a way to set the reasoning effort, in my case `#[ReasoningEffort('minimal')]`. With this in place, the responses are speedy and exactly what I need. 