### PR TITLE
[0.x] Pass through additionalContent from Prism steps

### DIFF
--- a/src/Gateway/Prism/PrismSteps.php
+++ b/src/Gateway/Prism/PrismSteps.php
@@ -38,6 +38,7 @@ class PrismSteps
             static::toLaravelFinishReason($step->finishReason),
             PrismUsage::toLaravelUsage($step->usage),
             new Meta($provider->name(), $step->meta->model),
+            $step->additionalContent,
         );
     }
 
@@ -54,6 +55,7 @@ class PrismSteps
             static::toLaravelFinishReason($step->finishReason),
             PrismUsage::toLaravelUsage($step->usage),
             new Meta($provider->name(), $step->meta->model),
+            $step->additionalContent,
         );
     }
 

--- a/src/Responses/Data/Step.php
+++ b/src/Responses/Data/Step.php
@@ -10,6 +10,7 @@ class Step implements Arrayable, JsonSerializable
     /**
      * @param  array<int, ToolCall>  $toolCalls
      * @param  array<int, ToolResult>  $toolResults
+     * @param  array<string, mixed>  $additionalContent
      */
     public function __construct(
         public string $text,
@@ -18,6 +19,7 @@ class Step implements Arrayable, JsonSerializable
         public FinishReason $finishReason,
         public Usage $usage,
         public Meta $meta,
+        public array $additionalContent = [],
     ) {}
 
     /**
@@ -32,6 +34,7 @@ class Step implements Arrayable, JsonSerializable
             'finish_reason' => $this->finishReason->value,
             'usage' => $this->usage,
             'meta' => $this->meta,
+            'additional_content' => $this->additionalContent,
         ];
     }
 

--- a/src/Responses/Data/StructuredStep.php
+++ b/src/Responses/Data/StructuredStep.php
@@ -8,6 +8,7 @@ class StructuredStep extends Step
      * @param  array<string, mixed>  $structured
      * @param  array<int, ToolCall>  $toolCalls
      * @param  array<int, ToolResult>  $toolResults
+     * @param  array<string, mixed>  $additionalContent
      */
     public function __construct(
         string $text,
@@ -17,7 +18,8 @@ class StructuredStep extends Step
         FinishReason $finishReason,
         Usage $usage,
         Meta $meta,
+        array $additionalContent = [],
     ) {
-        parent::__construct($text, $toolCalls, $toolResults, $finishReason, $usage, $meta);
+        parent::__construct($text, $toolCalls, $toolResults, $finishReason, $usage, $meta, $additionalContent);
     }
 }

--- a/tests/Feature/PrismStepsTest.php
+++ b/tests/Feature/PrismStepsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Ai\Gateway\Prism\PrismSteps;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\StructuredStep;
+use Laravel\Ai\Responses\Data\Usage;
+use Prism\Prism\Enums\FinishReason as PrismFinishReason;
+use Prism\Prism\Structured\Step as PrismStructuredStep;
+use Prism\Prism\Text\Step as PrismTextStep;
+use Prism\Prism\ValueObjects\Meta as PrismMeta;
+use Prism\Prism\ValueObjects\Usage as PrismUsage;
+use Tests\TestCase;
+
+class PrismStepsTest extends TestCase
+{
+    private function fakeProvider(): Provider
+    {
+        $provider = $this->createStub(Provider::class);
+        $provider->method('name')->willReturn('test');
+
+        return $provider;
+    }
+
+    public function test_additional_content_is_passed_through_for_text_steps(): void
+    {
+        $prismStep = new PrismTextStep(
+            text: 'Hello!',
+            finishReason: PrismFinishReason::Stop,
+            toolCalls: [],
+            toolResults: [],
+            providerToolCalls: [],
+            usage: new PrismUsage(10, 20),
+            meta: new PrismMeta(id: 'test-id', model: 'test-model'),
+            messages: [],
+            systemPrompts: [],
+            additionalContent: ['thinking' => 'I should greet the user.'],
+        );
+
+        $step = PrismSteps::toLaravelStep($prismStep, $this->fakeProvider());
+
+        $this->assertInstanceOf(Step::class, $step);
+        $this->assertEquals('Hello!', $step->text);
+        $this->assertArrayHasKey('thinking', $step->additionalContent);
+        $this->assertEquals('I should greet the user.', $step->additionalContent['thinking']);
+    }
+
+    public function test_additional_content_defaults_to_empty_array(): void
+    {
+        $prismStep = new PrismTextStep(
+            text: 'Hello!',
+            finishReason: PrismFinishReason::Stop,
+            toolCalls: [],
+            toolResults: [],
+            providerToolCalls: [],
+            usage: new PrismUsage(10, 20),
+            meta: new PrismMeta(id: 'test-id', model: 'test-model'),
+            messages: [],
+            systemPrompts: [],
+        );
+
+        $step = PrismSteps::toLaravelStep($prismStep, $this->fakeProvider());
+
+        $this->assertEmpty($step->additionalContent);
+    }
+
+    public function test_additional_content_is_passed_through_for_structured_steps(): void
+    {
+        $prismStep = new PrismStructuredStep(
+            text: '{"name":"Alice"}',
+            finishReason: PrismFinishReason::Stop,
+            usage: new PrismUsage(10, 20),
+            meta: new PrismMeta(id: 'test-id', model: 'test-model'),
+            messages: [],
+            systemPrompts: [],
+            additionalContent: ['thinking' => 'The user wants a name.'],
+            structured: ['name' => 'Alice'],
+        );
+
+        $step = PrismSteps::toLaravelStructuredStep($prismStep, $this->fakeProvider());
+
+        $this->assertInstanceOf(StructuredStep::class, $step);
+        $this->assertEquals(['name' => 'Alice'], $step->structured);
+        $this->assertArrayHasKey('thinking', $step->additionalContent);
+        $this->assertEquals('The user wants a name.', $step->additionalContent['thinking']);
+    }
+
+    public function test_additional_content_is_included_in_to_array(): void
+    {
+        $step = new Step(
+            text: 'Hello!',
+            toolCalls: [],
+            toolResults: [],
+            finishReason: FinishReason::Stop,
+            usage: new Usage,
+            meta: new Meta,
+            additionalContent: ['thinking' => 'Some reasoning content'],
+        );
+
+        $array = $step->toArray();
+
+        $this->assertArrayHasKey('additional_content', $array);
+        $this->assertEquals(['thinking' => 'Some reasoning content'], $array['additional_content']);
+    }
+
+    public function test_additional_content_is_empty_in_to_array_by_default(): void
+    {
+        $step = new Step(
+            text: 'Hello!',
+            toolCalls: [],
+            toolResults: [],
+            finishReason: FinishReason::Stop,
+            usage: new Usage,
+            meta: new Meta,
+        );
+
+        $array = $step->toArray();
+
+        $this->assertArrayHasKey('additional_content', $array);
+        $this->assertEquals([], $array['additional_content']);
+    }
+}


### PR DESCRIPTION
## Summary

- Pass through `additionalContent` from Prism's `Step` to the SDK's `Step` and `StructuredStep` response classes
- Defaults to `[]` — no behavior change for existing code

## Context

Prism providers can populate `additionalContent` on steps with provider-specific data. The xAI provider already uses this for reasoning/thinking content, and third-party providers like `meirdick/prism-workers-ai` do the same for Workers AI reasoning models (Kimi K2.5). Currently this data is dropped in `PrismSteps::toLaravelStep()` during the conversion to Laravel AI SDK response objects.

This is a minimal passthrough — it does not add convenience accessors like `$step->thinking()`. That could be considered as a follow-up if the team wants first-class reasoning/thinking support (see #170).

Relates to #170

## Test plan

- [x] 171 non-integration tests pass (374 assertions), zero regressions
- [x] 5 new tests covering text steps, structured steps, default empty, toArray serialization
- [x] Verified locally that `$response->steps[0]->additionalContent['thinking']` surfaces reasoning content through `agent()->prompt()` with a reasoning model