### PR TITLE
Fix conversation replay ordering when assistant used tools

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -123,7 +123,7 @@ class DatabaseConversationStore implements ConversationStore
                     $messages = [];
 
                     $messages[] = new AssistantMessage(
-                        $record->content ?: '',
+                        '',
                         $toolCalls->map(fn ($toolCall) => new ToolCall(
                             id: $toolCall['id'],
                             name: $toolCall['name'],
@@ -142,6 +142,10 @@ class DatabaseConversationStore implements ConversationStore
                                 resultId: $toolResult['result_id'] ?? null,
                             ))
                         );
+                    }
+
+                    if ($record->content) {
+                        $messages[] = new AssistantMessage($record->content);
                     }
 
                     return $messages;


### PR DESCRIPTION
Fixes #299

## Summary

- When `DatabaseConversationStore` replays conversations with tool calls, the final assistant text was bundled into the same `AssistantMessage` as the tool calls, producing an invalid message sequence
- Split into correct ordering: tool-calls-only assistant message → tool results → final text assistant message
- Confirmed fix with Gemini (which falls into text-completion mode with broken ordering) and OpenAI

## Changes

Two-line change in `DatabaseConversationStore::getLatestConversationMessages()`:

1. Changed `$record->content ?: ''` to `''` on the tool-calls `AssistantMessage`
2. Added a separate `AssistantMessage($record->content)` after the `ToolResultMessage`

## Test plan

- [x] Verified broken ordering causes Gemini to complete user sentences instead of responding
- [x] Verified fixed ordering produces proper responses on both Gemini and OpenAI
- [x] Existing conversation replay without tools is unaffected