### PR TITLE
[0.x] rename anonymous class helper methods to avoid Pint renaming

### DIFF
--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -49,13 +49,13 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function testInvokeTool(Tool $tool, array $arguments): string
+            public function callTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
         };
 
-        $handler->testInvokeTool($tool, ['schema_definition' => ['query' => 'test']]);
+        $handler->callTool($tool, ['schema_definition' => ['query' => 'test']]);
 
         $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
     }
@@ -98,13 +98,13 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function testInvokeTool(Tool $tool, array $arguments): string
+            public function callTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
         };
 
-        $handler->testInvokeTool($tool, ['query' => 'test']);
+        $handler->callTool($tool, ['query' => 'test']);
 
         $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
     }
@@ -147,13 +147,13 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function testInvokeTool(Tool $tool, array $arguments): string
+            public function callTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
         };
 
-        $handler->testInvokeTool($tool, []);
+        $handler->callTool($tool, []);
 
         $this->assertEquals([], $tool->receivedArguments);
     }

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -49,13 +49,13 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function callTool(Tool $tool, array $arguments): string
+            public function callInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
         };
 
-        $handler->callTool($tool, ['schema_definition' => ['query' => 'test']]);
+        $handler->callInvokeTool($tool, ['schema_definition' => ['query' => 'test']]);
 
         $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
     }
@@ -98,13 +98,13 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function callTool(Tool $tool, array $arguments): string
+            public function callInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
         };
 
-        $handler->callTool($tool, ['query' => 'test']);
+        $handler->callInvokeTool($tool, ['query' => 'test']);
 
         $this->assertEquals(['query' => 'test'], $tool->receivedArguments);
     }
@@ -147,13 +147,13 @@ class AddsToolsToPrismRequestsTest extends TestCase
                 $this->toolInvokedCallback = fn () => null;
             }
 
-            public function callTool(Tool $tool, array $arguments): string
+            public function callInvokeTool(Tool $tool, array $arguments): string
             {
                 return $this->invokeTool($tool, $arguments);
             }
         };
 
-        $handler->callTool($tool, []);
+        $handler->callInvokeTool($tool, []);
 
         $this->assertEquals([], $tool->receivedArguments);
     }


### PR DESCRIPTION
Sorry, another PR!

Pint's `php_unit_method_casing `rule was renaming one of the testInvokeTool anonymous class helper methods to `test_invoke_tool`, causing the test to fail when running locally.  I assumed it was a typo in my previous PR, but its actually pint :D 

This PR renames all three methods to callInvokeTool to prevent Pint from touching them which just prevents confusion for anyone testing unit tests locally.

TLDR - stops pint doing:
```diff
-            public function testInvokeTool(Tool $tool, array $arguments): string
+            public function test_invoke_tool(Tool $tool, array $arguments): string
```