### PR TITLE
[0.x] Fix missing Base64Document import in Store.

### DIFF
--- a/src/Store.php
+++ b/src/Store.php
@@ -8,10 +8,10 @@ use Laravel\Ai\Contracts\Files\HasProviderId;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Responses\AddedDocumentResponse;
 use Laravel\Ai\Responses\Data\StoreFileCounts;
-use Laravel\Ai\Files\Base64Document;
 
 class Store
 {

--- a/src/Store.php
+++ b/src/Store.php
@@ -11,6 +11,7 @@ use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Responses\AddedDocumentResponse;
 use Laravel\Ai\Responses\Data\StoreFileCounts;
+use Laravel\Ai\Files\Base64Document;
 
 class Store
 {


### PR DESCRIPTION
`add()` method references `Base64Document::fromUpload()` when handling `UploadedFile` instances. Class was never imported causing an error.