### PR TITLE
refactor: remove the `$options` parameter from `addProviderTools` method calls

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -76,7 +76,7 @@ class PrismGateway implements Gateway
 
         if (count($tools) > 0) {
             $this->addTools($request, $tools, $options);
-            $this->addProviderTools($provider, $request, $tools, $options);
+            $this->addProviderTools($provider, $request, $tools);
         }
 
         try {
@@ -135,7 +135,7 @@ class PrismGateway implements Gateway
 
         if (count($tools) > 0) {
             $this->addTools($request, $tools, $options);
-            $this->addProviderTools($provider, $request, $tools, $options);
+            $this->addProviderTools($provider, $request, $tools);
         }
 
         try {


### PR DESCRIPTION
Remove the `$options` parameter from `addProviderTools` method calls.

\Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests::addProviderTools does not have an $options parameter.
