### PR TITLE
[0.x] Handle rate limiting in Cohere, Voyage AI, and Jina gateways

### DIFF
--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
 use Laravel\Ai\Responses\EmbeddingsResponse;
@@ -16,6 +17,8 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class CohereGateway implements EmbeddingGateway, RerankingGateway
 {
+    use HandlesRateLimiting;
+
     /**
      * Generate embedding vectors representing the given inputs.
      *
@@ -28,20 +31,22 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         int $dimensions,
         int $timeout = 30,
     ): EmbeddingsResponse {
-        $response = $this->client($provider, $timeout)->post('/embed', [
-            'model' => $model,
-            'texts' => $inputs,
-            'input_type' => 'search_document',
-            'embedding_types' => ['float'],
-        ]);
+        return $this->withRateLimitHandling($provider->name(), function () use ($provider, $model, $inputs, $timeout) {
+            $response = $this->client($provider, $timeout)->post('/embed', [
+                'model' => $model,
+                'texts' => $inputs,
+                'input_type' => 'search_document',
+                'embedding_types' => ['float'],
+            ]);
 
-        $data = $response->json();
+            $data = $response->json();
 
-        return new EmbeddingsResponse(
-            $data['embeddings']['float'],
-            $data['meta']['billed_units']['input_tokens'] ?? 0,
-            new Meta($provider->name(), $model),
-        );
+            return new EmbeddingsResponse(
+                $data['embeddings']['float'],
+                $data['meta']['billed_units']['input_tokens'] ?? 0,
+                new Meta($provider->name(), $model),
+            );
+        });
     }
 
     /**
@@ -56,25 +61,28 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         string $query,
         ?int $limit = null
     ): RerankingResponse {
-        $response = $this->client($provider)->post('/rerank', array_filter([
-            'model' => $model,
-            'query' => $query,
-            'documents' => $documents,
-            'top_n' => $limit,
-        ]));
 
-        $data = $response->json();
+        return $this->withRateLimitHandling($provider->name(), function () use ($provider, $model, $documents, $query, $limit) {
+            $response = $this->client($provider)->post('/rerank', array_filter([
+                'model' => $model,
+                'query' => $query,
+                'documents' => $documents,
+                'top_n' => $limit,
+            ]));
 
-        $results = (new Collection($data['results']))->map(fn (array $result) => new RankedDocument(
-            index: $result['index'],
-            document: $documents[$result['index']],
-            score: $result['relevance_score'],
-        ))->all();
+            $data = $response->json();
 
-        return new RerankingResponse(
-            $results,
-            new Meta($provider->name(), $model),
-        );
+            $results = (new Collection($data['results']))->map(fn (array $result) => new RankedDocument(
+                index: $result['index'],
+                document: $documents[$result['index']],
+                score: $result['relevance_score'],
+            ))->all();
+
+            return new RerankingResponse(
+                $results,
+                new Meta($provider->name(), $model),
+            );
+        });
     }
 
     /**

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
 use Laravel\Ai\Responses\EmbeddingsResponse;
@@ -16,6 +17,8 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class JinaGateway implements EmbeddingGateway, RerankingGateway
 {
+    use HandlesRateLimiting;
+
     /**
      * Generate embedding vectors representing the given inputs.
      *
@@ -28,22 +31,24 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         int $dimensions,
         int $timeout = 30,
     ): EmbeddingsResponse {
-        $response = $this->client($provider, $timeout)->post('/embeddings', [
-            'model' => $model,
-            'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
-            'dimensions' => $dimensions,
-            'task' => 'retrieval.passage',
-        ]);
+        return $this->withRateLimitHandling($provider->name(), function () use ($provider, $model, $inputs, $dimensions, $timeout) {
+            $response = $this->client($provider, $timeout)->post('/embeddings', [
+                'model' => $model,
+                'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
+                'dimensions' => $dimensions,
+                'task' => 'retrieval.passage',
+            ]);
 
-        $data = $response->json();
+            $data = $response->json();
 
-        $embeddings = (new Collection($data['data']))->pluck('embedding')->all();
+            $embeddings = (new Collection($data['data']))->pluck('embedding')->all();
 
-        return new EmbeddingsResponse(
-            $embeddings,
-            $data['usage']['total_tokens'] ?? 0,
-            new Meta($provider->name(), $model),
-        );
+            return new EmbeddingsResponse(
+                $embeddings,
+                $data['usage']['total_tokens'] ?? 0,
+                new Meta($provider->name(), $model),
+            );
+        });
     }
 
     /**
@@ -58,25 +63,27 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         string $query,
         ?int $limit = null
     ): RerankingResponse {
-        $response = $this->client($provider)->post('/rerank', array_filter([
-            'model' => $model,
-            'query' => $query,
-            'documents' => $documents,
-            'top_n' => $limit,
-        ]));
+        return $this->withRateLimitHandling($provider->name(), function () use ($provider, $model, $documents, $query, $limit) {
+            $response = $this->client($provider)->post('/rerank', array_filter([
+                'model' => $model,
+                'query' => $query,
+                'documents' => $documents,
+                'top_n' => $limit,
+            ]));
 
-        $data = $response->json();
+            $data = $response->json();
 
-        $results = (new Collection($data['results']))->map(fn (array $result) => new RankedDocument(
-            index: $result['index'],
-            document: $documents[$result['index']],
-            score: $result['relevance_score'],
-        ))->all();
+            $results = (new Collection($data['results']))->map(fn (array $result) => new RankedDocument(
+                index: $result['index'],
+                document: $documents[$result['index']],
+                score: $result['relevance_score'],
+            ))->all();
 
-        return new RerankingResponse(
-            $results,
-            new Meta($provider->name(), $model),
-        );
+            return new RerankingResponse(
+                $results,
+                new Meta($provider->name(), $model),
+            );
+        });
     }
 
     /**

--- a/src/Gateway/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAiGateway.php
@@ -7,12 +7,15 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
 use Laravel\Ai\Responses\RerankingResponse;
 
 class VoyageAiGateway implements RerankingGateway
 {
+    use HandlesRateLimiting;
+
     /**
      * Rerank the given documents based on their relevance to the query.
      *
@@ -25,21 +28,24 @@ class VoyageAiGateway implements RerankingGateway
         string $query,
         ?int $limit = null
     ): RerankingResponse {
-        $data = $this->client($provider)->post('/rerank', array_filter([
-            'model' => $model,
-            'query' => $query,
-            'documents' => $documents,
-            'top_k' => $limit,
-        ]))->json();
 
-        return new RerankingResponse(
-            collect($data['data'])->map(fn (array $result) => new RankedDocument(
-                index: $result['index'],
-                document: $documents[$result['index']],
-                score: $result['relevance_score'],
-            ))->all(),
-            new Meta($provider->name(), $model),
-        );
+        return $this->withRateLimitHandling($provider->name(), function () use ($provider, $model, $documents, $query, $limit) {
+            $data = $this->client($provider)->post('/rerank', array_filter([
+                'model' => $model,
+                'query' => $query,
+                'documents' => $documents,
+                'top_k' => $limit,
+            ]))->json();
+
+            return new RerankingResponse(
+                collect($data['data'])->map(fn (array $result) => new RankedDocument(
+                    index: $result['index'],
+                    document: $documents[$result['index']],
+                    score: $result['relevance_score'],
+                ))->all(),
+                new Meta($provider->name(), $model),
+            );
+        });
     }
 
     /**


### PR DESCRIPTION
This PR fixes missing rate limit handling in the Cohere, VoyageAI, and Jina gateways.

It wraps the affected HTTP calls with `withRateLimitHandling()` so 429 responses throw `RateLimitedException`.
