### PR TITLE
CLI providers for subscription based AI usage

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -124,6 +124,24 @@ return [
             'driver' => 'xai',
             'key' => env('XAI_API_KEY'),
         ],
+
+        // 'claude-cli' => [
+        //     'driver' => 'claude-cli',
+        //     'default_model' => 'sonnet',
+        //     'timeout' => 300,
+        // ],
+
+        // 'codex-cli' => [
+        //     'driver' => 'codex-cli',
+        //     'default_model' => 'gpt-4.1',
+        //     'timeout' => 300,
+        // ],
+
+        // 'gemini-cli' => [
+        //     'driver' => 'gemini-cli',
+        //     'default_model' => 'gemini-2.5-flash',
+        //     'timeout' => 120,
+        // ],
     ],
 
 ];

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -13,7 +13,7 @@ return new class extends AiMigration
     {
         Schema::create('agent_conversations', function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->string('user_id')->nullable();
+            $table->foreignId('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -23,7 +23,7 @@ return new class extends AiMigration
         Schema::create('agent_conversation_messages', function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->string('user_id')->nullable();
+            $table->foreignId('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -15,8 +15,12 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
+use Laravel\Ai\Gateway\Cli\ClaudeCliGateway;
+use Laravel\Ai\Gateway\Cli\CodexCliGateway;
+use Laravel\Ai\Gateway\Cli\GeminiCliGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
 use Laravel\Ai\Providers\AzureOpenAiProvider;
+use Laravel\Ai\Providers\CliProvider;
 use Laravel\Ai\Providers\CohereProvider;
 use Laravel\Ai\Providers\DeepSeekProvider;
 use Laravel\Ai\Providers\ElevenLabsProvider;
@@ -283,6 +287,42 @@ class AiManager extends MultipleInstanceManager
             new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a Claude CLI powered instance.
+     */
+    public function createClaudeCliDriver(array $config): CliProvider
+    {
+        return new CliProvider(
+            new ClaudeCliGateway($config),
+            $config,
+            $this->app->make(Dispatcher::class),
+        );
+    }
+
+    /**
+     * Create a Codex CLI powered instance.
+     */
+    public function createCodexCliDriver(array $config): CliProvider
+    {
+        return new CliProvider(
+            new CodexCliGateway($config),
+            $config,
+            $this->app->make(Dispatcher::class),
+        );
+    }
+
+    /**
+     * Create a Gemini CLI powered instance.
+     */
+    public function createGeminiCliDriver(array $config): CliProvider
+    {
+        return new CliProvider(
+            new GeminiCliGateway($config),
+            $config,
+            $this->app->make(Dispatcher::class),
         );
     }
 

--- a/src/Exceptions/CliProcessException.php
+++ b/src/Exceptions/CliProcessException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+class CliProcessException extends AiException implements FailoverableException
+{
+    //
+}

--- a/src/Gateway/Cli/ClaudeCliGateway.php
+++ b/src/Gateway/Cli/ClaudeCliGateway.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Cli;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Exceptions\CliProcessException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+
+class ClaudeCliGateway extends CliGateway
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $conversationKey = $this->conversationKey($instructions, $messages);
+        $isContinuation = $this->isContinuation($messages);
+        $sessionId = $isContinuation ? $this->getSession($conversationKey) : null;
+
+        $command = $this->buildCommand($model, $instructions, $schema, $sessionId, $isContinuation);
+        $stdin = $isContinuation && $sessionId
+            ? $this->lastUserMessage($messages)
+            : $this->formatAllMessages(null, $messages);
+
+        $output = $this->runProcess($command, $stdin, $timeout);
+
+        $parsed = $this->parseJsonOutput($output);
+
+        if (isset($parsed['session_id'])) {
+            $this->storeSession($conversationKey, $parsed['session_id']);
+        }
+
+        $text = $parsed['result'] ?? $output;
+
+        if ($schema !== null && isset($parsed['structured_output'])) {
+            return new StructuredTextResponse(
+                $parsed['structured_output'],
+                is_array($parsed['structured_output']) ? json_encode($parsed['structured_output']) : (string) $parsed['structured_output'],
+                new Usage,
+                new Meta($provider->name(), $model),
+            );
+        }
+
+        return $this->makeTextResponse($text, $provider, $model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $conversationKey = $this->conversationKey($instructions, $messages);
+        $isContinuation = $this->isContinuation($messages);
+        $sessionId = $isContinuation ? $this->getSession($conversationKey) : null;
+
+        $command = $this->buildStreamCommand($model, $instructions, $sessionId, $isContinuation);
+        $stdin = $isContinuation && $sessionId
+            ? $this->lastUserMessage($messages)
+            : $this->formatAllMessages(null, $messages);
+
+        $process = $this->startProcess($command, $stdin, $timeout);
+
+        $messageId = (string) Str::uuid7();
+        $buffer = '';
+
+        try {
+            while ($process->isRunning()) {
+                $process->checkTimeout();
+
+                $incremental = $process->getIncrementalOutput();
+
+                if ($incremental === '') {
+                    usleep(10000); // 10ms
+
+                    continue;
+                }
+
+                $buffer .= $incremental;
+
+                while (($newlinePos = strpos($buffer, "\n")) !== false) {
+                    $line = substr($buffer, 0, $newlinePos);
+                    $buffer = substr($buffer, $newlinePos + 1);
+
+                    $delta = $this->parseStreamLine($line);
+
+                    if ($delta !== null) {
+                        yield new TextDelta(
+                            id: (string) Str::uuid7(),
+                            messageId: $messageId,
+                            delta: $delta,
+                            timestamp: time(),
+                        );
+                    }
+                }
+            }
+        } catch (ProcessTimedOutException $e) {
+            throw new CliProcessException(
+                'Claude CLI streaming timed out after '.$process->getTimeout().' seconds.',
+                previous: $e,
+            );
+        }
+
+        // Capture any output remaining in the process after it exited.
+        $buffer .= $process->getIncrementalOutput();
+
+        // Process any remaining buffer.
+        if ($buffer !== '') {
+            while (($newlinePos = strpos($buffer, "\n")) !== false) {
+                $line = substr($buffer, 0, $newlinePos);
+                $buffer = substr($buffer, $newlinePos + 1);
+
+                $delta = $this->parseStreamLine($line);
+
+                if ($delta !== null) {
+                    yield new TextDelta(
+                        id: (string) Str::uuid7(),
+                        messageId: $messageId,
+                        delta: $delta,
+                        timestamp: time(),
+                    );
+                }
+            }
+
+            // Handle any final line without a trailing newline.
+            if ($buffer !== '') {
+                $delta = $this->parseStreamLine($buffer);
+
+                if ($delta !== null) {
+                    yield new TextDelta(
+                        id: (string) Str::uuid7(),
+                        messageId: $messageId,
+                        delta: $delta,
+                        timestamp: time(),
+                    );
+                }
+            }
+        }
+
+        if (isset($this->sessions['_last_stream'])) {
+            $this->storeSession($conversationKey, $this->sessions['_last_stream']);
+            unset($this->sessions['_last_stream']);
+        }
+
+        if (! $process->isSuccessful()) {
+            $stderr = trim($process->getErrorOutput());
+
+            throw new CliProcessException(
+                $stderr ?: 'Claude CLI stream process exited with code '.$process->getExitCode().'.',
+            );
+        }
+
+        yield new StreamEnd(
+            id: (string) Str::uuid7(),
+            reason: 'end',
+            usage: new Usage,
+            timestamp: time(),
+        );
+    }
+
+    /**
+     * Build the command for a non-streaming request.
+     *
+     * @param  array<string, \Illuminate\JsonSchema\Types\Type>|null  $schema
+     * @return string[]
+     */
+    protected function buildCommand(string $model, ?string $instructions, ?array $schema, ?string $sessionId, bool $isContinuation): array
+    {
+        $command = [$this->binary(), '-p', '-', '--output-format', 'json'];
+
+        if ($instructions && ! ($isContinuation && $sessionId)) {
+            $command[] = '--system-prompt';
+            $command[] = $instructions;
+        }
+
+        if ($model) {
+            $command[] = '--model';
+            $command[] = $model;
+        }
+
+        if ($isContinuation && $sessionId) {
+            $command[] = '--resume';
+            $command[] = $sessionId;
+        }
+
+        if ($schema !== null) {
+            $command[] = '--json-schema';
+            $command[] = json_encode($this->convertSchema($schema));
+        }
+
+        return $command;
+    }
+
+    /**
+     * Build the command for a streaming request.
+     *
+     * @return string[]
+     */
+    protected function buildStreamCommand(string $model, ?string $instructions, ?string $sessionId, bool $isContinuation): array
+    {
+        $command = [$this->binary(), '-p', '-', '--output-format', 'stream-json', '--verbose', '--include-partial-messages'];
+
+        if ($instructions && ! ($isContinuation && $sessionId)) {
+            $command[] = '--system-prompt';
+            $command[] = $instructions;
+        }
+
+        if ($model) {
+            $command[] = '--model';
+            $command[] = $model;
+        }
+
+        if ($isContinuation && $sessionId) {
+            $command[] = '--resume';
+            $command[] = $sessionId;
+        }
+
+        return $command;
+    }
+
+    /**
+     * Parse the JSON output from Claude CLI.
+     *
+     * @return array<string, mixed>
+     */
+    protected function parseJsonOutput(string $output): array
+    {
+        $decoded = json_decode(trim($output), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_array($decoded)) {
+            return ['result' => $output];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Parse a single line from the stream-json output and return the text delta if present.
+     */
+    protected function parseStreamLine(string $line): ?string
+    {
+        $line = trim($line);
+
+        if ($line === '') {
+            return null;
+        }
+
+        $event = json_decode($line, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        // Claude stream-json with --include-partial-messages emits stream_event text deltas.
+        if (($event['type'] ?? null) === 'stream_event'
+            && ($event['event']['delta']['type'] ?? null) === 'text_delta') {
+            return $event['event']['delta']['text'] ?? null;
+        }
+
+        // Also capture the session_id from result events for session tracking.
+        if (($event['type'] ?? null) === 'result' && isset($event['session_id'])) {
+            $this->sessions['_last_stream'] = $event['session_id'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a Laravel AI schema array to a JSON Schema array.
+     *
+     * @param  array<string, \Illuminate\JsonSchema\Types\Type>  $schema
+     * @return array<string, mixed>
+     */
+    protected function convertSchema(array $schema): array
+    {
+        $properties = [];
+        $required = [];
+
+        foreach ($schema as $name => $type) {
+            $properties[$name] = $type->toArray();
+            $required[] = $name;
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $properties,
+            'required' => $required,
+        ];
+    }
+
+    /**
+     * Get the path to the Claude CLI binary.
+     */
+    protected function binary(): string
+    {
+        return $this->config['binary'] ?? 'claude';
+    }
+}

--- a/src/Gateway/Cli/CliGateway.php
+++ b/src/Gateway/Cli/CliGateway.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Cli;
+
+use Closure;
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Exceptions\CliProcessException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TextResponse;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
+abstract class CliGateway implements TextGateway
+{
+    protected ?Closure $invokingToolCallback = null;
+
+    protected ?Closure $toolInvokedCallback = null;
+
+    /**
+     * The session IDs tracked for conversation continuity.
+     *
+     * @var array<string, string>
+     */
+    protected array $sessions = [];
+
+    public function __construct(
+        protected array $config,
+    ) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse;
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onToolInvocation(Closure $invoking, Closure $invoked): self
+    {
+        $this->invokingToolCallback = $invoking;
+        $this->toolInvokedCallback = $invoked;
+
+        return $this;
+    }
+
+    /**
+     * Run a CLI process and return its stdout output.
+     *
+     * @param  string[]  $command
+     *
+     * @throws CliProcessException
+     */
+    protected function runProcess(array $command, ?string $stdin = null, ?int $timeout = null): string
+    {
+        $process = new Process(
+            $command,
+            null,
+            $this->environment(),
+            $stdin,
+            $timeout ?? $this->config['timeout'] ?? 300,
+        );
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException $e) {
+            throw new CliProcessException(
+                'CLI process timed out after '.$process->getTimeout().' seconds.',
+                previous: $e,
+            );
+        }
+
+        if (! $process->isSuccessful()) {
+            $stderr = trim($process->getErrorOutput());
+
+            throw new CliProcessException(
+                $stderr ?: 'CLI process exited with code '.$process->getExitCode().'.',
+            );
+        }
+
+        return $process->getOutput();
+    }
+
+    /**
+     * Start a CLI process for streaming and return the process instance.
+     *
+     * @param  string[]  $command
+     */
+    protected function startProcess(array $command, ?string $stdin = null, ?int $timeout = null): Process
+    {
+        $process = new Process(
+            $command,
+            null,
+            $this->environment(),
+            $stdin,
+            $timeout ?? $this->config['timeout'] ?? 300,
+        );
+
+        $process->start();
+
+        return $process;
+    }
+
+    /**
+     * Get the environment variables for the CLI process.
+     *
+     * @return array<string, string>
+     */
+    protected function environment(): array
+    {
+        $env = array_merge(getenv(), $this->config['env'] ?? []);
+
+        // Remove nesting-protection variables so CLI tools can be
+        // spawned from within other CLI tool sessions (e.g. Claude Code).
+        unset($env['CLAUDECODE'], $env['CLAUDE_CODE_ENTRYPOINT'], $env['CLAUDE_CODE_SESSION']);
+
+        return $env;
+    }
+
+    /**
+     * Determine if the given messages represent a continued conversation.
+     *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     */
+    protected function isContinuation(array $messages): bool
+    {
+        foreach ($messages as $message) {
+            if ($message instanceof AssistantMessage) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the last user message from the messages array.
+     *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     */
+    protected function lastUserMessage(array $messages): string
+    {
+        for ($i = count($messages) - 1; $i >= 0; $i--) {
+            if ($messages[$i] instanceof UserMessage) {
+                return $messages[$i]->content;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Format all messages into a single prompt string.
+     *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     */
+    protected function formatAllMessages(?string $instructions, array $messages): string
+    {
+        $parts = [];
+
+        if ($instructions) {
+            $parts[] = $instructions;
+        }
+
+        foreach ($messages as $message) {
+            if ($message instanceof UserMessage) {
+                $parts[] = $message->content;
+            } elseif ($message instanceof AssistantMessage) {
+                $parts[] = $message->content;
+            }
+        }
+
+        return implode("\n\n", $parts);
+    }
+
+    /**
+     * Generate a conversation key for session tracking.
+     *
+     * @param  \Laravel\Ai\Messages\Message[]  $messages
+     */
+    protected function conversationKey(?string $instructions, array $messages): string
+    {
+        $firstUserContent = '';
+
+        foreach ($messages as $message) {
+            if ($message instanceof UserMessage) {
+                $firstUserContent = $message->content;
+                break;
+            }
+        }
+
+        return md5(($instructions ?? '').$firstUserContent);
+    }
+
+    /**
+     * Store a session ID for a conversation.
+     */
+    protected function storeSession(string $conversationKey, string $sessionId): void
+    {
+        $this->sessions[$conversationKey] = $sessionId;
+    }
+
+    /**
+     * Retrieve a stored session ID for a conversation.
+     */
+    protected function getSession(string $conversationKey): ?string
+    {
+        return $this->sessions[$conversationKey] ?? null;
+    }
+
+    /**
+     * Create a new TextResponse with the given text and provider metadata.
+     */
+    protected function makeTextResponse(string $text, TextProvider $provider, string $model): TextResponse
+    {
+        return new TextResponse(
+            $text,
+            new Usage(0, 0),
+            new Meta($provider->name(), $model),
+        );
+    }
+}

--- a/src/Gateway/Cli/CodexCliGateway.php
+++ b/src/Gateway/Cli/CodexCliGateway.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Cli;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Exceptions\CliProcessException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+
+class CodexCliGateway extends CliGateway
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $conversationKey = $this->conversationKey($instructions, $messages);
+        $isContinuation = $this->isContinuation($messages);
+        $sessionId = $isContinuation ? $this->getSession($conversationKey) : null;
+
+        $command = $this->buildCommand($model, $instructions, $schema, $sessionId, $isContinuation);
+        $stdin = $isContinuation && $sessionId
+            ? $this->lastUserMessage($messages)
+            : $this->formatAllMessages(null, $messages);
+
+        $output = $this->runProcess($command, $stdin, $timeout);
+
+        $parsed = $this->parseOutput($output);
+
+        if (isset($parsed['session_id'])) {
+            $this->storeSession($conversationKey, $parsed['session_id']);
+        }
+
+        $text = $parsed['text'] ?? $output;
+
+        if ($schema !== null && isset($parsed['structured_output'])) {
+            return new StructuredTextResponse(
+                $parsed['structured_output'],
+                is_array($parsed['structured_output']) ? json_encode($parsed['structured_output']) : (string) $parsed['structured_output'],
+                new Usage,
+                new Meta($provider->name(), $model),
+            );
+        }
+
+        return $this->makeTextResponse($text, $provider, $model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $command = $this->buildCommand($model, $instructions, $schema, null, false, streaming: true);
+        $stdin = $this->formatAllMessages(null, $messages);
+
+        $process = $this->startProcess($command, $stdin, $timeout);
+
+        $messageId = (string) Str::uuid7();
+        $buffer = '';
+
+        try {
+            while ($process->isRunning()) {
+                $process->checkTimeout();
+
+                $incremental = $process->getIncrementalOutput();
+
+                if ($incremental === '') {
+                    usleep(10000);
+
+                    continue;
+                }
+
+                $buffer .= $incremental;
+
+                while (($newlinePos = strpos($buffer, "\n")) !== false) {
+                    $line = substr($buffer, 0, $newlinePos);
+                    $buffer = substr($buffer, $newlinePos + 1);
+
+                    $delta = $this->parseStreamLine($line);
+
+                    if ($delta !== null) {
+                        yield new TextDelta(
+                            id: (string) Str::uuid7(),
+                            messageId: $messageId,
+                            delta: $delta,
+                            timestamp: time(),
+                        );
+                    }
+                }
+            }
+        } catch (ProcessTimedOutException $e) {
+            throw new CliProcessException(
+                'Codex CLI streaming timed out after '.$process->getTimeout().' seconds.',
+                previous: $e,
+            );
+        }
+
+        // Capture any output remaining in the process after it exited.
+        $buffer .= $process->getIncrementalOutput();
+
+        if ($buffer !== '') {
+            while (($newlinePos = strpos($buffer, "\n")) !== false) {
+                $line = substr($buffer, 0, $newlinePos);
+                $buffer = substr($buffer, $newlinePos + 1);
+
+                $delta = $this->parseStreamLine($line);
+
+                if ($delta !== null) {
+                    yield new TextDelta(
+                        id: (string) Str::uuid7(),
+                        messageId: $messageId,
+                        delta: $delta,
+                        timestamp: time(),
+                    );
+                }
+            }
+
+            if ($buffer !== '') {
+                $delta = $this->parseStreamLine($buffer);
+
+                if ($delta !== null) {
+                    yield new TextDelta(
+                        id: (string) Str::uuid7(),
+                        messageId: $messageId,
+                        delta: $delta,
+                        timestamp: time(),
+                    );
+                }
+            }
+        }
+
+        if (! $process->isSuccessful()) {
+            $stderr = trim($process->getErrorOutput());
+
+            throw new CliProcessException(
+                $stderr ?: 'Codex CLI stream process exited with code '.$process->getExitCode().'.',
+            );
+        }
+
+        yield new StreamEnd(
+            id: (string) Str::uuid7(),
+            reason: 'end',
+            usage: new Usage,
+            timestamp: time(),
+        );
+    }
+
+    /**
+     * Build the command for a Codex CLI request.
+     *
+     * @param  array<string, \Illuminate\JsonSchema\Types\Type>|null  $schema
+     * @return string[]
+     */
+    protected function buildCommand(string $model, ?string $instructions, ?array $schema, ?string $sessionId, bool $isContinuation, bool $streaming = false): array
+    {
+        if ($isContinuation && $sessionId) {
+            $command = [$this->binary(), 'exec', 'resume', $sessionId];
+        } else {
+            $command = [$this->binary(), 'exec', '-'];
+        }
+
+        $command[] = '--json';
+        $command[] = '--skip-git-repo-check';
+
+        if ($model) {
+            $command[] = '--model';
+            $command[] = $model;
+        }
+
+        if ($instructions && ! ($isContinuation && $sessionId)) {
+            $command[] = '--system-prompt';
+            $command[] = $instructions;
+        }
+
+        if ($schema !== null) {
+            $command[] = '--output-schema';
+            $command[] = json_encode($this->convertSchema($schema));
+        }
+
+        return $command;
+    }
+
+    /**
+     * Parse the JSONL output from Codex CLI.
+     *
+     * @return array{text: string, session_id: ?string, structured_output: ?array<string, mixed>}
+     */
+    protected function parseOutput(string $output): array
+    {
+        $text = '';
+        $sessionId = null;
+        $structuredOutput = null;
+
+        foreach (explode("\n", trim($output)) as $line) {
+            $line = trim($line);
+
+            if ($line === '') {
+                continue;
+            }
+
+            $event = json_decode($line, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $text .= $line;
+
+                continue;
+            }
+
+            if (($event['type'] ?? null) === 'message' && isset($event['content'])) {
+                $text .= is_array($event['content']) ? json_encode($event['content']) : $event['content'];
+            }
+
+            if (isset($event['session_id'])) {
+                $sessionId = $event['session_id'];
+            }
+
+            if (isset($event['structured_output'])) {
+                $structuredOutput = $event['structured_output'];
+            }
+        }
+
+        return [
+            'text' => $text !== '' ? $text : $output,
+            'session_id' => $sessionId,
+            'structured_output' => $structuredOutput,
+        ];
+    }
+
+    /**
+     * Parse a single JSONL line from Codex streaming output.
+     */
+    protected function parseStreamLine(string $line): ?string
+    {
+        $line = trim($line);
+
+        if ($line === '') {
+            return null;
+        }
+
+        $event = json_decode($line, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        if (($event['type'] ?? null) === 'message' && isset($event['content'])) {
+            return is_array($event['content']) ? json_encode($event['content']) : $event['content'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a Laravel AI schema array to a JSON Schema array.
+     *
+     * @param  array<string, \Illuminate\JsonSchema\Types\Type>  $schema
+     * @return array<string, mixed>
+     */
+    protected function convertSchema(array $schema): array
+    {
+        $properties = [];
+        $required = [];
+
+        foreach ($schema as $name => $type) {
+            $properties[$name] = $type->toArray();
+            $required[] = $name;
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $properties,
+            'required' => $required,
+        ];
+    }
+
+    /**
+     * Get the path to the Codex CLI binary.
+     */
+    protected function binary(): string
+    {
+        return $this->config['binary'] ?? 'codex';
+    }
+}

--- a/src/Gateway/Cli/GeminiCliGateway.php
+++ b/src/Gateway/Cli/GeminiCliGateway.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Cli;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Exceptions\CliProcessException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+
+class GeminiCliGateway extends CliGateway
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        // Gemini CLI has no session management in headless mode,
+        // so we always format all messages into a single prompt.
+        $prompt = $this->formatAllMessages($instructions, $messages);
+
+        $command = $this->buildCommand($model, $prompt);
+
+        $output = $this->runProcess($command, null, $timeout);
+
+        $parsed = $this->parseJsonOutput($output);
+
+        $text = $parsed['response'] ?? $output;
+
+        return $this->makeTextResponse($text, $provider, $model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $prompt = $this->formatAllMessages($instructions, $messages);
+        $command = $this->buildCommand($model, $prompt);
+
+        $process = $this->startProcess($command, null, $timeout);
+
+        $messageId = (string) Str::uuid7();
+
+        try {
+            while ($process->isRunning()) {
+                $process->checkTimeout();
+
+                $incremental = $process->getIncrementalOutput();
+
+                if ($incremental === '') {
+                    usleep(10000);
+
+                    continue;
+                }
+
+                yield new TextDelta(
+                    id: (string) Str::uuid7(),
+                    messageId: $messageId,
+                    delta: $incremental,
+                    timestamp: time(),
+                );
+            }
+        } catch (ProcessTimedOutException $e) {
+            throw new CliProcessException(
+                'Gemini CLI streaming timed out after '.$process->getTimeout().' seconds.',
+                previous: $e,
+            );
+        }
+
+        // Capture any remaining output.
+        $remaining = $process->getIncrementalOutput();
+
+        if ($remaining !== '') {
+            yield new TextDelta(
+                id: (string) Str::uuid7(),
+                messageId: $messageId,
+                delta: $remaining,
+                timestamp: time(),
+            );
+        }
+
+        if (! $process->isSuccessful()) {
+            $stderr = trim($process->getErrorOutput());
+
+            throw new CliProcessException(
+                $stderr ?: 'Gemini CLI stream process exited with code '.$process->getExitCode().'.',
+            );
+        }
+
+        yield new StreamEnd(
+            id: (string) Str::uuid7(),
+            reason: 'end',
+            usage: new Usage,
+            timestamp: time(),
+        );
+    }
+
+    /**
+     * Build the command for a Gemini CLI request.
+     *
+     * @return string[]
+     */
+    protected function buildCommand(string $model, string $prompt = ''): array
+    {
+        $command = [$this->binary(), '--prompt', $prompt];
+
+        if ($model) {
+            $command[] = '--model';
+            $command[] = $model;
+        }
+
+        return $command;
+    }
+
+    /**
+     * Parse the JSON output from Gemini CLI.
+     *
+     * @return array<string, mixed>
+     */
+    protected function parseJsonOutput(string $output): array
+    {
+        $decoded = json_decode(trim($output), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_array($decoded)) {
+            return ['response' => trim($output)];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Get the path to the Gemini CLI binary.
+     */
+    protected function binary(): string
+    {
+        return $this->config['binary'] ?? 'gemini';
+    }
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -141,6 +141,8 @@ trait Promptable
     {
         $providers = $this->getProvidersAndModels($provider, $model);
 
+        $lastException = null;
+
         foreach ($providers as $provider => $model) {
             $provider = Ai::textProviderFor($this, $provider);
 
@@ -149,13 +151,15 @@ trait Promptable
             try {
                 return $callback($provider, $model);
             } catch (FailoverableException $e) {
+                $lastException = $e;
+
                 event(new AgentFailedOver($this, $provider, $model, $e));
 
                 continue;
             }
         }
 
-        throw $e;
+        throw $lastException ?? new \RuntimeException('No AI providers were configured.');
     }
 
     /**

--- a/src/Providers/CliProvider.php
+++ b/src/Providers/CliProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Cli\CliGateway;
+
+class CliProvider extends Provider implements TextProvider
+{
+    use Concerns\GeneratesText;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    public function __construct(
+        protected CliGateway $cliGateway,
+        protected array $config,
+        protected Dispatcher $events,
+    ) {}
+
+    /**
+     * Get the credentials for the underlying AI provider.
+     */
+    public function providerCredentials(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ?? $this->cliGateway;
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['default_model'] ?? 'default';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['cheapest'] ?? $this->defaultTextModel();
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['smartest'] ?? $this->defaultTextModel();
+    }
+}

--- a/tests/Feature/CliManagerTest.php
+++ b/tests/Feature/CliManagerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Gateway\Cli\ClaudeCliGateway;
+use Laravel\Ai\Gateway\Cli\CodexCliGateway;
+use Laravel\Ai\Gateway\Cli\GeminiCliGateway;
+use Laravel\Ai\Providers\CliProvider;
+use Tests\TestCase;
+
+class CliManagerTest extends TestCase
+{
+    private AiManager $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manager = $this->app->make(AiManager::class);
+    }
+
+    public function test_create_claude_cli_driver_returns_cli_provider(): void
+    {
+        $driver = $this->manager->createClaudeCliDriver(['name' => 'claude-cli', 'driver' => 'claude-cli', 'timeout' => 30]);
+        $this->assertInstanceOf(CliProvider::class, $driver);
+    }
+
+    public function test_create_codex_cli_driver_returns_cli_provider(): void
+    {
+        $driver = $this->manager->createCodexCliDriver(['name' => 'codex-cli', 'driver' => 'codex-cli', 'timeout' => 30]);
+        $this->assertInstanceOf(CliProvider::class, $driver);
+    }
+
+    public function test_create_gemini_cli_driver_returns_cli_provider(): void
+    {
+        $driver = $this->manager->createGeminiCliDriver(['name' => 'gemini-cli', 'driver' => 'gemini-cli', 'timeout' => 30]);
+        $this->assertInstanceOf(CliProvider::class, $driver);
+    }
+
+    public function test_claude_driver_text_gateway_is_claude_cli_gateway(): void
+    {
+        $driver = $this->manager->createClaudeCliDriver(['name' => 'claude-cli', 'driver' => 'claude-cli', 'timeout' => 30]);
+        $this->assertInstanceOf(ClaudeCliGateway::class, $driver->textGateway());
+    }
+
+    public function test_codex_driver_text_gateway_is_codex_cli_gateway(): void
+    {
+        $driver = $this->manager->createCodexCliDriver(['name' => 'codex-cli', 'driver' => 'codex-cli', 'timeout' => 30]);
+        $this->assertInstanceOf(CodexCliGateway::class, $driver->textGateway());
+    }
+
+    public function test_gemini_driver_text_gateway_is_gemini_cli_gateway(): void
+    {
+        $driver = $this->manager->createGeminiCliDriver(['name' => 'gemini-cli', 'driver' => 'gemini-cli', 'timeout' => 30]);
+        $this->assertInstanceOf(GeminiCliGateway::class, $driver->textGateway());
+    }
+}

--- a/tests/Feature/CliProviderTest.php
+++ b/tests/Feature/CliProviderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Gateway\Cli\ClaudeCliGateway;
+use Laravel\Ai\Gateway\Cli\GeminiCliGateway;
+use Laravel\Ai\Providers\CliProvider;
+use Tests\TestCase;
+
+class CliProviderTest extends TestCase
+{
+    private Dispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dispatcher = $this->app->make(Dispatcher::class);
+    }
+
+    public function test_text_gateway_returns_injected_cli_gateway(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 10]);
+        $provider = new CliProvider($gw, ['name' => 'test', 'driver' => 'claude-cli'], $this->dispatcher);
+        $this->assertSame($gw, $provider->textGateway());
+    }
+
+    public function test_default_text_model_returns_config_value(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'default_model' => 'opus'], $this->dispatcher);
+        $this->assertSame('opus', $provider->defaultTextModel());
+    }
+
+    public function test_default_text_model_returns_default_when_no_config(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'x', 'driver' => 'x'], $this->dispatcher);
+        $this->assertSame('default', $provider->defaultTextModel());
+    }
+
+    public function test_cheapest_text_model_returns_config_value(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'models' => ['cheapest' => 'haiku']], $this->dispatcher);
+        $this->assertSame('haiku', $provider->cheapestTextModel());
+    }
+
+    public function test_cheapest_text_model_falls_back_to_default(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'default_model' => 'sonnet'], $this->dispatcher);
+        $this->assertSame('sonnet', $provider->cheapestTextModel());
+    }
+
+    public function test_smartest_text_model_returns_config_value(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'models' => ['smartest' => 'opus']], $this->dispatcher);
+        $this->assertSame('opus', $provider->smartestTextModel());
+    }
+
+    public function test_smartest_text_model_falls_back_to_default(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'default_model' => 'sonnet'], $this->dispatcher);
+        $this->assertSame('sonnet', $provider->smartestTextModel());
+    }
+
+    public function test_use_text_gateway_overrides_injected_cli_gateway(): void
+    {
+        $original = new ClaudeCliGateway([]);
+        $override = new GeminiCliGateway([]);
+        $provider = new CliProvider($original, ['name' => 'test', 'driver' => 'test'], $this->dispatcher);
+
+        $this->assertSame($original, $provider->textGateway());
+        $provider->useTextGateway($override);
+        $this->assertSame($override, $provider->textGateway());
+    }
+
+    public function test_cheapest_cascades_to_default_model_to_default(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $p1 = new CliProvider($gw, ['name' => 'x', 'driver' => 'x'], $this->dispatcher);
+        $this->assertSame('default', $p1->cheapestTextModel());
+
+        $p2 = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'default_model' => 'sonnet'], $this->dispatcher);
+        $this->assertSame('sonnet', $p2->cheapestTextModel());
+    }
+
+    public function test_smartest_cascades_to_default_model_to_default(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $p1 = new CliProvider($gw, ['name' => 'x', 'driver' => 'x'], $this->dispatcher);
+        $this->assertSame('default', $p1->smartestTextModel());
+
+        $p2 = new CliProvider($gw, ['name' => 'x', 'driver' => 'x', 'default_model' => 'opus'], $this->dispatcher);
+        $this->assertSame('opus', $p2->smartestTextModel());
+    }
+
+    public function test_all_three_model_methods_independent(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, [
+            'name' => 'x', 'driver' => 'x',
+            'default_model' => 'sonnet',
+            'models' => ['cheapest' => 'haiku', 'smartest' => 'opus'],
+        ], $this->dispatcher);
+        $this->assertSame('sonnet', $provider->defaultTextModel());
+        $this->assertSame('haiku', $provider->cheapestTextModel());
+        $this->assertSame('opus', $provider->smartestTextModel());
+    }
+
+    public function test_provider_credentials_does_not_crash(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = new CliProvider($gw, ['name' => 'test', 'driver' => 'claude-cli'], $this->dispatcher);
+        $creds = $provider->providerCredentials();
+        $this->assertSame([], $creds);
+    }
+}

--- a/tests/Unit/Exceptions/CliProcessExceptionTest.php
+++ b/tests/Unit/Exceptions/CliProcessExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Exceptions;
+
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\CliProcessException;
+use Laravel\Ai\Exceptions\FailoverableException;
+use PHPUnit\Framework\TestCase;
+
+class CliProcessExceptionTest extends TestCase
+{
+    public function test_is_instance_of_ai_exception(): void
+    {
+        $e = new CliProcessException('test error');
+        $this->assertInstanceOf(AiException::class, $e);
+    }
+
+    public function test_is_instance_of_failoverable_exception(): void
+    {
+        $e = new CliProcessException('test error');
+        $this->assertInstanceOf(FailoverableException::class, $e);
+    }
+
+    public function test_carries_message_correctly(): void
+    {
+        $e = new CliProcessException('CLI failed');
+        $this->assertSame('CLI failed', $e->getMessage());
+    }
+
+    public function test_previous_exception_preserved(): void
+    {
+        $prev = new \RuntimeException('root cause');
+        $e = new CliProcessException('cli failed', previous: $prev);
+        $this->assertSame('cli failed', $e->getMessage());
+        $this->assertSame($prev, $e->getPrevious());
+        $this->assertSame('root cause', $e->getPrevious()->getMessage());
+    }
+
+    public function test_default_code_is_zero(): void
+    {
+        $e = new CliProcessException('error');
+        $this->assertSame(0, $e->getCode());
+    }
+}

--- a/tests/Unit/Gateway/Cli/ClaudeCliGatewayTest.php
+++ b/tests/Unit/Gateway/Cli/ClaudeCliGatewayTest.php
@@ -1,0 +1,619 @@
+<?php
+
+namespace Tests\Unit\Gateway\Cli;
+
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Cli\ClaudeCliGateway;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\UserMessage;
+use PHPUnit\Framework\TestCase;
+
+class ClaudeCliGatewayTest extends TestCase
+{
+    private ClaudeCliGateway $gw;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gw = new ClaudeCliGateway(['timeout' => 30]);
+    }
+
+    private function callMethod(object $obj, string $method, array $args = []): mixed
+    {
+        $ref = new \ReflectionMethod($obj, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($obj, $args);
+    }
+
+    private function getProperty(object $obj, string $prop): mixed
+    {
+        $ref = new \ReflectionProperty($obj, $prop);
+        $ref->setAccessible(true);
+
+        return $ref->getValue($obj);
+    }
+
+    private function mockProvider(string $name = 'test'): TextProvider
+    {
+        return new class($name) implements TextProvider
+        {
+            public function __construct(private string $n) {}
+
+            public function name(): string
+            {
+                return $this->n;
+            }
+
+            public function driver(): string
+            {
+                return $this->n;
+            }
+
+            public function prompt(\Laravel\Ai\Prompts\AgentPrompt $p): \Laravel\Ai\Responses\AgentResponse
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function stream(\Laravel\Ai\Prompts\AgentPrompt $p): \Laravel\Ai\Responses\StreamableAgentResponse
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function textGateway(): \Laravel\Ai\Contracts\Gateway\TextGateway
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function useTextGateway(\Laravel\Ai\Contracts\Gateway\TextGateway $g): self
+            {
+                return $this;
+            }
+
+            public function defaultTextModel(): string
+            {
+                return 'default';
+            }
+
+            public function cheapestTextModel(): string
+            {
+                return 'cheap';
+            }
+
+            public function smartestTextModel(): string
+            {
+                return 'smart';
+            }
+        };
+    }
+
+    private function mockArrayable(array $data): \Illuminate\Contracts\Support\Arrayable
+    {
+        return new class($data) implements \Illuminate\Contracts\Support\Arrayable
+        {
+            public function __construct(private array $data) {}
+
+            public function toArray(): array
+            {
+                return $this->data;
+            }
+        };
+    }
+
+    // ── A8: buildCommand() ──
+
+    public function test_build_command_base_includes_claude_p_dash_output_format_json(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, null, null, false]);
+        $this->assertSame('claude', $cmd[0]);
+        $this->assertSame('-p', $cmd[1]);
+        $this->assertSame('-', $cmd[2]);
+        $this->assertSame('--output-format', $cmd[3]);
+        $this->assertSame('json', $cmd[4]);
+    }
+
+    public function test_build_command_adds_model_when_non_empty(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['sonnet', null, null, null, false]);
+        $idx = array_search('--model', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('sonnet', $cmd[$idx + 1]);
+    }
+
+    public function test_build_command_adds_system_prompt_when_not_continuation_session(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', 'Be helpful', null, null, false]);
+        $idx = array_search('--system-prompt', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('Be helpful', $cmd[$idx + 1]);
+    }
+
+    public function test_build_command_skips_system_prompt_for_continuation_with_session(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', 'Be helpful', null, 'sess123', true]);
+        $this->assertNotContains('--system-prompt', $cmd);
+    }
+
+    public function test_build_command_adds_resume_for_continuation_with_session(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, null, 'sess123', true]);
+        $idx = array_search('--resume', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('sess123', $cmd[$idx + 1]);
+    }
+
+    public function test_build_command_adds_json_schema_when_schema_provided(): void
+    {
+        $mockType = $this->mockArrayable(['type' => 'string']);
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, ['name' => $mockType], null, false]);
+        $idx = array_search('--json-schema', $cmd);
+        $this->assertNotFalse($idx);
+        $decoded = json_decode($cmd[$idx + 1], true);
+        $this->assertSame('object', $decoded['type']);
+        $this->assertArrayHasKey('name', $decoded['properties']);
+    }
+
+    public function test_build_command_does_not_add_json_schema_when_null(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, null, null, false]);
+        $this->assertNotContains('--json-schema', $cmd);
+    }
+
+    // ── A9: buildStreamCommand() ──
+
+    public function test_build_stream_command_includes_stream_json_verbose_partial(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildStreamCommand', ['', null, null, false]);
+        $this->assertContains('stream-json', $cmd);
+        $this->assertContains('--verbose', $cmd);
+        $this->assertContains('--include-partial-messages', $cmd);
+    }
+
+    public function test_build_stream_command_adds_model_resume_skips_system_prompt(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildStreamCommand', ['sonnet', 'sys prompt', 'sess1', true]);
+        $this->assertNotContains('--system-prompt', $cmd);
+        $idx = array_search('--resume', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('sess1', $cmd[$idx + 1]);
+        $idx2 = array_search('--model', $cmd);
+        $this->assertNotFalse($idx2);
+        $this->assertSame('sonnet', $cmd[$idx2 + 1]);
+    }
+
+    public function test_build_stream_command_does_not_include_json_schema(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildStreamCommand', ['', null, null, false]);
+        $this->assertNotContains('--json-schema', $cmd);
+    }
+
+    // ── A10: parseJsonOutput() ──
+
+    public function test_parse_json_output_valid_json_returns_decoded(): void
+    {
+        $r = $this->callMethod($this->gw, 'parseJsonOutput', ['{"result":"hi","session_id":"s1"}']);
+        $this->assertSame('hi', $r['result']);
+        $this->assertSame('s1', $r['session_id']);
+    }
+
+    public function test_parse_json_output_invalid_json_returns_result_raw(): void
+    {
+        $r = $this->callMethod($this->gw, 'parseJsonOutput', ['not json at all']);
+        $this->assertSame('not json at all', $r['result']);
+    }
+
+    public function test_parse_json_output_result_and_session_id_accessible(): void
+    {
+        $r = $this->callMethod($this->gw, 'parseJsonOutput', ['{"result":"answer","session_id":"abc123"}']);
+        $this->assertSame('answer', $r['result']);
+        $this->assertSame('abc123', $r['session_id']);
+    }
+
+    // ── A11: parseStreamLine() ──
+
+    public function test_parse_stream_line_empty_string_returns_null(): void
+    {
+        $this->assertNull($this->callMethod($this->gw, 'parseStreamLine', ['']));
+    }
+
+    public function test_parse_stream_line_invalid_json_returns_null(): void
+    {
+        $this->assertNull($this->callMethod($this->gw, 'parseStreamLine', ['not json']));
+    }
+
+    public function test_parse_stream_line_text_delta_returns_text(): void
+    {
+        $event = json_encode([
+            'type' => 'stream_event',
+            'event' => ['delta' => ['type' => 'text_delta', 'text' => 'Hello']],
+        ]);
+        $this->assertSame('Hello', $this->callMethod($this->gw, 'parseStreamLine', [$event]));
+    }
+
+    public function test_parse_stream_line_result_with_session_id_stores_and_returns_null(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 30]);
+        $event = json_encode(['type' => 'result', 'session_id' => 'stream_sess_42']);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', [$event]));
+        $sessions = $this->getProperty($gw, 'sessions');
+        $this->assertSame('stream_sess_42', $sessions['_last_stream']);
+    }
+
+    public function test_parse_stream_line_other_event_type_returns_null(): void
+    {
+        $event = json_encode(['type' => 'init', 'data' => 'something']);
+        $this->assertNull($this->callMethod($this->gw, 'parseStreamLine', [$event]));
+    }
+
+    // ── A12: convertSchema() ──
+
+    public function test_convert_schema_single_property(): void
+    {
+        $mockType = $this->mockArrayable(['type' => 'string']);
+        $r = $this->callMethod($this->gw, 'convertSchema', [['name' => $mockType]]);
+        $this->assertSame('object', $r['type']);
+        $this->assertSame(['type' => 'string'], $r['properties']['name']);
+        $this->assertSame(['name'], $r['required']);
+    }
+
+    public function test_convert_schema_multi_property(): void
+    {
+        $mockType = $this->mockArrayable(['type' => 'string']);
+        $mockType2 = $this->mockArrayable(['type' => 'integer']);
+        $r = $this->callMethod($this->gw, 'convertSchema', [['name' => $mockType, 'age' => $mockType2]]);
+        $this->assertSame('object', $r['type']);
+        $this->assertSame(['type' => 'string'], $r['properties']['name']);
+        $this->assertSame(['type' => 'integer'], $r['properties']['age']);
+        $this->assertSame(['name', 'age'], $r['required']);
+    }
+
+    // ── A13: binary() ──
+
+    public function test_binary_returns_config_binary_when_set(): void
+    {
+        $gw = new ClaudeCliGateway(['binary' => '/usr/local/bin/claude']);
+        $this->assertSame('/usr/local/bin/claude', $this->callMethod($gw, 'binary'));
+    }
+
+    public function test_binary_returns_claude_when_not_set(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->assertSame('claude', $this->callMethod($gw, 'binary'));
+    }
+
+    // ── F1: parseJsonOutput non-array JSON values ──
+
+    public function test_parse_json_output_null_returns_fallback(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['null']);
+        $this->assertIsArray($r);
+        $this->assertSame('null', $r['result']);
+    }
+
+    public function test_parse_json_output_integer_returns_fallback(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['42']);
+        $this->assertIsArray($r);
+        $this->assertSame('42', $r['result']);
+    }
+
+    public function test_parse_json_output_string_returns_fallback(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['"hello"']);
+        $this->assertIsArray($r);
+    }
+
+    public function test_parse_json_output_boolean_returns_fallback(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['true']);
+        $this->assertIsArray($r);
+    }
+
+    public function test_parse_json_output_empty_array_returns_valid(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['[]']);
+        $this->assertIsArray($r);
+        $this->assertSame([], $r);
+    }
+
+    public function test_parse_json_output_whitespace_string_returns_fallback(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['   ']);
+        $this->assertIsArray($r);
+        $this->assertSame('   ', $r['result']);
+    }
+
+    // ── F3: Claude buildCommand falsy strings ──
+
+    public function test_build_command_zero_instructions_not_added(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', '0', null, null, false]);
+        $this->assertNotContains('--system-prompt', $cmd);
+    }
+
+    public function test_build_command_zero_model_not_added(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['0', null, null, null, false]);
+        $this->assertNotContains('--model', $cmd);
+    }
+
+    // ── F7: stdin construction paths ──
+
+    public function test_path1_non_continuation_instructions_not_in_stdin(): void
+    {
+        $gw = new class(['timeout' => 30]) extends ClaudeCliGateway
+        {
+            public ?string $capturedStdin = null;
+
+            public ?array $capturedCommand = null;
+
+            protected function runProcess(array $command, ?string $stdin = null, ?int $timeout = null): string
+            {
+                $this->capturedCommand = $command;
+                $this->capturedStdin = $stdin;
+
+                return json_encode(['result' => 'ok']);
+            }
+        };
+
+        $provider = $this->mockProvider('test');
+        $gw->generateText($provider, 'sonnet', 'Be concise', [new UserMessage('hello')]);
+
+        $idx = array_search('--system-prompt', $gw->capturedCommand);
+        $this->assertNotFalse($idx);
+        $this->assertSame('Be concise', $gw->capturedCommand[$idx + 1]);
+        $this->assertStringNotContainsString('Be concise', $gw->capturedStdin);
+        $this->assertStringContainsString('hello', $gw->capturedStdin);
+    }
+
+    public function test_path2_continuation_no_session_instructions_in_system_prompt_only(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $messages = [
+            new UserMessage('hi'),
+            new AssistantMessage('hello'),
+            new UserMessage('how are you'),
+        ];
+
+        $this->assertTrue($this->callMethod($gw, 'isContinuation', [$messages]));
+
+        $stdin = $this->callMethod($gw, 'formatAllMessages', [null, $messages]);
+        $this->assertStringNotContainsString('Be concise', $stdin);
+        $this->assertStringContainsString('hi', $stdin);
+        $this->assertStringContainsString('how are you', $stdin);
+
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', 'Be concise', null, null, true]);
+        $this->assertContains('--system-prompt', $cmd);
+    }
+
+    public function test_path3_continuation_with_session_stdin_is_last_user_message(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $messages = [
+            new UserMessage('original question'),
+            new AssistantMessage('original answer'),
+            new UserMessage('follow-up question'),
+        ];
+
+        $this->assertTrue($this->callMethod($gw, 'isContinuation', [$messages]));
+        $stdin = $this->callMethod($gw, 'lastUserMessage', [$messages]);
+        $this->assertSame('follow-up question', $stdin);
+
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', 'Be concise', null, 'sess-id', true]);
+        $this->assertNotContains('--system-prompt', $cmd);
+        $this->assertContains('--resume', $cmd);
+    }
+
+    public function test_continuation_all_assistant_messages_last_user_empty(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $messages = [new AssistantMessage('a1'), new AssistantMessage('a2')];
+        $this->assertTrue($this->callMethod($gw, 'isContinuation', [$messages]));
+        $this->assertSame('', $this->callMethod($gw, 'lastUserMessage', [$messages]));
+    }
+
+    // ── F8: Schema edge cases ──
+
+    public function test_convert_schema_empty_array_valid_empty_object(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'convertSchema', [[]]);
+        $this->assertSame(['type' => 'object', 'properties' => [], 'required' => []], $r);
+    }
+
+    public function test_parse_json_output_no_result_key(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['{"session_id":"abc","cost":0.01}']);
+        $this->assertArrayNotHasKey('result', $r);
+        $this->assertSame('abc', $r['session_id']);
+    }
+
+    public function test_parse_json_output_result_null_preserved(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['{"result":null}']);
+        $this->assertNull($r['result']);
+    }
+
+    // ── F9: Claude streaming parse edge cases ──
+
+    public function test_parse_stream_line_text_delta_empty_text_returns_empty_string(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $event = json_encode([
+            'type' => 'stream_event',
+            'event' => ['delta' => ['type' => 'text_delta', 'text' => '']],
+        ]);
+        $this->assertSame('', $this->callMethod($gw, 'parseStreamLine', [$event]));
+    }
+
+    public function test_parse_stream_line_text_delta_missing_text_returns_null(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $event = json_encode([
+            'type' => 'stream_event',
+            'event' => ['delta' => ['type' => 'text_delta']],
+        ]);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', [$event]));
+    }
+
+    public function test_parse_stream_line_wrong_delta_type_returns_null(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $event = json_encode([
+            'type' => 'stream_event',
+            'event' => ['delta' => ['type' => 'input_json_delta', 'partial_json' => '{}']],
+        ]);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', [$event]));
+    }
+
+    public function test_parse_stream_line_no_delta_at_all_returns_null(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $event = json_encode(['type' => 'stream_event', 'event' => ['something' => 'else']]);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', [$event]));
+    }
+
+    public function test_parse_stream_line_no_type_key_returns_null(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $event = json_encode(['data' => 'something', 'id' => '123']);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', [$event]));
+    }
+
+    // ── F5: parseStreamLine session edge case ──
+
+    public function test_parse_stream_line_result_without_session_id_no_last_stream(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $event = json_encode(['type' => 'result', 'subtype' => 'success']);
+        $this->callMethod($gw, 'parseStreamLine', [$event]);
+        $sessions = $this->getProperty($gw, 'sessions');
+        $this->assertArrayNotHasKey('_last_stream', $sessions);
+    }
+
+    // ── F16: parseJsonOutput unicode ──
+
+    public function test_parse_json_output_unicode_decoded_correctly(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $json = json_encode(['result' => 'こんにちは', 'session_id' => 'abc']);
+        $r = $this->callMethod($gw, 'parseJsonOutput', [$json]);
+        $this->assertSame('こんにちは', $r['result']);
+    }
+
+    public function test_parse_json_output_whitespace_and_newlines_trimmed(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ["  \n  {\"result\":\"hi\"}  \n  "]);
+        $this->assertSame('hi', $r['result']);
+    }
+
+    public function test_parse_stream_line_whitespace_only_returns_null(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', ["   \t  "]));
+    }
+
+    // ── G1: Instructions duplication ──
+
+    public function test_generate_text_stdin_does_not_duplicate_instructions(): void
+    {
+        $gw = new class(['timeout' => 30]) extends ClaudeCliGateway
+        {
+            public ?string $capturedStdin = null;
+
+            public ?array $capturedCommand = null;
+
+            protected function runProcess(array $command, ?string $stdin = null, ?int $timeout = null): string
+            {
+                $this->capturedCommand = $command;
+                $this->capturedStdin = $stdin;
+
+                return json_encode(['result' => 'mocked', 'session_id' => 'sess']);
+            }
+        };
+
+        $provider = $this->mockProvider('test');
+        $gw->generateText($provider, 'sonnet', 'System instructions', [new UserMessage('user prompt')]);
+
+        $this->assertContains('--system-prompt', $gw->capturedCommand);
+        $this->assertStringNotContainsString('System instructions', $gw->capturedStdin);
+        $this->assertStringContainsString('user prompt', $gw->capturedStdin);
+    }
+
+    // ── G3: Claude stream session persistence ──
+
+    public function test_parse_stream_line_session_id_from_result_stored(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $line = json_encode(['type' => 'result', 'subtype' => 'success', 'session_id' => 'stream-sess-123']);
+        $this->callMethod($gw, 'parseStreamLine', [$line]);
+        $sessions = $this->getProperty($gw, 'sessions');
+        $this->assertSame('stream-sess-123', $sessions['_last_stream'] ?? null);
+    }
+
+    public function test_stream_text_persists_session_id_to_conversation_key(): void
+    {
+        $gw = new class(['timeout' => 30]) extends ClaudeCliGateway
+        {
+            protected function startProcess(array $command, ?string $stdin = null, ?int $timeout = null): \Symfony\Component\Process\Process
+            {
+                $resultLine = json_encode(['type' => 'result', 'subtype' => 'success', 'session_id' => 'persisted-sess']);
+                $process = new \Symfony\Component\Process\Process(['echo', $resultLine]);
+                $process->start();
+
+                return $process;
+            }
+        };
+
+        $provider = $this->mockProvider('test');
+        $instructions = 'test instructions';
+        $messages = [new UserMessage('hello')];
+        $convKey = $this->callMethod($gw, 'conversationKey', [$instructions, $messages]);
+
+        $generator = $gw->streamText('inv-1', $provider, 'sonnet', $instructions, $messages);
+        foreach ($generator as $event) {
+            // consume all events
+        }
+
+        $sess = $this->callMethod($gw, 'getSession', [$convKey]);
+        $this->assertSame('persisted-sess', $sess);
+    }
+
+    // ── G4: Streaming timeout ──
+
+    public function test_streaming_timeout_throws_cli_process_exception(): void
+    {
+        $gw = new class(['timeout' => 30]) extends ClaudeCliGateway
+        {
+            protected function startProcess(array $command, ?string $stdin = null, ?int $timeout = null): \Symfony\Component\Process\Process
+            {
+                $process = new \Symfony\Component\Process\Process(
+                    ['php', '-r', 'sleep(10);'], null, null, null, 1
+                );
+                $process->start();
+
+                return $process;
+            }
+        };
+
+        $provider = $this->mockProvider('test');
+        $this->expectException(\Laravel\Ai\Exceptions\CliProcessException::class);
+
+        $gen = $gw->streamText('inv-1', $provider, 'sonnet', 'test', [new UserMessage('hello')]);
+        foreach ($gen as $event) {
+            // consume
+        }
+    }
+}

--- a/tests/Unit/Gateway/Cli/CliGatewayTest.php
+++ b/tests/Unit/Gateway/Cli/CliGatewayTest.php
@@ -1,0 +1,770 @@
+<?php
+
+namespace Tests\Unit\Gateway\Cli;
+
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Exceptions\CliProcessException;
+use Laravel\Ai\Gateway\Cli\ClaudeCliGateway;
+use Laravel\Ai\Gateway\Cli\CodexCliGateway;
+use Laravel\Ai\Gateway\Cli\GeminiCliGateway;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\TextResponse;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+
+class CliGatewayTest extends TestCase
+{
+    private ClaudeCliGateway $gw;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gw = new ClaudeCliGateway(['timeout' => 30]);
+    }
+
+    private function callMethod(object $obj, string $method, array $args = []): mixed
+    {
+        $ref = new \ReflectionMethod($obj, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($obj, $args);
+    }
+
+    private function getProperty(object $obj, string $prop): mixed
+    {
+        $ref = new \ReflectionProperty($obj, $prop);
+        $ref->setAccessible(true);
+
+        return $ref->getValue($obj);
+    }
+
+    private function mockProvider(string $name = 'test'): TextProvider
+    {
+        return new class($name) implements TextProvider
+        {
+            public function __construct(private string $n) {}
+
+            public function name(): string
+            {
+                return $this->n;
+            }
+
+            public function driver(): string
+            {
+                return $this->n;
+            }
+
+            public function prompt(\Laravel\Ai\Prompts\AgentPrompt $p): \Laravel\Ai\Responses\AgentResponse
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function stream(\Laravel\Ai\Prompts\AgentPrompt $p): \Laravel\Ai\Responses\StreamableAgentResponse
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function textGateway(): \Laravel\Ai\Contracts\Gateway\TextGateway
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function useTextGateway(\Laravel\Ai\Contracts\Gateway\TextGateway $g): self
+            {
+                return $this;
+            }
+
+            public function defaultTextModel(): string
+            {
+                return 'default';
+            }
+
+            public function cheapestTextModel(): string
+            {
+                return 'cheap';
+            }
+
+            public function smartestTextModel(): string
+            {
+                return 'smart';
+            }
+        };
+    }
+
+    // ── A1: environment() ──
+
+    public function test_environment_returns_array(): void
+    {
+        $env = $this->callMethod($this->gw, 'environment');
+        $this->assertIsArray($env);
+    }
+
+    public function test_environment_merges_config_env_values(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 30, 'env' => ['MY_CUSTOM_VAR' => 'hello']]);
+        $env = $this->callMethod($gw, 'environment');
+        $this->assertSame('hello', $env['MY_CUSTOM_VAR'] ?? null);
+    }
+
+    public function test_environment_strips_claudecode(): void
+    {
+        putenv('CLAUDECODE=1');
+        $_ENV['CLAUDECODE'] = '1';
+
+        try {
+            $env = $this->callMethod($this->gw, 'environment');
+            $this->assertArrayNotHasKey('CLAUDECODE', $env);
+        } finally {
+            putenv('CLAUDECODE');
+            unset($_ENV['CLAUDECODE']);
+        }
+    }
+
+    public function test_environment_strips_claude_code_entrypoint(): void
+    {
+        putenv('CLAUDE_CODE_ENTRYPOINT=test');
+        $_ENV['CLAUDE_CODE_ENTRYPOINT'] = 'test';
+
+        try {
+            $env = $this->callMethod($this->gw, 'environment');
+            $this->assertArrayNotHasKey('CLAUDE_CODE_ENTRYPOINT', $env);
+        } finally {
+            putenv('CLAUDE_CODE_ENTRYPOINT');
+            unset($_ENV['CLAUDE_CODE_ENTRYPOINT']);
+        }
+    }
+
+    public function test_environment_strips_claude_code_session(): void
+    {
+        putenv('CLAUDE_CODE_SESSION=abc');
+        $_ENV['CLAUDE_CODE_SESSION'] = 'abc';
+
+        try {
+            $env = $this->callMethod($this->gw, 'environment');
+            $this->assertArrayNotHasKey('CLAUDE_CODE_SESSION', $env);
+        } finally {
+            putenv('CLAUDE_CODE_SESSION');
+            unset($_ENV['CLAUDE_CODE_SESSION']);
+        }
+    }
+
+    public function test_environment_preserves_path_and_home(): void
+    {
+        $env = $this->callMethod($this->gw, 'environment');
+        $this->assertArrayHasKey('PATH', $env);
+        $this->assertArrayHasKey('HOME', $env);
+    }
+
+    // ── A2: isContinuation() ──
+
+    public function test_is_continuation_returns_false_for_empty_messages(): void
+    {
+        $this->assertFalse($this->callMethod($this->gw, 'isContinuation', [[]]));
+    }
+
+    public function test_is_continuation_returns_false_for_only_user_message(): void
+    {
+        $this->assertFalse($this->callMethod($this->gw, 'isContinuation', [[new UserMessage('hi')]]));
+    }
+
+    public function test_is_continuation_returns_true_when_assistant_message_present(): void
+    {
+        $this->assertTrue($this->callMethod($this->gw, 'isContinuation', [[
+            new UserMessage('hi'),
+            new AssistantMessage('hello'),
+        ]]));
+    }
+
+    // ── A3: lastUserMessage() ──
+
+    public function test_last_user_message_returns_empty_for_empty_array(): void
+    {
+        $this->assertSame('', $this->callMethod($this->gw, 'lastUserMessage', [[]]));
+    }
+
+    public function test_last_user_message_returns_content_of_only_user_message(): void
+    {
+        $this->assertSame('hello world', $this->callMethod($this->gw, 'lastUserMessage', [[new UserMessage('hello world')]]));
+    }
+
+    public function test_last_user_message_returns_last_user_message(): void
+    {
+        $this->assertSame('last', $this->callMethod($this->gw, 'lastUserMessage', [[
+            new UserMessage('first'),
+            new AssistantMessage('mid'),
+            new UserMessage('last'),
+        ]]));
+    }
+
+    public function test_last_user_message_returns_empty_when_only_assistant_messages(): void
+    {
+        $this->assertSame('', $this->callMethod($this->gw, 'lastUserMessage', [[new AssistantMessage('only assistant')]]));
+    }
+
+    // ── A4: formatAllMessages() ──
+
+    public function test_format_all_messages_returns_just_instructions_when_no_messages(): void
+    {
+        $this->assertSame('Be helpful', $this->callMethod($this->gw, 'formatAllMessages', ['Be helpful', []]));
+    }
+
+    public function test_format_all_messages_returns_just_content_when_instructions_null(): void
+    {
+        $this->assertSame('hi', $this->callMethod($this->gw, 'formatAllMessages', [null, [new UserMessage('hi')]]));
+    }
+
+    public function test_format_all_messages_joins_instructions_and_messages_with_newlines(): void
+    {
+        $result = $this->callMethod($this->gw, 'formatAllMessages', ['sys', [
+            new UserMessage('user1'),
+            new AssistantMessage('asst1'),
+        ]]);
+        $this->assertSame("sys\n\nuser1\n\nasst1", $result);
+    }
+
+    public function test_format_all_messages_handles_multiple_messages_in_order(): void
+    {
+        $result = $this->callMethod($this->gw, 'formatAllMessages', [null, [
+            new UserMessage('a'),
+            new AssistantMessage('b'),
+            new UserMessage('c'),
+        ]]);
+        $this->assertSame("a\n\nb\n\nc", $result);
+    }
+
+    // ── A5: conversationKey() + sessions ──
+
+    public function test_conversation_key_returns_md5_hash(): void
+    {
+        $key = $this->callMethod($this->gw, 'conversationKey', ['inst', [new UserMessage('hi')]]);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $key);
+    }
+
+    public function test_same_inputs_produce_same_key(): void
+    {
+        $msgs = [new UserMessage('hi')];
+        $k1 = $this->callMethod($this->gw, 'conversationKey', ['inst', $msgs]);
+        $k2 = $this->callMethod($this->gw, 'conversationKey', ['inst', $msgs]);
+        $this->assertSame($k1, $k2);
+    }
+
+    public function test_different_inputs_produce_different_keys(): void
+    {
+        $k1 = $this->callMethod($this->gw, 'conversationKey', ['a', [new UserMessage('x')]]);
+        $k2 = $this->callMethod($this->gw, 'conversationKey', ['b', [new UserMessage('y')]]);
+        $this->assertNotSame($k1, $k2);
+    }
+
+    public function test_store_session_and_get_session_round_trips(): void
+    {
+        $this->callMethod($this->gw, 'storeSession', ['testkey', 'session123']);
+        $this->assertSame('session123', $this->callMethod($this->gw, 'getSession', ['testkey']));
+    }
+
+    public function test_get_session_returns_null_for_unknown_key(): void
+    {
+        $this->assertNull($this->callMethod($this->gw, 'getSession', ['nonexistent_key_xyz']));
+    }
+
+    // ── A6: makeTextResponse() ──
+
+    public function test_make_text_response_returns_text_response_with_correct_text(): void
+    {
+        $provider = $this->mockProvider('claude-cli');
+        $r = $this->callMethod($this->gw, 'makeTextResponse', ['hello world', $provider, 'sonnet']);
+        $this->assertInstanceOf(TextResponse::class, $r);
+        $this->assertSame('hello world', $r->text);
+    }
+
+    public function test_make_text_response_usage_has_zero_tokens(): void
+    {
+        $provider = $this->mockProvider('claude-cli');
+        $r = $this->callMethod($this->gw, 'makeTextResponse', ['hi', $provider, 'sonnet']);
+        $this->assertSame(0, $r->usage->promptTokens);
+        $this->assertSame(0, $r->usage->completionTokens);
+    }
+
+    public function test_make_text_response_meta_has_correct_provider_and_model(): void
+    {
+        $provider = $this->mockProvider('claude-cli');
+        $r = $this->callMethod($this->gw, 'makeTextResponse', ['hi', $provider, 'sonnet']);
+        $this->assertSame('claude-cli', $r->meta->provider);
+        $this->assertSame('sonnet', $r->meta->model);
+    }
+
+    // ── A7: onToolInvocation() ──
+
+    public function test_on_tool_invocation_returns_self_fluent(): void
+    {
+        $result = $this->gw->onToolInvocation(function () {}, function () {});
+        $this->assertSame($this->gw, $result);
+    }
+
+    public function test_on_tool_invocation_stores_both_callbacks(): void
+    {
+        $cb1 = function () { return 'invoking'; };
+        $cb2 = function () { return 'invoked'; };
+        $this->gw->onToolInvocation($cb1, $cb2);
+        $this->assertSame($cb1, $this->getProperty($this->gw, 'invokingToolCallback'));
+        $this->assertSame($cb2, $this->getProperty($this->gw, 'toolInvokedCallback'));
+    }
+
+    // ── E: runProcess error paths ──
+
+    public function test_run_process_non_zero_exit_code_throws_cli_process_exception(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 10]);
+        try {
+            $this->callMethod($gw, 'runProcess', [['bash', '-c', 'echo "error msg" >&2; exit 1'], null, 10]);
+            $this->fail('Should throw CliProcessException');
+        } catch (CliProcessException $e) {
+            $this->assertStringContainsString('error msg', $e->getMessage());
+        }
+    }
+
+    public function test_run_process_timeout_throws_cli_process_exception(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 300]);
+        try {
+            $this->callMethod($gw, 'runProcess', [['sleep', '30'], null, 1]);
+            $this->fail('Should throw CliProcessException');
+        } catch (CliProcessException $e) {
+            $this->assertStringContainsString('timed out', $e->getMessage());
+        }
+    }
+
+    public function test_run_process_successful_run_returns_output(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 10]);
+        $output = $this->callMethod($gw, 'runProcess', [['echo', 'hello'], null, 10]);
+        $this->assertSame("hello\n", $output);
+    }
+
+    // ── F2: conversationKey collision and null handling ──
+
+    public function test_conversation_key_null_instructions_same_as_empty_string(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $msgs = [new UserMessage('hello')];
+        $k1 = $this->callMethod($gw, 'conversationKey', [null, $msgs]);
+        $k2 = $this->callMethod($gw, 'conversationKey', ['', $msgs]);
+        $this->assertSame($k1, $k2);
+    }
+
+    public function test_conversation_key_no_delimiter_causes_collision(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $k1 = $this->callMethod($gw, 'conversationKey', ['ab', [new UserMessage('c')]]);
+        $k2 = $this->callMethod($gw, 'conversationKey', ['a', [new UserMessage('bc')]]);
+        $this->assertSame($k1, $k2);
+    }
+
+    public function test_conversation_key_only_uses_first_user_message(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $k1 = $this->callMethod($gw, 'conversationKey', [null, [
+            new UserMessage('first'),
+            new UserMessage('second'),
+        ]]);
+        $k2 = $this->callMethod($gw, 'conversationKey', [null, [
+            new UserMessage('first'),
+            new UserMessage('DIFFERENT'),
+        ]]);
+        $this->assertSame($k1, $k2);
+    }
+
+    public function test_conversation_key_no_user_message_key_from_instructions_only(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $k1 = $this->callMethod($gw, 'conversationKey', ['inst', [new AssistantMessage('resp')]]);
+        $k2 = $this->callMethod($gw, 'conversationKey', ['inst', []]);
+        $this->assertSame($k1, $k2);
+    }
+
+    public function test_conversation_key_assistant_first_then_user_uses_user(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $k1 = $this->callMethod($gw, 'conversationKey', [null, [
+            new AssistantMessage('asst'),
+            new UserMessage('user'),
+        ]]);
+        $this->assertSame(md5(''.'user'), $k1);
+    }
+
+    // ── F3: formatAllMessages falsy strings ──
+
+    public function test_format_all_messages_empty_string_instructions_skipped(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'formatAllMessages', ['', [new UserMessage('hello')]]);
+        $this->assertSame('hello', $r);
+    }
+
+    public function test_format_all_messages_zero_string_instructions_skipped(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'formatAllMessages', ['0', [new UserMessage('test')]]);
+        $this->assertSame('test', $r);
+    }
+
+    // ── F4: Message array edge cases ──
+
+    public function test_is_continuation_assistant_message_first_still_true(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->assertTrue($this->callMethod($gw, 'isContinuation', [[
+            new AssistantMessage('first'),
+            new UserMessage('second'),
+        ]]));
+    }
+
+    public function test_last_user_message_empty_content_returned_as_is(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->assertSame('', $this->callMethod($gw, 'lastUserMessage', [[new UserMessage('')]]));
+    }
+
+    public function test_format_all_messages_empty_content_creates_empty_part(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'formatAllMessages', [null, [
+            new UserMessage('a'),
+            new AssistantMessage(''),
+            new UserMessage('b'),
+        ]]);
+        $this->assertSame("a\n\n\n\nb", $r);
+    }
+
+    public function test_format_all_messages_no_instructions_no_messages_empty_string(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->assertSame('', $this->callMethod($gw, 'formatAllMessages', [null, []]));
+    }
+
+    public function test_is_continuation_many_user_messages_no_assistant_false(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $msgs = array_fill(0, 10, new UserMessage('msg'));
+        $this->assertFalse($this->callMethod($gw, 'isContinuation', [$msgs]));
+    }
+
+    public function test_last_user_message_interleaved_picks_actual_last(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'lastUserMessage', [[
+            new UserMessage('first'),
+            new AssistantMessage('a1'),
+            new UserMessage('second'),
+            new AssistantMessage('a2'),
+            new UserMessage('LAST'),
+            new AssistantMessage('a3'),
+        ]]);
+        $this->assertSame('LAST', $r);
+    }
+
+    // ── F5: Session state edge cases ──
+
+    public function test_store_session_overwrites_existing(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->callMethod($gw, 'storeSession', ['key1', 'old-session']);
+        $this->callMethod($gw, 'storeSession', ['key1', 'new-session']);
+        $this->assertSame('new-session', $this->callMethod($gw, 'getSession', ['key1']));
+    }
+
+    public function test_sessions_not_shared_between_instances(): void
+    {
+        $gw1 = new ClaudeCliGateway([]);
+        $gw2 = new ClaudeCliGateway([]);
+        $this->callMethod($gw1, 'storeSession', ['key', 'sess1']);
+        $this->assertNull($this->callMethod($gw2, 'getSession', ['key']));
+    }
+
+    public function test_multiple_session_stores_different_keys_coexist(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->callMethod($gw, 'storeSession', ['conv-a', 'sess-a']);
+        $this->callMethod($gw, 'storeSession', ['conv-b', 'sess-b']);
+        $this->assertSame('sess-a', $this->callMethod($gw, 'getSession', ['conv-a']));
+        $this->assertSame('sess-b', $this->callMethod($gw, 'getSession', ['conv-b']));
+    }
+
+    // ── F6: Environment edge cases ──
+
+    public function test_config_env_overrides_system_env_var(): void
+    {
+        putenv('MY_EDGE_VAR=system');
+
+        try {
+            $gw = new ClaudeCliGateway(['env' => ['MY_EDGE_VAR' => 'config']]);
+            $env = $this->callMethod($gw, 'environment');
+            $this->assertSame('config', $env['MY_EDGE_VAR']);
+        } finally {
+            putenv('MY_EDGE_VAR');
+        }
+    }
+
+    public function test_config_env_claudecode_still_gets_stripped(): void
+    {
+        $gw = new ClaudeCliGateway(['env' => ['CLAUDECODE' => 'injected']]);
+        $env = $this->callMethod($gw, 'environment');
+        $this->assertArrayNotHasKey('CLAUDECODE', $env);
+    }
+
+    public function test_config_env_claude_code_entrypoint_still_gets_stripped(): void
+    {
+        $gw = new ClaudeCliGateway(['env' => ['CLAUDE_CODE_ENTRYPOINT' => 'injected']]);
+        $env = $this->callMethod($gw, 'environment');
+        $this->assertArrayNotHasKey('CLAUDE_CODE_ENTRYPOINT', $env);
+    }
+
+    public function test_config_env_claude_code_session_still_gets_stripped(): void
+    {
+        $gw = new ClaudeCliGateway(['env' => ['CLAUDE_CODE_SESSION' => 'injected']]);
+        $env = $this->callMethod($gw, 'environment');
+        $this->assertArrayNotHasKey('CLAUDE_CODE_SESSION', $env);
+    }
+
+    public function test_environment_all_three_nesting_vars_stripped_simultaneously(): void
+    {
+        $gw = new ClaudeCliGateway(['env' => [
+            'CLAUDECODE' => '1',
+            'CLAUDE_CODE_ENTRYPOINT' => '2',
+            'CLAUDE_CODE_SESSION' => '3',
+            'SAFE_VAR' => 'kept',
+        ]]);
+        $env = $this->callMethod($gw, 'environment');
+        $this->assertArrayNotHasKey('CLAUDECODE', $env);
+        $this->assertArrayNotHasKey('CLAUDE_CODE_ENTRYPOINT', $env);
+        $this->assertArrayNotHasKey('CLAUDE_CODE_SESSION', $env);
+        $this->assertSame('kept', $env['SAFE_VAR']);
+    }
+
+    // ── F13: runProcess timeout/stderr/exit code ──
+
+    public function test_run_process_exit_zero_with_stderr_returns_stdout_only(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $output = $this->callMethod($gw, 'runProcess', [
+            ['bash', '-c', 'echo stdout; echo stderr >&2; exit 0'], null, 10,
+        ]);
+        $this->assertSame("stdout\n", $output);
+    }
+
+    public function test_run_process_failure_with_empty_stderr_uses_exit_code(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        try {
+            $this->callMethod($gw, 'runProcess', [['bash', '-c', 'exit 42'], null, 10]);
+            $this->fail('Should have thrown');
+        } catch (CliProcessException $e) {
+            $this->assertStringContainsString('42', $e->getMessage());
+        }
+    }
+
+    public function test_run_process_failure_with_whitespace_stderr_uses_exit_code_msg(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        try {
+            $this->callMethod($gw, 'runProcess', [
+                ['bash', '-c', 'echo "  " >&2; exit 1'], null, 10,
+            ]);
+            $this->fail('Should have thrown');
+        } catch (CliProcessException $e) {
+            $this->assertStringContainsString('exited with code', $e->getMessage());
+        }
+    }
+
+    public function test_run_process_timeout_preserves_previous_exception(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        try {
+            $this->callMethod($gw, 'runProcess', [['sleep', '30'], null, 1]);
+            $this->fail('Should have thrown');
+        } catch (CliProcessException $e) {
+            $this->assertInstanceOf(ProcessTimedOutException::class, $e->getPrevious());
+        }
+    }
+
+    public function test_run_process_config_timeout_used_when_explicit_null(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 2]);
+        try {
+            $this->callMethod($gw, 'runProcess', [['sleep', '10'], null, null]);
+            $this->fail('Should have thrown');
+        } catch (CliProcessException $e) {
+            $this->assertStringContainsString('timed out', $e->getMessage());
+        }
+    }
+
+    public function test_run_process_explicit_timeout_overrides_config(): void
+    {
+        $gw = new ClaudeCliGateway(['timeout' => 300]);
+        try {
+            $this->callMethod($gw, 'runProcess', [['sleep', '30'], null, 1]);
+            $this->fail('Should have thrown');
+        } catch (CliProcessException $e) {
+            $this->assertStringContainsString('timed out', $e->getMessage());
+        }
+    }
+
+    public function test_run_process_defaults_to_300s_when_no_config(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $output = $this->callMethod($gw, 'runProcess', [['echo', 'ok'], null, null]);
+        $this->assertSame("ok\n", $output);
+    }
+
+    // ── F16: Unicode and special characters ──
+
+    public function test_format_all_messages_unicode_preserved(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'formatAllMessages', ['日本語', [new UserMessage('こんにちは')]]);
+        $this->assertSame("日本語\n\nこんにちは", $r);
+    }
+
+    public function test_conversation_key_unicode_produces_valid_md5(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $k = $this->callMethod($gw, 'conversationKey', ['指示', [new UserMessage('世界')]]);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $k);
+    }
+
+    public function test_make_text_response_emoji_and_unicode_preserved(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $provider = $this->mockProvider('test');
+        $r = $this->callMethod($gw, 'makeTextResponse', ['Ñoño 🎉 émoji', $provider, 'model']);
+        $this->assertSame('Ñoño 🎉 émoji', $r->text);
+    }
+
+    public function test_last_user_message_with_newlines_returned_intact(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $r = $this->callMethod($gw, 'lastUserMessage', [[
+            new UserMessage("line1\nline2\nline3"),
+        ]]);
+        $this->assertSame("line1\nline2\nline3", $r);
+    }
+
+    // ── F17: Command injection safety ──
+
+    public function test_build_command_shell_metacharacters_passed_as_literal(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $evil = 'echo "$(whoami)" && rm -rf / ; `cat /etc/passwd`';
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', $evil, null, null, false]);
+        $idx = array_search('--system-prompt', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame($evil, $cmd[$idx + 1]);
+    }
+
+    // ── F18: onToolInvocation overwrite ──
+
+    public function test_on_tool_invocation_second_call_overwrites_first(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $cb1 = function () { return 1; };
+        $cb2 = function () { return 2; };
+        $cb3 = function () { return 3; };
+        $cb4 = function () { return 4; };
+        $gw->onToolInvocation($cb1, $cb2);
+        $gw->onToolInvocation($cb3, $cb4);
+        $this->assertSame($cb3, $this->getProperty($gw, 'invokingToolCallback'));
+        $this->assertSame($cb4, $this->getProperty($gw, 'toolInvokedCallback'));
+    }
+
+    public function test_on_tool_invocation_initial_state_is_null(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $this->assertNull($this->getProperty($gw, 'invokingToolCallback'));
+        $this->assertNull($this->getProperty($gw, 'toolInvokedCallback'));
+    }
+
+    // ── F19: Stress / volume ──
+
+    public function test_format_all_messages_100_messages_joined_correctly(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $messages = [];
+        for ($i = 0; $i < 100; $i++) {
+            $messages[] = new UserMessage("msg{$i}");
+        }
+        $r = $this->callMethod($gw, 'formatAllMessages', ['sys', $messages]);
+        $parts = explode("\n\n", $r);
+        $this->assertCount(101, $parts);
+        $this->assertSame('sys', $parts[0]);
+        $this->assertSame('msg99', $parts[100]);
+    }
+
+    public function test_conversation_key_100_messages_still_uses_first(): void
+    {
+        $gw = new ClaudeCliGateway([]);
+        $messages = [];
+        for ($i = 0; $i < 100; $i++) {
+            $messages[] = new UserMessage("msg{$i}");
+        }
+        $k = $this->callMethod($gw, 'conversationKey', ['inst', $messages]);
+        $this->assertSame(md5('inst'.'msg0'), $k);
+    }
+
+    // ── F20: Cross-gateway consistency ──
+
+    public function test_all_gateways_environment_strips_same_vars(): void
+    {
+        $envConfig = ['env' => ['CLAUDECODE' => '1', 'CLAUDE_CODE_ENTRYPOINT' => '2', 'CLAUDE_CODE_SESSION' => '3']];
+        $gateways = [
+            new ClaudeCliGateway($envConfig),
+            new CodexCliGateway($envConfig),
+            new GeminiCliGateway($envConfig),
+        ];
+        foreach ($gateways as $gw) {
+            $env = $this->callMethod($gw, 'environment');
+            $this->assertArrayNotHasKey('CLAUDECODE', $env, get_class($gw).' should strip CLAUDECODE');
+            $this->assertArrayNotHasKey('CLAUDE_CODE_ENTRYPOINT', $env, get_class($gw).' should strip entrypoint');
+            $this->assertArrayNotHasKey('CLAUDE_CODE_SESSION', $env, get_class($gw).' should strip session');
+        }
+    }
+
+    public function test_all_gateways_is_continuation_identical_behavior(): void
+    {
+        $gateways = [new ClaudeCliGateway([]), new CodexCliGateway([]), new GeminiCliGateway([])];
+        $msgsTrue = [new UserMessage('a'), new AssistantMessage('b')];
+        $msgsFalse = [new UserMessage('a')];
+        foreach ($gateways as $gw) {
+            $class = get_class($gw);
+            $this->assertTrue($this->callMethod($gw, 'isContinuation', [$msgsTrue]), "{$class} continuation=true");
+            $this->assertFalse($this->callMethod($gw, 'isContinuation', [$msgsFalse]), "{$class} continuation=false");
+        }
+    }
+
+    public function test_all_gateways_conversation_key_same_for_same_inputs(): void
+    {
+        $gateways = [new ClaudeCliGateway([]), new CodexCliGateway([]), new GeminiCliGateway([])];
+        $msgs = [new UserMessage('test')];
+        $keys = [];
+        foreach ($gateways as $gw) {
+            $keys[] = $this->callMethod($gw, 'conversationKey', ['inst', $msgs]);
+        }
+        $this->assertSame($keys[0], $keys[1]);
+        $this->assertSame($keys[1], $keys[2]);
+    }
+
+    public function test_all_gateways_make_text_response_returns_correct_structure(): void
+    {
+        $gateways = [new ClaudeCliGateway([]), new CodexCliGateway([]), new GeminiCliGateway([])];
+        $provider = $this->mockProvider('test');
+        foreach ($gateways as $gw) {
+            $r = $this->callMethod($gw, 'makeTextResponse', ['hello', $provider, 'model']);
+            $this->assertInstanceOf(TextResponse::class, $r);
+            $this->assertSame('hello', $r->text);
+            $this->assertSame('test', $r->meta->provider);
+            $this->assertSame('model', $r->meta->model);
+            $this->assertSame(0, $r->usage->promptTokens);
+            $this->assertSame(0, $r->usage->completionTokens);
+        }
+    }
+}

--- a/tests/Unit/Gateway/Cli/CodexCliGatewayTest.php
+++ b/tests/Unit/Gateway/Cli/CodexCliGatewayTest.php
@@ -1,0 +1,426 @@
+<?php
+
+namespace Tests\Unit\Gateway\Cli;
+
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Cli\CodexCliGateway;
+use Laravel\Ai\Messages\UserMessage;
+use PHPUnit\Framework\TestCase;
+
+class CodexCliGatewayTest extends TestCase
+{
+    private CodexCliGateway $gw;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gw = new CodexCliGateway(['timeout' => 30]);
+    }
+
+    private function callMethod(object $obj, string $method, array $args = []): mixed
+    {
+        $ref = new \ReflectionMethod($obj, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($obj, $args);
+    }
+
+    private function mockProvider(string $name = 'test'): TextProvider
+    {
+        return new class($name) implements TextProvider
+        {
+            public function __construct(private string $n) {}
+
+            public function name(): string
+            {
+                return $this->n;
+            }
+
+            public function driver(): string
+            {
+                return $this->n;
+            }
+
+            public function prompt(\Laravel\Ai\Prompts\AgentPrompt $p): \Laravel\Ai\Responses\AgentResponse
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function stream(\Laravel\Ai\Prompts\AgentPrompt $p): \Laravel\Ai\Responses\StreamableAgentResponse
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function textGateway(): \Laravel\Ai\Contracts\Gateway\TextGateway
+            {
+                throw new \RuntimeException('not impl');
+            }
+
+            public function useTextGateway(\Laravel\Ai\Contracts\Gateway\TextGateway $g): self
+            {
+                return $this;
+            }
+
+            public function defaultTextModel(): string
+            {
+                return 'default';
+            }
+
+            public function cheapestTextModel(): string
+            {
+                return 'cheap';
+            }
+
+            public function smartestTextModel(): string
+            {
+                return 'smart';
+            }
+        };
+    }
+
+    private function mockArrayable(array $data): \Illuminate\Contracts\Support\Arrayable
+    {
+        return new class($data) implements \Illuminate\Contracts\Support\Arrayable
+        {
+            public function __construct(private array $data) {}
+
+            public function toArray(): array
+            {
+                return $this->data;
+            }
+        };
+    }
+
+    // ── A14: buildCommand() ──
+
+    public function test_build_command_new_conversation_uses_exec_dash(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, null, null, false]);
+        $this->assertSame('codex', $cmd[0]);
+        $this->assertSame('exec', $cmd[1]);
+        $this->assertSame('-', $cmd[2]);
+    }
+
+    public function test_build_command_continuation_with_session_uses_resume(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, null, 'sess1', true]);
+        $this->assertSame('codex', $cmd[0]);
+        $this->assertSame('exec', $cmd[1]);
+        $this->assertSame('resume', $cmd[2]);
+        $this->assertSame('sess1', $cmd[3]);
+    }
+
+    public function test_build_command_always_includes_json_and_skip_git(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, null, null, false]);
+        $this->assertContains('--json', $cmd);
+        $this->assertContains('--skip-git-repo-check', $cmd);
+    }
+
+    public function test_build_command_adds_model_when_provided(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['gpt-4.1', null, null, null, false]);
+        $idx = array_search('--model', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('gpt-4.1', $cmd[$idx + 1]);
+    }
+
+    public function test_build_command_adds_system_prompt_when_not_continuation_session(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', 'Be short', null, null, false]);
+        $idx = array_search('--system-prompt', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('Be short', $cmd[$idx + 1]);
+    }
+
+    public function test_build_command_adds_output_schema_when_provided(): void
+    {
+        $mockType = $this->mockArrayable(['type' => 'string']);
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', null, ['name' => $mockType], null, false]);
+        $idx = array_search('--output-schema', $cmd);
+        $this->assertNotFalse($idx);
+    }
+
+    // ── A15: parseOutput() ──
+
+    public function test_parse_output_single_message_extracts_text(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => 'hello']);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$line]);
+        $this->assertSame('hello', $r['text']);
+    }
+
+    public function test_parse_output_multiple_lines_concatenates(): void
+    {
+        $lines = json_encode(['type' => 'message', 'content' => 'hello '])."\n".
+                 json_encode(['type' => 'message', 'content' => 'world']);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$lines]);
+        $this->assertSame('hello world', $r['text']);
+    }
+
+    public function test_parse_output_extracts_session_id(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => 'hi', 'session_id' => 'sess42']);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$line]);
+        $this->assertSame('sess42', $r['session_id']);
+    }
+
+    public function test_parse_output_extracts_structured_output(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => 'hi', 'structured_output' => ['name' => 'John']]);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$line]);
+        $this->assertSame(['name' => 'John'], $r['structured_output']);
+    }
+
+    public function test_parse_output_invalid_json_treated_as_plain_text(): void
+    {
+        $r = $this->callMethod($this->gw, 'parseOutput', ['plain text output']);
+        $this->assertSame('plain text output', $r['text']);
+    }
+
+    public function test_parse_output_no_text_falls_back_to_raw(): void
+    {
+        $line = json_encode(['type' => 'status', 'data' => 'running']);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$line]);
+        $this->assertSame($line, $r['text']);
+    }
+
+    public function test_parse_output_array_content_json_encoded(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => ['key' => 'val']]);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$line]);
+        $this->assertSame(json_encode(['key' => 'val']), $r['text']);
+    }
+
+    public function test_parse_output_string_content_used_as_is(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => 'direct string']);
+        $r = $this->callMethod($this->gw, 'parseOutput', [$line]);
+        $this->assertSame('direct string', $r['text']);
+    }
+
+    // ── A16: parseStreamLine() ──
+
+    public function test_parse_stream_line_empty_returns_null(): void
+    {
+        $this->assertNull($this->callMethod($this->gw, 'parseStreamLine', ['']));
+    }
+
+    public function test_parse_stream_line_invalid_json_returns_null(): void
+    {
+        $this->assertNull($this->callMethod($this->gw, 'parseStreamLine', ['not json']));
+    }
+
+    public function test_parse_stream_line_message_string_content_returns_string(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => 'chunk']);
+        $this->assertSame('chunk', $this->callMethod($this->gw, 'parseStreamLine', [$line]));
+    }
+
+    public function test_parse_stream_line_message_array_content_json_encodes(): void
+    {
+        $line = json_encode(['type' => 'message', 'content' => ['a' => 1]]);
+        $this->assertSame(json_encode(['a' => 1]), $this->callMethod($this->gw, 'parseStreamLine', [$line]));
+    }
+
+    public function test_parse_stream_line_other_type_returns_null(): void
+    {
+        $line = json_encode(['type' => 'status', 'data' => 'ok']);
+        $this->assertNull($this->callMethod($this->gw, 'parseStreamLine', [$line]));
+    }
+
+    // ── A17: binary() ──
+
+    public function test_binary_returns_config_binary_when_set(): void
+    {
+        $gw = new CodexCliGateway(['binary' => '/opt/codex']);
+        $this->assertSame('/opt/codex', $this->callMethod($gw, 'binary'));
+    }
+
+    public function test_binary_returns_codex_when_not_set(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $this->assertSame('codex', $this->callMethod($gw, 'binary'));
+    }
+
+    // ── F3: Codex buildCommand falsy ──
+
+    public function test_build_command_zero_model_not_added(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['0', null, null, null, false]);
+        $this->assertNotContains('--model', $cmd);
+    }
+
+    // ── F8: Codex convertSchema ──
+
+    public function test_convert_schema_empty_array(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $r = $this->callMethod($gw, 'convertSchema', [[]]);
+        $this->assertSame(['type' => 'object', 'properties' => [], 'required' => []], $r);
+    }
+
+    // ── F9: Codex streaming parse edge cases ──
+
+    public function test_parse_stream_line_message_null_content_returns_null(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'message', 'content' => null]);
+        $this->assertNull($this->callMethod($gw, 'parseStreamLine', [$line]));
+    }
+
+    public function test_parse_stream_line_message_empty_string_returns_empty(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'message', 'content' => '']);
+        $this->assertSame('', $this->callMethod($gw, 'parseStreamLine', [$line]));
+    }
+
+    public function test_parse_stream_line_message_integer_content_not_null(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'message', 'content' => 42]);
+        $this->assertNotNull($this->callMethod($gw, 'parseStreamLine', [$line]));
+    }
+
+    // ── F10: Codex parseOutput edge cases ──
+
+    public function test_parse_output_all_blank_lines_falls_to_raw(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $input = "\n\n\n";
+        $r = $this->callMethod($gw, 'parseOutput', [$input]);
+        $this->assertSame($input, $r['text']);
+    }
+
+    public function test_parse_output_mixed_json_and_plain_text(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $input = "plain line\n".json_encode(['type' => 'message', 'content' => ' json part']);
+        $r = $this->callMethod($gw, 'parseOutput', [$input]);
+        $this->assertSame('plain line json part', $r['text']);
+    }
+
+    public function test_parse_output_multiple_session_ids_last_wins(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $input = json_encode(['session_id' => 'first'])."\n".
+                 json_encode(['session_id' => 'second']);
+        $r = $this->callMethod($gw, 'parseOutput', [$input]);
+        $this->assertSame('second', $r['session_id']);
+    }
+
+    public function test_parse_output_integer_zero_content_preserved(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'message', 'content' => 0]);
+        $r = $this->callMethod($gw, 'parseOutput', [$line]);
+        $this->assertSame('0', $r['text']);
+    }
+
+    public function test_parse_output_session_id_on_non_message_captured(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'status', 'session_id' => 'abc']);
+        $r = $this->callMethod($gw, 'parseOutput', [$line]);
+        $this->assertSame('abc', $r['session_id']);
+    }
+
+    public function test_parse_output_structured_output_on_non_message_captured(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'result', 'structured_output' => ['key' => 'val']]);
+        $r = $this->callMethod($gw, 'parseOutput', [$line]);
+        $this->assertSame(['key' => 'val'], $r['structured_output']);
+    }
+
+    public function test_parse_output_crlf_line_endings_handled(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $input = json_encode(['type' => 'message', 'content' => 'hello'])."\r\n".
+                 json_encode(['type' => 'message', 'content' => ' world']);
+        $r = $this->callMethod($gw, 'parseOutput', [$input]);
+        $this->assertSame('hello world', $r['text']);
+    }
+
+    // ── F15: Codex continuation edge cases ──
+
+    public function test_continuation_true_no_session_uses_exec_dash(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', null, null, null, true]);
+        $this->assertSame('exec', $cmd[1]);
+        $this->assertSame('-', $cmd[2]);
+        $this->assertNotContains('resume', $cmd);
+    }
+
+    public function test_instructions_skipped_for_continuation_with_session(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', 'Be helpful', null, 'sess1', true]);
+        $this->assertNotContains('--system-prompt', $cmd);
+    }
+
+    public function test_stream_always_ignores_session_state(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['gpt-4', 'sys', null, null, false, true]);
+        $this->assertSame('exec', $cmd[1]);
+        $this->assertSame('-', $cmd[2]);
+        $this->assertContains('--system-prompt', $cmd);
+        $this->assertNotContains('resume', $cmd);
+    }
+
+    // ── F19: Codex volume ──
+
+    public function test_parse_output_50_jsonl_lines_concatenated(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $lines = [];
+        for ($i = 0; $i < 50; $i++) {
+            $lines[] = json_encode(['type' => 'message', 'content' => "p{$i} "]);
+        }
+        $r = $this->callMethod($gw, 'parseOutput', [implode("\n", $lines)]);
+        $this->assertStringContainsString('p0 ', $r['text']);
+        $this->assertStringContainsString('p49 ', $r['text']);
+    }
+
+    // ── G1: Instructions duplication ──
+
+    public function test_generate_text_stdin_does_not_duplicate_instructions(): void
+    {
+        $gw = new class(['timeout' => 30]) extends CodexCliGateway
+        {
+            public ?string $capturedStdin = null;
+
+            public ?array $capturedCommand = null;
+
+            protected function runProcess(array $command, ?string $stdin = null, ?int $timeout = null): string
+            {
+                $this->capturedCommand = $command;
+                $this->capturedStdin = $stdin;
+
+                return json_encode(['type' => 'message', 'content' => 'mocked']);
+            }
+        };
+
+        $provider = $this->mockProvider('test');
+        $gw->generateText($provider, 'gpt-4', 'System instructions', [new UserMessage('user prompt')]);
+
+        $this->assertContains('--system-prompt', $gw->capturedCommand);
+        $this->assertStringNotContainsString('System instructions', $gw->capturedStdin);
+        $this->assertStringContainsString('user prompt', $gw->capturedStdin);
+    }
+
+    // ── G2: Codex "0" text ──
+
+    public function test_parse_output_text_zero_preserved(): void
+    {
+        $gw = new CodexCliGateway([]);
+        $line = json_encode(['type' => 'message', 'content' => '0']);
+        $r = $this->callMethod($gw, 'parseOutput', [$line]);
+        $this->assertSame('0', $r['text']);
+    }
+}

--- a/tests/Unit/Gateway/Cli/GeminiCliGatewayTest.php
+++ b/tests/Unit/Gateway/Cli/GeminiCliGatewayTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit\Gateway\Cli;
+
+use Laravel\Ai\Gateway\Cli\GeminiCliGateway;
+use PHPUnit\Framework\TestCase;
+
+class GeminiCliGatewayTest extends TestCase
+{
+    private GeminiCliGateway $gw;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gw = new GeminiCliGateway(['timeout' => 30]);
+    }
+
+    private function callMethod(object $obj, string $method, array $args = []): mixed
+    {
+        $ref = new \ReflectionMethod($obj, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($obj, $args);
+    }
+
+    // ── A18: buildCommand() ──
+
+    public function test_build_command_base_is_gemini_prompt_text(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', 'hello world']);
+        $this->assertSame('gemini', $cmd[0]);
+        $this->assertSame('--prompt', $cmd[1]);
+        $this->assertSame('hello world', $cmd[2]);
+        $this->assertCount(3, $cmd);
+    }
+
+    public function test_build_command_adds_model_when_provided(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['gemini-2.5-flash', 'test']);
+        $idx = array_search('--model', $cmd);
+        $this->assertNotFalse($idx);
+        $this->assertSame('gemini-2.5-flash', $cmd[$idx + 1]);
+    }
+
+    public function test_build_command_does_not_add_model_for_empty_string(): void
+    {
+        $cmd = $this->callMethod($this->gw, 'buildCommand', ['', 'test']);
+        $this->assertNotContains('--model', $cmd);
+    }
+
+    // ── A19: parseJsonOutput() ──
+
+    public function test_parse_json_output_valid_json_returns_decoded(): void
+    {
+        $r = $this->callMethod($this->gw, 'parseJsonOutput', ['{"response":"hi"}']);
+        $this->assertSame('hi', $r['response']);
+    }
+
+    public function test_parse_json_output_invalid_json_returns_response_trimmed(): void
+    {
+        $r = $this->callMethod($this->gw, 'parseJsonOutput', ['  plain text  ']);
+        $this->assertSame('plain text', $r['response']);
+    }
+
+    // ── A20: binary() ──
+
+    public function test_binary_returns_config_binary_when_set(): void
+    {
+        $gw = new GeminiCliGateway(['binary' => '/opt/gemini']);
+        $this->assertSame('/opt/gemini', $this->callMethod($gw, 'binary'));
+    }
+
+    public function test_binary_returns_gemini_when_not_set(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $this->assertSame('gemini', $this->callMethod($gw, 'binary'));
+    }
+
+    // ── F3: Gemini buildCommand falsy ──
+
+    public function test_build_command_zero_model_not_added(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['0', 'test']);
+        $this->assertNotContains('--model', $cmd);
+    }
+
+    // ── F12: Gemini edge cases ──
+
+    public function test_empty_model_empty_prompt_minimal_command(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', '']);
+        $this->assertSame(['gemini', '--prompt', ''], $cmd);
+    }
+
+    public function test_parse_json_output_array_returns_as_is(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['["a","b"]']);
+        $this->assertSame(['a', 'b'], $r);
+    }
+
+    public function test_parse_json_output_null_returns_fallback(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['null']);
+        $this->assertIsArray($r);
+        $this->assertSame('null', $r['response']);
+    }
+
+    public function test_parse_json_output_integer_returns_fallback(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['99']);
+        $this->assertIsArray($r);
+        $this->assertSame('99', $r['response']);
+    }
+
+    public function test_parse_json_output_empty_string_returns_fallback(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $r = $this->callMethod($gw, 'parseJsonOutput', ['']);
+        $this->assertIsArray($r);
+        $this->assertSame('', $r['response']);
+    }
+
+    // ── F17: Command injection safety ──
+
+    public function test_build_command_shell_metacharacters_passed_as_literal(): void
+    {
+        $gw = new GeminiCliGateway([]);
+        $evil = '$(whoami) | cat /etc/passwd';
+        $cmd = $this->callMethod($gw, 'buildCommand', ['', $evil]);
+        $this->assertSame($evil, $cmd[2]);
+    }
+}


### PR DESCRIPTION
## Summary

So basically right now if you wanna use Laravel AI you need API keys for every provider which means you gotta set up billing, get credits, manage keys etc

But most devs already have subscriptions to Claude, Codex, Gemini through their CLI tools. Like if you have a Claude Pro/Max subscription you can literally use the `claude` command in headless mode as an API alternative

This PR adds CLI gateway providers that let you use your existing AI subscriptions instead of paying for API access separately. Works with Claude Code, OpenAI Codex CLI and Google Gemini CLI

Reference on how Claude Code headless mode works as an API alternatie: https://code.claude.com/docs/en/headless

### Whats included

CLI gateway abstraction that handles process executon, session management for multi turn conversations, streaming support and environment isolation so nested CLI tools dont break each other

Three concrete gateways
- **ClaudeCliGateway** with full session resumption via `--resume`, structured output with json schema, and stream json parsing
- **CodexCliGateway** with JSONL output parsing, session continuity, and structured output support  
- **GeminiCliGateway** lightweight wrapper since gemini cli doesnt support sessions in headless mode

Plus a `CliProvider` that plugs right into the existing provider system so you can use it like any other provider with `Ai::provider('claude-cli')` and configure models, failovers etc

### Config

```php
'claude-cli' => [
    'driver' => 'claude-cli',
    'timeout' => 300,
    'binary' => 'claude',     // optional custom path
    'default_model' => 'sonnet',
    'models' => [
        'cheapest' => 'haiku',
        'smartest' => 'opus',
    ],
],
```

### Tests

197 tests covering basically evrything, unit tests for all gateway methods, edge cases like unicode handling, falsy PHP strings, command injection saftey, session isolation between instances, streaming timeout behavior etc. Also feature tests for the provider and manager factory integration

## Test plan

- [x] All 197 new tests passing
- [x] Existing unit tests unaffected (196 pass)
- [x] Existing feature tests unaffected (failures are pre existing API key issues)
- [x] Manual test with real Claude CLI subscription
- [x] Manual test with Codex CLI subscription
- [x] Manual test with Gemini CLI subscription