### PR TITLE
Add support for timeouts in transcription

### DIFF
--- a/src/Contracts/Gateway/TranscriptionGateway.php
+++ b/src/Contracts/Gateway/TranscriptionGateway.php
@@ -17,5 +17,6 @@ interface TranscriptionGateway
         TranscribableAudio $audio,
         ?string $language = null,
         bool $diarize = false,
+        int $timeout = 30
     ): TranscriptionResponse;
 }

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -59,6 +59,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         TranscribableAudio $audio,
         ?string $language = null,
         bool $diarize = false,
+        int $timeout = 30
     ): TranscriptionResponse {
         $audioContent = match (true) {
             $audio instanceof TranscribableAudio => $audio->content(),
@@ -70,7 +71,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 
         $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
             'xi-api-key' => $provider->providerCredentials()['key'],
-        ])->attach(
+        ])->timeout($timeout)->attach(
             'file', $audioContent, 'file', ['Content-Type' => $mimeType],
         )->post('https://api.elevenlabs.io/v1/speech-to-text', [
             'model_id' => $model,

--- a/src/Gateway/FakeTranscriptionGateway.php
+++ b/src/Gateway/FakeTranscriptionGateway.php
@@ -33,6 +33,7 @@ class FakeTranscriptionGateway implements TranscriptionGateway
         TranscribableAudio $audio,
         ?string $language = null,
         bool $diarize = false,
+        int $timeout = 30
     ): TranscriptionResponse {
         $transcriptionPrompt = new TranscriptionPrompt($audio, $language, $diarize, $provider, $model);
 

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -280,6 +280,7 @@ class PrismGateway implements Gateway
         TranscribableAudio $audio,
         ?string $language = null,
         bool $diarize = false,
+        int $timeout = 30
     ): TranscriptionResponse {
         try {
             if ($provider->driver() === 'openai' && ! $diarize) {
@@ -291,6 +292,9 @@ class PrismGateway implements Gateway
                     ...$provider->additionalConfiguration(),
                     'api_key' => $provider->providerCredentials()['key'],
                 ]))
+                ->withClientOptions([
+                    'timeout' => $timeout,
+                ])
                 ->withInput(match (true) {
                     $audio instanceof TranscribableAudio => Audio::fromBase64(
                         base64_encode($audio->content()), $audio->mimeType()

--- a/src/PendingResponses/PendingTranscriptionGeneration.php
+++ b/src/PendingResponses/PendingTranscriptionGeneration.php
@@ -26,6 +26,8 @@ class PendingTranscriptionGeneration
 
     protected bool $diarize = false;
 
+    protected int $timeout = 30;
+
     public function __construct(
         protected TranscribableAudio $audio,
     ) {}
@@ -51,6 +53,16 @@ class PendingTranscriptionGeneration
     }
 
     /**
+     * Specify the timeout (in seconds) for the transcription generation.
+     */
+    public function timeout(int $seconds = 30): self
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    /**
      * Generate the transcription.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): TranscriptionResponse
@@ -65,7 +77,7 @@ class PendingTranscriptionGeneration
             $model ??= $provider->defaultTranscriptionModel();
 
             try {
-                return $provider->transcribe($this->audio, $this->language, $this->diarize, $model);
+                return $provider->transcribe($this->audio, $this->language, $this->diarize, $model, $this->timeout);
             } catch (FailoverableException $e) {
                 event(new ProviderFailedOver($provider, $model, $e));
 

--- a/src/Prompts/TranscriptionPrompt.php
+++ b/src/Prompts/TranscriptionPrompt.php
@@ -13,6 +13,7 @@ class TranscriptionPrompt
         public readonly bool $diarize,
         public readonly TranscriptionProvider $provider,
         public readonly string $model,
+        public readonly ?int $timeout = null,
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesTranscriptions.php
+++ b/src/Providers/Concerns/GeneratesTranscriptions.php
@@ -20,12 +20,13 @@ trait GeneratesTranscriptions
         ?string $language = null,
         bool $diarize = false,
         ?string $model = null,
+        ?int $timeout = null,
     ): TranscriptionResponse {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultTranscriptionModel();
 
-        $prompt = new TranscriptionPrompt($audio, $language, $diarize, $this, $model);
+        $prompt = new TranscriptionPrompt($audio, $language, $diarize, $this, $model, $timeout);
 
         if (Ai::transcriptionsAreFaked()) {
             Ai::recordTranscriptionGeneration($prompt);
@@ -36,7 +37,7 @@ trait GeneratesTranscriptions
         ));
 
         return tap($this->transcriptionGateway()->generateTranscription(
-            $this, $model, $prompt->audio, $prompt->language, $prompt->diarize
+            $this, $model, $prompt->audio, $prompt->language, $prompt->diarize, $prompt->timeout
         ), function (TranscriptionResponse $response) use ($invocationId, $model, $prompt) {
             $this->events->dispatch(new TranscriptionGenerated(
                 $invocationId, $this, $model, $prompt, $response

--- a/tests/Feature/TranscriptionFakeTest.php
+++ b/tests/Feature/TranscriptionFakeTest.php
@@ -174,4 +174,15 @@ class TranscriptionFakeTest extends TestCase
             return $prompt->language === 'es' && $prompt->isDiarized();
         });
     }
+
+    public function test_transcription_can_have_timeouts(): void
+    {
+        Transcription::fake();
+
+        Transcription::of(base64_encode('audio'))->timeout(60)->generate();
+
+        Transcription::assertGenerated(function (TranscriptionPrompt $prompt) {
+            return $prompt->timeout === 60;
+        });
+    }
 }


### PR DESCRIPTION
Currently when using transcription you are stuck with the default timeout (especially with elevenlabs, which can't be changed by any env variables AFAIK)


This adds a new ->timeout(...) to transcriptions

```php
        $transcript = Transcription::fromPath('/home/forge/test.mp3')
            ->diarize(true)
            ->language('en')
            ->timeout(240)
            ->generate(Lab::ElevenLabs);
```

There's also 1 extra test for this timeout