### PR TITLE
Add content moderation support via OpenAI moderations endpoint

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -19,6 +19,7 @@ return [
     'default_for_transcription' => 'openai',
     'default_for_embeddings' => 'openai',
     'default_for_reranking' => 'cohere',
+    'default_for_moderation' => 'openai',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\ModerationProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
@@ -39,6 +40,7 @@ class AiManager extends MultipleInstanceManager
     use Concerns\InteractsWithFakeEmbeddings;
     use Concerns\InteractsWithFakeFiles;
     use Concerns\InteractsWithFakeImages;
+    use Concerns\InteractsWithFakeModeration;
     use Concerns\InteractsWithFakeReranking;
     use Concerns\InteractsWithFakeStores;
     use Concerns\InteractsWithFakeTranscriptions;
@@ -131,6 +133,34 @@ class AiManager extends MultipleInstanceManager
 
         return $this->rerankingIsFaked()
             ? (clone $provider)->useRerankingGateway($this->fakeRerankingGateway())
+            : $provider;
+    }
+
+    /**
+     * Get a moderation provider instance by name.
+     *
+     * @throws LogicException
+     */
+    public function moderationProvider(?string $name = null): ModerationProvider
+    {
+        return tap($this->instance($name), function ($instance) {
+            if (! $instance instanceof ModerationProvider) {
+                throw new LogicException('Provider ['.$instance::class.'] does not support moderation.');
+            }
+        });
+    }
+
+    /**
+     * Get a moderation provider instance, using a fake gateway if moderation is faked.
+     *
+     * @throws LogicException
+     */
+    public function fakeableModerationProvider(?string $name = null): ModerationProvider
+    {
+        $provider = $this->moderationProvider($name);
+
+        return $this->moderationIsFaked()
+            ? (clone $provider)->useModerationGateway($this->fakeModerationGateway())
             : $provider;
     }
 

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -56,6 +56,14 @@ class AiServiceProvider extends ServiceProvider
             return $request->generate(provider: $provider, model: $model)->embeddings[0];
         });
 
+        // Moderation macro...
+        Stringable::macro('moderate', function (
+            ?string $provider = null,
+            ?string $model = null,
+        ) {
+            return Moderation::check($this->value, provider: $provider, model: $model);
+        });
+
         // Reranking macro...
         Collection::macro('rerank', function (
             Closure|array|string $by,

--- a/src/Concerns/InteractsWithFakeModeration.php
+++ b/src/Concerns/InteractsWithFakeModeration.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Laravel\Ai\Concerns;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Gateway\FakeModerationGateway;
+use Laravel\Ai\Prompts\ModerationPrompt;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait InteractsWithFakeModeration
+{
+    /**
+     * The fake moderation gateway instance.
+     */
+    protected ?FakeModerationGateway $fakeModerationGateway = null;
+
+    /**
+     * All of the recorded moderations.
+     */
+    protected array $recordedModerations = [];
+
+    /**
+     * Fake moderation operations.
+     */
+    public function fakeModeration(Closure|array $responses = []): FakeModerationGateway
+    {
+        return $this->fakeModerationGateway = new FakeModerationGateway($responses);
+    }
+
+    /**
+     * Record a moderation.
+     */
+    public function recordModeration(ModerationPrompt $prompt): self
+    {
+        $this->recordedModerations[] = $prompt;
+
+        return $this;
+    }
+
+    /**
+     * Assert that a moderation was performed matching a given truth test.
+     */
+    public function assertChecked(Closure $callback): self
+    {
+        PHPUnit::assertTrue(
+            (new Collection($this->recordedModerations))->contains(function (ModerationPrompt $prompt) use ($callback) {
+                return $callback($prompt);
+            }),
+            'An expected moderation check was not recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that a moderation was not performed matching a given truth test.
+     */
+    public function assertNotChecked(Closure $callback): self
+    {
+        PHPUnit::assertTrue(
+            (new Collection($this->recordedModerations))->doesntContain(function (ModerationPrompt $prompt) use ($callback) {
+                return $callback($prompt);
+            }),
+            'An unexpected moderation check was recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that no moderations were performed.
+     */
+    public function assertNothingChecked(): self
+    {
+        PHPUnit::assertEmpty(
+            $this->recordedModerations,
+            'Unexpected moderation checks were recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Determine if moderation is faked.
+     */
+    public function moderationIsFaked(): bool
+    {
+        return $this->fakeModerationGateway !== null;
+    }
+
+    /**
+     * Get the fake moderation gateway.
+     */
+    public function fakeModerationGateway(): ?FakeModerationGateway
+    {
+        return $this->fakeModerationGateway;
+    }
+}

--- a/src/Contracts/Gateway/ModerationGateway.php
+++ b/src/Contracts/Gateway/ModerationGateway.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Gateway;
+
+use Laravel\Ai\Contracts\Providers\ModerationProvider;
+use Laravel\Ai\Responses\ModerationResponse;
+
+interface ModerationGateway
+{
+    /**
+     * Check the given input for content that may violate usage policies.
+     */
+    public function moderate(
+        ModerationProvider $provider,
+        string $model,
+        string $input
+    ): ModerationResponse;
+}

--- a/src/Contracts/Providers/ModerationProvider.php
+++ b/src/Contracts/Providers/ModerationProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Providers;
+
+use Laravel\Ai\Contracts\Gateway\ModerationGateway;
+use Laravel\Ai\Responses\ModerationResponse;
+
+interface ModerationProvider
+{
+    /**
+     * Check the given input for content that may violate usage policies.
+     */
+    public function moderate(string $input, ?string $model = null): ModerationResponse;
+
+    /**
+     * Get the provider's moderation gateway.
+     */
+    public function moderationGateway(): ModerationGateway;
+
+    /**
+     * Set the provider's moderation gateway.
+     */
+    public function useModerationGateway(ModerationGateway $gateway): self;
+
+    /**
+     * Get the name of the default moderation model.
+     */
+    public function defaultModerationModel(): string;
+}

--- a/src/Events/Moderated.php
+++ b/src/Events/Moderated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Prompts\ModerationPrompt;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\ModerationResponse;
+
+class Moderated
+{
+    public function __construct(
+        public string $invocationId,
+        public Provider $provider,
+        public string $model,
+        public ModerationPrompt $prompt,
+        public ModerationResponse $response,
+    ) {}
+}

--- a/src/Events/Moderating.php
+++ b/src/Events/Moderating.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Prompts\ModerationPrompt;
+use Laravel\Ai\Providers\Provider;
+
+class Moderating
+{
+    public function __construct(
+        public string $invocationId,
+        public Provider $provider,
+        public string $model,
+        public ModerationPrompt $prompt,
+    ) {}
+}

--- a/src/Gateway/FakeModerationGateway.php
+++ b/src/Gateway/FakeModerationGateway.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Closure;
+use Laravel\Ai\Contracts\Gateway\ModerationGateway;
+use Laravel\Ai\Contracts\Providers\ModerationProvider;
+use Laravel\Ai\Prompts\ModerationPrompt;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ModerationCategory;
+use Laravel\Ai\Responses\ModerationResponse;
+use RuntimeException;
+
+class FakeModerationGateway implements ModerationGateway
+{
+    protected int $currentResponseIndex = 0;
+
+    protected bool $preventStrayModerations = false;
+
+    public function __construct(
+        protected Closure|array $responses = [],
+    ) {}
+
+    /**
+     * Check the given input for content that may violate usage policies.
+     */
+    public function moderate(
+        ModerationProvider $provider,
+        string $model,
+        string $input
+    ): ModerationResponse {
+        $prompt = new ModerationPrompt($input, $provider, $model);
+
+        return $this->nextResponse($provider, $model, $prompt);
+    }
+
+    /**
+     * Get the next response instance.
+     */
+    protected function nextResponse(
+        ModerationProvider $provider,
+        string $model,
+        ModerationPrompt $prompt
+    ): ModerationResponse {
+        $response = is_array($this->responses)
+            ? ($this->responses[$this->currentResponseIndex] ?? null)
+            : call_user_func($this->responses, $prompt);
+
+        return tap($this->marshalResponse(
+            $response, $provider, $model, $prompt
+        ), fn () => $this->currentResponseIndex++);
+    }
+
+    /**
+     * Marshal the given response into a full response instance.
+     */
+    protected function marshalResponse(
+        mixed $response,
+        ModerationProvider $provider,
+        string $model,
+        ModerationPrompt $prompt
+    ): ModerationResponse {
+        if ($response instanceof Closure) {
+            $response = $response($prompt);
+        }
+
+        if (is_null($response)) {
+            if ($this->preventStrayModerations) {
+                throw new RuntimeException('Attempted moderation without a fake response.');
+            }
+
+            $response = $this->generateFakeModeration();
+        }
+
+        if ($response instanceof ModerationResponse) {
+            return $response;
+        }
+
+        if (is_array($response) && isset($response[0]) && $response[0] instanceof ModerationCategory) {
+            $flagged = array_any($response, fn (ModerationCategory $category) => $category->flagged);
+
+            return new ModerationResponse(
+                $flagged,
+                $response,
+                new Meta($provider->name(), $model),
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Generate a fake moderation response.
+     *
+     * @return array<int, ModerationCategory>
+     */
+    protected function generateFakeModeration(): array
+    {
+        return [
+            new ModerationCategory('hate', false, 0.0001),
+            new ModerationCategory('hate/threatening', false, 0.0001),
+            new ModerationCategory('harassment', false, 0.0001),
+            new ModerationCategory('harassment/threatening', false, 0.0001),
+            new ModerationCategory('illicit', false, 0.0001),
+            new ModerationCategory('illicit/violent', false, 0.0001),
+            new ModerationCategory('self-harm', false, 0.0001),
+            new ModerationCategory('self-harm/intent', false, 0.0001),
+            new ModerationCategory('self-harm/instructions', false, 0.0001),
+            new ModerationCategory('sexual', false, 0.0001),
+            new ModerationCategory('sexual/minors', false, 0.0001),
+            new ModerationCategory('violence', false, 0.0001),
+            new ModerationCategory('violence/graphic', false, 0.0001),
+        ];
+    }
+
+    /**
+     * Indicate that an exception should be thrown if any moderation is not faked.
+     */
+    public function preventStrayModerations(bool $prevent = true): self
+    {
+        $this->preventStrayModerations = $prevent;
+
+        return $this;
+    }
+}

--- a/src/Gateway/OpenAiModerationGateway.php
+++ b/src/Gateway/OpenAiModerationGateway.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\ModerationGateway;
+use Laravel\Ai\Contracts\Providers\ModerationProvider;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ModerationCategory;
+use Laravel\Ai\Responses\ModerationResponse;
+
+class OpenAiModerationGateway implements ModerationGateway
+{
+    /**
+     * Check the given input for content that may violate usage policies.
+     */
+    public function moderate(
+        ModerationProvider $provider,
+        string $model,
+        string $input
+    ): ModerationResponse {
+        $response = $this->client($provider)->post('/moderations', [
+            'model' => $model,
+            'input' => $input,
+        ]);
+
+        $data = $response->json();
+
+        $result = $data['results'][0];
+
+        $categories = (new Collection($result['categories']))->map(
+            fn (bool $flagged, string $name) => new ModerationCategory(
+                name: $name,
+                flagged: $flagged,
+                score: $result['category_scores'][$name] ?? 0.0,
+            )
+        )->values()->all();
+
+        return new ModerationResponse(
+            $result['flagged'],
+            $categories,
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Get an HTTP client for the OpenAI API.
+     */
+    protected function client(ModerationProvider $provider): PendingRequest
+    {
+        return Http::baseUrl('https://api.openai.com/v1')
+            ->withHeaders([
+                'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
+                'Content-Type' => 'application/json',
+            ])
+            ->throw();
+    }
+}

--- a/src/Moderation.php
+++ b/src/Moderation.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Ai;
+
+use Closure;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\FakeModerationGateway;
+use Laravel\Ai\PendingResponses\PendingModeration;
+use Laravel\Ai\Responses\ModerationResponse;
+
+class Moderation
+{
+    /**
+     * Check the given input for content that may violate usage policies.
+     */
+    public static function check(string $input, Lab|array|string|null $provider = null, ?string $model = null): ModerationResponse
+    {
+        return (new PendingModeration($input))->check($provider, $model);
+    }
+
+    /**
+     * Fake moderation operations.
+     */
+    public static function fake(Closure|array $responses = []): FakeModerationGateway
+    {
+        return Ai::fakeModeration($responses);
+    }
+
+    /**
+     * Assert that a moderation was performed matching a given truth test.
+     */
+    public static function assertChecked(Closure $callback): void
+    {
+        Ai::assertChecked($callback);
+    }
+
+    /**
+     * Assert that a moderation was not performed matching a given truth test.
+     */
+    public static function assertNotChecked(Closure $callback): void
+    {
+        Ai::assertNotChecked($callback);
+    }
+
+    /**
+     * Assert that no moderations were performed.
+     */
+    public static function assertNothingChecked(): void
+    {
+        Ai::assertNothingChecked();
+    }
+
+    /**
+     * Determine if moderation is faked.
+     */
+    public static function isFaked(): bool
+    {
+        return Ai::moderationIsFaked();
+    }
+}

--- a/src/PendingResponses/PendingModeration.php
+++ b/src/PendingResponses/PendingModeration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Ai\PendingResponses;
+
+use Illuminate\Support\Traits\Conditionable;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Events\ProviderFailedOver;
+use Laravel\Ai\Exceptions\FailoverableException;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\ModerationResponse;
+
+class PendingModeration
+{
+    use Conditionable;
+
+    /**
+     * Create a new pending moderation instance.
+     */
+    public function __construct(
+        protected string $input,
+    ) {}
+
+    /**
+     * Check the input for content that may violate usage policies.
+     */
+    public function check(Lab|array|string|null $provider = null, ?string $model = null): ModerationResponse
+    {
+        $providers = Provider::formatProviderAndModelList(
+            $provider ?? config('ai.default_for_moderation'), $model
+        );
+
+        foreach ($providers as $provider => $model) {
+            $provider = Ai::fakeableModerationProvider($provider);
+
+            $model ??= $provider->defaultModerationModel();
+
+            try {
+                return $provider->moderate($this->input, $model);
+            } catch (FailoverableException $e) {
+                event(new ProviderFailedOver($provider, $model, $e));
+
+                continue;
+            }
+        }
+
+        throw $e;
+    }
+}

--- a/src/Prompts/ModerationPrompt.php
+++ b/src/Prompts/ModerationPrompt.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Ai\Prompts;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Providers\ModerationProvider;
+
+class ModerationPrompt
+{
+    /**
+     * Create a new moderation prompt instance.
+     */
+    public function __construct(
+        public readonly string $input,
+        public readonly ModerationProvider $provider,
+        public readonly string $model,
+    ) {}
+
+    /**
+     * Determine if the input contains the given string.
+     */
+    public function contains(string $string): bool
+    {
+        return Str::contains($this->input, $string);
+    }
+}

--- a/src/Providers/Concerns/HasModerationGateway.php
+++ b/src/Providers/Concerns/HasModerationGateway.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Laravel\Ai\Contracts\Gateway\ModerationGateway;
+
+trait HasModerationGateway
+{
+    protected ModerationGateway $moderationGateway;
+
+    /**
+     * Get the provider's moderation gateway.
+     */
+    public function moderationGateway(): ModerationGateway
+    {
+        return $this->moderationGateway;
+    }
+
+    /**
+     * Set the provider's moderation gateway.
+     */
+    public function useModerationGateway(ModerationGateway $gateway): self
+    {
+        $this->moderationGateway = $gateway;
+
+        return $this;
+    }
+}

--- a/src/Providers/Concerns/Moderates.php
+++ b/src/Providers/Concerns/Moderates.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Events\Moderated;
+use Laravel\Ai\Events\Moderating;
+use Laravel\Ai\Prompts\ModerationPrompt;
+use Laravel\Ai\Responses\ModerationResponse;
+
+trait Moderates
+{
+    /**
+     * Check the given input for content that may violate usage policies.
+     */
+    public function moderate(string $input, ?string $model = null): ModerationResponse
+    {
+        $invocationId = (string) Str::uuid7();
+
+        $model ??= $this->defaultModerationModel();
+
+        $prompt = new ModerationPrompt($input, $this, $model);
+
+        if (Ai::moderationIsFaked()) {
+            Ai::recordModeration($prompt);
+        }
+
+        $this->events->dispatch(new Moderating(
+            $invocationId, $this, $model, $prompt,
+        ));
+
+        return tap($this->moderationGateway()->moderate(
+            $this,
+            $model,
+            $input
+        ), fn (ModerationResponse $response) => $this->events->dispatch(new Moderated(
+            $invocationId, $this, $model, $prompt, $response,
+        )));
+    }
+}

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -4,22 +4,25 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
+use Laravel\Ai\Contracts\Gateway\ModerationGateway;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\ModerationProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\OpenAiFileGateway;
+use Laravel\Ai\Gateway\OpenAiModerationGateway;
 use Laravel\Ai\Gateway\OpenAiStoreGateway;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
+class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, ModerationProvider, StoreProvider, SupportsFileSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
@@ -30,11 +33,13 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasFileGateway;
     use Concerns\HasImageGateway;
+    use Concerns\HasModerationGateway;
     use Concerns\HasStoreGateway;
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
     use Concerns\ManagesFiles;
     use Concerns\ManagesStores;
+    use Concerns\Moderates;
     use Concerns\StreamsText;
 
     /**
@@ -157,6 +162,22 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     public function defaultEmbeddingsDimensions(): int
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 1536;
+    }
+
+    /**
+     * Get the name of the default moderation model.
+     */
+    public function defaultModerationModel(): string
+    {
+        return $this->config['models']['moderation']['default'] ?? 'omni-moderation-latest';
+    }
+
+    /**
+     * Get the provider's moderation gateway.
+     */
+    public function moderationGateway(): ModerationGateway
+    {
+        return $this->moderationGateway ??= new OpenAiModerationGateway;
     }
 
     /**

--- a/src/Responses/Data/ModerationCategory.php
+++ b/src/Responses/Data/ModerationCategory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Ai\Responses\Data;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+use Stringable;
+
+class ModerationCategory implements Arrayable, JsonSerializable, Stringable
+{
+    /**
+     * Create a new moderation category instance.
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly bool $flagged,
+        public readonly float $score,
+    ) {}
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'flagged' => $this->flagged,
+            'score' => $this->score,
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Get the category name.
+     */
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Responses/ModerationResponse.php
+++ b/src/Responses/ModerationResponse.php
@@ -37,7 +37,7 @@ class ModerationResponse implements Arrayable, Countable, IteratorAggregate, Jso
     /**
      * Get only the flagged categories.
      */
-    public function flagged(): Collection
+    public function flaggedCategories(): Collection
     {
         return (new Collection($this->categories))->filter->flagged->values();
     }

--- a/src/Responses/ModerationResponse.php
+++ b/src/Responses/ModerationResponse.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use Countable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+use IteratorAggregate;
+use JsonSerializable;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ModerationCategory;
+use Traversable;
+
+class ModerationResponse implements Arrayable, Countable, IteratorAggregate, JsonSerializable
+{
+    /**
+     * Create a new moderation response instance.
+     *
+     * @param  array<int, ModerationCategory>  $categories
+     */
+    public function __construct(
+        public readonly bool $flagged,
+        public readonly array $categories,
+        public readonly Meta $meta,
+    ) {}
+
+    /**
+     * Get a specific category by name.
+     */
+    public function category(string $name): ?ModerationCategory
+    {
+        return (new Collection($this->categories))->first(
+            fn (ModerationCategory $category) => $category->name === $name
+        );
+    }
+
+    /**
+     * Get only the flagged categories.
+     */
+    public function flagged(): Collection
+    {
+        return (new Collection($this->categories))->filter->flagged->values();
+    }
+
+    /**
+     * Get the number of categories in the response.
+     */
+    public function count(): int
+    {
+        return count($this->categories);
+    }
+
+    /**
+     * Get the categories as a collection.
+     */
+    public function collect(): Collection
+    {
+        return new Collection($this->categories);
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'flagged' => $this->flagged,
+            'categories' => $this->categories,
+            'meta' => $this->meta,
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Get an iterator for the categories.
+     */
+    public function getIterator(): Traversable
+    {
+        foreach ($this->categories as $category) {
+            yield $category;
+        }
+    }
+}

--- a/tests/Feature/ModerationFakeTest.php
+++ b/tests/Feature/ModerationFakeTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Moderation;
+use Laravel\Ai\Prompts\ModerationPrompt;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ModerationCategory;
+use Laravel\Ai\Responses\ModerationResponse;
+use RuntimeException;
+use Tests\TestCase;
+
+class ModerationFakeTest extends TestCase
+{
+    public function test_moderation_can_be_faked(): void
+    {
+        Moderation::fake();
+
+        $response = Moderation::check('Hello world');
+
+        $this->assertFalse($response->flagged);
+        $this->assertCount(13, $response->categories);
+        $this->assertInstanceOf(ModerationCategory::class, $response->categories[0]);
+    }
+
+    public function test_moderation_can_be_faked_with_no_predefined_responses(): void
+    {
+        Moderation::fake();
+
+        $response = Moderation::check('First input');
+        $this->assertFalse($response->flagged);
+        $this->assertCount(13, $response->categories);
+
+        $response = Moderation::check('Second input');
+        $this->assertFalse($response->flagged);
+        $this->assertCount(13, $response->categories);
+    }
+
+    public function test_moderation_can_be_faked_with_predefined_responses(): void
+    {
+        Moderation::fake([
+            new ModerationResponse(
+                true,
+                [
+                    new ModerationCategory('hate', true, 0.95),
+                    new ModerationCategory('violence', false, 0.01),
+                ],
+                new Meta,
+            ),
+            new ModerationResponse(
+                false,
+                [
+                    new ModerationCategory('hate', false, 0.01),
+                ],
+                new Meta,
+            ),
+        ]);
+
+        $response = Moderation::check('First input');
+        $this->assertTrue($response->flagged);
+        $this->assertCount(2, $response->categories);
+        $this->assertEquals(0.95, $response->category('hate')->score);
+        $this->assertNull($response->category('nonexistent'));
+
+        $response = Moderation::check('Second input');
+        $this->assertFalse($response->flagged);
+        $this->assertCount(1, $response->categories);
+    }
+
+    public function test_moderation_can_be_faked_with_category_arrays(): void
+    {
+        Moderation::fake([
+            [
+                new ModerationCategory('hate', true, 0.9),
+                new ModerationCategory('violence', true, 0.8),
+                new ModerationCategory('sexual', false, 0.01),
+            ],
+        ]);
+
+        $response = Moderation::check('Hateful content');
+
+        $this->assertTrue($response->flagged);
+        $this->assertCount(3, $response->categories);
+        $this->assertTrue($response->category('hate')->flagged);
+        $this->assertTrue($response->category('violence')->flagged);
+        $this->assertCount(2, $response->flagged());
+        $this->assertEquals('hate', (string) $response->flagged()[0]);
+    }
+
+    public function test_moderation_can_be_faked_with_closure(): void
+    {
+        Moderation::fake(function (ModerationPrompt $prompt) {
+            if ($prompt->contains('hate')) {
+                return new ModerationResponse(
+                    true,
+                    [new ModerationCategory('hate', true, 0.99)],
+                    new Meta,
+                );
+            }
+
+            return new ModerationResponse(
+                false,
+                [new ModerationCategory('hate', false, 0.01)],
+                new Meta,
+            );
+        });
+
+        $response = Moderation::check('I hate this');
+        $this->assertTrue($response->flagged);
+        $this->assertEquals(0.99, $response->category('hate')->score);
+
+        $response = Moderation::check('I love this');
+        $this->assertFalse($response->flagged);
+    }
+
+    public function test_moderation_can_be_faked_with_a_single_closure_that_is_invoked_for_every_check(): void
+    {
+        Moderation::fake(function (ModerationPrompt $prompt) {
+            return new ModerationResponse(
+                false,
+                [new ModerationCategory('custom', false, 0.001)],
+                new Meta,
+            );
+        });
+
+        $response = Moderation::check('First input');
+        $this->assertFalse($response->flagged);
+        $this->assertEquals('custom', $response->categories[0]->name);
+
+        $response = Moderation::check('Second input');
+        $this->assertFalse($response->flagged);
+        $this->assertEquals('custom', $response->categories[0]->name);
+    }
+
+    public function test_moderation_can_be_faked_with_closures_in_response_array(): void
+    {
+        Moderation::fake([
+            fn (ModerationPrompt $prompt) => new ModerationResponse(
+                true,
+                [new ModerationCategory('hate', true, 0.9)],
+                new Meta,
+            ),
+            fn (ModerationPrompt $prompt) => new ModerationResponse(
+                false,
+                [new ModerationCategory('hate', false, 0.1)],
+                new Meta,
+            ),
+        ]);
+
+        $response = Moderation::check('First');
+        $this->assertTrue($response->flagged);
+
+        $response = Moderation::check('Second');
+        $this->assertFalse($response->flagged);
+    }
+
+    public function test_can_assert_checked(): void
+    {
+        Moderation::fake();
+
+        Moderation::check('Hello world');
+
+        Moderation::assertChecked(function (ModerationPrompt $prompt) {
+            return $prompt->contains('Hello');
+        });
+    }
+
+    public function test_can_assert_not_checked(): void
+    {
+        Moderation::fake();
+
+        Moderation::check('Hello world');
+
+        Moderation::assertNotChecked(function (ModerationPrompt $prompt) {
+            return $prompt->contains('Goodbye');
+        });
+    }
+
+    public function test_can_assert_nothing_checked(): void
+    {
+        Moderation::fake();
+
+        Moderation::assertNothingChecked();
+    }
+
+    public function test_moderation_can_prevent_stray_moderations(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        Moderation::fake()->preventStrayModerations();
+
+        Moderation::check('Hello world');
+    }
+
+    public function test_moderation_is_faked(): void
+    {
+        $this->assertFalse(Moderation::isFaked());
+
+        Moderation::fake();
+
+        $this->assertTrue(Moderation::isFaked());
+    }
+
+    public function test_check_accepts_ai_provider_enum(): void
+    {
+        Moderation::fake();
+
+        Moderation::check('Enum moderation', provider: Lab::OpenAI);
+
+        Moderation::assertChecked(fn (ModerationPrompt $prompt) => $prompt->contains('Enum moderation'));
+    }
+
+    public function test_check_accepts_provider_and_model(): void
+    {
+        Moderation::fake();
+
+        Moderation::check('Test input', provider: 'openai', model: 'omni-moderation-latest');
+
+        Moderation::assertChecked(function (ModerationPrompt $prompt) {
+            return $prompt->input === 'Test input'
+                && $prompt->model === 'omni-moderation-latest';
+        });
+    }
+
+    public function test_fake_default_categories_are_present(): void
+    {
+        Moderation::fake();
+
+        $response = Moderation::check('Test content');
+
+        $expectedCategories = [
+            'hate', 'hate/threatening', 'harassment', 'harassment/threatening',
+            'illicit', 'illicit/violent', 'self-harm', 'self-harm/intent',
+            'self-harm/instructions', 'sexual', 'sexual/minors', 'violence',
+            'violence/graphic',
+        ];
+
+        foreach ($expectedCategories as $name) {
+            $category = $response->category($name);
+            $this->assertNotNull($category, "Category '{$name}' should exist.");
+            $this->assertFalse($category->flagged);
+            $this->assertEquals(0.0001, $category->score);
+        }
+    }
+
+    public function test_prompt_input_is_recorded(): void
+    {
+        Moderation::fake();
+
+        Moderation::check('This is a test input');
+
+        Moderation::assertChecked(function (ModerationPrompt $prompt) {
+            return $prompt->input === 'This is a test input';
+        });
+    }
+}

--- a/tests/Feature/ModerationFakeTest.php
+++ b/tests/Feature/ModerationFakeTest.php
@@ -84,8 +84,8 @@ class ModerationFakeTest extends TestCase
         $this->assertCount(3, $response->categories);
         $this->assertTrue($response->category('hate')->flagged);
         $this->assertTrue($response->category('violence')->flagged);
-        $this->assertCount(2, $response->flagged());
-        $this->assertEquals('hate', (string) $response->flagged()[0]);
+        $this->assertCount(2, $response->flaggedCategories());
+        $this->assertEquals('hate', (string) $response->flaggedCategories()[0]);
     }
 
     public function test_moderation_can_be_faked_with_closure(): void

--- a/tests/Feature/ModerationIntegrationTest.php
+++ b/tests/Feature/ModerationIntegrationTest.php
@@ -32,7 +32,7 @@ class ModerationIntegrationTest extends TestCase
 
         $this->assertInstanceOf(ModerationResponse::class, $response);
         $this->assertTrue($response->flagged);
-        $this->assertTrue($response->flagged()->isNotEmpty());
+        $this->assertTrue($response->flaggedCategories()->isNotEmpty());
         $this->assertNotNull($response->category('violence'));
     }
 

--- a/tests/Feature/ModerationIntegrationTest.php
+++ b/tests/Feature/ModerationIntegrationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Events\Moderated;
+use Laravel\Ai\Events\Moderating;
+use Laravel\Ai\Moderation;
+use Laravel\Ai\Responses\ModerationResponse;
+use Tests\TestCase;
+
+class ModerationIntegrationTest extends TestCase
+{
+    public function test_input_can_be_moderated(): void
+    {
+        Event::fake();
+
+        $response = Moderation::check('I love programming with Laravel.');
+
+        $this->assertInstanceOf(ModerationResponse::class, $response);
+        $this->assertFalse($response->flagged);
+        $this->assertNotEmpty($response->categories);
+        $this->assertEquals('openai', $response->meta->provider);
+
+        Event::assertDispatched(Moderating::class);
+        Event::assertDispatched(Moderated::class);
+    }
+
+    public function test_flagged_input_is_detected(): void
+    {
+        $response = Moderation::check('I want hurt someone.');
+
+        $this->assertInstanceOf(ModerationResponse::class, $response);
+        $this->assertTrue($response->flagged);
+        $this->assertTrue($response->flagged()->isNotEmpty());
+        $this->assertNotNull($response->category('violence'));
+    }
+
+    public function test_input_can_be_moderated_with_specific_model(): void
+    {
+        $response = Moderation::check(
+            'Hello world',
+            provider: 'openai',
+            model: 'omni-moderation-latest'
+        );
+
+        $this->assertInstanceOf(ModerationResponse::class, $response);
+        $this->assertEquals('omni-moderation-latest', $response->meta->model);
+    }
+
+    public function test_input_can_be_moderated_using_stringable_macro(): void
+    {
+        $response = str('I love Laravel.')->moderate();
+
+        $this->assertInstanceOf(ModerationResponse::class, $response);
+        $this->assertFalse($response->flagged);
+    }
+}

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -147,7 +147,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function testInvokeTool(Tool $tool, array $arguments): string
+            public function test_invoke_tool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }


### PR DESCRIPTION
- Add content moderation support via OpenAI's /moderations endpoint
- Support for all 13 moderation categories with flagged status and confidence scores

```php
use Laravel\Ai\Moderation;

$response = Moderation::check('I want to hurt someone');

 // true/false
$response->flagged;                      

// all categories
$response->categories;

// only flagged ones
$response->flaggedCategories(); 

// specific category
$response->category('violence');

```