### PR TITLE
Fix tool call history not round-tripped in conversation context

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -79,9 +79,11 @@ class PrismGateway implements Gateway
             $this->addProviderTools($provider, $request, $tools, $options);
         }
 
+        $prismMessages = $this->toPrismMessages($messages);
+
         try {
             $response = $request
-                ->withMessages($this->toPrismMessages($messages))
+                ->withMessages($prismMessages)
                 ->{$structured ? 'asStructured' : 'asText'}();
         } catch (PrismVendorException $e) {
             throw PrismException::toAiException($e, $provider, $model);
@@ -106,7 +108,7 @@ class PrismGateway implements Gateway
                 PrismUsage::toLaravelUsage($response->usage),
                 new Meta($provider->name(), $response->meta->model, $citations),
             ))->withMessages(
-                PrismMessages::toLaravelMessages($response->messages)
+                PrismMessages::toLaravelMessages($response->messages)->slice(count($prismMessages))->values()
             )->withSteps(PrismSteps::toLaravelSteps($response->steps, $provider));
     }
 

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -73,6 +73,7 @@ trait GeneratesText
                         ->withSteps($response->steps)
                     : (new AgentResponse($invocationId, $response->text, $response->usage, $response->meta))
                         ->withMessages($response->messages)
+                        ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
                         ->withSteps($response->steps);
             });
 


### PR DESCRIPTION
### Issue

Currently, if an Agent executes a tool, it lacks the correct context to respond to follow up questions asking if the tool execution was successful or not.

This happens for two reasons:

1. The `fromLaravelMessages` converter in `PrismMessages.php` silently drops tool messages before sending to the provider:
    - `ToolResultMessage` objects are discarded entirely
    - `AssistantMessage` tool calls are ignored (creating `PrismAssistantMessage` with only **text** content)
2. When loading conversation history from storage, `DatabaseConversationStore` only reconstructs plain text messages, discarding any tool calls and tool results that were persisted.

### Changes in gateway

This PR ensures tool calls and tool results from previous turns are correctly round-tripped when passing conversation history back to the AI, by implementing the following changes:

- **`PrismMessages`**: Adds conversion support for `ToolResultMessage` and `AssistantMessage` tool calls when serializing Laravel messages back to Prism's format. Previously, both were silently dropped, causing the model to lose tool context in subsequent turns.

- **`PrismGateway`**: Slices the response messages before passing them to `withMessages()`, so only messages generated in the current turn are stored, not the full history that was sent as input.

- **`GeneratesText`**: Makes sure `withToolCallsAndResults()` is also called for non-structured `AgentResponse` instances, so tool call data is consistently available after each invocation.

### Changes in conversation messages retrieval

The changes above fix the gateway side. Once tool messages are present in the conversation history, they are now correctly serialized and sent to the provider. However, there is a second half to the problem.

The default `messages()` method in `RemembersConversations` only rehydrates plain text messages from storage. It does not reconstruct `AssistantMessage` objects with their `ToolCall` collection, nor `ToolResultMessage` objects with their `ToolResult` collection. This means tool history stored in the database is never being loaded back into the conversation context.

This PR also address that, making `DatabaseConversationStore::getLatestConversationMessages()` reconstruct `AssistantMessage` objects with their tool calls and `ToolResultMessage` objects with their tool results from the `tool_calls` and `tool_results` columns.

### Examples

Assuming an `Agent` with a `DeleteFolder` tool:

**Before**

```
You: delete folder "foo"
Assistant: The folder "foo" has been deleted successfully.

You: did you delete the folder?
Assistant: No, I haven't deleted the folder "foo" yet. Would you like me to proceed with the deletion?
```

**After**

```
You: delete folder "foo"
Assistant: The folder "foo" has been deleted successfully.

You: did you delete the folder?
Assistant: Yes, the folder "foo" has been deleted successfully.
```

### Tests

I've run the integration tests, happy to add unit tests if needed.