### PR TITLE
Fix BroadcastAgent passing wrong response type to then() callbacks

### DIFF
--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Jobs\BroadcastAgent;
+use Laravel\Ai\Responses\StreamedAgentResponse;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\TestCase;
+
+class BroadcastAgentTest extends TestCase
+{
+    public function test_then_callback_receives_streamed_agent_response(): void
+    {
+        Event::fake();
+        AssistantAgent::fake(['Hello world']);
+
+        $received = null;
+
+        $job = new BroadcastAgent(
+            agent: new AssistantAgent,
+            prompt: 'Say hello',
+            channels: new Channel('test-channel'),
+        );
+
+        $job->then(function ($response) use (&$received) {
+            $received = $response;
+        });
+
+        $job->handle();
+
+        $this->assertNotNull($received, 'then() callback was never invoked');
+        $this->assertInstanceOf(StreamedAgentResponse::class, $received);
+        $this->assertSame('Hello world', $received->text);
+    }
+
+    public function test_multiple_then_callbacks_all_receive_streamed_agent_response(): void
+    {
+        Event::fake();
+        AssistantAgent::fake(['Hello world']);
+
+        $receivedA = null;
+        $receivedB = null;
+
+        $job = new BroadcastAgent(
+            agent: new AssistantAgent,
+            prompt: 'Say hello',
+            channels: new Channel('test-channel'),
+        );
+
+        $job->then(function ($response) use (&$receivedA) {
+            $receivedA = $response;
+        });
+
+        $job->then(function ($response) use (&$receivedB) {
+            $receivedB = $response;
+        });
+
+        $job->handle();
+
+        $this->assertInstanceOf(StreamedAgentResponse::class, $receivedA);
+        $this->assertInstanceOf(StreamedAgentResponse::class, $receivedB);
+    }
+
+    public function test_streamed_response_passed_to_then_is_fully_resolved(): void
+    {
+        Event::fake();
+        AssistantAgent::fake(['Hello world']);
+
+        $received = null;
+
+        $job = new BroadcastAgent(
+            agent: new AssistantAgent,
+            prompt: 'Say hello',
+            channels: new Channel('test-channel'),
+        );
+
+        $job->then(function ($response) use (&$received) {
+            $received = $response;
+        });
+
+        $job->handle();
+
+        $this->assertNotNull($received, 'then() callback was never invoked');
+        $this->assertInstanceOf(StreamedAgentResponse::class, $received);
+        $this->assertNotEmpty($received->events);
+        $this->assertSame('Hello world', $received->text);
+    }
+}


### PR DESCRIPTION
Supersedes #224

Anyone who registers a then() callback on a broadcast agent job would recieve a StreamableAgentResponse instead of StreamedAgentResponse which is the wrong type and breaks the contract that then() callbacks rely on

The root cause is that BroadcastAgent::handle() was wrapping everything inside withCallbacks() and returning the result of each() which is StreamableAgentResponse not the fully resolved response after the stream completes

InvokeAgent does this correctly because prompt() directly returns an AgentResponse so withCallbacks() passes the right thing but BroadcastAgent was streaming async and returning the wrong object

**What breaks for end users**

```php
BroadcastAgent::dispatch($agent, 'Say hello', $channels)
    ->then(function ($response) {
        // $response was StreamableAgentResponse here, not StreamedAgentResponse
        // accessing $response->text or $response->usage would not behave as expected
        Storage::put('response.txt', $response->text);
    });
```

**The fix**

Capture the StreamedAgentResponse from the stream's own then() callback after all events are consumed, then pass that to withCallbacks() so every registered then() callback recives the correct fully resolved type

**Why this doesn't break anything**

The streaming and broadcasting behavior is completly unchanged, events still fire in the same order through each(), the only difference is what gets passed to the job's then() callbacks after the stream finishes

**Tests**

Added integration tests in BroadcastAgentTest covering the type mismatch directly, multiple callbacks all receiving the right type, and the resolved response having the correct text and events populated