### PR TITLE
Add cache control support for system prompts, messages, and tools

### DIFF
--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -4,10 +4,12 @@ namespace Laravel\Ai\Gateway\Prism\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\HasProviderOptions;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Prism\PrismTool;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -27,12 +29,12 @@ trait AddsToolsToPrismRequests
     /**
      * Add the given tools to the Prism request.
      */
-    protected function addTools($request, array $tools, ?TextGenerationOptions $options = null)
+    protected function addTools($request, Provider $provider, array $tools, ?TextGenerationOptions $options = null)
     {
         return $request
             ->withTools(
-                (new Collection($tools))->map(function ($tool) {
-                    return ! $tool instanceof ProviderTool ? $this->createPrismTool($tool) : null;
+                (new Collection($tools))->map(function ($tool) use ($provider) {
+                    return ! $tool instanceof ProviderTool ? $this->createPrismTool($tool, $provider) : null;
                 })->filter()->values()->all()
             )
             ->withToolChoice(ToolChoice::Auto)
@@ -44,13 +46,13 @@ trait AddsToolsToPrismRequests
     /**
      * Create a Prism tool from the given tool.
      */
-    protected function createPrismTool(Tool $tool): PrismTool
+    protected function createPrismTool(Tool $tool, ?Provider $provider = null): PrismTool
     {
         $toolName = method_exists($tool, 'name')
             ? $tool->name()
             : class_basename($tool);
 
-        return (new PrismTool)
+        $prismTool = (new PrismTool)
             ->as($toolName)
             ->for((string) $tool->description())
             ->when(
@@ -61,6 +63,18 @@ trait AddsToolsToPrismRequests
             )
             ->using(fn ($arguments) => $this->invokeTool($tool, $arguments))
             ->withoutErrorHandling();
+
+        if ($provider && $tool instanceof HasProviderOptions) {
+            $providerOptions = $tool->providerOptions(
+                Lab::tryFrom($provider->driver()) ?? $provider->driver()
+            );
+
+            if (! empty($providerOptions)) {
+                $prismTool->withProviderOptions($providerOptions);
+            }
+        }
+
+        return $prismTool;
     }
 
     /**

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -64,6 +64,12 @@ trait CreatesPrismTextRequests
             Lab::tryFrom($provider->driver()) ?? $provider->driver()
         );
 
+        // Remove options consumed by PrismGateway before passing to Prism...
+        if (is_array($agentProviderOptions)) {
+            unset($agentProviderOptions['system_prompt_caching']);
+            $agentProviderOptions = $agentProviderOptions ?: null;
+        }
+
         if ($provider instanceof AnthropicProvider) {
             $providerOptions = array_filter([
                 'use_tool_calling' => $schema ? true : null,

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Files\LocalImage;
@@ -36,6 +37,7 @@ use Prism\Prism\Exceptions\PrismException as PrismVendorException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\ValueObjects\Media\Audio;
 use Prism\Prism\ValueObjects\Media\Image as PrismImage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 class PrismGateway implements Gateway
 {
@@ -70,12 +72,10 @@ class PrismGateway implements Gateway
             ! empty($schema),
         ];
 
-        if (! empty($instructions)) {
-            $request->withSystemPrompt($instructions);
-        }
+        $this->applySystemPrompt($request, $provider, $instructions, $options);
 
         if (count($tools) > 0) {
-            $this->addTools($request, $tools, $options);
+            $this->addTools($request, $provider, $tools, $options);
             $this->addProviderTools($provider, $request, $tools);
         }
 
@@ -131,12 +131,10 @@ class PrismGateway implements Gateway
             ! empty($schema),
         ];
 
-        if (! empty($instructions)) {
-            $request->withSystemPrompt($instructions);
-        }
+        $this->applySystemPrompt($request, $provider, $instructions, $options);
 
         if (count($tools) > 0) {
-            $this->addTools($request, $tools, $options);
+            $this->addTools($request, $provider, $tools, $options);
             $this->addProviderTools($provider, $request, $tools);
         }
 
@@ -163,6 +161,49 @@ class PrismGateway implements Gateway
     protected function toPrismMessages(array $messages): array
     {
         return PrismMessages::fromLaravelMessages(new Collection($messages))->all();
+    }
+
+    /**
+     * Apply the system prompt with optional cache control.
+     *
+     * When the agent specifies a `system_prompt_caching` provider option, the system
+     * prompt will be wrapped in a SystemMessage with the appropriate cache control
+     * options. This is primarily useful for Anthropic's prompt caching, which avoids
+     * re-processing large system prompts on every step of a multi-step agent loop.
+     *
+     * The option accepts a cache type string or an array with `type` and optional `ttl`:
+     *
+     *     // In the agent's providerOptions():
+     *     'system_prompt_caching' => 'ephemeral'
+     *     'system_prompt_caching' => ['type' => 'ephemeral', 'ttl' => '5m']
+     *
+     * Anthropic currently supports 'ephemeral' as the cache type, with TTL
+     * values of '5m' (default) or '1h'.
+     */
+    protected function applySystemPrompt(mixed $request, TextProvider $provider, ?string $instructions, ?TextGenerationOptions $options): void
+    {
+        if (empty($instructions)) {
+            return;
+        }
+
+        $caching = $options?->providerOptions(
+            Lab::tryFrom($provider->driver()) ?? $provider->driver()
+        )['system_prompt_caching'] ?? null;
+
+        if (is_null($caching)) {
+            $request->withSystemPrompt($instructions);
+
+            return;
+        }
+
+        $message = new SystemMessage($instructions);
+
+        $message->withProviderOptions(array_filter([
+            'cacheType' => is_array($caching) ? ($caching['type'] ?? 'ephemeral') : $caching,
+            'cacheTtl' => is_array($caching) ? ($caching['ttl'] ?? null) : null,
+        ]));
+
+        $request->withSystemPrompt($message);
     }
 
     /**

--- a/src/Gateway/Prism/PrismMessages.php
+++ b/src/Gateway/Prism/PrismMessages.php
@@ -44,7 +44,7 @@ class PrismMessages
         return $messages
             ->map(function ($message) {
                 if ($message instanceof ToolResultMessage) {
-                    return new PrismToolResultMessage(
+                    $prismMessage = new PrismToolResultMessage(
                         $message->toolResults->map(fn ($toolResult) => new PrismToolResult(
                             toolCallId: $toolResult->id,
                             toolName: $toolResult->name,
@@ -53,15 +53,27 @@ class PrismMessages
                             toolCallResultId: $toolResult->resultId,
                         ))->all()
                     );
+
+                    if (! empty($message->providerOptions)) {
+                        $prismMessage->withProviderOptions($message->providerOptions);
+                    }
+
+                    return $prismMessage;
                 }
 
                 $message = Message::tryFrom($message);
 
                 if ($message->role === MessageRole::User) {
-                    return new PrismUserMessage(
+                    $prismMessage = new PrismUserMessage(
                         $message->content,
                         additionalContent: static::fromLaravelAttachments($message->attachments ?? new Collection)->all(),
                     );
+
+                    if (! empty($message->providerOptions)) {
+                        $prismMessage->withProviderOptions($message->providerOptions);
+                    }
+
+                    return $prismMessage;
                 }
 
                 if ($message->role === MessageRole::Assistant) {
@@ -76,10 +88,16 @@ class PrismMessages
                         ))->all()
                         : [];
 
-                    return new PrismAssistantMessage(
+                    $prismMessage = new PrismAssistantMessage(
                         $message->content ?? '',
                         toolCalls: $toolCalls,
                     );
+
+                    if (! empty($message->providerOptions)) {
+                        $prismMessage->withProviderOptions($message->providerOptions);
+                    }
+
+                    return $prismMessage;
                 }
             })->filter()->values();
     }

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -17,6 +17,13 @@ class Message
     public ?string $content;
 
     /**
+     * The provider-specific options for the message.
+     *
+     * @var array<string, mixed>
+     */
+    public array $providerOptions = [];
+
+    /**
      * Create a new text conversation message instance.
      */
     public function __construct(MessageRole|string $role, ?string $content = '')
@@ -26,6 +33,23 @@ class Message
         $this->role = $role instanceof MessageRole
             ? $role
             : (MessageRole::tryFrom($role) ?? throw new InvalidArgumentException('Invalid message role.'));
+    }
+
+    /**
+     * Set provider-specific options on the message.
+     *
+     * These options are passed through to the underlying provider's message
+     * representation. For example, Anthropic supports cache control:
+     *
+     *     $message->withProviderOptions(['cacheType' => 'ephemeral'])
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function withProviderOptions(array $options): static
+    {
+        $this->providerOptions = $options;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Summary

There's currently no way to configure cache control on system prompts, messages, or tools. Providers like Anthropic support [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) via cache breakpoints, and Prism already supports this via `withProviderOptions()` on messages and tools — but the Laravel AI SDK doesn't expose it.

This PR adds cache control support at three levels:

### 1. System prompt caching (via agent provider options)

```php
class MyAgent implements Agent, HasProviderOptions
{
    public function providerOptions(Lab|string $provider): array
    {
        return match ($provider) {
            Lab::Anthropic => [
                'system_prompt_caching' => 'ephemeral',
                // or with TTL:
                // 'system_prompt_caching' => ['type' => 'ephemeral', 'ttl' => '5m'],
            ],
            default => [],
        };
    }
}
```

Anthropic supports `'ephemeral'` as the cache type, with TTL values of `'5m'` (default) or `'1h'`.

### 2. Message-level cache control

Adds `withProviderOptions()` to the `Message` base class. Options flow through to Prism messages during conversion:

```php
use Laravel\Ai\Messages\UserMessage;

$message = (new UserMessage('...'))->withProviderOptions([
    'cacheType' => 'ephemeral',
]);
```

Works on `UserMessage`, `AssistantMessage`, and `ToolResultMessage`.

### 3. Tool cache control

When a tool implements `HasProviderOptions`, its provider options are passed through to the Prism tool:

```php
use Laravel\Ai\Contracts\HasProviderOptions;
use Laravel\Ai\Contracts\Tool;
use Laravel\Ai\Enums\Lab;

class SearchTool implements Tool, HasProviderOptions
{
    public function providerOptions(Lab|string $provider): array
    {
        return match ($provider) {
            Lab::Anthropic => ['cacheType' => 'ephemeral'],
            default => [],
        };
    }
}
```

### Changes

- **`PrismGateway`**: Extracted `applySystemPrompt()` that reads `system_prompt_caching` from agent provider options and wraps instructions in a `SystemMessage` with cache control. Updated `addTools()` to pass the provider through.
- **`CreatesPrismTextRequests`**: Strips `system_prompt_caching` from agent provider options before passing to Prism (gateway-level concern, not a request-level Prism option).
- **`AddsToolsToPrismRequests`**: `createPrismTool()` now checks if the tool implements `HasProviderOptions` and passes options to the Prism tool via `withProviderOptions()`.
- **`Message`**: Added `$providerOptions` property and `withProviderOptions()` method.
- **`PrismMessages`**: Updated `fromLaravelMessages()` to transfer provider options from Laravel AI messages to Prism messages for all message types.