### PR TITLE
Add configurable timeout for embedding requests

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -43,6 +43,7 @@ class AiServiceProvider extends ServiceProvider
             ?int $dimensions = null,
             ?string $model = null,
             bool|int|null $cache = null,
+            ?int $timeout = null,
         ) {
             $request = Embeddings::for([$this->value]);
 
@@ -52,6 +53,10 @@ class AiServiceProvider extends ServiceProvider
 
             if ($cache !== false && ! is_null($cache)) {
                 $request->cache(is_int($cache) ? $cache : null);
+            }
+
+            if (! is_null($timeout)) {
+                $request->timeout($timeout);
             }
 
             return $request->generate(provider: $provider, model: $model)->embeddings[0];

--- a/src/Contracts/Gateway/EmbeddingGateway.php
+++ b/src/Contracts/Gateway/EmbeddingGateway.php
@@ -12,5 +12,5 @@ interface EmbeddingGateway
      *
      * @param  string[]  $inputs
      */
-    public function generateEmbeddings(EmbeddingProvider $provider, string $model, array $inputs, int $dimensions): EmbeddingsResponse;
+    public function generateEmbeddings(EmbeddingProvider $provider, string $model, array $inputs, int $dimensions, int $timeout = 30): EmbeddingsResponse;
 }

--- a/src/Contracts/Providers/EmbeddingProvider.php
+++ b/src/Contracts/Providers/EmbeddingProvider.php
@@ -12,7 +12,7 @@ interface EmbeddingProvider
      *
      * @param  string[]  $inputs
      */
-    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null): EmbeddingsResponse;
+    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse;
 
     /**
      * Get the provider's embedding gateway.

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -25,9 +25,10 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         EmbeddingProvider $provider,
         string $model,
         array $inputs,
-        int $dimensions
+        int $dimensions,
+        int $timeout = 30,
     ): EmbeddingsResponse {
-        $response = $this->client($provider)->post('/embed', [
+        $response = $this->client($provider, $timeout)->post('/embed', [
             'model' => $model,
             'texts' => $inputs,
             'input_type' => 'search_document',
@@ -79,7 +80,7 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
     /**
      * Get an HTTP client for the Cohere API.
      */
-    protected function client(EmbeddingProvider|RerankingProvider $provider): PendingRequest
+    protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
     {
         $config = $provider->additionalConfiguration();
 
@@ -88,6 +89,7 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
+            ->timeout($timeout)
             ->throw();
     }
 }

--- a/src/Gateway/FakeEmbeddingGateway.php
+++ b/src/Gateway/FakeEmbeddingGateway.php
@@ -30,9 +30,10 @@ class FakeEmbeddingGateway implements EmbeddingGateway
         EmbeddingProvider $provider,
         string $model,
         array $inputs,
-        int $dimensions
+        int $dimensions,
+        int $timeout = 30,
     ): EmbeddingsResponse {
-        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $provider, $model);
+        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $provider, $model, $timeout);
 
         return $this->nextResponse($provider, $model, $prompt);
     }

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -25,9 +25,10 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         EmbeddingProvider $provider,
         string $model,
         array $inputs,
-        int $dimensions
+        int $dimensions,
+        int $timeout = 30,
     ): EmbeddingsResponse {
-        $response = $this->client($provider)->post('/embeddings', [
+        $response = $this->client($provider, $timeout)->post('/embeddings', [
             'model' => $model,
             'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
             'dimensions' => $dimensions,
@@ -81,13 +82,14 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
     /**
      * Get an HTTP client for the Jina API.
      */
-    protected function client(EmbeddingProvider|RerankingProvider $provider): PendingRequest
+    protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
     {
         return Http::baseUrl('https://api.jina.ai/v1')
             ->withHeaders([
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
+            ->timeout($timeout)
             ->throw();
     }
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -336,12 +336,15 @@ class PrismGateway implements Gateway
         EmbeddingProvider $provider,
         string $model,
         array $inputs,
-        int $dimensions): EmbeddingsResponse
-    {
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
         $request = tap(
             Prism::embeddings(),
             fn ($prism) => $this->configure($prism, $provider, $model)
-        );
+        )->withClientOptions([
+            'timeout' => $timeout,
+        ]);
 
         $request->withProviderOptions(match ($provider->driver()) {
             'gemini' => ['outputDimensionality' => $dimensions],

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -25,6 +25,8 @@ class PendingEmbeddingsGeneration
 
     protected ?int $cacheSeconds = null;
 
+    protected int $timeout = 30;
+
     public function __construct(
         protected array $inputs,
     ) {}
@@ -45,6 +47,16 @@ class PendingEmbeddingsGeneration
     public function cache(?int $seconds = null): self
     {
         $this->cacheSeconds = $seconds ?? config('ai.caching.embeddings.seconds', 60 * 60 * 24 * 30);
+
+        return $this;
+    }
+
+    /**
+     * Specify the timeout (in seconds) for the embeddings generation.
+     */
+    public function timeout(int $seconds = 30): self
+    {
+        $this->timeout = $seconds;
 
         return $this;
     }
@@ -73,7 +85,7 @@ class PendingEmbeddingsGeneration
 
             try {
                 return tap(
-                    $provider->embeddings($this->inputs, $dimensions, $model),
+                    $provider->embeddings($this->inputs, $dimensions, $model, $this->timeout),
                     fn ($response) => $this->cacheEmbeddings($provider, $model, $dimensions, $response)
                 );
             } catch (FailoverableException $e) {
@@ -146,7 +158,8 @@ class PendingEmbeddingsGeneration
                     $this->inputs,
                     $this->dimensions,
                     $provider,
-                    $model
+                    $model,
+                    $this->timeout,
                 )
             );
 

--- a/src/Prompts/EmbeddingsPrompt.php
+++ b/src/Prompts/EmbeddingsPrompt.php
@@ -13,6 +13,7 @@ class EmbeddingsPrompt implements Countable
         public readonly int $dimensions,
         public readonly EmbeddingProvider $provider,
         public readonly string $model,
+        public readonly int $timeout = 30,
     ) {}
 
     /**

--- a/src/Prompts/QueuedEmbeddingsPrompt.php
+++ b/src/Prompts/QueuedEmbeddingsPrompt.php
@@ -13,6 +13,7 @@ class QueuedEmbeddingsPrompt implements Countable
         public readonly ?int $dimensions,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
+        public readonly int $timeout = 30,
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -17,7 +17,7 @@ trait GeneratesEmbeddings
      *
      * @param  string[]  $input
      */
-    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null): EmbeddingsResponse
+    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
     {
         if (! is_null($model) && is_null($dimensions)) {
             throw new InvalidArgumentException('Dimensions must be provided when model is specified.');
@@ -28,7 +28,7 @@ trait GeneratesEmbeddings
         $model ??= $this->defaultEmbeddingsModel();
         $dimensions ??= $this->defaultEmbeddingsDimensions();
 
-        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $this, $model);
+        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $this, $model, $timeout);
 
         if (Ai::embeddingsAreFaked()) {
             Ai::recordEmbeddingsGeneration($prompt);
@@ -42,7 +42,8 @@ trait GeneratesEmbeddings
             $this,
             $model,
             $inputs,
-            $dimensions
+            $dimensions,
+            $timeout,
         ), fn (EmbeddingsResponse $response) => $this->events->dispatch(new EmbeddingsGenerated(
             $invocationId, $this, $model, $prompt, $response,
         )));

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -68,6 +68,29 @@ class EmbeddingsFakeTest extends TestCase
         $this->assertCount(256, $response->first());
     }
 
+    public function test_embeddings_timeout_defaults_to_sdk_fallback(): void
+    {
+        Embeddings::fake();
+
+        Embeddings::for(['Hello world'])->generate();
+
+        Embeddings::assertGenerated(fn (EmbeddingsPrompt $prompt) => $prompt->timeout === 30);
+    }
+
+    public function test_fake_embeddings_closure_receives_timeout(): void
+    {
+        Embeddings::fake(function (EmbeddingsPrompt $prompt) {
+            $this->assertSame(45, $prompt->timeout);
+
+            return array_map(
+                fn () => array_fill(0, $prompt->dimensions, 0.1),
+                $prompt->inputs
+            );
+        });
+
+        Embeddings::for(['Hello world'])->timeout(45)->generate();
+    }
+
     public function test_can_assert_embeddings_generated(): void
     {
         Embeddings::fake();
@@ -172,6 +195,17 @@ class EmbeddingsFakeTest extends TestCase
 
         Embeddings::assertQueued(function (QueuedEmbeddingsPrompt $prompt) {
             return $prompt->dimensions === 256 && $prompt->count() === 1;
+        });
+    }
+
+    public function test_queued_embeddings_timeout_is_recorded(): void
+    {
+        Embeddings::fake();
+
+        Embeddings::for(['Hello world'])->timeout(90)->queue();
+
+        Embeddings::assertQueued(function (QueuedEmbeddingsPrompt $prompt) {
+            return $prompt->timeout === 90 && $prompt->count() === 1;
         });
     }
 }

--- a/tests/Feature/EmbeddingsIntegrationTest.php
+++ b/tests/Feature/EmbeddingsIntegrationTest.php
@@ -21,8 +21,8 @@ class EmbeddingsIntegrationTest extends TestCase
         $this->assertCount(1536, $response->embeddings[0]);
         $this->assertEquals('openai', $response->meta->provider);
 
-        Event::assertDispatched(GeneratingEmbeddings::class);
-        Event::assertDispatched(EmbeddingsGenerated::class);
+        Event::assertDispatched(GeneratingEmbeddings::class, fn (GeneratingEmbeddings $event) => $event->prompt->timeout === 30);
+        Event::assertDispatched(EmbeddingsGenerated::class, fn (EmbeddingsGenerated $event) => $event->prompt->timeout === 30);
     }
 
     public function test_embeddings_can_be_generated_with_custom_dimensions(): void


### PR DESCRIPTION
> [!NOTE]
> AI assistance was used for this PR

### Description

This PR adds support for configurable timeouts for embeddings requests.

Default timeouts of 30 seconds makes this a non-breaking change.

Potentially closes #191 

### Examples

#### `Embeddings::for`
```php
$response = Embeddings::for(['Hellow world'])
  ->timeout(45)
  ->generate();
```

#### `Str`

```php
Str::of('Hello world')->toEmbeddings(timeout: 30);
```

