### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "source": "https://github.com/laravel/ai"
     },
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "illuminate/console": "^12.0",
         "illuminate/container": "^12.0",
         "illuminate/contracts": "^12.0",

--- a/src/Files/Document.php
+++ b/src/Files/Document.php
@@ -59,9 +59,9 @@ abstract class Document extends File
      */
     public static function fromUpload(UploadedFile $file, ?string $mimeType = null): Base64Document
     {
-        return new Base64Document(
+        return (new Base64Document(
             base64_encode($file->getContent()),
             $mimeType ?? $file->getClientMimeType(),
-        )->as($file->getClientOriginalName());
+        ))->as($file->getClientOriginalName());
     }
 }

--- a/src/Files/Image.php
+++ b/src/Files/Image.php
@@ -51,9 +51,9 @@ abstract class Image extends File
      */
     public static function fromUpload(UploadedFile $file, ?string $mimeType = null): Base64Image
     {
-        return new Base64Image(
+        return (new Base64Image(
             base64_encode($file->getContent()),
             $mimeType ?? $file->getClientMimeType(),
-        )->as($file->getClientOriginalName());
+        ))->as($file->getClientOriginalName());
     }
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -316,7 +316,7 @@ class PrismGateway implements Gateway
 
         return new TranscriptionResponse(
             $response->text,
-            new Collection($response->additionalContent['segments'] ?? [])->map(function ($segment) {
+            (new Collection($response->additionalContent['segments'] ?? []))->map(function ($segment) {
                 return new TranscriptionSegment(
                     $segment['text'],
                     $segment['speaker'],

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -49,7 +49,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -98,7 +98,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
@@ -147,7 +147,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }


### PR DESCRIPTION
Lowers the PHP version requirement from `^8.4` to `^8.3`. The codebase only used one PHP 8.4-specific feature — method chaining on `new` expressions without parentheses — which is wrapped in parentheses for 8.3 compatibility.
