### PR TITLE
[0.x] Add community package link for AI health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The Laravel AI SDK provides a unified, expressive API for interacting with AI pr
 
 Documentation for the Laravel AI SDK can be found on the [Laravel website](https://laravel.com/docs/ai-sdk).
 
+## Community Packages
+
+The following community package provides AI provider health checks via an Artisan command:
+
+- [`vaibhavjethva/laravel-ai-health`](https://packagist.org/packages/vaibhavjethva/laravel-ai-health) (`composer require vaibhavjethva/laravel-ai-health`)
+
 ## Contributing
 
 Thank you for considering contributing to Laravel! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).


### PR DESCRIPTION
This PR intentionally does not add framework code.

  Based on prior maintainer feedback about keeping core maintenance surface small, I moved AI provider health checks into a standalone community
  package and am only adding a README reference here.

  ## Changes
  - Add a `Community Packages` section to `README.md`
  - Link community package:
    - `vaibhavjethva/laravel-ai-health`
    - `composer require vaibhavjethva/laravel-ai-health`

  ## Why
  - Keeps `laravel/ai` core lean
  - Avoids adding long-term maintenance burden
  - Still makes the functionality available to users

  ## Package
  - Packagist: https://packagist.org/packages/vaibhavjethva/laravel-ai-health
  - Source: https://github.com/vaibhavjethva/laravel-ai-health
  - Command provided by package: `php artisan ai:health`