### PR TITLE
[0.x] Remove redundant Collection wrapping in StreamEnd::combineUsage().

### DIFF
--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -23,7 +23,7 @@ class StreamEnd extends StreamEvent
     {
         $events = is_array($events) ? new Collection($events) : $events;
 
-        return (new Collection($events))->whereInstanceOf(StreamEnd::class)
+        return $events->whereInstanceOf(StreamEnd::class)
             ->values()
             ->map
             ->usage


### PR DESCRIPTION
This PR removes redundant Collection wrapping in `StreamEnd::combineUsage()`

The method accepts `array|Collection` and already normalizes `$events` into a `Collection`. The extra `new Collection($events)` wrap on line 26 was therefore redundant.