### PR TITLE
Improve base URL logic to prevent double path segments

### DIFF
--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -83,6 +83,10 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextPro
     {
         $url = rtrim($this->config['url'] ?? '', '/');
 
+        if (str_contains($url, '/openai/v1')) {
+            return $url;
+        }
+
         return "{$url}/openai/v1";
     }
 }


### PR DESCRIPTION
handle direct OpenAI V1 URLs in Azure provider: If the URL already contains '/openai/v1', return it immediately to prevent redundant path appending.