### PR TITLE
Make provider default models configurable via ai config

### DIFF
--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -58,7 +58,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
      */
     public function defaultTextModel(): string
     {
-        return 'claude-sonnet-4-5-20250929';
+        return $this->config['models']['text']['default'] ?? 'claude-sonnet-4-5-20250929';
     }
 
     /**
@@ -66,7 +66,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
      */
     public function cheapestTextModel(): string
     {
-        return 'claude-haiku-4-5-20251001';
+        return $this->config['models']['text']['cheapest'] ?? 'claude-haiku-4-5-20251001';
     }
 
     /**
@@ -74,7 +74,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
      */
     public function smartestTextModel(): string
     {
-        return 'claude-opus-4-6';
+        return $this->config['models']['text']['smartest'] ?? 'claude-opus-4-6';
     }
 
     /**

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -62,7 +62,7 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextPro
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 1536;
+        return $this->config['models']['embeddings']['dimensions'] ?? 1536;
     }
 
     /**

--- a/src/Providers/CohereProvider.php
+++ b/src/Providers/CohereProvider.php
@@ -26,7 +26,7 @@ class CohereProvider extends Provider implements EmbeddingProvider, RerankingPro
      */
     public function defaultEmbeddingsModel(): string
     {
-        return 'embed-v4.0';
+        return $this->config['models']['embeddings']['default'] ?? 'embed-v4.0';
     }
 
     /**
@@ -34,7 +34,7 @@ class CohereProvider extends Provider implements EmbeddingProvider, RerankingPro
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 1536;
+        return $this->config['models']['embeddings']['dimensions'] ?? 1536;
     }
 
     /**
@@ -50,7 +50,7 @@ class CohereProvider extends Provider implements EmbeddingProvider, RerankingPro
      */
     public function defaultRerankingModel(): string
     {
-        return 'rerank-v3.5';
+        return $this->config['models']['reranking']['default'] ?? 'rerank-v3.5';
     }
 
     /**

--- a/src/Providers/DeepSeekProvider.php
+++ b/src/Providers/DeepSeekProvider.php
@@ -15,7 +15,7 @@ class DeepSeekProvider extends Provider implements TextProvider
      */
     public function defaultTextModel(): string
     {
-        return 'deepseek-chat';
+        return $this->config['models']['text']['default'] ?? 'deepseek-chat';
     }
 
     /**
@@ -23,7 +23,7 @@ class DeepSeekProvider extends Provider implements TextProvider
      */
     public function cheapestTextModel(): string
     {
-        return 'deepseek-chat';
+        return $this->config['models']['text']['cheapest'] ?? 'deepseek-chat';
     }
 
     /**
@@ -31,6 +31,6 @@ class DeepSeekProvider extends Provider implements TextProvider
      */
     public function smartestTextModel(): string
     {
-        return 'deepseek-reasoner';
+        return $this->config['models']['text']['smartest'] ?? 'deepseek-reasoner';
     }
 }

--- a/src/Providers/ElevenLabsProvider.php
+++ b/src/Providers/ElevenLabsProvider.php
@@ -41,7 +41,7 @@ class ElevenLabsProvider extends Provider implements AudioProvider, Transcriptio
      */
     public function defaultAudioModel(): string
     {
-        return 'eleven_multilingual_v2';
+        return $this->config['models']['audio']['default'] ?? 'eleven_multilingual_v2';
     }
 
     /**
@@ -49,6 +49,6 @@ class ElevenLabsProvider extends Provider implements AudioProvider, Transcriptio
      */
     public function defaultTranscriptionModel(): string
     {
-        return 'scribe_v2';
+        return $this->config['models']['transcription']['default'] ?? 'scribe_v2';
     }
 }

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -86,7 +86,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
      */
     public function defaultTextModel(): string
     {
-        return 'gemini-3-flash-preview';
+        return $this->config['models']['text']['default'] ?? 'gemini-3-flash-preview';
     }
 
     /**
@@ -94,7 +94,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
      */
     public function cheapestTextModel(): string
     {
-        return 'gemini-2.5-flash-lite';
+        return $this->config['models']['text']['cheapest'] ?? 'gemini-2.5-flash-lite';
     }
 
     /**
@@ -102,7 +102,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
      */
     public function smartestTextModel(): string
     {
-        return 'gemini-3-pro-preview';
+        return $this->config['models']['text']['smartest'] ?? 'gemini-3-pro-preview';
     }
 
     /**
@@ -110,7 +110,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
      */
     public function defaultImageModel(): string
     {
-        return 'gemini-3-pro-image-preview';
+        return $this->config['models']['image']['default'] ?? 'gemini-3-pro-image-preview';
     }
 
     /**
@@ -139,7 +139,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
      */
     public function defaultEmbeddingsModel(): string
     {
-        return 'gemini-embedding-001';
+        return $this->config['models']['embeddings']['default'] ?? 'gemini-embedding-001';
     }
 
     /**
@@ -147,7 +147,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 3072;
+        return $this->config['models']['embeddings']['dimensions'] ?? 3072;
     }
 
     /**

--- a/src/Providers/GroqProvider.php
+++ b/src/Providers/GroqProvider.php
@@ -15,7 +15,7 @@ class GroqProvider extends Provider implements TextProvider
      */
     public function defaultTextModel(): string
     {
-        return 'openai/gpt-oss-120b';
+        return $this->config['models']['text']['default'] ?? 'openai/gpt-oss-120b';
     }
 
     /**
@@ -23,7 +23,7 @@ class GroqProvider extends Provider implements TextProvider
      */
     public function cheapestTextModel(): string
     {
-        return 'openai/gpt-oss-20b';
+        return $this->config['models']['text']['cheapest'] ?? 'openai/gpt-oss-20b';
     }
 
     /**
@@ -31,6 +31,6 @@ class GroqProvider extends Provider implements TextProvider
      */
     public function smartestTextModel(): string
     {
-        return 'openai/gpt-oss-120b';
+        return $this->config['models']['text']['smartest'] ?? 'openai/gpt-oss-120b';
     }
 }

--- a/src/Providers/JinaProvider.php
+++ b/src/Providers/JinaProvider.php
@@ -26,7 +26,7 @@ class JinaProvider extends Provider implements EmbeddingProvider, RerankingProvi
      */
     public function defaultEmbeddingsModel(): string
     {
-        return 'jina-embeddings-v4';
+        return $this->config['models']['embeddings']['default'] ?? 'jina-embeddings-v4';
     }
 
     /**
@@ -34,7 +34,7 @@ class JinaProvider extends Provider implements EmbeddingProvider, RerankingProvi
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 2048;
+        return $this->config['models']['embeddings']['dimensions'] ?? 2048;
     }
 
     /**
@@ -50,7 +50,7 @@ class JinaProvider extends Provider implements EmbeddingProvider, RerankingProvi
      */
     public function defaultRerankingModel(): string
     {
-        return 'jina-reranker-v3';
+        return $this->config['models']['reranking']['default'] ?? 'jina-reranker-v3';
     }
 
     /**

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -21,7 +21,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function defaultTextModel(): string
     {
-        return 'mistral-medium-latest';
+        return $this->config['models']['text']['default'] ?? 'mistral-medium-latest';
     }
 
     /**
@@ -29,7 +29,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function cheapestTextModel(): string
     {
-        return 'mistral-small-latest';
+        return $this->config['models']['text']['cheapest'] ?? 'mistral-small-latest';
     }
 
     /**
@@ -37,7 +37,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function smartestTextModel(): string
     {
-        return 'mistral-large-latest';
+        return $this->config['models']['text']['smartest'] ?? 'mistral-large-latest';
     }
 
     /**
@@ -45,7 +45,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function defaultTranscriptionModel(): string
     {
-        return 'voxtral-small-latest';
+        return $this->config['models']['transcription']['default'] ?? 'voxtral-small-latest';
     }
 
     /**
@@ -53,7 +53,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function defaultEmbeddingsModel(): string
     {
-        return 'mistral-embed';
+        return $this->config['models']['embeddings']['default'] ?? 'mistral-embed';
     }
 
     /**
@@ -61,6 +61,6 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 1024;
+        return $this->config['models']['embeddings']['dimensions'] ?? 1024;
     }
 }

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -82,7 +82,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTextModel(): string
     {
-        return 'gpt-5.2';
+        return $this->config['models']['text']['default'] ?? 'gpt-5.2';
     }
 
     /**
@@ -90,7 +90,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function cheapestTextModel(): string
     {
-        return 'gpt-5-nano';
+        return $this->config['models']['text']['cheapest'] ?? 'gpt-5-nano';
     }
 
     /**
@@ -98,7 +98,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function smartestTextModel(): string
     {
-        return 'gpt-5.2-pro';
+        return $this->config['models']['text']['smartest'] ?? 'gpt-5.2-pro';
     }
 
     /**
@@ -106,7 +106,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultImageModel(): string
     {
-        return 'gpt-image-1.5';
+        return $this->config['models']['image']['default'] ?? 'gpt-image-1.5';
     }
 
     /**
@@ -132,7 +132,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultAudioModel(): string
     {
-        return 'gpt-4o-mini-tts';
+        return $this->config['models']['audio']['default'] ?? 'gpt-4o-mini-tts';
     }
 
     /**
@@ -140,7 +140,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTranscriptionModel(): string
     {
-        return 'gpt-4o-transcribe-diarize';
+        return $this->config['models']['transcription']['default'] ?? 'gpt-4o-transcribe-diarize';
     }
 
     /**
@@ -148,7 +148,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultEmbeddingsModel(): string
     {
-        return 'text-embedding-3-small';
+        return $this->config['models']['embeddings']['default'] ?? 'text-embedding-3-small';
     }
 
     /**
@@ -156,7 +156,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 1536;
+        return $this->config['models']['embeddings']['dimensions'] ?? 1536;
     }
 
     /**

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -15,7 +15,7 @@ class OpenRouterProvider extends Provider implements TextProvider
      */
     public function defaultTextModel(): string
     {
-        return 'anthropic/claude-sonnet-4.5';
+        return $this->config['models']['text']['default'] ?? 'anthropic/claude-sonnet-4.5';
     }
 
     /**
@@ -23,7 +23,7 @@ class OpenRouterProvider extends Provider implements TextProvider
      */
     public function cheapestTextModel(): string
     {
-        return 'anthropic/claude-haiku-4.5';
+        return $this->config['models']['text']['cheapest'] ?? 'anthropic/claude-haiku-4.5';
     }
 
     /**
@@ -31,6 +31,6 @@ class OpenRouterProvider extends Provider implements TextProvider
      */
     public function smartestTextModel(): string
     {
-        return 'anthropic/claude-opus-4.5';
+        return $this->config['models']['text']['smartest'] ?? 'anthropic/claude-opus-4.5';
     }
 }

--- a/src/Providers/VoyageAiProvider.php
+++ b/src/Providers/VoyageAiProvider.php
@@ -19,7 +19,7 @@ class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingP
      */
     public function defaultEmbeddingsModel(): string
     {
-        return 'voyage-4';
+        return $this->config['models']['embeddings']['default'] ?? 'voyage-4';
     }
 
     /**
@@ -27,7 +27,7 @@ class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingP
      */
     public function defaultEmbeddingsDimensions(): int
     {
-        return 1024;
+        return $this->config['models']['embeddings']['dimensions'] ?? 1024;
     }
 
     /**
@@ -35,7 +35,7 @@ class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingP
      */
     public function defaultRerankingModel(): string
     {
-        return 'rerank-2.5-lite';
+        return $this->config['models']['reranking']['default'] ?? 'rerank-2.5-lite';
     }
 
     /**

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -20,7 +20,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function defaultTextModel(): string
     {
-        return 'grok-4-1-fast-reasoning';
+        return $this->config['models']['text']['default'] ?? 'grok-4-1-fast-reasoning';
     }
 
     /**
@@ -28,7 +28,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function cheapestTextModel(): string
     {
-        return 'grok-4-1-fast-reasoning';
+        return $this->config['models']['text']['cheapest'] ?? 'grok-4-1-fast-reasoning';
     }
 
     /**
@@ -36,7 +36,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function smartestTextModel(): string
     {
-        return 'grok-4-1-fast-reasoning';
+        return $this->config['models']['text']['smartest'] ?? 'grok-4-1-fast-reasoning';
     }
 
     /**
@@ -52,7 +52,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function defaultImageModel(): string
     {
-        return 'grok-imagine-image';
+        return $this->config['models']['image']['default'] ?? 'grok-imagine-image';
     }
 
     /**


### PR DESCRIPTION
Allow overriding provider default models via ai.providers.<provider>.models.* configuration (fallbacks remain unchanged).

Applies consistently across providers for text, image, audio, transcription, embeddings (and dimensions), and reranking where supported.