### PR TITLE
Renamed image to image_size in geminiprovider according to gemini api

### DIFF
--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -119,7 +119,7 @@ class GeminiProvider extends Provider implements EmbeddingProvider, FileProvider
     public function defaultImageOptions(?string $size = null, $quality = null): array
     {
         return array_filter([
-            'size' => match ($quality) {
+            'image_size' => match ($quality) {
                 'low', '1K' => '1K',
                 'medium', '2K' => '2K',
                 'high', '4K' => '4K',


### PR DESCRIPTION
The laravel SDK sends a generationConfig to Gemini with size. The gemini api however expects image_size. Changing this allows to succesfully generate 1K, 2K and 4K resolutions like intended.