### PR TITLE
Add configurable timeout for audio requests

### DIFF
--- a/src/Contracts/Gateway/AudioGateway.php
+++ b/src/Contracts/Gateway/AudioGateway.php
@@ -16,5 +16,6 @@ interface AudioGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        int $timeout = 30,
     ): AudioResponse;
 }

--- a/src/Contracts/Providers/AudioProvider.php
+++ b/src/Contracts/Providers/AudioProvider.php
@@ -15,6 +15,7 @@ interface AudioProvider
         string $voice = 'default-female',
         ?string $instructions = null,
         ?string $model = null,
+        int $timeout = 30,
     ): AudioResponse;
 
     /**

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -28,8 +28,9 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         string $model,
         string $text,
         string $voice,
-        ?string $instructions = null): AudioResponse
-    {
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'onwK4e9ZLuTAKqWW03F9',
             'default-female' => 'XrExE9yKIg1WjnnlVkGX',
@@ -38,7 +39,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 
         $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
             'xi-api-key' => $provider->providerCredentials()['key'],
-        ])->post('https://api.elevenlabs.io/v1/text-to-speech/'.$voice, [
+        ])->timeout($timeout)->post('https://api.elevenlabs.io/v1/text-to-speech/'.$voice, [
             'model_id' => $model,
             'text' => $text,
         ])->throw());

--- a/src/Gateway/FakeAudioGateway.php
+++ b/src/Gateway/FakeAudioGateway.php
@@ -29,8 +29,9 @@ class FakeAudioGateway implements AudioGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        int $timeout = 30,
     ): AudioResponse {
-        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model);
+        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout);
 
         return $this->nextResponse($provider, $model, $audioPrompt);
     }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -242,6 +242,7 @@ class PrismGateway implements Gateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        int $timeout = 30,
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'ash',
@@ -255,6 +256,9 @@ class PrismGateway implements Gateway
                     ...$provider->additionalConfiguration(),
                     'api_key' => $provider->providerCredentials()['key'],
                 ]))
+                ->withClientOptions([
+                    'timeout' => $timeout,
+                ])
                 ->withInput($text)
                 ->withVoice($voice)
                 ->withProviderOptions(array_filter([

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -22,6 +22,8 @@ class PendingAudioGeneration
 
     protected ?string $instructions = null;
 
+    protected int $timeout = 30;
+
     public function __construct(
         protected string $text,
     ) {}
@@ -67,6 +69,16 @@ class PendingAudioGeneration
     }
 
     /**
+     * Specify the timeout (in seconds) for the audio generation.
+     */
+    public function timeout(int $seconds = 30): self
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    /**
      * Generate the audio.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): AudioResponse
@@ -84,7 +96,7 @@ class PendingAudioGeneration
 
             try {
                 return $provider->audio(
-                    $this->text, $this->voice, $this->instructions, $model
+                    $this->text, $this->voice, $this->instructions, $model, $this->timeout
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -110,7 +122,8 @@ class PendingAudioGeneration
                     $this->voice,
                     $this->instructions,
                     $provider,
-                    $model
+                    $model,
+                    $this->timeout,
                 )
             );
 

--- a/src/Prompts/AudioPrompt.php
+++ b/src/Prompts/AudioPrompt.php
@@ -13,6 +13,7 @@ class AudioPrompt
         public readonly ?string $instructions,
         public readonly AudioProvider $provider,
         public readonly string $model,
+        public readonly int $timeout = 30,
     ) {}
 
     /**

--- a/src/Prompts/QueuedAudioPrompt.php
+++ b/src/Prompts/QueuedAudioPrompt.php
@@ -13,6 +13,7 @@ class QueuedAudioPrompt
         public readonly ?string $instructions,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
+        public readonly int $timeout = 30,
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesAudio.php
+++ b/src/Providers/Concerns/GeneratesAudio.php
@@ -19,12 +19,13 @@ trait GeneratesAudio
         string $voice = 'default-female',
         ?string $instructions = null,
         ?string $model = null,
+        int $timeout = 30,
     ): AudioResponse {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultAudioModel();
 
-        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model);
+        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout);
 
         if (Ai::audioIsFaked()) {
             Ai::recordAudioGeneration($prompt);
@@ -35,7 +36,7 @@ trait GeneratesAudio
         ));
 
         return tap($this->audioGateway()->generateAudio(
-            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions,
+            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout,
         ), function (AudioResponse $response) use ($invocationId, $model, $prompt) {
             $this->events->dispatch(new AudioGenerated(
                 $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/AudioFakeTest.php
+++ b/tests/Feature/AudioFakeTest.php
@@ -71,6 +71,26 @@ class AudioFakeTest extends TestCase
         $this->assertEquals(base64_encode('audio-for-Second text'), $response->audio);
     }
 
+    public function test_audio_timeout_defaults_to_sdk_fallback(): void
+    {
+        Audio::fake();
+
+        Audio::of('Hello world')->generate();
+
+        Audio::assertGenerated(fn (AudioPrompt $prompt) => $prompt->timeout === 30);
+    }
+
+    public function test_fake_audio_closure_receives_timeout(): void
+    {
+        Audio::fake(function (AudioPrompt $prompt) {
+            $this->assertSame(45, $prompt->timeout);
+
+            return base64_encode('audio-for-'.$prompt->text);
+        });
+
+        Audio::of('Hello world')->timeout(45)->generate();
+    }
+
     public function test_audio_can_prevent_stray_generations(): void
     {
         $this->expectException(RuntimeException::class);
@@ -158,6 +178,17 @@ class AudioFakeTest extends TestCase
             return $prompt->text === 'Hello world'
                 && $prompt->voice === 'default-male'
                 && $prompt->instructions === 'Speak quickly';
+        });
+    }
+
+    public function test_queued_audio_timeout_is_recorded(): void
+    {
+        Audio::fake();
+
+        Audio::of('Hello world')->timeout(90)->queue();
+
+        Audio::assertQueued(function (QueuedAudioPrompt $prompt) {
+            return $prompt->timeout === 90 && $prompt->contains('Hello world');
         });
     }
 }

--- a/tests/Feature/AudioIntegrationTest.php
+++ b/tests/Feature/AudioIntegrationTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Audio;
+use Laravel\Ai\Events\AudioGenerated;
+use Laravel\Ai\Events\GeneratingAudio;
 use Laravel\Ai\Files;
 use Laravel\Ai\Transcription;
 use Tests\TestCase;
@@ -11,8 +14,13 @@ class AudioIntegrationTest extends TestCase
 {
     public function test_audio_can_be_generated_and_transcribed(): void
     {
+        Event::fake();
+
         $response = Audio::of('Hello there! How are you today?')->generate();
         $this->assertEquals($response->meta->provider, 'openai');
+
+        Event::assertDispatched(GeneratingAudio::class, fn (GeneratingAudio $event) => $event->prompt->timeout === 30);
+        Event::assertDispatched(AudioGenerated::class, fn (AudioGenerated $event) => $event->prompt->timeout === 30);
 
         $transcription = Transcription::of($response->audio)->generate();
         $this->assertTrue(str_contains(strtolower((string) $transcription), 'how are you today'));


### PR DESCRIPTION
> [!NOTE]
> AI assistance was used for this PR

### Description

This PR adds support for configurable timeouts for audio requests.

Default timeouts of 30 seconds makes this a non-breaking change.

Potentially closes #250 

### Examples

#### `Audio::of`
```php
$response = Audio::of('Hello world')
  ->timeout(45)
  ->generate();
```