### PR TITLE
Fix dall-e-3 error from unsupported 'moderation' parameter

### DIFF
--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -123,7 +123,6 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
                 null => 'auto',
                 default => $size,
             },
-            'moderation' => 'low',
         ];
     }
 

--- a/tests/Unit/Providers/OpenAiProviderDefaultImageOptionsTest.php
+++ b/tests/Unit/Providers/OpenAiProviderDefaultImageOptionsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Providers;
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\OpenAiProvider;
+use Tests\TestCase;
+
+class OpenAiProviderDefaultImageOptionsTest extends TestCase
+{
+    public function test_default_image_options_does_not_include_moderation(): void
+    {
+        $provider = Ai::imageProvider('openai');
+
+        $options = $provider->defaultImageOptions();
+
+        $this->assertArrayNotHasKey('moderation', $options);
+    }
+
+    public function test_default_image_options_contains_expected_keys(): void
+    {
+        $provider = Ai::imageProvider('openai');
+
+        $options = $provider->defaultImageOptions();
+
+        $this->assertArrayHasKey('quality', $options);
+        $this->assertArrayHasKey('size', $options);
+        $this->assertCount(2, $options);
+    }
+
+    public function test_default_image_options_maps_size_correctly(): void
+    {
+        $provider = Ai::imageProvider('openai');
+
+        $this->assertEquals('1024x1024', $provider->defaultImageOptions('1:1')['size']);
+        $this->assertEquals('1024x1536', $provider->defaultImageOptions('2:3')['size']);
+        $this->assertEquals('1536x1024', $provider->defaultImageOptions('3:2')['size']);
+        $this->assertEquals('auto', $provider->defaultImageOptions()['size']);
+        $this->assertEquals('512x512', $provider->defaultImageOptions('512x512')['size']);
+    }
+
+    public function test_default_image_options_quality_defaults_to_auto(): void
+    {
+        $provider = Ai::imageProvider('openai');
+
+        $this->assertEquals('auto', $provider->defaultImageOptions()['quality']);
+        $this->assertEquals('hd', $provider->defaultImageOptions(quality: 'hd')['quality']);
+    }
+}


### PR DESCRIPTION
## Summary

- Removes the unconditional `'moderation' => 'low'` from `OpenAiProvider::defaultImageOptions()`
- The `moderation` parameter is only supported by newer OpenAI image models (e.g. `gpt-image-1`) but not by `dall-e-3`, which rejects it with a `400 invalid_request_error`
- Users who need this parameter for supported models can still pass it explicitly via provider options

Fixes #255

## Test plan

- [x] Unit test added: `OpenAiProviderDefaultImageOptionsTest` verifies that `defaultImageOptions()` does not include `moderation`, contains only the expected keys (`quality`, `size`), maps sizes correctly, and handles quality defaults
- [ ] Generate an image using `dall-e-3` via `Image::of($prompt)->square()->generate($provider)` — should no longer return a 400 error about unknown parameter `moderation`
- [ ] Generate an image using `gpt-image-1` — should continue to work (moderation defaults to OpenAI's server-side default)
- [ ] Verify that `moderation` can still be passed explicitly when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)