### PR TITLE
Add Concurrent marker interface for tools

### DIFF
--- a/src/Contracts/Concurrent.php
+++ b/src/Contracts/Concurrent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+interface Concurrent
+{
+    //
+}

--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Prism\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Concurrent;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
@@ -60,7 +61,8 @@ trait AddsToolsToPrismRequests
                 )
             )
             ->using(fn ($arguments) => $this->invokeTool($tool, $arguments))
-            ->withoutErrorHandling();
+            ->withoutErrorHandling()
+            ->when($tool instanceof Concurrent, fn (PrismTool $prismTool) => $prismTool->concurrent());
     }
 
     /**

--- a/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
+++ b/tests/Unit/Gateway/Prism/AddsToolsToPrismRequestsTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Unit\Gateway\Prism;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Concurrent;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Gateway\Prism\Concerns\AddsToolsToPrismRequests;
+use Laravel\Ai\Gateway\Prism\PrismTool;
 use Laravel\Ai\Tools\Request;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -156,5 +158,95 @@ class AddsToolsToPrismRequestsTest extends TestCase
         $handler->callInvokeTool($tool, []);
 
         $this->assertEquals([], $tool->receivedArguments);
+    }
+
+    public function test_concurrent_tool_is_marked_as_concurrent_on_prism_tool(): void
+    {
+        $tool = new class implements Concurrent, Tool
+        {
+            public function description(): Stringable|string
+            {
+                return 'Concurrent test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function callCreatePrismTool(Tool $tool): PrismTool
+            {
+                return $this->createPrismTool($tool);
+            }
+        };
+
+        $prismTool = $handler->callCreatePrismTool($tool);
+
+        $this->assertTrue($prismTool->isConcurrent());
+    }
+
+    public function test_non_concurrent_tool_is_not_marked_as_concurrent_on_prism_tool(): void
+    {
+        $tool = new class implements Tool
+        {
+            public function description(): Stringable|string
+            {
+                return 'Non-concurrent test tool';
+            }
+
+            public function handle(Request $request): Stringable|string
+            {
+                return 'result';
+            }
+
+            public function schema(JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $handler = new class
+        {
+            use AddsToolsToPrismRequests;
+
+            protected $invokingToolCallback;
+
+            protected $toolInvokedCallback;
+
+            public function __construct()
+            {
+                $this->invokingToolCallback = fn () => null;
+                $this->toolInvokedCallback = fn () => null;
+            }
+
+            public function callCreatePrismTool(Tool $tool): PrismTool
+            {
+                return $this->createPrismTool($tool);
+            }
+        };
+
+        $prismTool = $handler->callCreatePrismTool($tool);
+
+        $this->assertFalse($prismTool->isConcurrent());
     }
 }


### PR DESCRIPTION
## Summary

Prism PHP supports [concurrent tool execution](https://prismphp.com/docs/core-concepts/tools-function-calling#concurrent-tool-execution) via `->concurrent()` on tools, allowing multiple I/O-bound tool calls to run in parallel using Laravel's Concurrency facade. However, the Laravel AI SDK has no way to expose this — `createPrismTool()` never calls `->concurrent()`.

This PR adds a `Concurrent` marker interface that tools can implement to opt-in to parallel execution.

### Changes

- **New `Laravel\Ai\Contracts\Concurrent` interface** — empty marker interface following the existing pattern (`HasTools`, `HasStructuredOutput`, `HasMiddleware`, etc.)
- **Modified `AddsToolsToPrismRequests::createPrismTool()`** — checks if the tool implements `Concurrent` and calls `->concurrent()` on the Prism tool
- **Added tests** — verifies concurrent tools get marked, and non-concurrent tools don't

### Usage

```php
use Laravel\Ai\Contracts\Concurrent;
use Laravel\Ai\Contracts\Tool;

class SearchPlacesTool implements Concurrent, Tool
{
    // Tool implementation...
}
```

When the AI model requests multiple tool calls in a single step, tools implementing `Concurrent` will execute in parallel rather than sequentially — reducing total wait time for I/O-bound operations like API calls, database queries, or file reads.

### How it works

Prism groups tool calls by their concurrency flag. Concurrent tools are batched and executed via `Concurrency::run()` (Laravel's Concurrency facade), while sequential tools run one at a time. Results are returned in the original order regardless of execution timing. Error handling is identical for both — if one concurrent tool fails, others still complete.