### PR TITLE
[0.x] Allow for arrays and enum for providers in the macros

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -11,6 +11,7 @@ use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeAgentMiddlewareCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 
 class AiServiceProvider extends ServiceProvider
@@ -38,7 +39,7 @@ class AiServiceProvider extends ServiceProvider
 
         // Embeddings macro...
         Stringable::macro('toEmbeddings', function (
-            ?string $provider = null,
+            Lab|array|string|null $provider = null,
             ?int $dimensions = null,
             ?string $model = null,
             bool|int|null $cache = null,
@@ -61,7 +62,7 @@ class AiServiceProvider extends ServiceProvider
             Closure|array|string $by,
             string $query,
             ?int $limit = null,
-            array|string|null $provider = null,
+            Lab|array|string|null $provider = null,
             ?string $model = null
         ) {
             $resolver = match (true) {


### PR DESCRIPTION
This allows arrays and enums to be passed through the macros to match the APIs at `\Laravel\Ai\PendingResponses\PendingEmbeddingsGeneration::generate` and `\Laravel\Ai\PendingResponses\PendingReranking::rerank`