### PR TITLE
Fix conversation leakage in RemembersConversations::forUser()

### DIFF
--- a/src/Concerns/RemembersConversations.php
+++ b/src/Concerns/RemembersConversations.php
@@ -15,6 +15,7 @@ trait RemembersConversations
      */
     public function forUser($user): static
     {
+        $this->conversationId = null;
         $this->conversationUser = $user;
 
         return $this;


### PR DESCRIPTION
This PR fixes a security bug where reusing an agent instance across multiple users would leak conversation history between users.

This happens because the `forUser()` method only updates the `$conversationUser` and does not reset the `$conversationId`. When the same agent instance is used for multiple users, the second user would continue 1st user's conversation, allowing access to private conversation history.

The fix resets `$conversationId` to null in `forUser()` to ensure each user starts a new conversation.