### PR TITLE
feat: add `extra` property to Meta class for full Prism metadata

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -91,12 +91,14 @@ class PrismGateway implements Gateway
             new Collection($response->additionalContent['citations'] ?? [])
         );
 
+        $meta = PrismMeta::toLaravelMeta($provider->name(), $response->meta, $citations);
+
         return $structured
             ? (new StructuredTextResponse(
                 $response->structured,
                 $response->text,
                 PrismUsage::toLaravelUsage($response->usage),
-                new Meta($provider->name(), $response->meta->model, $citations),
+                $meta,
             ))->withToolCallsAndResults(
                 toolCalls: (new Collection($response->toolCalls))->map(PrismTool::toLaravelToolCall(...)),
                 toolResults: (new Collection($response->toolResults))->map(PrismTool::toLaravelToolResult(...)),
@@ -104,7 +106,7 @@ class PrismGateway implements Gateway
             : (new TextResponse(
                 $response->text,
                 PrismUsage::toLaravelUsage($response->usage),
-                new Meta($provider->name(), $response->meta->model, $citations),
+                $meta,
             ))->withMessages(
                 PrismMessages::toLaravelMessages($response->messages)
             )->withSteps(PrismSteps::toLaravelSteps($response->steps, $provider));
@@ -200,7 +202,7 @@ class PrismGateway implements Gateway
                 return new GeneratedImage($image->base64, $image->mimeType);
             }),
             PrismUsage::toLaravelUsage($response->usage),
-            new Meta($provider->name(), $model),
+            PrismMeta::toLaravelMeta($provider->name(), $response->meta),
         );
     }
 
@@ -360,7 +362,7 @@ class PrismGateway implements Gateway
         return new EmbeddingsResponse(
             (new Collection($response->embeddings))->map->embedding->all(),
             $response->usage->tokens,
-            new Meta($provider->name(), $model),
+            PrismMeta::toLaravelMeta($provider->name(), $response->meta),
         );
     }
 

--- a/src/Gateway/Prism/PrismMeta.php
+++ b/src/Gateway/Prism/PrismMeta.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Prism;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Responses\Data\Meta;
+use Prism\Prism\ValueObjects\Meta as PrismMetaValueObject;
+
+class PrismMeta
+{
+    /**
+     * Convert the Prism meta value object to a Laravel AI SDK usage object.
+     */
+    public static function toLaravelMeta(
+        ?string $provider,
+        ?PrismMetaValueObject $meta,
+        ?Collection $citations = null
+    ): Meta {
+        return new Meta(
+            provider: $provider,
+            model: $meta?->model ?? null,
+            citations: $citations,
+            extra: $meta
+                ? collect(array_diff_key($meta->toArray(), ['model' => true]))
+                : null
+        );
+    }
+}

--- a/src/Gateway/Prism/PrismSteps.php
+++ b/src/Gateway/Prism/PrismSteps.php
@@ -5,7 +5,6 @@ namespace Laravel\Ai\Gateway\Prism;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
-use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\StructuredStep;
 use Prism\Prism\Enums\FinishReason as PrismFinishReason;
@@ -37,7 +36,7 @@ class PrismSteps
             (new Collection($step->toolResults))->map(PrismTool::toLaravelToolResult(...))->all(),
             static::toLaravelFinishReason($step->finishReason),
             PrismUsage::toLaravelUsage($step->usage),
-            new Meta($provider->name(), $step->meta->model),
+            PrismMeta::toLaravelMeta($provider->name(), $step->meta),
         );
     }
 
@@ -53,7 +52,7 @@ class PrismSteps
             (new Collection($step->toolResults))->map(PrismTool::toLaravelToolResult(...))->all(),
             static::toLaravelFinishReason($step->finishReason),
             PrismUsage::toLaravelUsage($step->usage),
-            new Meta($provider->name(), $step->meta->model),
+            PrismMeta::toLaravelMeta($provider->name(), $step->meta),
         );
     }
 

--- a/src/Responses/Data/Meta.php
+++ b/src/Responses/Data/Meta.php
@@ -10,12 +10,16 @@ class Meta implements Arrayable, JsonSerializable
 {
     public Collection $citations;
 
+    public Collection $extra;
+
     public function __construct(
         public ?string $provider = null,
         public ?string $model = null,
         ?Collection $citations = null,
+        ?Collection $extra = null
     ) {
         $this->citations = $citations ?? new Collection;
+        $this->extra = $extra ?? new Collection;
     }
 
     /**
@@ -26,9 +30,8 @@ class Meta implements Arrayable, JsonSerializable
         return [
             'provider' => $this->provider,
             'model' => $this->model,
-            'citations' => $this->citations
-                ? $this->citations->all()
-                : [],
+            'citations' => $this->citations->all(),
+            'extra' => $this->extra->all(),
         ];
     }
 

--- a/tests/Unit/Gateway/Prism/PrismMetaTest.php
+++ b/tests/Unit/Gateway/Prism/PrismMetaTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Gateway\Prism\PrismMeta;
+use Laravel\Ai\Responses\Data\Meta;
+use PHPUnit\Framework\TestCase;
+use Prism\Prism\ValueObjects\Meta as PrismMetaValueObject;
+use Prism\Prism\ValueObjects\ProviderRateLimit;
+
+class PrismMetaTest extends TestCase
+{
+    public function test_converts_prism_meta_with_all_fields(): void
+    {
+        $prismMeta = new PrismMetaValueObject(
+            id: 'req_abc123',
+            model: 'gpt-4',
+            rateLimits: [
+                new ProviderRateLimit(
+                    name: 'daily',
+                    limit: 1000,
+                    remaining: 850
+                ),
+            ],
+            serviceTier: 'auto'
+        );
+
+        $meta = PrismMeta::toLaravelMeta('provider-name', $prismMeta);
+
+        $this->assertInstanceOf(Meta::class, $meta);
+        $this->assertEquals('provider-name', $meta->provider);
+        $this->assertEquals('gpt-4', $meta->model);
+        $this->assertInstanceOf(Collection::class, $meta->extra);
+        $this->assertTrue($meta->extra->has('id'));
+        $this->assertEquals('req_abc123', $meta->extra->get('id'));
+        $this->assertTrue($meta->extra->has('rate_limits'));
+        $this->assertIsArray($meta->extra->get('rate_limits'));
+        $this->assertTrue($meta->extra->has('service_tier'));
+        $this->assertEquals('auto', $meta->extra->get('service_tier'));
+    }
+
+    public function test_converts_prism_meta_with_citations(): void
+    {
+        $prismMeta = new PrismMetaValueObject(
+            id: 'req_abc123',
+            model: 'gpt-4'
+        );
+
+        $citations = new Collection([
+            ['title' => 'Test Citation', 'url' => 'https://example.com'],
+        ]);
+
+        $meta = PrismMeta::toLaravelMeta('provider-name', $prismMeta, $citations);
+
+        $this->assertInstanceOf(Collection::class, $meta->citations);
+        $this->assertCount(1, $meta->citations);
+    }
+
+    public function test_model_is_not_duplicated_in_extra(): void
+    {
+        $prismMeta = new PrismMetaValueObject(
+            id: 'req_abc123',
+            model: 'gpt-4',
+            rateLimits: [],
+            serviceTier: 'auto'
+        );
+
+        $meta = PrismMeta::toLaravelMeta('provider-name', $prismMeta);
+
+        $this->assertFalse($meta->extra->has('model'));
+        $this->assertEquals('gpt-4', $meta->model);
+    }
+
+    public function test_handles_null_prism_meta(): void
+    {
+        $meta = PrismMeta::toLaravelMeta('provider-name', null);
+
+        $this->assertInstanceOf(Meta::class, $meta);
+        $this->assertNull($meta->model);
+        $this->assertInstanceOf(Collection::class, $meta->extra);
+        $this->assertTrue($meta->extra->isEmpty());
+    }
+
+    public function test_extra_contains_id_even_when_only_id_and_model_provided(): void
+    {
+        $prismMeta = new PrismMetaValueObject(
+            id: 'req_abc123',
+            model: 'gpt-4'
+        );
+
+        $meta = PrismMeta::toLaravelMeta('provider-name', $prismMeta);
+
+        $this->assertFalse($meta->extra->isEmpty());
+        $this->assertTrue($meta->extra->has('id'));
+        $this->assertEquals('req_abc123', $meta->extra->get('id'));
+    }
+
+    public function test_meta_toarray_includes_extra(): void
+    {
+        $prismMeta = new PrismMetaValueObject(
+            id: 'req_abc123',
+            model: 'gpt-4',
+            rateLimits: [
+                new ProviderRateLimit(
+                    name: 'daily',
+                    limit: 1000,
+                    remaining: 850
+                ),
+            ],
+            serviceTier: 'auto'
+        );
+
+        $meta = PrismMeta::toLaravelMeta('provider-name', $prismMeta);
+
+        $array = $meta->toArray();
+
+        $this->assertArrayHasKey('extra', $array);
+        $this->assertArrayHasKey('id', $array['extra']);
+        $this->assertArrayHasKey('rate_limits', $array['extra']);
+        $this->assertArrayHasKey('service_tier', $array['extra']);
+    }
+}


### PR DESCRIPTION
This PR adds an `extra` property to the `Meta` class that exposes all metadata from Prism responses, including fields like `rate_limits`, `service_tier`, and `id`.

The Prism Meta class contains additional data about the request (rate_limits, service_tier, id) that wasn't being exposed to Laravel AI SDK users. Manually mapping each field would:
- Require continuous updates as Prism adds new fields
- Bloat the Meta class with provider-specific fields
- Miss undocumented or experimental fields

Added an `extra` Collection property to the `Meta` class that captures all Prism metadata. The `PrismMeta` converter filters out the `model` field (which is already a top-level property) and includes everything else in `extra`.

### Usage
$extra = SalesCoach::make()->prompt('Test')->meta->extra
$extra->get('id'); // 'req_abc123'
$extra->get('rate_limits'); // [...]
$extra->get('service_tier'); // 'auto'

Requested by https://github.com/laravel/ai/issues/204