### PR TITLE
Fix ErrorEvent property access in PrismStreamEvent

### DIFF
--- a/src/Gateway/Prism/PrismStreamEvent.php
+++ b/src/Gateway/Prism/PrismStreamEvent.php
@@ -47,7 +47,7 @@ class PrismStreamEvent
             PrismStreamEventType::ProviderToolEvent => static::toProviderToolEvent($event),
             // PrismStreamEventType::Citation => new Citation($id ?? $event->id, $event->messageId, PrismCitations::toLaravelCitation($event->citation), $event->timestamp),
             PrismStreamEventType::StreamEnd => static::toStreamEndEvent($event),
-            PrismStreamEventType::Error => new Error($event->id, $event->type, $event->message, $event->recoverable, $event->timestamp, $event->metadata),
+            PrismStreamEventType::Error => new Error($event->id, $event->errorType, $event->message, $event->recoverable, $event->timestamp, $event->metadata),
             default => null
         }, function ($event) use ($invocationId) {
             $event?->withInvocationId($invocationId);

--- a/tests/Unit/Gateway/Prism/PrismStreamEventTest.php
+++ b/tests/Unit/Gateway/Prism/PrismStreamEventTest.php
@@ -76,4 +76,27 @@ class PrismStreamEventTest extends TestCase
         $this->assertEquals(100, $result->usage->promptTokens);
         $this->assertEquals(50, $result->usage->completionTokens);
     }
+
+    public function test_error_event_maps_correctly(): void
+    {
+        $event = new \Prism\Prism\Streaming\Events\ErrorEvent(
+            id: 'event-5',
+            timestamp: 1234567890,
+            errorType: 'server_error',
+            message: 'Something went wrong',
+            recoverable: false,
+            metadata: ['foo' => 'bar'],
+        );
+
+        $result = PrismStreamEvent::toLaravelStreamEvent('invocation-1', $event, 'openai', 'gpt-4');
+
+        $this->assertInstanceOf(\Laravel\Ai\Streaming\Events\Error::class, $result);
+        /** @var \Laravel\Ai\Streaming\Events\Error $result */
+        $this->assertEquals('event-5', $result->id);
+        $this->assertEquals('server_error', $result->type);
+        $this->assertEquals('Something went wrong', $result->message);
+        $this->assertFalse($result->recoverable);
+        $this->assertEquals(1234567890, $result->timestamp);
+        $this->assertEquals(['foo' => 'bar'], $result->metadata);
+    }
 }


### PR DESCRIPTION
Fixes #186 by mapping $event->errorType correctly inside PrismStreamEvent.