### PR TITLE
Add dynamic structured schema sources

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,6 +14,7 @@ use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Schemable;
 
 /**
  * Get an ad-hoc agent instance.
@@ -22,7 +23,7 @@ function agent(
     string $instructions = '',
     iterable $messages = [],
     iterable $tools = [],
-    ?Closure $schema = null,
+    Closure|array|Schemable|null $schema = null,
 ): Agent {
     return $schema
         ? new StructuredAnonymousAgent($instructions, $messages, $tools, $schema)

--- a/src/Contracts/Gateway/TextGateway.php
+++ b/src/Contracts/Gateway/TextGateway.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Contracts\Gateway;
 use Closure;
 use Generator;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Schemable;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\TextResponse;
 
@@ -13,7 +14,7 @@ interface TextGateway
     /**
      * Generate text representing the next message in a conversation.
      *
-     * @param  array<string, \Illuminate\JsonSchema\Types\Type>|null  $schema
+     * @param  array<string, \Illuminate\JsonSchema\Types\Type>|Schemable|null  $schema
      */
     public function generateText(
         TextProvider $provider,
@@ -21,7 +22,7 @@ interface TextGateway
         ?string $instructions,
         array $messages = [],
         array $tools = [],
-        ?array $schema = null,
+        array|Schemable|null $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): TextResponse;
@@ -29,7 +30,7 @@ interface TextGateway
     /**
      * Stream text representing the next message in a conversation.
      *
-     * @param  array<string, \Illuminate\JsonSchema\Types\Type>|null  $schema
+     * @param  array<string, \Illuminate\JsonSchema\Types\Type>|Schemable|null  $schema
      */
     public function streamText(
         string $invocationId,
@@ -38,7 +39,7 @@ interface TextGateway
         ?string $instructions,
         array $messages = [],
         array $tools = [],
-        ?array $schema = null,
+        array|Schemable|null $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): Generator;

--- a/src/Contracts/Gateway/TextGateway.php
+++ b/src/Contracts/Gateway/TextGateway.php
@@ -14,6 +14,8 @@ interface TextGateway
     /**
      * Generate text representing the next message in a conversation.
      *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     * @param  \Laravel\Ai\Contracts\Tool[]  $tools
      * @param  array<string, \Illuminate\JsonSchema\Types\Type>|Schemable|null  $schema
      */
     public function generateText(
@@ -30,6 +32,8 @@ interface TextGateway
     /**
      * Stream text representing the next message in a conversation.
      *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     * @param  \Laravel\Ai\Contracts\Tool[]  $tools
      * @param  array<string, \Illuminate\JsonSchema\Types\Type>|Schemable|null  $schema
      */
     public function streamText(

--- a/src/Contracts/HasStructuredOutput.php
+++ b/src/Contracts/HasStructuredOutput.php
@@ -9,5 +9,5 @@ interface HasStructuredOutput
     /**
      * Get the agent's structured output schema definition.
      */
-    public function schema(JsonSchema $schema): array;
+    public function schema(JsonSchema $schema): array|Schemable;
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Contracts\Schemable;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Files\LocalImage;
@@ -61,7 +62,7 @@ class PrismGateway implements Gateway
         ?string $instructions,
         array $messages = [],
         array $tools = [],
-        ?array $schema = null,
+        array|Schemable|null $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): TextResponse {
@@ -120,7 +121,7 @@ class PrismGateway implements Gateway
         ?string $instructions,
         array $messages = [],
         array $tools = [],
-        ?array $schema = null,
+        array|Schemable|null $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): Generator {

--- a/src/RawSchema.php
+++ b/src/RawSchema.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Laravel\Ai;
+
+use InvalidArgumentException;
+use JsonException;
+use Laravel\Ai\Contracts\Schemable;
+use Prism\Prism\Contracts\Schema as PrismSchema;
+
+class RawSchema implements PrismSchema, Schemable
+{
+    /**
+     * @param  array<string, mixed>  $schema
+     */
+    public function __construct(
+        protected array $schema,
+        protected string $name = 'schema_definition',
+    ) {}
+
+    /**
+     * Create a new schema from an array.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    public static function fromArray(array $schema, string $name = 'schema_definition'): self
+    {
+        return new self($schema, $name);
+    }
+
+    /**
+     * Create a new schema from a JSON string.
+     *
+     * @throws JsonException
+     */
+    public static function fromJson(string $json, string $name = 'schema_definition'): self
+    {
+        $schema = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+
+        if (! is_array($schema)) {
+            throw new InvalidArgumentException('The provided JSON schema must decode to an array.');
+        }
+
+        return new self($schema, $name);
+    }
+
+    /**
+     * Create a new schema from a JSON file.
+     *
+     * @throws JsonException
+     */
+    public static function fromFile(string $path, string $name = 'schema_definition'): self
+    {
+        if (! is_file($path) || ! is_readable($path)) {
+            throw new InvalidArgumentException("The schema file [{$path}] does not exist or is not readable.");
+        }
+
+        $json = file_get_contents($path);
+
+        if ($json === false) {
+            throw new InvalidArgumentException("Unable to read schema file [{$path}].");
+        }
+
+        return static::fromJson($json, $name);
+    }
+
+    /**
+     * Get the schema name.
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Create a new schema with the given name.
+     */
+    public function withName(string $name): self
+    {
+        return new self($this->schema, $name);
+    }
+
+    /**
+     * Get the raw schema definition without the schema name.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return $this->schema;
+    }
+
+    /**
+     * Get the array representation of the schema.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->toSchema();
+    }
+
+    /**
+     * Get the schema payload including name.
+     *
+     * @return array<string, mixed>
+     */
+    public function toSchema(): array
+    {
+        if (isset($this->schema['name']) && is_string($this->schema['name'])) {
+            return $this->schema;
+        }
+
+        return [
+            'name' => $this->name,
+            ...$this->schema,
+        ];
+    }
+}

--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -5,23 +5,28 @@ namespace Laravel\Ai;
 use Closure;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Contracts\Schemable;
 use Laravel\SerializableClosure\SerializableClosure;
 
 class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOutput
 {
-    public $schema;
+    public array|Schemable|SerializableClosure $schema;
 
     public function __construct(
         public string $instructions,
         public iterable $messages,
         public iterable $tools,
-        Closure $schema,
+        Closure|array|Schemable $schema,
     ) {
-        $this->schema = new SerializableClosure($schema);
+        $this->schema = $schema instanceof Closure
+            ? new SerializableClosure($schema)
+            : $schema;
     }
 
-    public function schema(JsonSchema $schema): array
+    public function schema(JsonSchema $schema): array|Schemable
     {
-        return call_user_func($this->schema, $schema);
+        return $this->schema instanceof SerializableClosure
+            ? call_user_func($this->schema, $schema)
+            : $this->schema;
     }
 }

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -6,14 +6,18 @@ use Exception;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\QueuedAgentPrompt;
+use Laravel\Ai\RawSchema;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\StructuredAnonymousAgent;
 use RuntimeException;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\StructuredAgent;
 use Tests\TestCase;
+
+use function Laravel\Ai\agent;
 
 class AgentFakeTest extends TestCase
 {
@@ -111,6 +115,44 @@ class AgentFakeTest extends TestCase
         StructuredAgent::fake();
 
         $response = (new StructuredAgent)->prompt('Gold prompt');
+
+        $this->assertIsString($response['symbol']);
+    }
+
+    public function test_ad_hoc_agents_with_raw_schema_objects_can_be_faked(): void
+    {
+        Ai::fakeAgent(StructuredAnonymousAgent::class, [
+            ['symbol' => 'Ag'],
+        ]);
+
+        $response = agent(
+            schema: RawSchema::fromArray([
+                'type' => 'object',
+                'properties' => [
+                    'symbol' => ['type' => 'string'],
+                ],
+                'required' => ['symbol'],
+                'additionalProperties' => false,
+            ]),
+        )->prompt('What is the chemical symbol for silver?');
+
+        $this->assertSame('Ag', $response['symbol']);
+    }
+
+    public function test_ad_hoc_agents_with_raw_schema_arrays_can_be_faked_without_predefined_responses(): void
+    {
+        Ai::fakeAgent(StructuredAnonymousAgent::class);
+
+        $response = agent(
+            schema: [
+                'type' => 'object',
+                'properties' => [
+                    'symbol' => ['type' => 'string'],
+                ],
+                'required' => ['symbol'],
+                'additionalProperties' => false,
+            ],
+        )->prompt('What is the chemical symbol for silver?');
 
         $this->assertIsString($response['symbol']);
     }

--- a/tests/Feature/RawSchemaTest.php
+++ b/tests/Feature/RawSchemaTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\RawSchema;
+use Tests\TestCase;
+
+class RawSchemaTest extends TestCase
+{
+    public function test_it_can_be_created_from_array(): void
+    {
+        $schema = RawSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                'symbol' => ['type' => 'string'],
+            ],
+            'required' => ['symbol'],
+            'additionalProperties' => false,
+        ], 'chemical_symbol');
+
+        $this->assertSame('chemical_symbol', $schema->name());
+        $this->assertSame('chemical_symbol', $schema->toSchema()['name']);
+        $this->assertSame('object', $schema->toSchema()['type']);
+    }
+
+    public function test_it_can_be_created_from_json(): void
+    {
+        $schema = RawSchema::fromJson(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'symbol' => ['type' => 'string'],
+            ],
+            'required' => ['symbol'],
+            'additionalProperties' => false,
+        ]));
+
+        $this->assertSame('schema_definition', $schema->name());
+        $this->assertSame('object', $schema->toSchema()['type']);
+        $this->assertIsArray($schema->definition()['properties']);
+    }
+
+    public function test_it_can_be_created_from_file(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'ai-schema-');
+
+        file_put_contents($path, json_encode([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+            'required' => ['name'],
+            'additionalProperties' => false,
+        ]));
+
+        try {
+            $schema = RawSchema::fromFile($path, 'person');
+
+            $this->assertSame('person', $schema->name());
+            $this->assertSame('person', $schema->toSchema()['name']);
+            $this->assertSame('object', $schema->toSchema()['type']);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for dynamic structured output schemas in Laravel AI.

Today, structured schemas are effectively defined through PHP `JsonSchema` builders only. This change keeps that flow intact and adds a new path for schemas loaded at runtime (file, DB, API, etc).

## Intent

Enable structured output schemas to be injected dynamically without forcing schema definitions to live only in PHP code.

## What’s added

- New `RawSchema` value object for runtime schema payloads:
  - `fromArray(...)`
  - `fromJson(...)`
  - `fromFile(...)`
- Ad-hoc `agent()` now accepts:
  - `Closure|array|Schemable|null` for `schema`
- Structured schema flow now accepts `array|Schemable` through text gateway and Prism gateway paths.
- Prism request creation now normalizes schema input:
  - Laravel Type-map arrays => existing `ObjectSchema` flow
  - Raw JSON-schema arrays => `RawSchema`
  - `Schemable` instances => passed as schema payload
- Fake gateway supports generating fake structured data for raw JSON-schema payloads too.

## Examples

### 1) Existing PHP schema flow (unchanged)

```php
$response = agent(
    schema: fn ($schema) => [
        'symbol' => $schema->string()->required(),
    ],
)->prompt('What is the chemical symbol for silver?');
```

### 2) Schema loaded from file

```php
use Laravel\Ai\RawSchema;

$schema = RawSchema::fromFile(storage_path('ai/schemas/chemical-symbol.json'));

$response = agent(schema: $schema)->prompt(
    'What is the chemical symbol for silver?'
);
```

### 3) Schema loaded from DB

```php
use Laravel\Ai\RawSchema;

$json = DB::table('ai_schemas')->where('key', 'chemical-symbol')->value('schema');

$response = agent(
    schema: RawSchema::fromJson($json),
)->prompt('What is the chemical symbol for silver?');
```

## Backward compatibility

- Existing closure-based and PHP `JsonSchemaTypeFactory` structured schemas continue to work.
- This is additive support for dynamic schema sources.