### PR TITLE
Add timeout parameter to Agent contract

### DIFF
--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -23,7 +23,8 @@ interface Agent
         string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
-        ?string $model = null
+        ?string $model = null,
+        ?int $timeout = null
     ): AgentResponse;
 
     /**
@@ -33,7 +34,8 @@ interface Agent
         string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
-        ?string $model = null
+        ?string $model = null,
+        ?int $timeout = null
     ): StreamableAgentResponse;
 
     /**


### PR DESCRIPTION
The `Promptable` trait's `prompt()` and `stream()` methods accept `?int $timeout = null`, but the `Agent` contract interface does not declare this parameter. This causes static analyzers like PHPStan to flag `timeout:` as an unknown argument when calling `prompt()` on the `Agent` return type — e.g. from the `agent()` helper.

```php
// agent() returns Agent (the contract), which lacks $timeout
agent(instructions: '...')->prompt(
    prompt: '...',
    provider: 'claude-cli',
    model: 'claude-sonnet-4-5',
    timeout: 600, // PHPStan: Unknown parameter $timeout
);
```

This was introduced in #20 which added `$timeout` to the trait but didn't update the contract.

This PR adds `?int $timeout = null` to both `prompt()` and `stream()` on the `Agent` interface to match the `Promptable` trait implementation.