### PR TITLE
Add failover support for insufficient credits and quota errors

### DIFF
--- a/src/Exceptions/InsufficientCreditsException.php
+++ b/src/Exceptions/InsufficientCreditsException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+use Throwable;
+
+class InsufficientCreditsException extends AiException implements FailoverableException
+{
+    public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
+    {
+        return new static(
+            'AI provider ['.$provider.'] has insufficient credits or quota.',
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/Gateway/Prism/PrismException.php
+++ b/src/Gateway/Prism/PrismException.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Prism;
 
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Providers\Provider;
@@ -12,8 +13,22 @@ use Prism\Prism\Exceptions\PrismRateLimitedException;
 class PrismException
 {
     /**
+     * The patterns used to detect insufficient credits or quota errors from provider responses.
+     *
+     * @var list<string>
+     */
+    protected static array $insufficientCreditPatterns = [
+        'credit balance',
+        'insufficient',
+        'quota exceeded',
+        'exceeded your current quota',
+        'billing',
+    ];
+
+    /**
      * Create a new AI exception from a Prism exception.
      *
+     * @throws InsufficientCreditsException
      * @throws ProviderOverloadedException
      * @throws RateLimitedException
      * @throws \Throwable Rethrows the previous exception when the message indicates a tool call failed.
@@ -39,10 +54,32 @@ class PrismException
             throw $e->getPrevious();
         }
 
+        if (static::isInsufficientCreditsError($e)) {
+            throw InsufficientCreditsException::forProvider(
+                $provider->name(), $e->getCode(), $e->getPrevious()
+            );
+        }
+
         return new AiException(
             $e->getMessage(),
             code: $e->getCode(),
             previous: $e->getPrevious(),
         );
+    }
+
+    /**
+     * Determine if the given exception indicates an insufficient credits or quota error.
+     */
+    protected static function isInsufficientCreditsError(\Prism\Prism\Exceptions\PrismException $e): bool
+    {
+        $message = strtolower($e->getMessage());
+
+        foreach (static::$insufficientCreditPatterns as $pattern) {
+            if (str_contains($message, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

When a provider returns a billing/credit error (e.g., Anthropic's "Your credit balance is too low" or OpenAI's "You exceeded your current quota"), the error is an HTTP 400 which gets converted to a plain `AiException`. Since `withModelFailover` only catches `FailoverableException`, the failover mechanism does not attempt the next provider.

This PR adds:

- **`InsufficientCreditsException`** — extends `AiException` and implements `FailoverableException`, so billing errors trigger the standard failover flow
- **Detection in `PrismException::toAiException`** — pattern-matches error messages for common billing/credit/quota phrases before falling through to the generic `AiException`

### Before
```php
// config/ai.php: 'default' => ['anthropic', 'gemini']
// When Anthropic credits are exhausted:
// ❌ Throws AiException, Gemini is never tried
```

### After
```php
// config/ai.php: 'default' => ['anthropic', 'gemini']
// When Anthropic credits are exhausted:
// ✅ Throws InsufficientCreditsException (FailoverableException)
// ✅ Gemini is tried automatically
```

### Detected patterns
- `credit balance` (Anthropic)
- `insufficient` (OpenRouter, DeepSeek)
- `quota exceeded` / `exceeded your current quota` (OpenAI)
- `billing` (general)

The patterns are stored in a static property (`$insufficientCreditPatterns`) on `PrismException` for easy extension.

## Test plan

- [ ] Verify existing failover tests still pass
- [ ] Add test: `AiException` with "credit balance" message triggers failover to next provider
- [ ] Add test: `AiException` with unrelated message does NOT trigger failover
- [ ] Test with real exhausted Anthropic account and `['anthropic', 'gemini']` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)