### PR TITLE
Add Deepgram Provider for Laravel AI

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -69,6 +69,11 @@ return [
             'key' => env('COHERE_API_KEY'),
         ],
 
+        'deepgram' => [
+            'driver' => 'deepgram',
+            'key' => env('DEEPGRAM_API_KEY'),
+        ],
+
         'deepseek' => [
             'driver' => 'deepseek',
             'key' => env('DEEPSEEK_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -18,6 +18,7 @@ use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
 use Laravel\Ai\Providers\AzureOpenAiProvider;
 use Laravel\Ai\Providers\CohereProvider;
+use Laravel\Ai\Providers\DeepgramProvider;
 use Laravel\Ai\Providers\DeepSeekProvider;
 use Laravel\Ai\Providers\ElevenLabsProvider;
 use Laravel\Ai\Providers\GeminiProvider;
@@ -272,6 +273,17 @@ class AiManager extends MultipleInstanceManager
     public function createCohereDriver(array $config): CohereProvider
     {
         return new CohereProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a Deepgram powered instance.
+     */
+    public function createDeepgramDriver(array $config): DeepgramProvider
+    {
+        return new DeepgramProvider(
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -7,6 +7,7 @@ enum Lab: string
     case Anthropic = 'anthropic';
     case Azure = 'azure';
     case Cohere = 'cohere';
+    case Deepgram = 'deepgram';
     case DeepSeek = 'deepseek';
     case ElevenLabs = 'eleven';
     case Gemini = 'gemini';

--- a/src/Gateway/DeepgramGateway.php
+++ b/src/Gateway/DeepgramGateway.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TranscriptionResponse;
+
+class DeepgramGateway implements AudioGateway, TranscriptionGateway
+{
+    use Concerns\HandlesRateLimiting;
+
+    /**
+     * Generate audio from the given text.
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null): AudioResponse
+    {
+        $model = match ($voice) {
+            'default-male' => 'aura-2-perseus-en',
+            'default-female' => 'aura-2-thalia-en',
+            default => $voice,
+        };
+
+        $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
+            'Authorization' => 'Token '.$provider->providerCredentials()['key'],
+        ])->withBody(json_encode(['text' => $text]), 'application/json')
+            ->post('https://api.deepgram.com/v1/speak?model='.$model)
+            ->throw());
+
+        return new AudioResponse(
+            base64_encode((string) $response),
+            new Meta($provider->name(), $model),
+            'audio/mpeg'
+        );
+    }
+
+    /**
+     * Generate text from the given audio.
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+    ): TranscriptionResponse {
+        $audioContent = match (true) {
+            $audio instanceof TranscribableAudio => $audio->content(),
+        };
+
+        $mimeType = match (true) {
+            $audio instanceof TranscribableAudio => $audio->mimeType(),
+        };
+
+        $query = array_filter([
+            'model' => $model,
+            'language' => $language,
+            'diarize' => $diarize ? 'true' : null,
+            'punctuate' => 'true',
+        ]);
+
+        $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
+            'Authorization' => 'Token '.$provider->providerCredentials()['key'],
+            'Content-Type' => $mimeType,
+        ])->withBody($audioContent, $mimeType)
+            ->post('https://api.deepgram.com/v1/listen?'.http_build_query($query))
+            ->throw());
+
+        $response = $response->json();
+
+        $transcript = $response['results']['channels'][0]['alternatives'][0]['transcript'] ?? '';
+
+        $segments = $diarize
+            ? ($response['results']['channels'][0]['alternatives'][0]['words'] ?? [])
+            : [];
+
+        return new TranscriptionResponse(
+            $transcript,
+            (new Collection($segments))->map(function ($segment) {
+                return new TranscriptionSegment(
+                    $segment['word'],
+                    (string) ($segment['speaker'] ?? ''),
+                    $segment['start'],
+                    $segment['end'],
+                );
+            })->values(),
+            new Usage,
+            new Meta($provider->name(), $model),
+        );
+    }
+}

--- a/src/Providers/DeepgramProvider.php
+++ b/src/Providers/DeepgramProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\DeepgramGateway;
+
+class DeepgramProvider extends Provider implements AudioProvider, TranscriptionProvider
+{
+    use Concerns\GeneratesAudio;
+    use Concerns\GeneratesTranscriptions;
+    use Concerns\HasAudioGateway;
+    use Concerns\HasTranscriptionGateway;
+
+    public function __construct(
+        protected array $config,
+        protected Dispatcher $events) {}
+
+    /**
+     * Get the provider's audio gateway.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ?? new DeepgramGateway;
+    }
+
+    /**
+     * Get the provider's transcription gateway.
+     */
+    public function transcriptionGateway(): TranscriptionGateway
+    {
+        return $this->transcriptionGateway ?? new DeepgramGateway;
+    }
+
+    /**
+     * Get the name of the default audio (TTS) model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return 'aura-2-thalia-en';
+    }
+
+    /**
+     * Get the name of the default transcription (STT) model.
+     */
+    public function defaultTranscriptionModel(): string
+    {
+        return 'nova-3';
+    }
+}


### PR DESCRIPTION
Add Deepgram provider for speech-to-text and text-to-speech

### Summary

  - Adds [Deepgram](https://deepgram.com/) as a new AI provider supporting both audio generation (TTS) and transcription (STT)
  - TTS uses Deepgram's Aura-2 models (aura-2-thalia-en default female, aura-2-perseus-en default male)
  - STT uses Deepgram's Nova-3 model with support for language selection and speaker diarization

### Changes

  - `src/Providers/DeepgramProvider.php` - New provider implementing AudioProvider and TranscriptionProvider
  - `src/Gateway/DeepgramGateway.php` - New gateway handling Deepgram API calls for both TTS and STT
  - `src/Enums/Lab.php` - Added Deepgram enum case
  - `src/AiManager.php` - Added createDeepgramDriver factory method
  - `config/ai.php` - Added deepgram provider config with DEEPGRAM_API_KEY

### Test plan

  - Configure `DEEPGRAM_API_KEY` and set deepgram as the audio/transcription provider
  - Verify TTS with Ai::audioProvider('deepgram')->audio('Hello world')
  - Verify STT with Ai::transcriptionProvider('deepgram')->transcribe($audio)
  - Verify diarization returns speaker-segmented transcription segments
  - Verify default voice mapping (default-female, default-male)
  - Verify rate limit handling returns RateLimitedException on 429 responses