### PR TITLE
Add human-in-the-loop tool approval

### DIFF
--- a/src/Concerns/HasApprovalFlow.php
+++ b/src/Concerns/HasApprovalFlow.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Ai\Concerns;
+
+use Laravel\Ai\Events\ToolApproved;
+use Laravel\Ai\Events\ToolRejected;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\PendingToolCall;
+use Laravel\Ai\Tools\Request;
+
+trait HasApprovalFlow
+{
+    /**
+     * Approve a pending tool call, execute the tool, and re-prompt the agent with the result.
+     */
+    public function approve(PendingToolCall $pendingToolCall): AgentResponse
+    {
+        event(new ToolApproved($this, $pendingToolCall));
+
+        $result = $pendingToolCall->tool->handle(new Request($pendingToolCall->arguments));
+
+        return $this->prompt(
+            "The tool '{$pendingToolCall->toolName()}' was approved and executed. Result: {$result}"
+        );
+    }
+
+    /**
+     * Reject a pending tool call.
+     */
+    public function reject(PendingToolCall $pendingToolCall, ?string $reason = null): AgentResponse
+    {
+        event(new ToolRejected($this, $pendingToolCall, $reason));
+
+        $message = $reason
+            ? "The tool '{$pendingToolCall->toolName()}' was rejected. Reason: {$reason}"
+            : "The tool '{$pendingToolCall->toolName()}' was rejected by the user.";
+
+        return $this->prompt($message);
+    }
+}

--- a/src/Events/ToolApprovalRequested.php
+++ b/src/Events/ToolApprovalRequested.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Responses\Data\PendingToolCall;
+
+class ToolApprovalRequested
+{
+    public function __construct(
+        public string $invocationId,
+        public Agent $agent,
+        public Tool $tool,
+        public array $arguments,
+        public PendingToolCall $pendingToolCall,
+    ) {}
+}

--- a/src/Events/ToolApproved.php
+++ b/src/Events/ToolApproved.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Responses\Data\PendingToolCall;
+
+class ToolApproved
+{
+    public function __construct(
+        public Agent $agent,
+        public PendingToolCall $pendingToolCall,
+    ) {}
+}

--- a/src/Events/ToolRejected.php
+++ b/src/Events/ToolRejected.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Responses\Data\PendingToolCall;
+
+class ToolRejected
+{
+    public function __construct(
+        public Agent $agent,
+        public PendingToolCall $pendingToolCall,
+        public ?string $reason = null,
+    ) {}
+}

--- a/src/Exceptions/ToolApprovalRequiredException.php
+++ b/src/Exceptions/ToolApprovalRequiredException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+use Laravel\Ai\Contracts\Tool;
+use RuntimeException;
+
+class ToolApprovalRequiredException extends RuntimeException
+{
+    /**
+     * Create a new exception instance.
+     */
+    public function __construct(
+        public readonly Tool $tool,
+        public readonly array $arguments,
+    ) {
+        $toolName = method_exists($tool, 'name')
+            ? $tool->name()
+            : class_basename($tool);
+
+        parent::__construct("Tool [{$toolName}] requires approval before execution.");
+    }
+}

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
+use Laravel\Ai\Exceptions\ToolApprovalRequiredException;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
@@ -48,8 +49,8 @@ class PrismGateway implements Gateway
 
     public function __construct(protected Dispatcher $events)
     {
-        $this->invokingToolCallback = fn () => true;
-        $this->toolInvokedCallback = fn () => true;
+        $this->invokingToolCallback = fn() => true;
+        $this->toolInvokedCallback = fn() => true;
     }
 
     /**
@@ -83,6 +84,13 @@ class PrismGateway implements Gateway
             $response = $request
                 ->withMessages($this->toPrismMessages($messages))
                 ->{$structured ? 'asStructured' : 'asText'}();
+        } catch (ToolApprovalRequiredException $e) {
+            return TextResponse::pendingApproval(
+                $e->tool,
+                $e->arguments,
+                $provider,
+                $model,
+            );
         } catch (PrismVendorException $e) {
             throw PrismException::toAiException($e, $provider, $model);
         }
@@ -145,7 +153,10 @@ class PrismGateway implements Gateway
 
             foreach ($events as $event) {
                 if (! is_null($event = PrismStreamEvent::toLaravelStreamEvent(
-                    $invocationId, $event, $provider->name(), $model
+                    $invocationId,
+                    $event,
+                    $provider->name(),
+                    $model
                 ))) {
                     yield $event;
                 }
@@ -212,7 +223,7 @@ class PrismGateway implements Gateway
         return (new Collection($attachments))->map(function ($attachment) {
             if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
                 throw new InvalidArgumentException(
-                    'Unsupported attachment type ['.$attachment::class.']'
+                    'Unsupported attachment type [' . $attachment::class . ']'
                 );
             }
 
@@ -220,7 +231,7 @@ class PrismGateway implements Gateway
                 $attachment instanceof LocalImage => PrismImage::fromLocalPath($attachment->path, $attachment->mime),
                 $attachment instanceof StoredImage => PrismImage::fromStoragePath($attachment->path, $attachment->disk),
                 $attachment instanceof UploadedFile && static::isImage($attachment) => PrismImage::fromBase64(base64_encode($attachment->get()), $attachment->getClientMimeType()),
-                default => throw new InvalidArgumentException('Unsupported attachment type ['.$attachment::class.']'),
+                default => throw new InvalidArgumentException('Unsupported attachment type [' . $attachment::class . ']'),
             };
 
             if ($attachment instanceof File && $attachment->name) {
@@ -297,7 +308,8 @@ class PrismGateway implements Gateway
                 ])
                 ->withInput(match (true) {
                     $audio instanceof TranscribableAudio => Audio::fromBase64(
-                        base64_encode($audio->content()), $audio->mimeType()
+                        base64_encode($audio->content()),
+                        $audio->mimeType()
                     ),
                 });
 
@@ -336,11 +348,11 @@ class PrismGateway implements Gateway
         EmbeddingProvider $provider,
         string $model,
         array $inputs,
-        int $dimensions): EmbeddingsResponse
-    {
+        int $dimensions
+    ): EmbeddingsResponse {
         $request = tap(
             Prism::embeddings(),
-            fn ($prism) => $this->configure($prism, $provider, $model)
+            fn($prism) => $this->configure($prism, $provider, $model)
         );
 
         $request->withProviderOptions(match ($provider->driver()) {
@@ -371,7 +383,7 @@ class PrismGateway implements Gateway
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
-            'azure' => PrismProvider::OpenAI, 
+            'azure' => PrismProvider::OpenAI,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
             'groq' => PrismProvider::Groq,
@@ -381,7 +393,7 @@ class PrismGateway implements Gateway
             'openrouter' => PrismProvider::OpenRouter,
             'voyageai' => PrismProvider::VoyageAI,
             'xai' => PrismProvider::XAI,
-            default => throw new InvalidArgumentException('Gateway does not support provider ['.$provider.'].'),
+            default => throw new InvalidArgumentException('Gateway does not support provider [' . $provider . '].'),
         };
     }
 

--- a/src/Responses/Data/PendingToolCall.php
+++ b/src/Responses/Data/PendingToolCall.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Laravel\Ai\Responses\Data;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Tool;
+
+class PendingToolCall implements Arrayable
+{
+    public readonly string $id;
+
+    public function __construct(
+        public readonly Tool $tool,
+        public readonly array $arguments,
+        public readonly string $agentClass,
+        public readonly string $invocationId,
+        ?string $id = null,
+    ) {
+        $this->id = $id ?? (string) Str::uuid7();
+    }
+
+    /**
+     * Get the tool's name.
+     */
+    public function toolName(): string
+    {
+        return method_exists($this->tool, 'name')
+            ? $this->tool->name()
+            : class_basename($this->tool);
+    }
+
+    /**
+     * Get the tool's class name.
+     */
+    public function toolClass(): string
+    {
+        return $this->tool::class;
+    }
+
+    /**
+     * Get the array representation of the pending tool call.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'tool_name' => $this->toolName(),
+            'tool_class' => $this->toolClass(),
+            'arguments' => $this->arguments,
+            'agent_class' => $this->agentClass,
+            'invocation_id' => $this->invocationId,
+        ];
+    }
+}

--- a/src/Responses/PendingApprovalResponse.php
+++ b/src/Responses/PendingApprovalResponse.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\PendingToolCall;
+use Laravel\Ai\Responses\Data\Usage;
+
+class PendingApprovalResponse extends AgentResponse
+{
+    /**
+     * The pending tool calls requiring approval.
+     *
+     * @var \Illuminate\Support\Collection<int, PendingToolCall>
+     */
+    public Collection $pendingToolCalls;
+
+    public function __construct(string $invocationId, string $text, Usage $usage, Meta $meta)
+    {
+        parent::__construct($invocationId, $text, $usage, $meta);
+
+        $this->pendingToolCalls = new Collection;
+    }
+
+    /**
+     * Add a pending tool call to the response.
+     */
+    public function addPendingToolCall(PendingToolCall $pendingToolCall): self
+    {
+        $this->pendingToolCalls->push($pendingToolCall);
+
+        return $this;
+    }
+
+    /**
+     * Determine if the response is pending approval.
+     */
+    public function isPendingApproval(): bool
+    {
+        return $this->pendingToolCalls->isNotEmpty();
+    }
+
+    /**
+     * Determine if the response requires approval.
+     */
+    public function requiresApproval(): bool
+    {
+        return $this->isPendingApproval();
+    }
+}

--- a/src/Responses/TextResponse.php
+++ b/src/Responses/TextResponse.php
@@ -3,6 +3,8 @@
 namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Responses\Data\Meta;
@@ -27,6 +29,50 @@ class TextResponse
     }
 
     /**
+     * The tool calls pending approval.
+     *
+     * @var array<int, array{tool: Tool, arguments: array}>
+     */
+    protected array $pendingToolApprovals = [];
+
+    /**
+     * Create a response indicating that a tool requires approval.
+     */
+    public static function pendingApproval(
+        Tool $tool,
+        array $arguments,
+        TextProvider $provider,
+        string $model,
+    ): static {
+        $response = new static('', new Usage, new Meta($provider->name(), $model));
+
+        $response->pendingToolApprovals[] = [
+            'tool' => $tool,
+            'arguments' => $arguments,
+        ];
+
+        return $response;
+    }
+
+    /**
+     * Determine if this response has pending tool approvals.
+     */
+    public function hasPendingApprovals(): bool
+    {
+        return ! empty($this->pendingToolApprovals);
+    }
+
+    /**
+     * Get the pending tool approvals.
+     *
+     * @return array<int, array{tool: Tool, arguments: array}>
+     */
+    public function pendingApprovals(): array
+    {
+        return $this->pendingToolApprovals;
+    }
+
+    /**
      * Provide the message context for the response.
      */
     public function withMessages(Collection $messages): self
@@ -36,11 +82,11 @@ class TextResponse
         $this->withToolCallsAndResults(
             toolCalls: $this->messages
                 ->whereInstanceOf(AssistantMessage::class)
-                ->map(fn ($message) => $message->toolCalls)
+                ->map(fn($message) => $message->toolCalls)
                 ->flatten(),
             toolResults: $this->messages
                 ->whereInstanceOf(ToolResultMessage::class)
-                ->map(fn ($message) => $message->toolResults)
+                ->map(fn($message) => $message->toolResults)
                 ->flatten(),
         );
 
@@ -54,7 +100,7 @@ class TextResponse
     {
         // Filter Anthropic tool use for "JSON mode"...
         $this->toolCalls = $toolCalls->reject(
-            fn ($toolCall) => $toolCall->name === 'output_structured_data'
+            fn($toolCall) => $toolCall->name === 'output_structured_data'
         )->values();
 
         $this->toolResults = $toolResults;

--- a/tests/Feature/Agents/ApprovalAgent.php
+++ b/tests/Feature/Agents/ApprovalAgent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Concerns\HasApprovalFlow;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Feature\Tools\DangerousTool;
+
+class ApprovalAgent implements Agent, HasTools
+{
+    use Promptable, HasApprovalFlow;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that can perform dangerous operations. Always use the tool when asked to delete files.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     *
+     * @return Tool[]
+     */
+    public function tools(): iterable
+    {
+        return [new DangerousTool];
+    }
+}

--- a/tests/Feature/ToolApprovalTest.php
+++ b/tests/Feature/ToolApprovalTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Events\ToolApprovalRequested;
+use Laravel\Ai\Events\ToolApproved;
+use Laravel\Ai\Events\ToolRejected;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\PendingToolCall;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\PendingApprovalResponse;
+use Tests\Feature\Agents\ApprovalAgent;
+use Tests\Feature\Agents\ToolUsingAgent;
+use Tests\Feature\Tools\ConditionalApprovalTool;
+use Tests\Feature\Tools\DangerousTool;
+use Tests\TestCase;
+
+class ToolApprovalTest extends TestCase
+{
+    public function test_approving_a_pending_tool_call_executes_tool_and_re_prompts(): void
+    {
+        ApprovalAgent::fake(['The files have been deleted.']);
+
+        $pendingToolCall = new PendingToolCall(
+            tool: new DangerousTool,
+            arguments: ['user_id' => 42],
+            agentClass: ApprovalAgent::class,
+            invocationId: 'test-invocation-id',
+        );
+
+        $response = (new ApprovalAgent)->approve($pendingToolCall);
+
+        $this->assertEquals('The files have been deleted.', $response->text);
+    }
+
+    public function test_approving_a_pending_tool_call_dispatches_tool_approved_event(): void
+    {
+        Event::fake([ToolApproved::class]);
+
+        ApprovalAgent::fake(['The files have been deleted.']);
+
+        $pendingToolCall = new PendingToolCall(
+            tool: new DangerousTool,
+            arguments: ['user_id' => 42],
+            agentClass: ApprovalAgent::class,
+            invocationId: 'test-invocation-id',
+        );
+
+        (new ApprovalAgent)->approve($pendingToolCall);
+
+        Event::assertDispatched(ToolApproved::class, function ($event) use ($pendingToolCall) {
+            return $event->pendingToolCall === $pendingToolCall
+                && $event->agent instanceof ApprovalAgent;
+        });
+    }
+
+    public function test_rejecting_a_pending_tool_call_dispatches_tool_rejected_event(): void
+    {
+        Event::fake([ToolRejected::class]);
+
+        ApprovalAgent::fake(['Understood, the operation was cancelled.']);
+
+        $pendingToolCall = new PendingToolCall(
+            tool: new DangerousTool,
+            arguments: ['user_id' => 42],
+            agentClass: ApprovalAgent::class,
+            invocationId: 'test-invocation-id',
+        );
+
+        (new ApprovalAgent)->reject($pendingToolCall, 'Too risky');
+
+        Event::assertDispatched(ToolRejected::class, function ($event) use ($pendingToolCall) {
+            return $event->pendingToolCall === $pendingToolCall
+                && $event->agent instanceof ApprovalAgent
+                && $event->reason === 'Too risky';
+        });
+    }
+
+    public function test_rejecting_without_reason_dispatches_event_with_null_reason(): void
+    {
+        Event::fake([ToolRejected::class]);
+
+        ApprovalAgent::fake(['OK.']);
+
+        $pendingToolCall = new PendingToolCall(
+            tool: new DangerousTool,
+            arguments: ['user_id' => 42],
+            agentClass: ApprovalAgent::class,
+            invocationId: 'test-invocation-id',
+        );
+
+        (new ApprovalAgent)->reject($pendingToolCall);
+
+        Event::assertDispatched(ToolRejected::class, function ($event) {
+            return is_null($event->reason);
+        });
+    }
+
+    public function test_conditional_approval_tool_respects_dynamic_state(): void
+    {
+        $tool = new ConditionalApprovalTool(shouldRequireApproval: false);
+        $this->assertFalse($tool->requiresApproval());
+
+        $tool = new ConditionalApprovalTool(shouldRequireApproval: true);
+        $this->assertTrue($tool->requiresApproval());
+    }
+
+    public function test_pending_tool_call_has_unique_id(): void
+    {
+        $pending1 = new PendingToolCall(new DangerousTool, [], ApprovalAgent::class, 'inv-1');
+        $pending2 = new PendingToolCall(new DangerousTool, [], ApprovalAgent::class, 'inv-1');
+
+        $this->assertNotEquals($pending1->id, $pending2->id);
+    }
+
+    public function test_pending_tool_call_serializes_to_array(): void
+    {
+        $pending = new PendingToolCall(
+            tool: new DangerousTool,
+            arguments: ['user_id' => 42],
+            agentClass: ApprovalAgent::class,
+            invocationId: 'inv-123',
+            id: 'custom-id',
+        );
+
+        $array = $pending->toArray();
+
+        $this->assertEquals('custom-id', $array['id']);
+        $this->assertEquals('DangerousTool', $array['tool_name']);
+        $this->assertEquals(['user_id' => 42], $array['arguments']);
+        $this->assertEquals(ApprovalAgent::class, $array['agent_class']);
+        $this->assertEquals('inv-123', $array['invocation_id']);
+    }
+
+    public function test_pending_tool_call_returns_tool_class(): void
+    {
+        $pending = new PendingToolCall(new DangerousTool, [], ApprovalAgent::class, 'inv-1');
+
+        $this->assertEquals(DangerousTool::class, $pending->toolClass());
+    }
+
+    public function test_pending_approval_response_tracks_pending_calls(): void
+    {
+        $response = new PendingApprovalResponse('inv-1', '', new Usage, new Meta('openai', 'gpt-4'));
+
+        $this->assertFalse($response->isPendingApproval());
+        $this->assertCount(0, $response->pendingToolCalls);
+
+        $pending = new PendingToolCall(new DangerousTool, ['user_id' => 1], ApprovalAgent::class, 'inv-1');
+        $response->addPendingToolCall($pending);
+
+        $this->assertTrue($response->isPendingApproval());
+        $this->assertTrue($response->requiresApproval());
+        $this->assertCount(1, $response->pendingToolCalls);
+        $this->assertSame($pending, $response->pendingToolCalls->first());
+    }
+
+    public function test_pending_approval_response_extends_agent_response(): void
+    {
+        $response = new PendingApprovalResponse('inv-1', 'text', new Usage, new Meta('openai', 'gpt-4'));
+
+        $this->assertInstanceOf(\Laravel\Ai\Responses\AgentResponse::class, $response);
+    }
+}

--- a/tests/Feature/Tools/ConditionalApprovalTool.php
+++ b/tests/Feature/Tools/ConditionalApprovalTool.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class ConditionalApprovalTool implements Tool
+{
+    public function __construct(public bool $shouldRequireApproval = false) {}
+
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'This tool conditionally requires approval.';
+    }
+
+    /**
+     * Determine if the tool requires approval before execution.
+     */
+    public function requiresApproval(): bool
+    {
+        return $this->shouldRequireApproval;
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        return 'Conditional tool executed';
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/tests/Feature/Tools/DangerousTool.php
+++ b/tests/Feature/Tools/DangerousTool.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class DangerousTool implements Tool
+{
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'This tool performs a dangerous operation that requires human approval.';
+    }
+
+    /**
+     * Determine if the tool requires approval before execution.
+     */
+    public function requiresApproval(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        return "Deleted files for user {$request['user_id']}";
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'user_id' => $schema->integer()->description('The user ID')->required(),
+        ];
+    }
+}


### PR DESCRIPTION
 [0.x] Introduce Human-in-the-Loop Tool Approval

## Summary

This PR introduces a **fully opt-in, stateless mechanism** for requiring human approval before specific tools are executed.

As AI agents are given more destructive or sensitive capabilities (deleting records, sending emails, generating payments), developers need a straightforward way to interrupt the agent's execution loop, present the pending action to a human, and then easily resume execution upon approval or rejection.

## How it Works

The implementation leans heavily into Laravel's existing conventions, avoiding completely the need for new dependencies or modifications to the underlying `Prism` package.

**1. Tools opt-in via a `requiresApproval()` method:**
```php
class DeleteUserFiles implements Tool
{
    public function requiresApproval(): bool
    {
        return true; 
    }
    // ...
}
```

**2. The Prompt returns a `PendingApprovalResponse` instead of executing:**
If an agent attempts to call an opted-in tool, the execution loop is gracefully intercepted via an internal `ToolApprovalRequiredException`. The prompt call returns a `PendingApprovalResponse` containing the pending tool calls, rather than an executed text/structured response.

```php
$response = (new FileManager)->prompt('Delete files for user 42');

if ($response instanceof PendingApprovalResponse) {
    // Present $response->pendingToolCalls to the user
}
```

**3. Developers approve (or reject) to resume from where the agent paused:**
Using the new `HasApprovalFlow` trait, agents gain `approve()` and `reject()` methods that execute the tool (if approved) and dynamically re-prompt the agent with the result or rejection reason.

```php
$response = (new FileManager)->approve($pendingToolCall);
```

## Known Limitations 

Because `laravel/ai` currently leverages Prism's internal synchronous step loop, it cannot literally "pause" a process mid-flight and resume it from memory later. Thus, calling `approve()` or `reject()` relies on **re-prompting** the agent in a new API call with the tool's result injected into the conversation.

This works perfectly, but incurs an extra LLM API call. I believe this is an acceptable trade-off for the simplicity and power of human-in-the-loop flows without needing background workers natively.

**Next Steps / Discussion:**
Currently, the developer is responsible for storing the `PendingToolCall` between requests (e.g., in the session or cache). If you feel `laravel/ai` should prescribe a default persistence mechanism (similar to how `RemembersConversations` opinionates a DB schema), I would be happy to build that out in a follow-up commit or PR.

## Tests

Added  comprehensive Feature tests asserting the interception flow, event dispatching, and conditional toggling. Zero regressions on the existing unit and integration suite.
