### PR TITLE
Fix undefined variable $e in withModelFailover when providers array is empty

### DIFF
--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->string('user_id')->nullable();
+            $table->foreignId('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->string('user_id')->nullable();
+            $table->foreignId('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -141,6 +141,8 @@ trait Promptable
     {
         $providers = $this->getProvidersAndModels($provider, $model);
 
+        $lastException = null;
+
         foreach ($providers as $provider => $model) {
             $provider = Ai::textProviderFor($this, $provider);
 
@@ -149,13 +151,15 @@ trait Promptable
             try {
                 return $callback($provider, $model);
             } catch (FailoverableException $e) {
+                $lastException = $e;
+
                 event(new AgentFailedOver($this, $provider, $model, $e));
 
                 continue;
             }
         }
 
-        throw $e;
+        throw $lastException ?? new \RuntimeException('No AI providers were configured.');
     }
 
     /**

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -24,6 +24,7 @@ use Laravel\Ai\Responses\QueuedAgentResponse;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use ReflectionClass;
+use RuntimeException;
 
 trait Promptable
 {
@@ -159,7 +160,7 @@ trait Promptable
             }
         }
 
-        throw $lastException ?? new \RuntimeException('No AI providers were configured.');
+        throw $lastException ?? new RuntimeException('No AI providers were configured.');
     }
 
     /**


### PR DESCRIPTION
Fixes a fatal error where `throw $e` is reached with an uninitialized variable when the providers array is empty.