### PR TITLE
Allow instructions() to return an array for prompt cache optimization

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@ use Laravel\Ai\Contracts\Agent;
  * Get an ad-hoc agent instance.
  */
 function agent(
-    string $instructions = '',
+    string|array $instructions = '',
     iterable $messages = [],
     iterable $tools = [],
     ?Closure $schema = null,

--- a/src/AnonymousAgent.php
+++ b/src/AnonymousAgent.php
@@ -10,9 +10,9 @@ class AnonymousAgent implements Agent, Conversational, HasTools
 {
     use Promptable;
 
-    public function __construct(public string $instructions, public iterable $messages, public iterable $tools) {}
+    public function __construct(public string|array $instructions, public iterable $messages, public iterable $tools) {}
 
-    public function instructions(): string
+    public function instructions(): string|array
     {
         return $this->instructions;
     }

--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -13,8 +13,10 @@ interface Agent
 {
     /**
      * Get the instructions that the agent should follow.
+     *
+     * @return Stringable|string|array<int, Stringable|string>
      */
-    public function instructions(): Stringable|string;
+    public function instructions(): Stringable|string|array;
 
     /**
      * Invoke the agent with a given prompt.

--- a/src/Contracts/Gateway/TextGateway.php
+++ b/src/Contracts/Gateway/TextGateway.php
@@ -20,7 +20,7 @@ interface TextGateway
     public function generateText(
         TextProvider $provider,
         string $model,
-        ?string $instructions,
+        string|array|null $instructions,
         array $messages = [],
         array $tools = [],
         ?array $schema = null,
@@ -39,7 +39,7 @@ interface TextGateway
         string $invocationId,
         TextProvider $provider,
         string $model,
-        ?string $instructions,
+        string|array|null $instructions,
         array $messages = [],
         array $tools = [],
         ?array $schema = null,

--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -42,7 +42,7 @@ class FakeTextGateway implements TextGateway
     public function generateText(
         TextProvider $provider,
         string $model,
-        ?string $instructions,
+        string|array|null $instructions,
         array $messages = [],
         array $tools = [],
         ?array $schema = null,
@@ -67,7 +67,7 @@ class FakeTextGateway implements TextGateway
         string $invocationId,
         TextProvider $provider,
         string $model,
-        ?string $instructions,
+        string|array|null $instructions,
         array $messages = [],
         array $tools = [],
         ?array $schema = null,

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -58,7 +58,7 @@ class PrismGateway implements Gateway
     public function generateText(
         TextProvider $provider,
         string $model,
-        ?string $instructions,
+        string|array|null $instructions,
         array $messages = [],
         array $tools = [],
         ?array $schema = null,
@@ -70,8 +70,10 @@ class PrismGateway implements Gateway
             ! empty($schema),
         ];
 
-        if (! empty($instructions)) {
-            $request->withSystemPrompt($instructions);
+        foreach ((array) ($instructions ?? []) as $instruction) {
+            if (! empty($instruction)) {
+                $request->withSystemPrompt($instruction);
+            }
         }
 
         if (count($tools) > 0) {
@@ -117,7 +119,7 @@ class PrismGateway implements Gateway
         string $invocationId,
         TextProvider $provider,
         string $model,
-        ?string $instructions,
+        string|array|null $instructions,
         array $messages = [],
         array $tools = [],
         ?array $schema = null,
@@ -129,8 +131,10 @@ class PrismGateway implements Gateway
             ! empty($schema),
         ];
 
-        if (! empty($instructions)) {
-            $request->withSystemPrompt($instructions);
+        foreach ((array) ($instructions ?? []) as $instruction) {
+            if (! empty($instruction)) {
+                $request->withSystemPrompt($instruction);
+            }
         }
 
         if (count($tools) > 0) {

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -56,10 +56,12 @@ trait GeneratesText
 
                 $this->listenForToolInvocations($invocationId, $agent);
 
+                $instructions = $agent->instructions();
+
                 $response = $this->textGateway()->generateText(
                     $this,
                     $prompt->model,
-                    (string) $agent->instructions(),
+                    is_array($instructions) ? array_map(strval(...), $instructions) : (string) $instructions,
                     $messages,
                     $agent instanceof HasTools ? $agent->tools() : [],
                     $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null,

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -54,11 +54,13 @@ trait StreamsText
 
                         $this->listenForToolInvocations($invocationId, $agent);
 
+                        $instructions = $agent->instructions();
+
                         yield from $this->textGateway()->streamText(
                             $invocationId,
                             $this,
                             $prompt->model,
-                            (string) $agent->instructions(),
+                            is_array($instructions) ? array_map(strval(...), $instructions) : (string) $instructions,
                             $messages,
                             $agent instanceof HasTools ? $agent->tools() : [],
                             null,

--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -12,7 +12,7 @@ class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOu
     public $schema;
 
     public function __construct(
-        public string $instructions,
+        public string|array $instructions,
         public iterable $messages,
         public iterable $tools,
         Closure $schema,

--- a/tests/Feature/AgentIntegrationTest.php
+++ b/tests/Feature/AgentIntegrationTest.php
@@ -16,8 +16,11 @@ use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\TextResponseFake;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\ConversationalAgent;
+use Tests\Feature\Agents\MultiInstructionAgent;
 use Tests\Feature\Agents\StructuredAgent;
 use Tests\Feature\Agents\ToolUsingAgent;
 use Tests\TestCase;
@@ -265,5 +268,20 @@ class AgentIntegrationTest extends TestCase
         }
 
         $this->assertTrue($caught);
+    }
+
+    public function test_agents_can_have_multiple_system_prompts(): void
+    {
+        $fake = Prism::fake([TextResponseFake::make()->withText('Hello John!')]);
+
+        (new MultiInstructionAgent)->prompt('Hi there');
+
+        $fake->assertRequest(function (array $requests) {
+            $systemPrompts = $requests[0]->systemPrompts();
+
+            $this->assertCount(2, $systemPrompts);
+            $this->assertEquals('You are a helpful assistant.', $systemPrompts[0]->content);
+            $this->assertEquals('The user is John.', $systemPrompts[1]->content);
+        });
     }
 }

--- a/tests/Feature/Agents/MultiInstructionAgent.php
+++ b/tests/Feature/Agents/MultiInstructionAgent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+class MultiInstructionAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): array
+    {
+        return ['You are a helpful assistant.', 'The user is John.'];
+    }
+}


### PR DESCRIPTION
Providers like Anthropic and Gemini support prompt caching, but only when static content is isolated in its own system message block. Today, `instructions()` returns a single string, so any per-request context (variables, user-specific data) mixed into the prompt invalidates the entire cache on every call. That means you're paying full token costs repeatedly for content that never changes.

By allowing `instructions()` to return an array, each element becomes a separate `withSystemPrompt()` call. This lets you split long, static instructions into one block (cached across requests) and volatile context into another. On prompt-heavy agents, this can significantly reduce API costs.

Fully backward compatible — returning a string works identically. New test verifies both array elements reach the Prism request as separate `SystemMessage` objects.