### PR TITLE
[0.x] Allow nullable user IDs in conversation tables

### DIFF
--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->foreignId('user_id');
+            $table->foreignId('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->foreignId('user_id');
+            $table->foreignId('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');


### PR DESCRIPTION
The `ConversationStore` contract and the `RememberConversation` middleware already allow `null` user IDs, but the migration columns were not nullable causing a database error. This PR makes both columns nullable.