### PR TITLE
[0.x] Fix file_get_contents() return value not handled if the file does not exist in Local file classes

### DIFF
--- a/src/Files/LocalAudio.php
+++ b/src/Files/LocalAudio.php
@@ -31,7 +31,7 @@ class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableF
         $content = file_get_contents($this->path);
 
         if ($content === false) {
-            throw new RuntimeException("File does not exist at path {$this->path}");
+            throw new RuntimeException("File does not exist at path [{$this->path}]");
         }
 
         return $content;

--- a/src/Files/LocalAudio.php
+++ b/src/Files/LocalAudio.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
 use Laravel\Ai\PendingResponses\PendingTranscriptionGeneration;
 use Laravel\Ai\Transcription;
+use RuntimeException;
 
 class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableFile, TranscribableAudio
 {
@@ -27,7 +28,13 @@ class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableF
      */
     public function content(): string
     {
-        return file_get_contents($this->path);
+        $content = file_get_contents($this->path);
+
+        if ($content === false) {
+            throw new RuntimeException("File does not exist at path {$this->path}");
+        }
+
+        return $content;
     }
 
     /**

--- a/src/Files/LocalDocument.php
+++ b/src/Files/LocalDocument.php
@@ -7,6 +7,7 @@ use Illuminate\Filesystem\Filesystem;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
+use RuntimeException;
 
 class LocalDocument extends Document implements Arrayable, JsonSerializable, StorableFile
 {
@@ -24,7 +25,13 @@ class LocalDocument extends Document implements Arrayable, JsonSerializable, Sto
      */
     public function content(): string
     {
-        return file_get_contents($this->path);
+        $content = file_get_contents($this->path);
+
+        if ($content === false) {
+            throw new RuntimeException("File does not exist at path {$this->path}");
+        }
+
+        return $content;
     }
 
     /**

--- a/src/Files/LocalDocument.php
+++ b/src/Files/LocalDocument.php
@@ -28,7 +28,7 @@ class LocalDocument extends Document implements Arrayable, JsonSerializable, Sto
         $content = file_get_contents($this->path);
 
         if ($content === false) {
-            throw new RuntimeException("File does not exist at path {$this->path}");
+            throw new RuntimeException("File does not exist at path [{$this->path}]");
         }
 
         return $content;

--- a/src/Files/LocalImage.php
+++ b/src/Files/LocalImage.php
@@ -28,7 +28,7 @@ class LocalImage extends Image implements Arrayable, JsonSerializable, StorableF
         $content = file_get_contents($this->path);
 
         if ($content === false) {
-            throw new RuntimeException("File does not exist at path {$this->path}");
+            throw new RuntimeException("File does not exist at path [{$this->path}]");
         }
 
         return $content;

--- a/src/Files/LocalImage.php
+++ b/src/Files/LocalImage.php
@@ -7,6 +7,7 @@ use Illuminate\Filesystem\Filesystem;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
+use RuntimeException;
 
 class LocalImage extends Image implements Arrayable, JsonSerializable, StorableFile
 {
@@ -24,7 +25,13 @@ class LocalImage extends Image implements Arrayable, JsonSerializable, StorableF
      */
     public function content(): string
     {
-        return file_get_contents($this->path);
+        $content = file_get_contents($this->path);
+
+        if ($content === false) {
+            throw new RuntimeException("File does not exist at path {$this->path}");
+        }
+
+        return $content;
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug in local file handling where `file_get_contents()` returns false when a file cannot be read. 
In `LocalDocument`, `LocalImage`, `LocalAudio` the `content()` method is declared to return a string. Previously, the result of `file_get_contents()` was not explicitly validated.

This change checks if the return value of `file_get_contents()` is `false` and throws a `RuntimeException` with the file path value.