### PR TITLE
[0.x] Adjust AddsToolsToPrismRequestsTest

### DIFF
--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -147,7 +147,7 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function test_invoke_tool(Tool $tool, array $arguments): string
+            public function testInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }


### PR DESCRIPTION
There's a typo here, as `test_invoke_tool_handles_empty_arguments` calls `$handler->testInvokeTool` meaning as is the test fails- guessing this was pint?

The other tests already do this, just this one that didnt.

Noticed this while I was poking the tests.