### PR TITLE
feat: add deferred tool

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -17,21 +17,18 @@ class AiServiceProvider extends ServiceProvider
 {
     /**
      * Register the package's services.
-     *
-     * @return void
      */
     public function register(): void
     {
         $this->app->scoped(AiManager::class, fn ($app): AiManager => new AiManager($app));
         $this->app->singleton(ConversationStore::class, DatabaseConversationStore::class);
+        $this->app->singleton(DeferredToolManager::class);
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');
     }
 
     /**
      * Bootstrap the package's services.
-     *
-     * @return void
      */
     public function boot(): void
     {

--- a/src/Attributes/Deferred.php
+++ b/src/Attributes/Deferred.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Deferred
+{
+    //
+}

--- a/src/Contracts/ShouldDeferTool.php
+++ b/src/Contracts/ShouldDeferTool.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+interface ShouldDeferTool
+{
+    //
+}

--- a/src/DeferredToolManager.php
+++ b/src/DeferredToolManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Ai;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\DeferredToolQueued;
+use Laravel\Ai\Jobs\RunDeferredTool;
+use Laravel\Ai\Tools\Request;
+use RuntimeException;
+
+class DeferredToolManager
+{
+    public function __construct(protected Dispatcher $events) {}
+
+    public function defer(Tool $tool, array $arguments): array
+    {
+        $toolCallId = (string) Str::uuid7();
+        $toolClass = $this->toolClass($tool);
+
+        RunDeferredTool::dispatch($toolClass, $arguments, $toolCallId);
+
+        $this->events->dispatch(new DeferredToolQueued($toolClass, $arguments, $toolCallId));
+
+        return [
+            'status' => 'pending',
+            'tool_call_id' => $toolCallId,
+        ];
+    }
+
+    public function resume(Tool|string $tool, array $arguments, string $toolCallId): mixed
+    {
+        if (is_string($tool)) {
+            $tool = app($tool);
+        }
+
+        if (! $tool instanceof Tool) {
+            throw new RuntimeException('Deferred tool class must implement '.Tool::class.'.');
+        }
+
+        return $tool->handle(new Request($arguments));
+    }
+
+    /**
+     * Resolve the tool class used for deferred execution.
+     */
+    protected function toolClass(Tool $tool): string
+    {
+        $class = $tool::class;
+
+        if (str_contains($class, '@anonymous')) {
+            throw new RuntimeException('Deferred tools must be concrete classes resolvable by the container.');
+        }
+
+        return $class;
+    }
+}

--- a/src/Events/DeferredToolQueued.php
+++ b/src/Events/DeferredToolQueued.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+class DeferredToolQueued
+{
+    public function __construct(
+        public string $toolClass,
+        public array $arguments,
+        public string $toolCallId,
+    ) {}
+}

--- a/src/Jobs/RunDeferredTool.php
+++ b/src/Jobs/RunDeferredTool.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Laravel\Ai\DeferredToolManager;
+
+class RunDeferredTool implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public string $toolClass,
+        public array $arguments,
+        public string $toolCallId,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(DeferredToolManager $manager): void
+    {
+        $manager->resume($this->toolClass, $this->arguments, $this->toolCallId);
+    }
+}

--- a/tests/Unit/DeferredToolManagerTest.php
+++ b/tests/Unit/DeferredToolManagerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\DeferredToolManager;
+use Laravel\Ai\Events\DeferredToolQueued;
+use Laravel\Ai\Jobs\RunDeferredTool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+use Tests\TestCase;
+
+class DeferredToolManagerTest extends TestCase
+{
+    public function test_defer_dispatches_deferred_job_and_returns_pending_payload(): void
+    {
+        Bus::fake();
+        Event::fake();
+
+        $manager = $this->app->make(DeferredToolManager::class);
+        $tool = new DeferredToolManagerTestTool;
+
+        $result = $manager->defer($tool, ['query' => 'test']);
+
+        $this->assertSame('pending', $result['status']);
+        $this->assertArrayHasKey('tool_call_id', $result);
+
+        Bus::assertDispatched(RunDeferredTool::class, function (RunDeferredTool $job) use ($result) {
+            return $job->toolClass === DeferredToolManagerTestTool::class
+                && $job->arguments === ['query' => 'test']
+                && $job->toolCallId === $result['tool_call_id'];
+        });
+
+        Event::assertDispatched(DeferredToolQueued::class, function (DeferredToolQueued $event) use ($result) {
+            return $event->toolClass === DeferredToolManagerTestTool::class
+                && $event->arguments === ['query' => 'test']
+                && $event->toolCallId === $result['tool_call_id'];
+        });
+    }
+
+    public function test_resume_invokes_tool_handle(): void
+    {
+        $manager = $this->app->make(DeferredToolManager::class);
+
+        $tool = new DeferredToolManagerRecordingTool;
+
+        $result = $manager->resume($tool, ['id' => 1], 'call_123');
+
+        $this->assertSame('done', (string) $result);
+        $this->assertSame(['id' => 1], $tool->arguments);
+    }
+
+    public function test_resume_resolves_tool_from_class_name(): void
+    {
+        $manager = $this->app->make(DeferredToolManager::class);
+
+        $result = $manager->resume(DeferredToolManagerTestTool::class, ['id' => 1], 'call_123');
+
+        $this->assertSame('ok', (string) $result);
+    }
+}
+
+class DeferredToolManagerTestTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'A deferred test tool';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'ok';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+class DeferredToolManagerRecordingTool implements Tool
+{
+    public array $arguments = [];
+
+    public function description(): Stringable|string
+    {
+        return 'A deferred test tool';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $this->arguments = $request->all();
+
+        return 'done';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Unit\Gateway\Prism;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Deferred;
+use Laravel\Ai\Contracts\ShouldDeferTool;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\DeferredToolManager;
 use Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests;
 use Laravel\Ai\Tools\Request;
 use PHPUnit\Framework\TestCase;
@@ -13,116 +16,45 @@ class AddsToolsToPrismRequestsTest extends TestCase
 {
     public function test_invoke_tool_unwraps_schema_definition(): void
     {
-        $tool = new class implements Tool
-        {
-            public array $receivedArguments = [];
+        $tool = new TestRecordingTool;
 
-            public function description(): Stringable|string
-            {
-                return 'Test tool';
-            }
+        $this->handler()->invokeToolForTest($tool, ['schema_definition' => ['query' => 'test']]);
 
-            public function handle(Request $request): Stringable|string
-            {
-                $this->receivedArguments = $request->all();
-
-                return 'result';
-            }
-
-            public function schema(JsonSchema $schema): array
-            {
-                return [];
-            }
-        };
-
-        $handler = new class
-        {
-            use AddsToolsToPrismRequests;
-
-            protected $invokingToolCallback;
-
-            protected $toolInvokedCallback;
-
-            public function __construct()
-            {
-                $this->invokingToolCallback = fn () => null;
-                $this->toolInvokedCallback = fn () => null;
-            }
-
-            public function test_invoke_tool(Tool $tool, array $arguments): string
-            {
-                return $this->invokeTool($tool, $arguments);
-            }
-        };
-
-        $handler->testInvokeTool($tool, ['schema_definition' => ['query' => 'test']]);
-
-        $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
+        $this->assertSame(['query' => 'test'], $tool->receivedArguments);
     }
 
     public function test_invoke_tool_falls_back_to_raw_arguments_when_schema_definition_is_missing(): void
     {
-        $tool = new class implements Tool
-        {
-            public array $receivedArguments = [];
+        $tool = new TestRecordingTool;
 
-            public function description(): Stringable|string
-            {
-                return 'Test tool';
-            }
+        $this->handler()->invokeToolForTest($tool, ['query' => 'test']);
 
-            public function handle(Request $request): Stringable|string
-            {
-                $this->receivedArguments = $request->all();
-
-                return 'result';
-            }
-
-            public function schema(JsonSchema $schema): array
-            {
-                return [];
-            }
-        };
-
-        $handler = new class
-        {
-            use AddsToolsToPrismRequests;
-
-            protected $invokingToolCallback;
-
-            protected $toolInvokedCallback;
-
-            public function __construct()
-            {
-                $this->invokingToolCallback = fn () => null;
-                $this->toolInvokedCallback = fn () => null;
-            }
-
-            public function test_invoke_tool(Tool $tool, array $arguments): string
-            {
-                return $this->invokeTool($tool, $arguments);
-            }
-        };
-
-        $handler->testInvokeTool($tool, ['query' => 'test']);
-
-        $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
+        $this->assertSame(['query' => 'test'], $tool->receivedArguments);
     }
 
     public function test_invoke_tool_handles_empty_arguments(): void
     {
-        $tool = new class implements Tool
+        $tool = new TestRecordingTool;
+
+        $this->handler()->invokeToolForTest($tool, []);
+
+        $this->assertSame([], $tool->receivedArguments);
+    }
+
+    public function test_invoke_tool_returns_pending_payload_when_tool_implements_should_defer_tool(): void
+    {
+        $tool = new class implements ShouldDeferTool, Tool
         {
-            public array $receivedArguments = [];
+            public bool $handled = false;
 
             public function description(): Stringable|string
             {
-                return 'Test tool';
+                return 'Deferred tool';
             }
 
             public function handle(Request $request): Stringable|string
             {
-                $this->receivedArguments = $request->all();
+                $this->handled = true;
 
                 return 'result';
             }
@@ -133,28 +65,136 @@ class AddsToolsToPrismRequestsTest extends TestCase
             }
         };
 
-        $handler = new class
+        $manager = new TestDeferredToolManager;
+        $result = $this->handler($manager)->invokeToolForTest($tool, ['query' => 'test']);
+
+        $this->assertFalse($tool->handled);
+        $this->assertSame(['query' => 'test'], $manager->arguments);
+        $this->assertJsonStringEqualsJsonString('{"status":"pending","tool_call_id":"call_1"}', $result);
+    }
+
+    public function test_should_defer_tool_returns_true_for_deferred_attribute(): void
+    {
+        $tool = new #[Deferred] class implements Tool
         {
-            use AddsToolsToPrismRequests;
-
-            protected $invokingToolCallback;
-
-            protected $toolInvokedCallback;
-
-            public function __construct()
+            public function description(): Stringable|string
             {
-                $this->invokingToolCallback = fn () => null;
-                $this->toolInvokedCallback = fn () => null;
+                return 'Deferred tool';
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function handle(Request $request): Stringable|string
             {
-                return $this->invokeTool($tool, $arguments);
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
             }
         };
 
-        $handler->testInvokeTool($tool, []);
+        $this->assertTrue($this->handler()->shouldDeferToolForTest($tool));
+    }
 
-        $this->assertEquals([], $tool->receivedArguments);
+    public function test_should_defer_tool_returns_false_for_standard_tools(): void
+    {
+        $tool = new class implements Tool
+        {
+            public function description(): Stringable|string
+            {
+                return 'Standard tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $this->assertFalse($this->handler()->shouldDeferToolForTest($tool));
+    }
+
+    private function handler(?DeferredToolManager $manager = null): TestAddsToolsToPrismRequestsHandler
+    {
+        return new TestAddsToolsToPrismRequestsHandler($manager ?? new TestDeferredToolManager);
+    }
+}
+
+class TestAddsToolsToPrismRequestsHandler
+{
+    use AddsToolsToPrismRequests;
+
+    protected $invokingToolCallback;
+
+    protected $toolInvokedCallback;
+
+    public function __construct(private readonly DeferredToolManager $manager)
+    {
+        $this->invokingToolCallback = fn () => null;
+        $this->toolInvokedCallback = fn () => null;
+    }
+
+    protected function deferredToolManager(): DeferredToolManager
+    {
+        return $this->manager;
+    }
+
+    public function invokeToolForTest(Tool $tool, array $arguments): string
+    {
+        return $this->invokeTool($tool, $arguments);
+    }
+
+    public function shouldDeferToolForTest(Tool $tool): bool
+    {
+        return $this->shouldDeferTool($tool);
+    }
+}
+
+class TestRecordingTool implements Tool
+{
+    public array $receivedArguments = [];
+
+    public function description(): Stringable|string
+    {
+        return 'Test tool';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $this->receivedArguments = $request->all();
+
+        return 'result';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}
+
+class TestDeferredToolManager extends DeferredToolManager
+{
+    public array $arguments = [];
+
+    public function __construct() {}
+
+    public function defer(Tool $tool, array $arguments): array
+    {
+        $this->arguments = $arguments;
+
+        return [
+            'status' => 'pending',
+            'tool_call_id' => 'call_1',
+        ];
+    }
+
+    public function resume(Tool|string $tool, array $arguments, string $toolCallId): mixed
+    {
+        return null;
     }
 }


### PR DESCRIPTION
fixes #200 


What you get:

```php
class SyncInventoryTool implements Tool, ShouldDeferTool
{
  // ...
}

// or 

#[Deferred]
class ReindexKnowledgeBaseTool implements Tool
{
    // ...
}
```

Event triggered: `DeferredToolQueued`

```sh
php artisan queue:listen

   INFO  Processing jobs from the [default] queue.  

  2026-02-22 13:29:54 Laravel\Ai\Jobs\RunDeferredTool ................ RUNNING
  2026-02-22 13:29:54 Laravel\Ai\Jobs\RunDeferredTool ............ 4.05ms DONE

```
