### PR TITLE
Adding agent methods for text generation options

### DIFF
--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -47,9 +47,15 @@ class TextGenerationOptions
         $temperature = $reflection->getAttributes(Temperature::class);
 
         return new self(
-            maxSteps: ! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null,
-            maxTokens: ! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null,
-            temperature: ! empty($temperature) ? $temperature[0]->newInstance()->value : null,
+            maxSteps: method_exists($agent, 'maxSteps')
+                ? $agent->maxSteps()
+                : (! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null),
+            maxTokens: method_exists($agent, 'maxTokens')
+                ? $agent->maxTokens()
+                : (! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null),
+            temperature: method_exists($agent, 'temperature')
+                ? $agent->temperature()
+                : (! empty($temperature) ? $temperature[0]->newInstance()->value : null),
             agent: $agent,
         );
     }

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -58,7 +58,11 @@ class TextGenerationOptions
     private static function resolve(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): int|float|null
     {
         if (method_exists($agent, $method)) {
-            $value = $agent->{$method}();
+            try {
+                $value = $agent->{$method}();
+            } catch (\ArgumentCountError|\Error) {
+                $value = null;
+            }
 
             if (! is_null($value)) {
                 return $value;

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -42,21 +42,35 @@ class TextGenerationOptions
     {
         $reflection = new ReflectionClass($agent);
 
-        $maxSteps = $reflection->getAttributes(MaxSteps::class);
-        $maxTokens = $reflection->getAttributes(MaxTokens::class);
-        $temperature = $reflection->getAttributes(Temperature::class);
-
         return new self(
-            maxSteps: method_exists($agent, 'maxSteps')
-                ? $agent->maxSteps()
-                : (! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null),
-            maxTokens: method_exists($agent, 'maxTokens')
-                ? $agent->maxTokens()
-                : (! empty($maxTokens) ? $maxTokens[0]->newInstance()->value : null),
-            temperature: method_exists($agent, 'temperature')
-                ? $agent->temperature()
-                : (! empty($temperature) ? $temperature[0]->newInstance()->value : null),
+            maxSteps: self::resolve($agent, $reflection, 'maxSteps', MaxSteps::class),
+            maxTokens: self::resolve($agent, $reflection, 'maxTokens', MaxTokens::class),
+            temperature: self::resolve($agent, $reflection, 'temperature', Temperature::class),
             agent: $agent,
         );
+    }
+
+    /**
+     * Resolve an option from the agent's method, falling back to the attribute.
+     *
+     * @param  class-string  $attribute
+     */
+    private static function resolve(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): int|float|null
+    {
+        if ($reflection->hasMethod($method)) {
+            $reflectionMethod = $reflection->getMethod($method);
+
+            if ($reflectionMethod->isPublic() && ! $reflectionMethod->isStatic() && $reflectionMethod->getNumberOfRequiredParameters() === 0) {
+                $value = $agent->{$method}();
+
+                if (! is_null($value)) {
+                    return $value;
+                }
+            }
+        }
+
+        $attributes = $reflection->getAttributes($attribute);
+
+        return ! empty($attributes) ? $attributes[0]->newInstance()->value : null;
     }
 }

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -57,15 +57,11 @@ class TextGenerationOptions
      */
     private static function resolve(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): int|float|null
     {
-        if ($reflection->hasMethod($method)) {
-            $reflectionMethod = $reflection->getMethod($method);
+        if (method_exists($agent, $method)) {
+            $value = $agent->{$method}();
 
-            if ($reflectionMethod->isPublic() && ! $reflectionMethod->isStatic() && $reflectionMethod->getNumberOfRequiredParameters() === 0) {
-                $value = $agent->{$method}();
-
-                if (! is_null($value)) {
-                    return $value;
-                }
+            if (! is_null($value)) {
+                return $value;
             }
         }
 

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -5,8 +5,10 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\IncompatibleMethodsAgent;
 use Tests\Fixtures\Agents\MethodOptionsAgent;
 use Tests\Fixtures\Agents\MethodOverridesAttributeAgent;
+use Tests\Fixtures\Agents\NullableMethodOptionsAgent;
 
 test('text generation options can be created from agent attributes', function () {
     $options = TextGenerationOptions::forAgent(new AttributeAgent);
@@ -38,6 +40,22 @@ test('agent methods take priority over attributes', function () {
     expect($options->maxSteps)->toBe(1)
         ->and($options->maxTokens)->toBe(512)
         ->and($options->temperature)->toBe(0.2);
+});
+
+test('null return from agent method falls back to attributes', function () {
+    $options = TextGenerationOptions::forAgent(new NullableMethodOptionsAgent);
+
+    expect($options->maxSteps)->toBe(10)
+        ->and($options->maxTokens)->toBe(4096)
+        ->and($options->temperature)->toBe(0.7);
+});
+
+test('non-public or parameterized option methods are ignored', function () {
+    $options = TextGenerationOptions::forAgent(new IncompatibleMethodsAgent);
+
+    expect($options->maxSteps)->toBe(8)
+        ->and($options->maxTokens)->toBe(1024)
+        ->and($options->temperature)->toBe(0.9);
 });
 
 test('provider attribute is used when prompting', function () {

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -5,6 +5,8 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\MethodOptionsAgent;
+use Tests\Fixtures\Agents\MethodOverridesAttributeAgent;
 
 test('text generation options can be created from agent attributes', function () {
     $options = TextGenerationOptions::forAgent(new AttributeAgent);
@@ -20,6 +22,22 @@ test('text generation options are null when agent has no attributes', function (
     expect($options->maxSteps)->toBeNull()
         ->and($options->maxTokens)->toBeNull()
         ->and($options->temperature)->toBeNull();
+});
+
+test('text generation options can be resolved from agent methods', function () {
+    $options = TextGenerationOptions::forAgent(new MethodOptionsAgent);
+
+    expect($options->maxSteps)->toBe(3)
+        ->and($options->maxTokens)->toBe(2048)
+        ->and($options->temperature)->toBe(0.5);
+});
+
+test('agent methods take priority over attributes', function () {
+    $options = TextGenerationOptions::forAgent(new MethodOverridesAttributeAgent);
+
+    expect($options->maxSteps)->toBe(1)
+        ->and($options->maxTokens)->toBe(512)
+        ->and($options->temperature)->toBe(0.2);
 });
 
 test('provider attribute is used when prompting', function () {

--- a/tests/Fixtures/Agents/IncompatibleMethodsAgent.php
+++ b/tests/Fixtures/Agents/IncompatibleMethodsAgent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[MaxSteps(8)]
+#[MaxTokens(1024)]
+#[Temperature(0.9)]
+class IncompatibleMethodsAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function maxSteps(int $scale): int
+    {
+        return $scale * 2;
+    }
+
+    protected function maxTokens(): int
+    {
+        return 256;
+    }
+
+    private function temperature(): float
+    {
+        return 0.1;
+    }
+}

--- a/tests/Fixtures/Agents/MethodOptionsAgent.php
+++ b/tests/Fixtures/Agents/MethodOptionsAgent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+class MethodOptionsAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function maxSteps(): int
+    {
+        return 3;
+    }
+
+    public function maxTokens(): int
+    {
+        return 2048;
+    }
+
+    public function temperature(): float
+    {
+        return 0.5;
+    }
+}

--- a/tests/Fixtures/Agents/MethodOverridesAttributeAgent.php
+++ b/tests/Fixtures/Agents/MethodOverridesAttributeAgent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[MaxSteps(10)]
+#[MaxTokens(4096)]
+#[Temperature(0.7)]
+class MethodOverridesAttributeAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function maxSteps(): int
+    {
+        return 1;
+    }
+
+    public function maxTokens(): int
+    {
+        return 512;
+    }
+
+    public function temperature(): float
+    {
+        return 0.2;
+    }
+}

--- a/tests/Fixtures/Agents/NullableMethodOptionsAgent.php
+++ b/tests/Fixtures/Agents/NullableMethodOptionsAgent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[MaxSteps(10)]
+#[MaxTokens(4096)]
+#[Temperature(0.7)]
+class NullableMethodOptionsAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function maxSteps(): ?int
+    {
+        return null;
+    }
+
+    public function maxTokens(): ?int
+    {
+        return null;
+    }
+
+    public function temperature(): ?float
+    {
+        return null;
+    }
+}


### PR DESCRIPTION

This PR adds method-based resolution for `maxSteps`, `maxTokens`, and `temperature` on agents, following the same pattern already used by `provider()`, `model()`, and `timeout()`.

Currently these options can only be set via PHP 8 attributes, which are compile-time constants. This makes it impossible to configure them dynamically from a database, config, or any runtime source.

### Resolution priority (method → attribute → null)

```php
maxSteps: method_exists($agent, 'maxSteps')
    ? $agent->maxSteps()
    : (! empty($maxSteps) ? $maxSteps[0]->newInstance()->value : null),
```

### Usage

```php
class SupportAgent implements Agent
{
    use Promptable;

    public function maxSteps(): int
    {
        return config('agents.support.max_steps', 5);
    }

    public function maxTokens(): int
    {
        return $this->user->plan->maxTokens();
    }

    public function temperature(): float
    {
        return Setting::get('support_agent_temperature', 0.7);
    }
}
```

Attributes continue to work as before — methods are checked first, then attributes, then `null`.

### Changes

- `TextGenerationOptions::forAgent()` — added `method_exists()` checks before attribute reflection
- Added `MethodOptionsAgent` and `MethodOverridesAttributeAgent` test agents
- Added `TextGenerationOptionsTest` with 3 tests covering method resolution, method-over-attribute priority, and the null fallback
