### PR TITLE
Allow external Prism providers in PrismGateway

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -378,8 +378,13 @@ class PrismGateway implements Gateway
 
     /**
      * Map the given Laravel AI provider to a Prism provider.
+     *
+     * Built-in drivers are mapped to their corresponding Prism provider enum.
+     * Unknown drivers fall through as strings, allowing external Prism providers
+     * registered via PrismManager::extend() (e.g. prism-php/bedrock) to be
+     * resolved by Prism's own provider resolution.
      */
-    protected static function toPrismProvider(Provider $provider): PrismProvider
+    protected static function toPrismProvider(Provider $provider): PrismProvider|string
     {
         return match ($provider->driver()) {
             'anthropic' => PrismProvider::Anthropic,
@@ -393,7 +398,7 @@ class PrismGateway implements Gateway
             'openrouter' => PrismProvider::OpenRouter,
             'voyageai' => PrismProvider::VoyageAI,
             'xai' => PrismProvider::XAI,
-            default => throw new InvalidArgumentException('Gateway does not support provider ['.$provider.'].'),
+            default => $provider->driver(),
         };
     }
 

--- a/tests/Unit/Gateway/Prism/ToPrismProviderTest.php
+++ b/tests/Unit/Gateway/Prism/ToPrismProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Gateway\Prism;
+
+use InvalidArgumentException;
+use Laravel\Ai\Gateway\Prism\PrismGateway;
+use Laravel\Ai\Providers\Provider;
+use Prism\Prism\Enums\Provider as PrismProvider;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class ToPrismProviderTest extends TestCase
+{
+    /**
+     * Call the protected static toPrismProvider method via reflection.
+     */
+    protected function callToPrismProvider(Provider $provider): PrismProvider|string
+    {
+        $method = new ReflectionMethod(PrismGateway::class, 'toPrismProvider');
+
+        return $method->invoke(null, $provider);
+    }
+
+    /**
+     * Create a minimal Provider stub with the given driver name.
+     */
+    protected function makeProvider(string $driver): Provider
+    {
+        return new class($driver) extends Provider
+        {
+            public function __construct(string $driver)
+            {
+                parent::__construct(
+                    new \Laravel\Ai\Gateway\Prism\PrismGateway(app('events')),
+                    ['driver' => $driver, 'key' => 'test-key', 'name' => $driver],
+                    app('events'),
+                );
+            }
+        };
+    }
+
+    public function test_built_in_drivers_return_prism_provider_enum(): void
+    {
+        $mappings = [
+            'anthropic' => PrismProvider::Anthropic,
+            'azure' => PrismProvider::OpenAI,
+            'deepseek' => PrismProvider::DeepSeek,
+            'gemini' => PrismProvider::Gemini,
+            'groq' => PrismProvider::Groq,
+            'mistral' => PrismProvider::Mistral,
+            'ollama' => PrismProvider::Ollama,
+            'openai' => PrismProvider::OpenAI,
+            'openrouter' => PrismProvider::OpenRouter,
+            'voyageai' => PrismProvider::VoyageAI,
+            'xai' => PrismProvider::XAI,
+        ];
+
+        foreach ($mappings as $driver => $expectedEnum) {
+            $result = $this->callToPrismProvider($this->makeProvider($driver));
+
+            $this->assertInstanceOf(PrismProvider::class, $result, "Driver '{$driver}' should return a PrismProvider enum");
+            $this->assertSame($expectedEnum, $result, "Driver '{$driver}' mapped to wrong enum");
+        }
+    }
+
+    public function test_unknown_driver_returns_string_for_custom_prism_providers(): void
+    {
+        $result = $this->callToPrismProvider($this->makeProvider('bedrock'));
+
+        $this->assertIsString($result);
+        $this->assertSame('bedrock', $result);
+    }
+
+    public function test_custom_driver_name_is_returned_as_is(): void
+    {
+        $result = $this->callToPrismProvider($this->makeProvider('workers-ai'));
+
+        $this->assertIsString($result);
+        $this->assertSame('workers-ai', $result);
+    }
+}


### PR DESCRIPTION
## Summary

- `toPrismProvider()` now returns the driver name as a string for unrecognized drivers instead of throwing `InvalidArgumentException`
- Return type changed from `PrismProvider` to `PrismProvider|string` (matches what `Prism::using()` already accepts)
- All existing built-in drivers continue to map to their `PrismProvider` enum values — zero behavior change for current users

## Problem

External Prism providers registered via `PrismManager::extend()` — like [prism-php/bedrock](https://github.com/prism-php/bedrock) (100k+ Packagist downloads) — cannot be used through the `agent()` system because `toPrismProvider()` throws for any driver not in its hardcoded match.

The Prism layer already supports this: `Prism::using()` accepts `string|ProviderEnum`, and `PrismManager::resolve()` checks `customCreators` first. The gap is only in the Laravel AI gateway layer.

## Fix

```diff
- default => throw new InvalidArgumentException('Gateway does not support provider ['.$provider.'].'),
+ default => $provider->driver(),
```

The string driver name flows through to `Prism::using()` → `PrismManager::resolve()` which resolves custom providers via `extend()`, or throws its own `InvalidArgumentException("Provider [{$name}] is not supported.")` if truly unknown.

## Test plan

- [x] All 11 built-in drivers still return correct `PrismProvider` enum values
- [x] Unknown drivers (e.g. `'bedrock'`, `'workers-ai'`) return the driver name as a string
- [x] All 21 existing unit tests pass (91 assertions)

Closes #283