### PR TITLE
[0.x] Create a CI test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,18 @@ jobs:
             laravel: 12
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - uses: shivammathur/setup-php@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
           coverage: none
 
-      - run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"
 
-      - run: vendor/bin/phpunit --testsuite Unit
+      - name: Execute tests
+        run: vendor/bin/phpunit --testsuite Unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+
+jobs:
+  tests:
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+        laravel: [12, 13]
+        exclude:
+          - php: '8.5'
+            laravel: 12
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"
+
+      - run: vendor/bin/phpunit --testsuite Unit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "laravel/pint": "^1.26",
         "mockery/mockery": "^1.6.12",
-        "orchestra/testbench": "^10.6"
+        "orchestra/testbench": "^10.6|^11.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Feel free to close if this is too early, or you'd prefer to handle it internally.

This adds a workflow for the unit tests (integration doesnt work because it expects real API tokens, so left it out for now)                                                     
                                                                                                                                                                                 
Without a CI workflow, reviewers / contributors have no feedback on whether a PR breaks. 

I've left code styling out as wasnt sure if you'd  use Style CI etc. 

so TLDR is this just gives at least some feedback rather than none, and helps spotting any regression unit test wise.

left fairly basic so it can be improved but follows all the other laravel package tests.

Here's the action output: https://github.com/jackbayliss/ai/actions/runs/22927878150
🫡 