### PR TITLE
Chore: Fix unit tests

### DIFF
--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -49,7 +49,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -98,7 +98,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -147,7 +147,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }


### PR DESCRIPTION
If you run the following command, you should see 3 unit test errors:

```sh
vendor/bin/phpunit --testsuite=Unit
```

This PR fixes those errors.