### PR TITLE
Fix Gemini 400 error when agent has only ProviderTools

### DIFF
--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -33,12 +33,15 @@ trait AddsToolsToPrismRequests
             return ! $tool instanceof ProviderTool ? $this->createPrismTool($tool) : null;
         })->filter()->values()->all();
 
-        return $request
-            ->withTools($prismTools)
-            ->when(! empty($prismTools), fn ($request) => $request->withToolChoice(ToolChoice::Auto))
-            ->withMaxSteps(
-                $options?->maxSteps ?? round(count($tools) * 1.5)
-            );
+        $request->withTools($prismTools);
+
+        if (! empty($prismTools)) {
+            $request->withToolChoice(ToolChoice::Auto);
+        }
+
+        return $request->withMaxSteps(
+            $options?->maxSteps ?? round(count($tools) * 1.5)
+        );
     }
 
     /**

--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -29,13 +29,13 @@ trait AddsToolsToPrismRequests
      */
     protected function addTools($request, array $tools, ?TextGenerationOptions $options = null)
     {
+        $prismTools = (new Collection($tools))->map(function ($tool) {
+            return ! $tool instanceof ProviderTool ? $this->createPrismTool($tool) : null;
+        })->filter()->values()->all();
+
         return $request
-            ->withTools(
-                (new Collection($tools))->map(function ($tool) {
-                    return ! $tool instanceof ProviderTool ? $this->createPrismTool($tool) : null;
-                })->filter()->values()->all()
-            )
-            ->withToolChoice(ToolChoice::Auto)
+            ->withTools($prismTools)
+            ->when(! empty($prismTools), fn ($request) => $request->withToolChoice(ToolChoice::Auto))
             ->withMaxSteps(
                 $options?->maxSteps ?? round(count($tools) * 1.5)
             );

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Gateway\Prism;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests;
+use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Tools\Request;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -156,5 +157,219 @@ class AddsToolsToPrismRequestsTest extends TestCase
         $handler->callInvokeTool($tool, []);
 
         $this->assertEquals([], $tool->receivedArguments);
+    }
+
+    public function test_add_tools_does_not_set_tool_choice_when_only_provider_tools_are_present(): void
+    {
+        $providerTool = new class extends ProviderTool {};
+
+        $request = new class
+        {
+            public array $tools = [];
+
+            public bool $toolChoiceSet = false;
+
+            public int $maxSteps = 0;
+
+            public function withTools(array $tools): self
+            {
+                $this->tools = $tools;
+
+                return $this;
+            }
+
+            public function withToolChoice($choice): self
+            {
+                $this->toolChoiceSet = true;
+
+                return $this;
+            }
+
+            public function withMaxSteps(int $steps): self
+            {
+                $this->maxSteps = $steps;
+
+                return $this;
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function callAddTools($request, array $tools)
+            {
+                return $this->addTools($request, $tools);
+            }
+        };
+
+        $handler->callAddTools($request, [$providerTool]);
+
+        $this->assertEmpty($request->tools);
+        $this->assertFalse($request->toolChoiceSet, 'withToolChoice should not be called when only ProviderTools are present');
+    }
+
+    public function test_add_tools_sets_tool_choice_when_regular_tools_are_present(): void
+    {
+        $tool = new class implements Tool
+        {
+            public function description(): Stringable|string
+            {
+                return 'Test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $request = new class
+        {
+            public array $tools = [];
+
+            public bool $toolChoiceSet = false;
+
+            public int $maxSteps = 0;
+
+            public function withTools(array $tools): self
+            {
+                $this->tools = $tools;
+
+                return $this;
+            }
+
+            public function withToolChoice($choice): self
+            {
+                $this->toolChoiceSet = true;
+
+                return $this;
+            }
+
+            public function withMaxSteps(int $steps): self
+            {
+                $this->maxSteps = $steps;
+
+                return $this;
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function callAddTools($request, array $tools)
+            {
+                return $this->addTools($request, $tools);
+            }
+        };
+
+        $handler->callAddTools($request, [$tool]);
+
+        $this->assertNotEmpty($request->tools);
+        $this->assertTrue($request->toolChoiceSet, 'withToolChoice should be called when regular tools are present');
+    }
+
+    public function test_add_tools_sets_tool_choice_when_mixed_tools_are_present(): void
+    {
+        $tool = new class implements Tool
+        {
+            public function description(): Stringable|string
+            {
+                return 'Test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $providerTool = new class extends ProviderTool {};
+
+        $request = new class
+        {
+            public array $tools = [];
+
+            public bool $toolChoiceSet = false;
+
+            public int $maxSteps = 0;
+
+            public function withTools(array $tools): self
+            {
+                $this->tools = $tools;
+
+                return $this;
+            }
+
+            public function withToolChoice($choice): self
+            {
+                $this->toolChoiceSet = true;
+
+                return $this;
+            }
+
+            public function withMaxSteps(int $steps): self
+            {
+                $this->maxSteps = $steps;
+
+                return $this;
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function callAddTools($request, array $tools)
+            {
+                return $this->addTools($request, $tools);
+            }
+        };
+
+        $handler->callAddTools($request, [$tool, $providerTool]);
+
+        $this->assertCount(1, $request->tools, 'Only the regular tool should be in prismTools');
+        $this->assertTrue($request->toolChoiceSet, 'withToolChoice should be called when regular tools are present alongside ProviderTools');
     }
 }


### PR DESCRIPTION
Fixes #259

## Summary

When an agent has only `ProviderTool` instances (e.g., `WebSearch`), the `addTools()` method filters them out of `$prismTools` but still calls `withToolChoice(ToolChoice::Auto)`. Gemini's API rejects `tool_config` (function calling config) when there are no `function_declarations`, returning a 400 error.

The fix conditionally applies `withToolChoice(ToolChoice::Auto)` only when the filtered `$prismTools` array is non-empty.

## Bug found in original fix

The original approach in #259 used `->when()` on the `PendingRequest`, but `when()` is not a method on `PendingRequest` — it is a `Conditionable` trait method not included on that class. Replaced with a simple `if` statement that correctly guards the `withToolChoice()` call.

## Regression tests

Added 3 tests to `AgentTest.php` covering all tool combination scenarios:

- **`test_add_tools_does_not_set_tool_choice_when_only_provider_tools_are_present`** — verifies that when an agent has only `ProviderTool` instances, `withToolChoice(ToolChoice::Auto)` is NOT called (the fix)
- **`test_add_tools_sets_tool_choice_when_regular_tools_are_present`** — verifies that when an agent has regular (non-provider) tools, `withToolChoice(ToolChoice::Auto)` IS called
- **`test_add_tools_sets_tool_choice_when_mixed_tools_are_present`** — verifies that when an agent has both regular tools and provider tools, `withToolChoice(ToolChoice::Auto)` IS called

All 6 tests pass (3 existing + 3 new).

## Test plan

- [x] Agent with only ProviderTools (e.g., WebSearch) does not set tool choice
- [x] Agent with regular tools still sets ToolChoice::Auto
- [x] Agent with mixed tools (regular + provider) still sets ToolChoice::Auto
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)