### PR TITLE
fix: structured output schema definition

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -54,9 +54,6 @@ class Schema implements PrismSchema, Schemable
      */
     public function toSchema(): array
     {
-        return [
-            'name' => $this->name,
-            ...$this->schema->toArray(),
-        ];
+        return $this->schema->toArray();
     }
 }


### PR DESCRIPTION
I was using the structured output definition with an OpenRouter token when I got the following exception:

```
Laravel\Ai\Exceptions\AiException: OpenRouter Bad Request: output_config.format.schema: For 'object' type, property 'name' is not supported.
```

The `Schema::toSchema()` (line 55-61) injects a `name` property into the schema array:

```php
public function toSchema(): array
{
    return [
        'name' => $this->name,
        ...$this->schema->toArray(),
    ];
}
```

Since `toArray()` delegates to `toSchema()`, every consumer of `->toArray()` receives the `name` key inside the JSON schema object.

Prism's provider handlers (e.g. OpenRouter, OpenAI, XAI) already extract the name via the dedicated `->name()` method and place it in the correct wrapper position. For example, `Prism\Prism\Providers\OpenRouter\Handlers\Structured` (line 62-69):

```php
'response_format' => [
    'type' => 'json_schema',
    'json_schema' => [
        'name' => $request->schema()->name(),   // Name in wrapper...
        'strict' => true,
        'schema' => $request->schema()->toArray(), // Duplicate property `name`...
    ],
],
```

This produces a payload where `name` appears both in the wrapper and inside the schema object.

The fix is simple: removing the explicit `name` injection into the `toSchema()` method as the `Schema` object already contains a `name()` method. 

It appears that other providers are not requiring this nested `name` property either, as for example Gemini was already stripping it manually. Not sure what provider this code originally was developed with, but I think this should be fine as `Schema` is a Prism object handled by Prism so the `name` doesn't need to be injected in the Schema-array _as well_.

Thanks!