### PR TITLE
Fix undefined variable $e in PendingResponse failover loops

### DIFF
--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -75,6 +75,8 @@ class PendingAudioGeneration
             $provider ?? config('ai.default_for_audio'), $model
         );
 
+        $lastException = null;
+
         foreach ($providers as $provider => $model) {
             $provider = Ai::fakeableAudioProvider($provider);
 
@@ -85,13 +87,15 @@ class PendingAudioGeneration
                     $this->text, $this->voice, $this->instructions, $model
                 );
             } catch (FailoverableException $e) {
+                $lastException = $e;
+
                 event(new ProviderFailedOver($provider, $model, $e));
 
                 continue;
             }
         }
 
-        throw $e;
+        throw $lastException;
     }
 
     /**

--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -118,6 +118,8 @@ class PendingImageGeneration
             $provider ?? config('ai.default_for_images'), $model
         );
 
+        $lastException = null;
+
         foreach ($providers as $provider => $model) {
             $provider = Ai::fakeableImageProvider($provider);
 
@@ -128,13 +130,15 @@ class PendingImageGeneration
                     $this->prompt, $this->attachments, $this->size, $this->quality, $model, $this->timeout
                 );
             } catch (FailoverableException $e) {
+                $lastException = $e;
+
                 event(new ProviderFailedOver($provider, $model, $e));
 
                 continue;
             }
         }
 
-        throw $e;
+        throw $lastException;
     }
 
     /**


### PR DESCRIPTION
Same undefined variable $e bug from Promptable::withModelFailover exists in 5 PendingResponse failover loops — if the providers array is empty, $e is never assigned before throw $e. Fixed in PendingImageGeneration, PendingAudioGeneration, PendingTranscriptionGeneration, PendingEmbeddingsGeneration, and PendingReranking.