### PR TITLE
[0.x] Add make:agent-middleware command

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Stringable;
 use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
+use Laravel\Ai\Console\Commands\MakeAgentMiddlewareCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Storage\DatabaseConversationStore;
@@ -93,6 +94,7 @@ class AiServiceProvider extends ServiceProvider
         $this->commands([
             // ChatCommand::class,
             MakeAgentCommand::class,
+            MakeAgentMiddlewareCommand::class,
             MakeToolCommand::class,
         ]);
     }
@@ -110,6 +112,7 @@ class AiServiceProvider extends ServiceProvider
             __DIR__.'/../stubs/agent.stub' => base_path('stubs/agent.stub'),
             __DIR__.'/../stubs/structured-agent.stub' => base_path('stubs/structured-agent.stub'),
             __DIR__.'/../stubs/tool.stub' => base_path('stubs/tool.stub'),
+            __DIR__.'/../stubs/middleware.stub' => base_path('stubs/middleware.stub'),
         ], 'ai-stubs');
 
         $this->publishesMigrations([

--- a/src/Console/Commands/MakeAgentMiddlewareCommand.php
+++ b/src/Console/Commands/MakeAgentMiddlewareCommand.php
@@ -28,7 +28,7 @@ class MakeAgentMiddlewareCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $type = 'Middleware';
+    protected $type = 'Agent Middleware';
 
     /**
      * Get the default namespace for the class.

--- a/src/Console/Commands/MakeAgentMiddlewareCommand.php
+++ b/src/Console/Commands/MakeAgentMiddlewareCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Ai\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:agent-middleware')]
+class MakeAgentMiddlewareCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:agent-middleware';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new agent middleware';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Middleware';
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Ai\Middleware';
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/middleware.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.'/../../../'.$stub;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the agent even if the agent already exists'],
+        ];
+    }
+}

--- a/src/Console/Commands/MakeAgentMiddlewareCommand.php
+++ b/src/Console/Commands/MakeAgentMiddlewareCommand.php
@@ -72,7 +72,7 @@ class MakeAgentMiddlewareCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the agent even if the agent already exists'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the middleware even if the middleware already exists'],
         ];
     }
 }

--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use Closure;
 use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\AgentResponse;
 
 class {{ class }}
 {
@@ -12,6 +13,8 @@ class {{ class }}
      */
     public function handle(AgentPrompt $prompt, Closure $next)
     {
-        return $next($prompt);
+        return $next($prompt)->then(function (AgentResponse $response) {
+            // ...
+        });
     }
 }

--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+class {{ class }}
+{
+    /**
+     * Handle the incoming prompt.
+     */
+    public function handle(AgentPrompt $prompt, Closure $next)
+    {
+        return $next($prompt);
+    }
+}

--- a/tests/Feature/Console/MakeAgentMiddlewareCommandTest.php
+++ b/tests/Feature/Console/MakeAgentMiddlewareCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+class MakeAgentMiddlewareCommandTest extends TestCase
+{
+    public function test_can_create_an_agent_middleware_class(): void
+    {
+        $response = $this->artisan('make:agent-middleware', [
+            'name' => 'TestMiddleware',
+        ]);
+
+        $response->assertExitCode(0)->run();
+
+        $this->assertFileExists(app_path('Ai/Middleware/TestMiddleware.php'));
+    }
+
+    public function test_may_publish_custom_middleware_stub(): void
+    {
+        $this->artisan('vendor:publish', [
+            '--tag' => 'ai-stubs',
+            '--force' => true,
+        ])->assertExitCode(0)->run();
+
+        $this->assertFileExists(base_path('stubs/middleware.stub'));
+    }
+}


### PR DESCRIPTION
Currently there is no Artisan command to generate agent middleware. This PR adds `make:agent-middleware` to keep the developer experience consistent with other AI scaffolding commands (`make:agent`, `make:tool`).

## Changes Summary

- Adds a new `make:agent-middleware` Artisan command for scaffolding agent middleware classes, similar to the existing `make:agent` and `make:tool` commands
- Includes a middleware stub, service provider registration, and publishable stub support
- Adds feature tests for the command and stub publishing

