### PR TITLE
Add OpenAI gateway for Responses API

### DIFF
--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
 use Laravel\Ai\Providers\AzureOpenAiProvider;
@@ -397,7 +398,7 @@ class AiManager extends MultipleInstanceManager
     public function createOpenaiDriver(array $config): OpenAiProvider
     {
         return new OpenAiProvider(
-            new PrismGateway($this->app['events']),
+            new OpenAiGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -24,15 +24,6 @@ trait InvokesTools
     }
 
     /**
-     * Initialize the tool invocation callbacks.
-     */
-    protected function initializeToolCallbacks(): void
-    {
-        $this->invokingToolCallback ??= fn () => true;
-        $this->toolInvokedCallback ??= fn () => true;
-    }
-
-    /**
      * Execute the given tool with the given arguments.
      */
     protected function executeTool(Tool $tool, array $arguments): string
@@ -57,5 +48,14 @@ trait InvokesTools
         }
 
         return null;
+    }
+
+    /**
+     * Initialize the tool invocation callbacks.
+     */
+    protected function initializeToolCallbacks(): void
+    {
+        $this->invokingToolCallback ??= fn () => true;
+        $this->toolInvokedCallback ??= fn () => true;
     }
 }

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Closure;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+trait InvokesTools
+{
+    protected Closure $invokingToolCallback;
+
+    protected Closure $toolInvokedCallback;
+
+    /**
+     * Specify callbacks that should be invoked when tools are invoking / invoked.
+     */
+    public function onToolInvocation(Closure $invoking, Closure $invoked): self
+    {
+        $this->invokingToolCallback = $invoking;
+        $this->toolInvokedCallback = $invoked;
+
+        return $this;
+    }
+
+    /**
+     * Initialize the tool invocation callbacks.
+     */
+    protected function initializeToolCallbacks(): void
+    {
+        $this->invokingToolCallback ??= fn () => true;
+        $this->toolInvokedCallback ??= fn () => true;
+    }
+
+    /**
+     * Execute the given tool with the given arguments.
+     */
+    protected function executeTool(Tool $tool, array $arguments): string
+    {
+        call_user_func($this->invokingToolCallback, $tool, $arguments);
+
+        return (string) tap(
+            $tool->handle(new Request($arguments)),
+            fn ($result) => call_user_func($this->toolInvokedCallback, $tool, $arguments, $result)
+        );
+    }
+
+    /**
+     * Find a tool by its name from the given tools array.
+     */
+    protected function findTool(string $name, array $tools): ?Tool
+    {
+        foreach ($tools as $tool) {
+            if ($tool instanceof Tool && class_basename($tool) === $name) {
+                return $tool;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Gateway/Concerns/ParsesServerSentEvents.php
+++ b/src/Gateway/Concerns/ParsesServerSentEvents.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Generator;
+
+trait ParsesServerSentEvents
+{
+    /**
+     * Parse an SSE stream body into decoded JSON data objects.
+     */
+    protected function parseServerSentEvents($streamBody): Generator
+    {
+        $buffer = '';
+
+        while (! $streamBody->eof()) {
+            $buffer .= $streamBody->read(8192);
+
+            while (($pos = strpos($buffer, "\n")) !== false) {
+                $line = substr($buffer, 0, $pos);
+                $buffer = substr($buffer, $pos + 1);
+
+                $line = trim($line);
+
+                if ($line === '') {
+                    continue;
+                }
+
+                if (! str_starts_with($line, 'data:')) {
+                    continue;
+                }
+
+                $data = trim(substr($line, 5));
+
+                if ($data === '[DONE]') {
+                    return;
+                }
+
+                $decoded = json_decode($data, true);
+
+                if (json_last_error() === JSON_ERROR_NONE && $decoded !== null) {
+                    yield $decoded;
+                }
+            }
+        }
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    /**
+     * Build the request body for the OpenAI Responses API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $input = $this->mapMessagesToInput($messages, $instructions);
+
+        $body = ['model' => $model, 'input' => $input];
+
+        if (filled($tools)) {
+            $body['tools'] = $this->mapTools($tools, $provider);
+            $body['tool_choice'] = 'auto';
+        }
+
+        if (filled($schema)) {
+            $body['text'] = $this->buildSchemaFormat($schema);
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_output_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the text format options for structured output.
+     */
+    protected function buildSchemaFormat(array $schema): array
+    {
+        $objectSchema = new ObjectSchema($schema);
+        $schemaArray = $objectSchema->toSchema();
+
+        return [
+            'format' => [
+                'type' => 'json_schema',
+                'name' => $schemaArray['name'] ?? 'schema_definition',
+                'schema' => Arr::except($schemaArray, ['name']),
+                'strict' => true,
+            ],
+        ];
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -26,8 +26,8 @@ trait BuildsTextRequests
         $body = ['model' => $model, 'input' => $input];
 
         if (filled($tools)) {
-            $body['tools'] = $this->mapTools($tools, $provider);
             $body['tool_choice'] = 'auto';
+            $body['tools'] = $this->mapTools($tools, $provider);
         }
 
         if (filled($schema)) {

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -51,6 +51,7 @@ trait BuildsTextRequests
     protected function buildSchemaFormat(array $schema): array
     {
         $objectSchema = new ObjectSchema($schema);
+
         $schemaArray = $objectSchema->toSchema();
 
         return [

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -59,13 +59,13 @@ trait HandlesTextStreaming
         $usage = null;
 
         foreach ($this->parseServerSentEvents($streamBody) as $data) {
-            $type = data_get($data, 'type', '');
+            $type = $data['type'] ?? '';
 
             if ($type === 'error') {
                 yield (new Error(
                     $this->generateEventId(),
-                    data_get($data, 'error.code', 'unknown_error'),
-                    data_get($data, 'error.message', 'Unknown error'),
+                    $data['error']['code'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
                     false,
                     time(),
                 ))->withInvocationId($invocationId);
@@ -75,12 +75,12 @@ trait HandlesTextStreaming
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
                 $streamStartEmitted = true;
-                $responseId = data_get($data, 'response.id', '');
+                $responseId = $data['response']['id'] ?? '';
 
                 yield (new StreamStart(
                     $this->generateEventId(),
                     $provider->name(),
-                    data_get($data, 'response.model', $model),
+                    $data['response']['model'] ?? $model,
                     time(),
                 ))->withInvocationId($invocationId);
 
@@ -88,7 +88,7 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'response.reasoning_summary_text.delta') {
-                $delta = (string) data_get($data, 'delta', '');
+                $delta = (string) ($data['delta'] ?? '');
 
                 if ($delta !== '') {
                     if ($reasoningId === '') {
@@ -112,10 +112,10 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            if ($type === 'response.output_item.done' && data_get($data, 'item.type') === 'reasoning') {
+            if ($type === 'response.output_item.done' && ($data['item']['type'] ?? '') === 'reasoning') {
                 $reasoningItems[] = [
-                    'id' => data_get($data, 'item.id'),
-                    'summary' => data_get($data, 'item.summary', []),
+                    'id' => $data['item']['id'] ?? null,
+                    'summary' => $data['item']['summary'] ?? [],
                 ];
 
                 if ($reasoningId !== '') {
@@ -132,14 +132,14 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'response.output_item.done') {
-                $itemType = data_get($data, 'item.type', '');
+                $itemType = $data['item']['type'] ?? '';
 
                 if ($itemType !== 'function_call' && str_ends_with((string) $itemType, '_call')) {
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
-                        data_get($data, 'item.id', ''),
+                        $data['item']['id'] ?? '',
                         $itemType,
-                        data_get($data, 'item', []),
+                        $data['item'] ?? [],
                         'completed',
                         time(),
                     ))->withInvocationId($invocationId);
@@ -154,7 +154,7 @@ trait HandlesTextStreaming
                 if (count($parts) === 3 && str_ends_with($parts[1], '_call')) {
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
-                        data_get($data, 'item_id', ''),
+                        $data['item_id'] ?? '',
                         $parts[1],
                         $data,
                         $parts[2],
@@ -165,13 +165,13 @@ trait HandlesTextStreaming
                 }
             }
 
-            if (data_get($data, 'item.type') === 'function_call' && $type === 'response.output_item.added') {
-                $index = (int) data_get($data, 'output_index', count($pendingToolCalls));
+            if (($data['item']['type'] ?? '') === 'function_call' && $type === 'response.output_item.added') {
+                $index = (int) ($data['output_index'] ?? count($pendingToolCalls));
 
                 $toolCall = [
-                    'id' => data_get($data, 'item.id'),
-                    'call_id' => data_get($data, 'item.call_id'),
-                    'name' => data_get($data, 'item.name'),
+                    'id' => $data['item']['id'] ?? null,
+                    'call_id' => $data['item']['call_id'] ?? null,
+                    'name' => $data['item']['name'] ?? null,
                     'arguments' => '',
                 ];
 
@@ -187,11 +187,11 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'response.function_call_arguments.delta') {
-                $callId = data_get($data, 'item_id');
+                $callId = $data['item_id'] ?? null;
 
                 foreach ($pendingToolCalls as &$call) {
                     if (($call['id'] ?? null) === $callId) {
-                        $call['arguments'] .= data_get($data, 'delta', '');
+                        $call['arguments'] .= $data['delta'] ?? '';
                         break;
                     }
                 }
@@ -201,8 +201,8 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'response.function_call_arguments.done') {
-                $callId = data_get($data, 'item_id');
-                $arguments = data_get($data, 'arguments', '');
+                $callId = $data['item_id'] ?? null;
+                $arguments = $data['arguments'] ?? '';
 
                 foreach ($pendingToolCalls as &$call) {
                     if (($call['id'] ?? null) === $callId) {
@@ -232,7 +232,7 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'response.output_text.delta') {
-                $textDelta = (string) data_get($data, 'delta', '');
+                $textDelta = (string) ($data['delta'] ?? '');
 
                 if ($textDelta !== '') {
                     if (! $textStartEmitted) {
@@ -269,14 +269,16 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'response.completed') {
-                $responseId = data_get($data, 'response.id', $responseId);
+                $response = $data['response'] ?? [];
+                $responseId = $response['id'] ?? $responseId;
+                $responseUsage = $response['usage'] ?? [];
 
                 $usage = new Usage(
-                    data_get($data, 'response.usage.input_tokens', 0) - data_get($data, 'response.usage.input_tokens_details.cached_tokens', 0),
-                    data_get($data, 'response.usage.output_tokens', 0),
+                    ($responseUsage['input_tokens'] ?? 0) - ($responseUsage['input_tokens_details']['cached_tokens'] ?? 0),
+                    $responseUsage['output_tokens'] ?? 0,
                     0,
-                    data_get($data, 'response.usage.input_tokens_details.cached_tokens', 0),
-                    data_get($data, 'response.usage.output_tokens_details.reasoning_tokens', 0),
+                    $responseUsage['input_tokens_details']['cached_tokens'] ?? 0,
+                    $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
                 );
             }
         }
@@ -392,12 +394,12 @@ trait HandlesTextStreaming
     protected function mapStreamToolCalls(array $toolCalls): array
     {
         return array_map(fn (array $tc) => new ToolCall(
-            data_get($tc, 'id', ''),
-            data_get($tc, 'name', ''),
-            json_decode(data_get($tc, 'arguments', '{}'), true) ?? [],
-            data_get($tc, 'call_id'),
-            data_get($tc, 'reasoning_id'),
-            data_get($tc, 'reasoning_summary'),
+            $tc['id'] ?? '',
+            $tc['name'] ?? '',
+            json_decode($tc['arguments'] ?? '{}', true) ?? [],
+            $tc['call_id'] ?? null,
+            $tc['reasoning_id'] ?? null,
+            $tc['reasoning_summary'] ?? null,
         ), array_values($toolCalls));
     }
 }

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -25,14 +25,6 @@ use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 trait HandlesTextStreaming
 {
     /**
-     * Generate a lowercase UUID v7 for use as a stream event ID.
-     */
-    protected function generateEventId(): string
-    {
-        return strtolower((string) Str::uuid7());
-    }
-
-    /**
      * Process an OpenAI streaming response and yield Laravel stream events.
      */
     protected function processTextStream(
@@ -81,6 +73,43 @@ trait HandlesTextStreaming
                     $this->generateEventId(),
                     $provider->name(),
                     $data['response']['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                continue;
+            }
+
+            if ($type === 'response.output_text.delta') {
+                $textDelta = (string) ($data['delta'] ?? '');
+
+                if ($textDelta !== '') {
+                    if (! $textStartEmitted) {
+                        $textStartEmitted = true;
+
+                        yield (new TextStart(
+                            $this->generateEventId(),
+                            $messageId,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+
+                    $currentText .= $textDelta;
+
+                    yield (new TextDelta(
+                        $this->generateEventId(),
+                        $messageId,
+                        $textDelta,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                continue;
+            }
+
+            if ($type === 'response.output_text.done' && $textStartEmitted) {
+                yield (new TextEnd(
+                    $this->generateEventId(),
+                    $messageId,
                     time(),
                 ))->withInvocationId($invocationId);
 
@@ -177,6 +206,7 @@ trait HandlesTextStreaming
 
                 if (filled($reasoningItems)) {
                     $latestReasoning = end($reasoningItems);
+
                     $toolCall['reasoning_id'] = $latestReasoning['id'];
                     $toolCall['reasoning_summary'] = $latestReasoning['summary'] ?? [];
                 }
@@ -226,44 +256,8 @@ trait HandlesTextStreaming
                         break;
                     }
                 }
+
                 unset($call);
-
-                continue;
-            }
-
-            if ($type === 'response.output_text.delta') {
-                $textDelta = (string) ($data['delta'] ?? '');
-
-                if ($textDelta !== '') {
-                    if (! $textStartEmitted) {
-                        $textStartEmitted = true;
-
-                        yield (new TextStart(
-                            $this->generateEventId(),
-                            $messageId,
-                            time(),
-                        ))->withInvocationId($invocationId);
-                    }
-
-                    $currentText .= $textDelta;
-
-                    yield (new TextDelta(
-                        $this->generateEventId(),
-                        $messageId,
-                        $textDelta,
-                        time(),
-                    ))->withInvocationId($invocationId);
-                }
-
-                continue;
-            }
-
-            if ($type === 'response.output_text.done' && $textStartEmitted) {
-                yield (new TextEnd(
-                    $this->generateEventId(),
-                    $messageId,
-                    time(),
-                ))->withInvocationId($invocationId);
 
                 continue;
             }
@@ -321,6 +315,7 @@ trait HandlesTextStreaming
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
         $toolResults = [];
+
         foreach ($mappedToolCalls as $toolCall) {
             $tool = $this->findTool($toolCall->name, $tools);
 
@@ -401,5 +396,13 @@ trait HandlesTextStreaming
             $tc['reasoning_id'] ?? null,
             $tc['reasoning_summary'] ?? null,
         ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
     }
 }

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+
+    /**
+     * Process an OpenAI streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        int $depth = 0,
+        ?int $maxSteps = null,
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $responseId = '';
+        $reasoningId = '';
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $reasoningItems = [];
+        $usage = null;
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            $type = data_get($data, 'type', '');
+
+            if ($type === 'error') {
+                yield (new Error(
+                    $this->generateEventId(),
+                    data_get($data, 'error.code', 'unknown_error'),
+                    data_get($data, 'error.message', 'Unknown error'),
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            if ($type === 'response.created' && ! $streamStartEmitted) {
+                $streamStartEmitted = true;
+                $responseId = data_get($data, 'response.id', '');
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    data_get($data, 'response.model', $model),
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                continue;
+            }
+
+            if ($type === 'response.reasoning_summary_text.delta') {
+                $delta = (string) data_get($data, 'delta', '');
+
+                if ($delta !== '') {
+                    if ($reasoningId === '') {
+                        $reasoningId = $this->generateEventId();
+
+                        yield (new ReasoningStart(
+                            $this->generateEventId(),
+                            $reasoningId,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+
+                    yield (new ReasoningDelta(
+                        $this->generateEventId(),
+                        $reasoningId,
+                        $delta,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                continue;
+            }
+
+            if ($type === 'response.output_item.done' && data_get($data, 'item.type') === 'reasoning') {
+                $reasoningItems[] = [
+                    'id' => data_get($data, 'item.id'),
+                    'summary' => data_get($data, 'item.summary', []),
+                ];
+
+                if ($reasoningId !== '') {
+                    yield (new ReasoningEnd(
+                        $this->generateEventId(),
+                        $reasoningId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+
+                    $reasoningId = '';
+                }
+
+                continue;
+            }
+
+            if ($type === 'response.output_item.done') {
+                $itemType = data_get($data, 'item.type', '');
+
+                if ($itemType !== 'function_call' && str_ends_with((string) $itemType, '_call')) {
+                    yield (new ProviderToolEvent(
+                        $this->generateEventId(),
+                        data_get($data, 'item.id', ''),
+                        $itemType,
+                        data_get($data, 'item', []),
+                        'completed',
+                        time(),
+                    ))->withInvocationId($invocationId);
+
+                    continue;
+                }
+            }
+
+            if (str_starts_with($type, 'response.') && str_contains($type, '_call.')) {
+                $parts = explode('.', $type, 3);
+
+                if (count($parts) === 3 && str_ends_with($parts[1], '_call')) {
+                    yield (new ProviderToolEvent(
+                        $this->generateEventId(),
+                        data_get($data, 'item_id', ''),
+                        $parts[1],
+                        $data,
+                        $parts[2],
+                        time(),
+                    ))->withInvocationId($invocationId);
+
+                    continue;
+                }
+            }
+
+            if (data_get($data, 'item.type') === 'function_call' && $type === 'response.output_item.added') {
+                $index = (int) data_get($data, 'output_index', count($pendingToolCalls));
+
+                $toolCall = [
+                    'id' => data_get($data, 'item.id'),
+                    'call_id' => data_get($data, 'item.call_id'),
+                    'name' => data_get($data, 'item.name'),
+                    'arguments' => '',
+                ];
+
+                if (filled($reasoningItems)) {
+                    $latestReasoning = end($reasoningItems);
+                    $toolCall['reasoning_id'] = $latestReasoning['id'];
+                    $toolCall['reasoning_summary'] = $latestReasoning['summary'] ?? [];
+                }
+
+                $pendingToolCalls[$index] = $toolCall;
+
+                continue;
+            }
+
+            if ($type === 'response.function_call_arguments.delta') {
+                $callId = data_get($data, 'item_id');
+
+                foreach ($pendingToolCalls as &$call) {
+                    if (($call['id'] ?? null) === $callId) {
+                        $call['arguments'] .= data_get($data, 'delta', '');
+                        break;
+                    }
+                }
+                unset($call);
+
+                continue;
+            }
+
+            if ($type === 'response.function_call_arguments.done') {
+                $callId = data_get($data, 'item_id');
+                $arguments = data_get($data, 'arguments', '');
+
+                foreach ($pendingToolCalls as &$call) {
+                    if (($call['id'] ?? null) === $callId) {
+                        if ($arguments !== '') {
+                            $call['arguments'] = $arguments;
+                        }
+
+                        yield (new ToolCallEvent(
+                            $this->generateEventId(),
+                            new ToolCall(
+                                $call['id'],
+                                $call['name'],
+                                json_decode($call['arguments'] ?? '{}', true) ?? [],
+                                $call['call_id'] ?? null,
+                                $call['reasoning_id'] ?? null,
+                                $call['reasoning_summary'] ?? null,
+                            ),
+                            time(),
+                        ))->withInvocationId($invocationId);
+
+                        break;
+                    }
+                }
+                unset($call);
+
+                continue;
+            }
+
+            if ($type === 'response.output_text.delta') {
+                $textDelta = (string) data_get($data, 'delta', '');
+
+                if ($textDelta !== '') {
+                    if (! $textStartEmitted) {
+                        $textStartEmitted = true;
+
+                        yield (new TextStart(
+                            $this->generateEventId(),
+                            $messageId,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+
+                    $currentText .= $textDelta;
+
+                    yield (new TextDelta(
+                        $this->generateEventId(),
+                        $messageId,
+                        $textDelta,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                continue;
+            }
+
+            if ($type === 'response.output_text.done' && $textStartEmitted) {
+                yield (new TextEnd(
+                    $this->generateEventId(),
+                    $messageId,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                continue;
+            }
+
+            if ($type === 'response.completed') {
+                $responseId = data_get($data, 'response.id', $responseId);
+
+                $usage = new Usage(
+                    data_get($data, 'response.usage.input_tokens', 0) - data_get($data, 'response.usage.input_tokens_details.cached_tokens', 0),
+                    data_get($data, 'response.usage.output_tokens', 0),
+                    0,
+                    data_get($data, 'response.usage.input_tokens_details.cached_tokens', 0),
+                    data_get($data, 'response.usage.output_tokens_details.reasoning_tokens', 0),
+                );
+            }
+        }
+
+        if (filled($pendingToolCalls)) {
+            yield from $this->handleStreamingToolCalls(
+                $invocationId, $responseId, $provider, $model, $tools, $schema, $options,
+                $pendingToolCalls, $currentText, $reasoningItems,
+                $depth, $maxSteps,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            'stop',
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        string $responseId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $pendingToolCalls,
+        string $currentText,
+        array $reasoningItems,
+        int $depth,
+        ?int $maxSteps,
+    ): Generator {
+        $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+        $toolResults = [];
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+            $body = [
+                'model' => $model,
+                'previous_response_id' => $responseId,
+                'input' => $this->buildToolResultsInput($toolResults),
+                'stream' => true,
+            ];
+
+            if (filled($tools)) {
+                $body['tools'] = $this->mapTools($tools, $provider);
+            }
+
+            if (filled($schema)) {
+                $body['text'] = $this->buildSchemaFormat($schema);
+            }
+
+            $response = $this->withRateLimitHandling(
+                $provider->name(),
+                fn () => $this->client($provider)
+                    ->withOptions(['stream' => true])
+                    ->post('responses', $body),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId, $provider, $model, $tools, $schema, $options,
+                $response->getBody(), $depth + 1, $maxSteps,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $tc) => new ToolCall(
+            data_get($tc, 'id', ''),
+            data_get($tc, 'name', ''),
+            json_decode(data_get($tc, 'arguments', '{}'), true) ?? [],
+            data_get($tc, 'call_id'),
+            data_get($tc, 'reasoning_id'),
+            data_get($tc, 'reasoning_summary'),
+        ), array_values($toolCalls));
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalDocument;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\ProviderDocument;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredDocument;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to OpenAI content parts.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof ProviderImage => [
+                    'type' => 'input_image',
+                    'file_id' => $attachment->id,
+                ],
+                $attachment instanceof Base64Image => [
+                    'type' => 'input_image',
+                    'image_url' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'input_image',
+                    'image_url' => $attachment->url,
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'input_image',
+                    'image_url' => 'data:'.$attachment->mime.';base64,'.base64_encode(file_get_contents($attachment->path)),
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'input_image',
+                    'image_url' => 'data:image/png;base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
+                ],
+                $attachment instanceof ProviderDocument => [
+                    'type' => 'input_file',
+                    'file_id' => $attachment->id,
+                ],
+                $attachment instanceof Base64Document => [
+                    'type' => 'input_file',
+                    'file_data' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
+                ],
+                $attachment instanceof LocalDocument => [
+                    'type' => 'input_file',
+                    'file_data' => 'data:application/octet-stream;base64,'.base64_encode(file_get_contents($attachment->path)),
+                ],
+                $attachment instanceof RemoteDocument => [
+                    'type' => 'input_file',
+                    'file_url' => $attachment->url,
+                ],
+                $attachment instanceof StoredDocument => [
+                    'type' => 'input_file',
+                    'file_data' => 'data:application/octet-stream;base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'input_image',
+                    'image_url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
+                ],
+                $attachment instanceof UploadedFile => [
+                    'type' => 'input_file',
+                    'file_data' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
+                ],
+                default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -61,7 +61,7 @@ trait MapsMessages
      */
     protected function mapAssistantMessage(AssistantMessage|Message $message, array &$input): void
     {
-        if ($message->content !== '' && $message->content !== '0') {
+        if (filled($message->content)) {
             $input[] = [
                 'role' => 'assistant',
                 'content' => [

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to OpenAI Responses API input format.
+     */
+    protected function mapMessagesToInput(array $messages, ?string $instructions = null): array
+    {
+        $input = [];
+
+        if (filled($instructions)) {
+            $input[] = [
+                'role' => 'system',
+                'content' => $instructions,
+            ];
+        }
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $input),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $input),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $input),
+            };
+        }
+
+        return $input;
+    }
+
+    /**
+     * Map a user message to OpenAI format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$input): void
+    {
+        $content = [
+            ['type' => 'input_text', 'text' => $message->content],
+        ];
+
+        if ($message instanceof UserMessage && $message->attachments->isNotEmpty()) {
+            $content = array_merge($content, $this->mapAttachments($message->attachments));
+        }
+
+        $input[] = [
+            'role' => 'user',
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * Map an assistant message to OpenAI format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$input): void
+    {
+        if ($message->content !== '' && $message->content !== '0') {
+            $input[] = [
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'output_text',
+                        'text' => $message->content,
+                    ],
+                ],
+            ];
+        }
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            $reasoningBlocks = $message->toolCalls
+                ->whereNotNull('reasoningId')
+                ->unique('reasoningId')
+                ->map(fn ($toolCall) => [
+                    'type' => 'reasoning',
+                    'id' => $toolCall->reasoningId,
+                    'summary' => $toolCall->reasoningSummary,
+                ])
+                ->values()
+                ->all();
+
+            array_push($input, ...$reasoningBlocks);
+
+            foreach ($message->toolCalls as $toolCall) {
+                $input[] = [
+                    'id' => $toolCall->id,
+                    'call_id' => $toolCall->resultId,
+                    'type' => 'function_call',
+                    'name' => $toolCall->name,
+                    'arguments' => json_encode($toolCall->arguments),
+                ];
+            }
+        }
+    }
+
+    /**
+     * Map a tool result message to OpenAI format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$input): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        foreach ($message->toolResults as $toolResult) {
+            $input[] = [
+                'type' => 'function_call_output',
+                'call_id' => $toolResult->resultId,
+                'output' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/MapsTools.php
+++ b/src/Gateway/OpenAi/Concerns/MapsTools.php
@@ -47,7 +47,7 @@ trait MapsTools
             'strict' => true,
         ];
 
-        if (! empty($schema)) {
+        if (filled($schema)) {
             $objectSchema = new ObjectSchema($schema);
 
             $schemaArray = $objectSchema->toSchema();

--- a/src/Gateway/OpenAi/Concerns/MapsTools.php
+++ b/src/Gateway/OpenAi/Concerns/MapsTools.php
@@ -25,11 +25,7 @@ trait MapsTools
         foreach ($tools as $tool) {
             if ($tool instanceof ProviderTool) {
                 $mapped[] = $this->mapProviderTool($tool, $provider);
-
-                continue;
-            }
-
-            if ($tool instanceof Tool) {
+            } elseif ($tool instanceof Tool) {
                 $mapped[] = $this->mapTool($tool);
             }
         }
@@ -53,6 +49,7 @@ trait MapsTools
 
         if (! empty($schema)) {
             $objectSchema = new ObjectSchema($schema);
+
             $schemaArray = $objectSchema->toSchema();
 
             $definition['parameters'] = [

--- a/src/Gateway/OpenAi/Concerns/MapsTools.php
+++ b/src/Gateway/OpenAi/Concerns/MapsTools.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\FileSearch;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebSearch;
+use RuntimeException;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to OpenAI function definitions.
+     */
+    protected function mapTools(array $tools, Provider $provider): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                $mapped[] = $this->mapProviderTool($tool, $provider);
+
+                continue;
+            }
+
+            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to an OpenAI function definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $definition = [
+            'type' => 'function',
+            'name' => class_basename($tool),
+            'description' => (string) $tool->description(),
+            'strict' => true,
+        ];
+
+        if (! empty($schema)) {
+            $objectSchema = new ObjectSchema($schema);
+            $schemaArray = $objectSchema->toSchema();
+
+            $definition['parameters'] = [
+                'type' => 'object',
+                'properties' => $schemaArray['properties'] ?? [],
+                'required' => $schemaArray['required'] ?? [],
+                'additionalProperties' => false,
+            ];
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Map a provider tool to an OpenAI provider tool definition.
+     */
+    protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
+    {
+        return match (true) {
+            $tool instanceof FileSearch => $this->mapFileSearchTool($tool, $provider),
+            $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
+            default => [],
+        };
+    }
+
+    /**
+     * Map a file search tool to an OpenAI file search definition.
+     */
+    protected function mapFileSearchTool(FileSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsFileSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support file search.');
+        }
+
+        return [
+            'type' => 'file_search',
+            ...$provider->fileSearchToolOptions($tool),
+        ];
+    }
+
+    /**
+     * Map a web search tool to an OpenAI web search definition.
+     */
+    protected function mapWebSearchTool(WebSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
+        }
+
+        return [
+            'type' => 'web_search_preview',
+            ...$provider->webSearchToolOptions($tool),
+        ];
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -22,6 +22,32 @@ use Laravel\Ai\Responses\TextResponse;
 trait ParsesTextResponses
 {
     /**
+     * Validate the OpenAI response data.
+     *
+     * @throws \Laravel\Ai\Exceptions\AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || isset($data['error'])) {
+            throw new AiException(sprintf(
+                'OpenAI Error: [%s] %s',
+                $data['error']['type'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown OpenAI error.',
+            ));
+        }
+
+        if (($data['status'] ?? '') === 'failed') {
+            $error = $data['error'] ?? [];
+
+            throw new AiException(sprintf(
+                'OpenAI Error: [%s] %s',
+                $error['code'] ?? 'unknown',
+                $error['message'] ?? 'The response failed without an error message.',
+            ));
+        }
+    }
+
+    /**
      * Parse the OpenAI response data into a TextResponse.
      */
     protected function parseTextResponse(
@@ -58,9 +84,9 @@ trait ParsesTextResponses
         int $depth = 0,
         ?int $maxSteps = null,
     ): TextResponse {
-        $responseId = data_get($data, 'id', '');
-        $output = data_get($data, 'output', []);
-        $model = data_get($data, 'model', '');
+        $responseId = $data['id'] ?? '';
+        $output = $data['output'] ?? [];
+        $model = $data['model'] ?? '';
 
         $text = $this->extractText($output);
         $toolCalls = $this->extractToolCalls($output);
@@ -209,11 +235,7 @@ trait ParsesTextResponses
 
         $data = $response->json();
 
-        if (isset($data['error'])) {
-            throw new AiException(
-                data_get($data, 'error.message', 'Unknown OpenAI error.'),
-            );
-        }
+        $this->validateTextResponse($data);
 
         return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps);
     }
@@ -258,7 +280,7 @@ trait ParsesTextResponses
         $lastOutput = last($output);
 
         if (is_array($lastOutput)) {
-            return data_get($lastOutput, 'content.0.text', '') ?? '';
+            return $lastOutput['content'][0]['text'] ?? '';
         }
 
         return '';
@@ -312,15 +334,16 @@ trait ParsesTextResponses
      */
     protected function extractUsage(array $data): Usage
     {
-        $inputTokens = data_get($data, 'usage.input_tokens', 0);
-        $cachedTokens = data_get($data, 'usage.input_tokens_details.cached_tokens', 0);
+        $usage = $data['usage'] ?? [];
+        $inputTokens = $usage['input_tokens'] ?? 0;
+        $cachedTokens = $usage['input_tokens_details']['cached_tokens'] ?? 0;
 
         return new Usage(
             $inputTokens - $cachedTokens,
-            data_get($data, 'usage.output_tokens', 0),
+            $usage['output_tokens'] ?? 0,
             0,
             $cachedTokens,
-            data_get($data, 'usage.output_tokens_details.reasoning_tokens', 0),
+            $usage['output_tokens_details']['reasoning_tokens'] ?? 0,
         );
     }
 
@@ -329,9 +352,9 @@ trait ParsesTextResponses
      */
     protected function extractFinishReason(array $data): FinishReason
     {
-        $lastOutput = last(data_get($data, 'output', []));
-        $status = data_get($lastOutput, 'status', data_get($data, 'status', ''));
-        $type = data_get($lastOutput, 'type', '');
+        $lastOutput = last($data['output'] ?? []);
+        $status = $lastOutput['status'] ?? $data['status'] ?? '';
+        $type = $lastOutput['type'] ?? '';
 
         return match ($status) {
             'incomplete' => FinishReason::Length,
@@ -355,12 +378,12 @@ trait ParsesTextResponses
         $firstReasoning = $reasonings[0] ?? null;
 
         return array_map(fn (array $tc) => new ToolCall(
-            data_get($tc, 'id', ''),
-            data_get($tc, 'name', ''),
-            json_decode(data_get($tc, 'arguments', '{}'), true) ?? [],
-            data_get($tc, 'call_id'),
-            $firstReasoning ? data_get($firstReasoning, 'id') : null,
-            $firstReasoning ? data_get($firstReasoning, 'summary') : null,
+            $tc['id'] ?? '',
+            $tc['name'] ?? '',
+            json_decode($tc['arguments'] ?? '{}', true) ?? [],
+            $tc['call_id'] ?? null,
+            $firstReasoning ? $firstReasoning['id'] ?? null : null,
+            $firstReasoning ? $firstReasoning['summary'] ?? null : null,
         ), $toolCalls);
     }
 

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\UrlCitation;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Parse the OpenAI response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+    ): TextResponse {
+        $steps = new Collection;
+        $allMessages = new Collection;
+
+        return $this->processResponse(
+            $data, $provider, $structured, $tools, $schema, $steps, $allMessages, maxSteps: $options?->maxSteps,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        int $depth = 0,
+        ?int $maxSteps = null,
+    ): TextResponse {
+        $output = data_get($data, 'output', []);
+        $responseId = data_get($data, 'id', '');
+        $model = data_get($data, 'model', '');
+
+        $text = $this->extractText($output);
+        $toolCalls = $this->extractToolCalls($output);
+        $reasonings = $this->extractReasonings($output);
+        $citations = $this->extractCitations($output);
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->mapFinishReason($data);
+
+        // Associate reasoning with tool calls
+        $mappedToolCalls = $this->mapToolCallsWithReasoning($toolCalls, $reasonings);
+
+        $step = new Step(
+            $text,
+            $mappedToolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model, $citations),
+        );
+
+        $steps->push($step);
+
+        // Build assistant message for conversation context
+        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+        $messages->push($assistantMessage);
+
+        // Handle tool calls
+        if ($finishReason === FinishReason::ToolCalls && filled($mappedToolCalls) && $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+
+            // Update step with tool results
+            $steps->pop();
+            $steps->push(new Step(
+                $text,
+                $mappedToolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model, $citations),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps,
+            );
+        }
+
+        // Build final response
+        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
+        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
+
+        if ($structured) {
+            $structuredData = json_decode($text, true) ?? [];
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                $text,
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model, $citations),
+            ))->withToolCallsAndResults(
+                toolCalls: $allToolCalls,
+                toolResults: $allToolResults,
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model, $citations),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        string $responseId,
+        string $model,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        array $toolResults,
+        int $depth,
+        ?int $maxSteps,
+    ): TextResponse {
+        $body = [
+            'model' => $model,
+            'previous_response_id' => $responseId,
+            'input' => $this->buildToolResultsInput($toolResults),
+        ];
+
+        if (filled($tools)) {
+            $body['tools'] = $this->mapTools($tools, $provider);
+        }
+
+        if (filled($schema)) {
+            $body['text'] = $this->buildSchemaFormat($schema);
+        }
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('responses', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Extract text content from the output array.
+     */
+    protected function extractText(array $output): string
+    {
+        $lastOutput = last($output);
+
+        if (! is_array($lastOutput)) {
+            return '';
+        }
+
+        return data_get($lastOutput, 'content.0.text', '') ?? '';
+    }
+
+    /**
+     * Extract tool calls from the output array.
+     */
+    protected function extractToolCalls(array $output): array
+    {
+        return array_values(array_filter($output, fn (array $item) => ($item['type'] ?? '') === 'function_call'));
+    }
+
+    /**
+     * Extract reasoning blocks from the output array.
+     */
+    protected function extractReasonings(array $output): array
+    {
+        return array_values(array_filter($output, fn (array $item) => ($item['type'] ?? '') === 'reasoning'));
+    }
+
+    /**
+     * Extract citations from the output array.
+     */
+    protected function extractCitations(array $output): Collection
+    {
+        $citations = new Collection;
+
+        foreach ($output as $item) {
+            if (($item['type'] ?? '') !== 'message') {
+                continue;
+            }
+
+            foreach ($item['content'] ?? [] as $content) {
+                foreach ($content['annotations'] ?? [] as $annotation) {
+                    if (($annotation['type'] ?? '') === 'url_citation') {
+                        $citations->push(new UrlCitation(
+                            $annotation['url'] ?? '',
+                            $annotation['title'] ?? null,
+                        ));
+                    }
+                }
+            }
+        }
+
+        return $citations->unique('title')->values();
+    }
+
+    /**
+     * Extract usage data from the response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $inputTokens = data_get($data, 'usage.input_tokens', 0);
+        $cachedTokens = data_get($data, 'usage.input_tokens_details.cached_tokens', 0);
+
+        return new Usage(
+            $inputTokens - $cachedTokens,
+            data_get($data, 'usage.output_tokens', 0),
+            0,
+            $cachedTokens,
+            data_get($data, 'usage.output_tokens_details.reasoning_tokens', 0),
+        );
+    }
+
+    /**
+     * Map the finish reason from the OpenAI response.
+     */
+    protected function mapFinishReason(array $data): FinishReason
+    {
+        $lastOutput = last(data_get($data, 'output', []));
+        $status = data_get($lastOutput, 'status', data_get($data, 'status', ''));
+        $type = data_get($lastOutput, 'type', '');
+
+        return match ($status) {
+            'incomplete' => FinishReason::Length,
+            'failed' => FinishReason::Error,
+            'completed' => match ($type) {
+                'function_call' => FinishReason::ToolCalls,
+                'message' => FinishReason::Stop,
+                default => str_ends_with((string) $type, '_call') ? FinishReason::ToolCalls : FinishReason::Unknown,
+            },
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Map tool calls with their associated reasoning blocks.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapToolCallsWithReasoning(array $toolCalls, array $reasonings): array
+    {
+        $firstReasoning = $reasonings[0] ?? null;
+
+        return array_map(fn (array $tc) => new ToolCall(
+            data_get($tc, 'id', ''),
+            data_get($tc, 'name', ''),
+            json_decode(data_get($tc, 'arguments', '{}'), true) ?? [],
+            data_get($tc, 'call_id'),
+            $firstReasoning ? data_get($firstReasoning, 'id') : null,
+            $firstReasoning ? data_get($firstReasoning, 'summary') : null,
+        ), $toolCalls);
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+
+    /**
+     * Build the input array containing only tool results for a follow-up request.
+     *
+     * @param  array<ToolResult>  $toolResults
+     */
+    protected function buildToolResultsInput(array $toolResults): array
+    {
+        $input = [];
+
+        foreach ($toolResults as $result) {
+            $input[] = [
+                'type' => 'function_call_output',
+                'call_id' => $result->resultId,
+                'output' => $this->serializeToolResultOutput($result->result),
+            ];
+        }
+
+        return $input;
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+
+    /**
+     * Validate the text response data.
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (isset($data['error'])) {
+            throw new AiException(
+                data_get($data, 'error.message', 'Unknown OpenAI error'),
+            );
+        }
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -141,7 +141,7 @@ trait ParsesTextResponses
             );
         }
 
-        // Build final response
+        // Build final response...
         $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
         $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
 

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -32,11 +32,15 @@ trait ParsesTextResponses
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
     ): TextResponse {
-        $steps = new Collection;
-        $allMessages = new Collection;
-
         return $this->processResponse(
-            $data, $provider, $structured, $tools, $schema, $steps, $allMessages, maxSteps: $options?->maxSteps,
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            maxSteps: $options?->maxSteps,
         );
     }
 
@@ -54,8 +58,8 @@ trait ParsesTextResponses
         int $depth = 0,
         ?int $maxSteps = null,
     ): TextResponse {
-        $output = data_get($data, 'output', []);
         $responseId = data_get($data, 'id', '');
+        $output = data_get($data, 'output', []);
         $model = data_get($data, 'model', '');
 
         $text = $this->extractText($output);
@@ -63,9 +67,9 @@ trait ParsesTextResponses
         $reasonings = $this->extractReasonings($output);
         $citations = $this->extractCitations($output);
         $usage = $this->extractUsage($data);
-        $finishReason = $this->mapFinishReason($data);
+        $finishReason = $this->extractFinishReason($data);
 
-        // Associate reasoning with tool calls
+        // Associate reasoning with tool calls...
         $mappedToolCalls = $this->mapToolCallsWithReasoning($toolCalls, $reasonings);
 
         $step = new Step(
@@ -79,16 +83,20 @@ trait ParsesTextResponses
 
         $steps->push($step);
 
-        // Build assistant message for conversation context
+        // Build assistant message for conversation context...
         $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+
         $messages->push($assistantMessage);
 
-        // Handle tool calls
-        if ($finishReason === FinishReason::ToolCalls && filled($mappedToolCalls) && $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+        // Execute tool calls...
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($mappedToolCalls) &&
+            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
 
-            // Update step with tool results
+            // Update step with tool results...
             $steps->pop();
+
             $steps->push(new Step(
                 $text,
                 $mappedToolCalls,
@@ -99,6 +107,7 @@ trait ParsesTextResponses
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
@@ -129,6 +138,38 @@ trait ParsesTextResponses
             $this->combineUsage($steps),
             new Meta($provider->name(), $model, $citations),
         ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
     }
 
     /**
@@ -168,55 +209,59 @@ trait ParsesTextResponses
 
         $data = $response->json();
 
-        $this->validateTextResponse($data);
+        if (isset($data['error'])) {
+            throw new AiException(
+                data_get($data, 'error.message', 'Unknown OpenAI error.'),
+            );
+        }
 
         return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps);
     }
 
     /**
-     * Execute tool calls and return tool results.
+     * Build the input array containing only tool results for a follow-up request.
      *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
+     * @param  array<ToolResult>  $toolResults
      */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
+    protected function buildToolResultsInput(array $toolResults): array
     {
-        $results = [];
+        $input = [];
 
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
+        foreach ($toolResults as $result) {
+            $input[] = [
+                'type' => 'function_call_output',
+                'call_id' => $result->resultId,
+                'output' => $this->serializeToolResultOutput($result->result),
+            ];
         }
 
-        return $results;
+        return $input;
     }
 
     /**
-     * Extract text content from the output array.
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+
+    /**
+     * Extract the text content from the output array.
      */
     protected function extractText(array $output): string
     {
         $lastOutput = last($output);
 
-        if (! is_array($lastOutput)) {
-            return '';
+        if (is_array($lastOutput)) {
+            return data_get($lastOutput, 'content.0.text', '') ?? '';
         }
 
-        return data_get($lastOutput, 'content.0.text', '') ?? '';
+        return '';
     }
 
     /**
@@ -280,9 +325,9 @@ trait ParsesTextResponses
     }
 
     /**
-     * Map the finish reason from the OpenAI response.
+     * Extract and map the finish reason from the OpenAI response.
      */
-    protected function mapFinishReason(array $data): FinishReason
+    protected function extractFinishReason(array $data): FinishReason
     {
         $lastOutput = last(data_get($data, 'output', []));
         $status = data_get($lastOutput, 'status', data_get($data, 'status', ''));
@@ -328,49 +373,5 @@ trait ParsesTextResponses
             fn (Usage $carry, Step $step) => $carry->add($step->usage),
             new Usage(0, 0)
         );
-    }
-
-    /**
-     * Build the input array containing only tool results for a follow-up request.
-     *
-     * @param  array<ToolResult>  $toolResults
-     */
-    protected function buildToolResultsInput(array $toolResults): array
-    {
-        $input = [];
-
-        foreach ($toolResults as $result) {
-            $input[] = [
-                'type' => 'function_call_output',
-                'call_id' => $result->resultId,
-                'output' => $this->serializeToolResultOutput($result->result),
-            ];
-        }
-
-        return $input;
-    }
-
-    /**
-     * Serialize a tool result output value to a string.
-     */
-    protected function serializeToolResultOutput(mixed $output): string
-    {
-        if (is_string($output)) {
-            return $output;
-        }
-
-        return is_array($output) ? json_encode($output) : strval($output);
-    }
-
-    /**
-     * Validate the text response data.
-     */
-    protected function validateTextResponse(array $data): void
-    {
-        if (isset($data['error'])) {
-            throw new AiException(
-                data_get($data, 'error.message', 'Unknown OpenAI error'),
-            );
-        }
     }
 }

--- a/src/Gateway/OpenAi/OpenAiFileGateway.php
+++ b/src/Gateway/OpenAi/OpenAiFileGateway.php
@@ -1,18 +1,20 @@
 <?php
 
-namespace Laravel\Ai\Gateway;
+namespace Laravel\Ai\Gateway\OpenAi;
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\PreparesStorableFiles;
 use Laravel\Ai\Responses\FileResponse;
 use Laravel\Ai\Responses\StoredFileResponse;
 
 class OpenAiFileGateway implements FileGateway
 {
-    use Concerns\HandlesRateLimiting;
-    use Concerns\PreparesStorableFiles;
+    use HandlesRateLimiting;
+    use PreparesStorableFiles;
 
     /**
      * Get a file by its ID.

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -151,6 +151,66 @@ class OpenAiGateway implements Gateway
     }
 
     /**
+     * Send an image generation request.
+     */
+    protected function sendImageGenerationRequest(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        ?string $size,
+        ?string $quality,
+        ?int $timeout,
+    ) {
+        return $this->client($provider, $timeout ?? 120)->post('images/generations', [
+            'model' => $model,
+            'prompt' => $prompt,
+            'n' => 1,
+            'response_format' => 'b64_json',
+            ...$provider->defaultImageOptions($size, $quality),
+        ]);
+    }
+
+    /**
+     * Send an image edit request with attachments.
+     */
+    protected function sendImageEditRequest(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments,
+        ?string $size,
+        ?string $quality,
+        ?int $timeout,
+    ) {
+        $request = $this->client($provider, $timeout ?? 120);
+
+        foreach ($attachments as $attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            $content = match (true) {
+                $attachment instanceof LocalImage => file_get_contents($attachment->path),
+                $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
+                $attachment instanceof UploadedFile => $attachment->get(),
+                default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
+            };
+
+            $request = $request->attach('image[]', $content, 'image.png');
+        }
+
+        return $request->post('images/edits', array_filter([
+            'model' => $model,
+            'prompt' => $prompt,
+            'n' => 1,
+            'response_format' => 'b64_json',
+            ...$provider->defaultImageOptions($size, $quality),
+        ]));
+    }
+
+    /**
      * Generate audio from the given text.
      */
     public function generateAudio(
@@ -267,65 +327,5 @@ class OpenAiGateway implements Gateway
             ->withToken($provider->providerCredentials()['key'])
             ->timeout($timeout ?? 60)
             ->throw();
-    }
-
-    /**
-     * Send an image generation request.
-     */
-    protected function sendImageGenerationRequest(
-        ImageProvider $provider,
-        string $model,
-        string $prompt,
-        ?string $size,
-        ?string $quality,
-        ?int $timeout,
-    ) {
-        return $this->client($provider, $timeout ?? 120)->post('images/generations', [
-            'model' => $model,
-            'prompt' => $prompt,
-            'n' => 1,
-            'response_format' => 'b64_json',
-            ...$provider->defaultImageOptions($size, $quality),
-        ]);
-    }
-
-    /**
-     * Send an image edit request with attachments.
-     */
-    protected function sendImageEditRequest(
-        ImageProvider $provider,
-        string $model,
-        string $prompt,
-        array $attachments,
-        ?string $size,
-        ?string $quality,
-        ?int $timeout,
-    ) {
-        $request = $this->client($provider, $timeout ?? 120);
-
-        foreach ($attachments as $attachment) {
-            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
-                throw new InvalidArgumentException(
-                    'Unsupported attachment type ['.get_class($attachment).']'
-                );
-            }
-
-            $content = match (true) {
-                $attachment instanceof LocalImage => file_get_contents($attachment->path),
-                $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
-                $attachment instanceof UploadedFile => $attachment->get(),
-                default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
-            };
-
-            $request = $request->attach('image[]', $content, 'image.png');
-        }
-
-        return $request->post('images/edits', array_filter([
-            'model' => $model,
-            'prompt' => $prompt,
-            'n' => 1,
-            'response_format' => 'b64_json',
-            ...$provider->defaultImageOptions($size, $quality),
-        ]));
     }
 }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\Gateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\Data\GeneratedImage;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\ImageResponse;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Responses\TranscriptionResponse;
+
+class OpenAiGateway implements Gateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesRateLimiting;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+        );
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('responses', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse($data, $provider, ! empty($schema), $tools, $schema, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+        );
+
+        $body['stream'] = true;
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('responses', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId, $provider, $model, $tools, $schema, $options,
+            $response->getBody(),
+        );
+    }
+
+    /**
+     * Generate an image.
+     *
+     * @param  array<ImageFile>  $attachments
+     * @param  '3:2'|'2:3'|'1:1'  $size
+     * @param  'low'|'medium'|'high'  $quality
+     */
+    public function generateImage(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments = [],
+        ?string $size = null,
+        ?string $quality = null,
+        ?int $timeout = null,
+    ): ImageResponse {
+        $hasAttachments = filled($attachments);
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $hasAttachments
+                ? $this->sendImageEditRequest($provider, $model, $prompt, $attachments, $size, $quality, $timeout)
+                : $this->sendImageGenerationRequest($provider, $model, $prompt, $size, $quality, $timeout),
+        );
+
+        $data = $response->json();
+
+        return new ImageResponse(
+            collect($data['data'] ?? [])->map(fn (array $image) => new GeneratedImage(
+                $image['b64_json'] ?? '',
+                'image/png',
+            )),
+            new Usage(0, 0),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Generate audio from the given text.
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        $voice = match ($voice) {
+            'default-male' => 'ash',
+            'default-female' => 'alloy',
+            default => $voice,
+        };
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
+                'model' => $model,
+                'input' => $text,
+                'voice' => $voice,
+                'response_format' => 'mp3',
+                'speed' => 1.0,
+                'instructions' => $instructions,
+            ])),
+        );
+
+        return new AudioResponse(
+            base64_encode($response->body()),
+            new Meta($provider->name(), $model),
+            'audio/mpeg',
+        );
+    }
+
+    /**
+     * Generate text from the given audio.
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+    ): TranscriptionResponse {
+        if ($provider->driver() === 'openai' && ! $diarize) {
+            $model = str_replace('-diarize', '', $model);
+        }
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->attach('file', $audio->content(), 'audio.mp3', ['Content-Type' => $audio->mimeType()])
+                ->post('audio/transcriptions', array_filter([
+                    'model' => $model,
+                    'language' => $language,
+                    'response_format' => $diarize ? 'diarized_json' : 'json',
+                ])),
+        );
+
+        $data = $response->json();
+
+        return new TranscriptionResponse(
+            $data['text'] ?? '',
+            collect($data['segments'] ?? [])->map(fn (array $segment) => new TranscriptionSegment(
+                $segment['text'],
+                $segment['speaker'] ?? '',
+                $segment['start'] ?? 0,
+                $segment['end'] ?? 0,
+            )),
+            new Usage(
+                data_get($data, 'usage.input_tokens', 0),
+                data_get($data, 'usage.total_tokens', 0),
+            ),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('embeddings', [
+                'model' => $model,
+                'input' => $inputs,
+                'dimensions' => $dimensions,
+            ]),
+        );
+
+        $data = $response->json();
+
+        return new EmbeddingsResponse(
+            collect($data['data'] ?? [])->pluck('embedding')->all(),
+            $data['usage']['prompt_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Get an HTTP client for the OpenAI API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl('https://api.openai.com/v1')
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Send an image generation request.
+     */
+    protected function sendImageGenerationRequest(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        ?string $size,
+        ?string $quality,
+        ?int $timeout,
+    ) {
+        return $this->client($provider, $timeout ?? 120)->post('images/generations', [
+            'model' => $model,
+            'prompt' => $prompt,
+            'n' => 1,
+            'response_format' => 'b64_json',
+            ...$provider->defaultImageOptions($size, $quality),
+        ]);
+    }
+
+    /**
+     * Send an image edit request with attachments.
+     */
+    protected function sendImageEditRequest(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments,
+        ?string $size,
+        ?string $quality,
+        ?int $timeout,
+    ) {
+        $request = $this->client($provider, $timeout ?? 120);
+
+        foreach ($attachments as $attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            $content = match (true) {
+                $attachment instanceof LocalImage => file_get_contents($attachment->path),
+                $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
+                $attachment instanceof UploadedFile => $attachment->get(),
+                default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
+            };
+
+            $request = $request->attach('image[]', $content, 'image.png');
+        }
+
+        return $request->post('images/edits', array_filter([
+            'model' => $model,
+            'prompt' => $prompt,
+            'n' => 1,
+            'response_format' => 'b64_json',
+            ...$provider->defaultImageOptions($size, $quality),
+        ]));
+    }
+}

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -77,7 +77,7 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, ! empty($schema), $tools, $schema, $options);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options);
     }
 
     /**
@@ -164,8 +164,6 @@ class OpenAiGateway implements Gateway
         return $this->client($provider, $timeout ?? 120)->post('images/generations', [
             'model' => $model,
             'prompt' => $prompt,
-            'n' => 1,
-            'response_format' => 'b64_json',
             ...$provider->defaultImageOptions($size, $quality),
         ]);
     }
@@ -204,8 +202,6 @@ class OpenAiGateway implements Gateway
         return $request->post('images/edits', array_filter([
             'model' => $model,
             'prompt' => $prompt,
-            'n' => 1,
-            'response_format' => 'b64_json',
             ...$provider->defaultImageOptions($size, $quality),
         ]));
     }
@@ -277,14 +273,14 @@ class OpenAiGateway implements Gateway
         return new TranscriptionResponse(
             $data['text'] ?? '',
             collect($data['segments'] ?? [])->map(fn (array $segment) => new TranscriptionSegment(
-                $segment['text'],
+                $segment['text'] ?? '',
                 $segment['speaker'] ?? '',
                 $segment['start'] ?? 0,
                 $segment['end'] ?? 0,
             )),
             new Usage(
-                data_get($data, 'usage.input_tokens', 0),
-                data_get($data, 'usage.total_tokens', 0),
+                $data['usage']['input_tokens'] ?? 0,
+                $data['usage']['total_tokens'] ?? 0,
             ),
             new Meta($provider->name(), $model),
         );

--- a/src/Gateway/OpenAi/OpenAiStoreGateway.php
+++ b/src/Gateway/OpenAi/OpenAiStoreGateway.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Ai\Gateway;
+namespace Laravel\Ai\Gateway\OpenAi;
 
 use DateInterval;
 use Illuminate\Support\Carbon;
@@ -8,12 +8,13 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Responses\Data\StoreFileCounts;
 use Laravel\Ai\Store;
 
 class OpenAiStoreGateway implements StoreGateway
 {
-    use Concerns\HandlesRateLimiting;
+    use HandlesRateLimiting;
 
     /**
      * Get a vector store by its ID.
@@ -80,7 +81,7 @@ class OpenAiStoreGateway implements StoreGateway
             fn () => Http::withToken($provider->providerCredentials()['key'])
                 ->post("https://api.openai.com/v1/vector_stores/{$storeId}/files", array_filter([
                     'file_id' => $fileId,
-                    'attributes' => ! empty($metadata) ? $metadata : null,
+                    'attributes' => filled($metadata) ? $metadata : null,
                 ]))
                 ->throw()
         );
@@ -108,9 +109,12 @@ class OpenAiStoreGateway implements StoreGateway
      */
     public function deleteStore(StoreProvider $provider, string $storeId): bool
     {
-        $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withToken($provider->providerCredentials()['key'])
-            ->delete("https://api.openai.com/v1/vector_stores/{$storeId}")
-            ->throw());
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => Http::withToken($provider->providerCredentials()['key'])
+                ->delete("https://api.openai.com/v1/vector_stores/{$storeId}")
+                ->throw()
+        );
 
         return $response->json('deleted', false);
     }

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -44,7 +44,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     {
         return array_filter([
             'vector_store_ids' => $search->ids(),
-            'filters' => ! empty($search->filters) ? [
+            'filters' => filled($search->filters) ? [
                 'type' => 'and',
                 'filters' => (new Collection($search->filters))->map(fn ($filter) => match ($filter['type']) {
                     default => [
@@ -63,7 +63,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     public function webSearchToolOptions(WebSearch $search): array
     {
         return array_filter([
-            'filters' => ! empty($search->allowedDomains)
+            'filters' => filled($search->allowedDomains)
                 ? ['allowed_domains' => $search->allowedDomains]
                 : null,
             'user_location' => $search->hasLocation()

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -14,8 +14,8 @@ use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
-use Laravel\Ai\Gateway\OpenAiFileGateway;
-use Laravel\Ai\Gateway\OpenAiStoreGateway;
+use Laravel\Ai\Gateway\OpenAi\OpenAiFileGateway;
+use Laravel\Ai\Gateway\OpenAi\OpenAiStoreGateway;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 


### PR DESCRIPTION
The OpenAI provider previously went through Prism PHP for text generation. This adds a dedicated gateway that talks directly to the OpenAI Responses API, giving full access to provider-specific features while other providers continue using Prism.

### Why a direct gateway instead of staying on Prism?

Prism's abstraction forces OpenAI-specific features like `previous_response_id`, provider tool options (`web_search_preview`, `file_search` with filters), and `text.format` structured output through `withProviderOptions()`, an escape hatch that defeats the purpose of the abstraction. A direct gateway lets us adopt new Responses API features immediately without waiting for upstream releases, removes one translation layer for easier debugging, and gives direct control over rate limiting, streaming, and error handling. 


**Other providers (Anthropic, Gemini, Groq, etc.) still use Prism.**

https://developers.openai.com/api/docs/guides/text?lang=curl

> [!WARNING]
> This changes the OpenAI provider's gateway from `PrismGateway` to `OpenAiGateway`. The public API (`Ai` facade, agents, tools) is unchanged, but any code that directly references or extends `PrismGateway` for OpenAI will need updating.