### PR TITLE
Handle audio file attachments in message conversion

### DIFF
--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->string('user_id')->nullable();
+            $table->foreignId('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->string('user_id')->nullable();
+            $table->foreignId('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');

--- a/src/Gateway/Prism/PrismMessages.php
+++ b/src/Gateway/Prism/PrismMessages.php
@@ -5,15 +5,19 @@ namespace Laravel\Ai\Gateway\Prism;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Audio;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalAudio;
 use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteAudio;
 use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredAudio;
 use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -75,6 +79,10 @@ class PrismMessages
                 $attachment instanceof LocalDocument => PrismDocument::fromPath($attachment->path),
                 $attachment instanceof RemoteDocument => PrismDocument::fromUrl($attachment->url),
                 $attachment instanceof StoredDocument => PrismDocument::fromStoragePath($attachment->path, $attachment->disk),
+                $attachment instanceof Base64Audio => PrismAudio::fromBase64($attachment->base64, $attachment->mime),
+                $attachment instanceof LocalAudio => PrismAudio::fromLocalPath($attachment->path, $attachment->mime),
+                $attachment instanceof RemoteAudio => PrismAudio::fromUrl($attachment->url, $attachment->mime),
+                $attachment instanceof StoredAudio => PrismAudio::fromStoragePath($attachment->path, $attachment->disk),
                 $attachment instanceof UploadedFile && static::isImage($attachment) => PrismImage::fromBase64(base64_encode($attachment->get()), $attachment->getClientMimeType()),
                 $attachment instanceof UploadedFile && static::isAudio($attachment) => PrismAudio::fromBase64(base64_encode($attachment->get()), $attachment->getClientMimeType()),
                 $attachment instanceof UploadedFile => PrismDocument::fromBase64(base64_encode($attachment->get()), $attachment->getClientMimeType()),

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -141,6 +141,8 @@ trait Promptable
     {
         $providers = $this->getProvidersAndModels($provider, $model);
 
+        $lastException = null;
+
         foreach ($providers as $provider => $model) {
             $provider = Ai::textProviderFor($this, $provider);
 
@@ -149,13 +151,15 @@ trait Promptable
             try {
                 return $callback($provider, $model);
             } catch (FailoverableException $e) {
+                $lastException = $e;
+
                 event(new AgentFailedOver($this, $provider, $model, $e));
 
                 continue;
             }
         }
 
-        throw $e;
+        throw $lastException ?? new \RuntimeException('No AI providers were configured.');
     }
 
     /**


### PR DESCRIPTION
## Summary

- `Base64Audio`, `LocalAudio`, `RemoteAudio`, and `StoredAudio` were missing from the `match` in `PrismMessages::fromLaravelAttachments()`, causing `UnhandledMatchError` at runtime when any audio `File` type is used as a chat message attachment