### PR TITLE
Add direct Anthropic gateway for Messages API

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -53,6 +53,7 @@ return [
         'anthropic' => [
             'driver' => 'anthropic',
             'key' => env('ANTHROPIC_API_KEY'),
+            'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1'),
         ],
 
         'azure' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
 use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
@@ -281,7 +282,7 @@ class AiManager extends MultipleInstanceManager
     public function createAnthropicDriver(array $config): AnthropicProvider
     {
         return new AnthropicProvider(
-            new PrismGateway($this->app['events']),
+            new AnthropicGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Exceptions/ProviderOverloadedException.php
+++ b/src/Exceptions/ProviderOverloadedException.php
@@ -2,16 +2,7 @@
 
 namespace Laravel\Ai\Exceptions;
 
-use Throwable;
-
 class ProviderOverloadedException extends AiException implements FailoverableException
 {
-    public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
-    {
-        return new static(
-            'AI provider ['.$provider.'] is temporarily overloaded.',
-            $code,
-            $previous,
-        );
-    }
+    //
 }

--- a/src/Exceptions/ProviderOverloadedException.php
+++ b/src/Exceptions/ProviderOverloadedException.php
@@ -2,7 +2,16 @@
 
 namespace Laravel\Ai\Exceptions;
 
+use Throwable;
+
 class ProviderOverloadedException extends AiException implements FailoverableException
 {
-    //
+    public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
+    {
+        return new static(
+            'AI provider ['.$provider.'] is temporarily overloaded.',
+            $code,
+            $previous,
+        );
+    }
 }

--- a/src/Exceptions/ProviderOverloadedException.php
+++ b/src/Exceptions/ProviderOverloadedException.php
@@ -2,7 +2,16 @@
 
 namespace Laravel\Ai\Exceptions;
 
+use Throwable;
+
 class ProviderOverloadedException extends AiException implements FailoverableException
 {
-    //
+    public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
+    {
+        return new static(
+            'AI provider ['.$provider.'] is overloaded.',
+            $code,
+            $previous,
+        );
+    }
 }

--- a/src/Gateway/Anthropic/AnthropicFileGateway.php
+++ b/src/Gateway/Anthropic/AnthropicFileGateway.php
@@ -2,17 +2,20 @@
 
 namespace Laravel\Ai\Gateway\Anthropic;
 
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Gateway\Concerns\PreparesStorableFiles;
+use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\FileResponse;
 use Laravel\Ai\Responses\StoredFileResponse;
 
 class AnthropicFileGateway implements FileGateway
 {
+    use Concerns\CreatesAnthropicClient;
     use HandlesRateLimiting;
     use PreparesStorableFiles;
 
@@ -21,11 +24,10 @@ class AnthropicFileGateway implements FileGateway
      */
     public function getFile(FileProvider $provider, string $fileId): FileResponse
     {
-        $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
-            'x-api-key' => $provider->providerCredentials()['key'],
-            'anthropic-version' => '2023-06-01',
-            'anthropic-beta' => 'files-api-2025-04-14',
-        ])->get("https://api.anthropic.com/v1/files/{$fileId}")->throw());
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->get("files/{$fileId}"),
+        );
 
         return new FileResponse(
             id: $response->json('id'),
@@ -42,14 +44,12 @@ class AnthropicFileGateway implements FileGateway
     ): StoredFileResponse {
         [$content, $mime, $name] = $this->prepareStorableFile($file);
 
-        $response = $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
-            'x-api-key' => $provider->providerCredentials()['key'],
-            'anthropic-version' => '2023-06-01',
-            'anthropic-beta' => 'files-api-2025-04-14',
-        ])
-            ->attach('file', $content, $name, ['Content-Type' => $mime])
-            ->post('https://api.anthropic.com/v1/files')
-            ->throw());
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)
+                ->attach('file', $content, $name, ['Content-Type' => $mime])
+                ->post('files'),
+        );
 
         return new StoredFileResponse($response->json('id'));
     }
@@ -59,12 +59,24 @@ class AnthropicFileGateway implements FileGateway
      */
     public function deleteFile(FileProvider $provider, string $fileId): void
     {
-        $this->withRateLimitHandling($provider->name(), fn () => Http::withHeaders([
-            'x-api-key' => $provider->providerCredentials()['key'],
-            'anthropic-version' => '2023-06-01',
-            'anthropic-beta' => 'files-api-2025-04-14',
-        ])
-            ->delete("https://api.anthropic.com/v1/files/{$fileId}")
-            ->throw());
+        $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->delete("files/{$fileId}"),
+        );
+    }
+
+    /**
+     * Get an HTTP client for the Anthropic Files API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withHeaders([
+                'x-api-key' => $provider->providerCredentials()['key'],
+                'anthropic-version' => $provider->additionalConfiguration()['version'] ?? '2023-06-01',
+                'anthropic-beta' => 'files-api-2025-04-14',
+            ])
+            ->timeout($timeout ?? 60)
+            ->throw();
     }
 }

--- a/src/Gateway/Anthropic/AnthropicFileGateway.php
+++ b/src/Gateway/Anthropic/AnthropicFileGateway.php
@@ -1,18 +1,20 @@
 <?php
 
-namespace Laravel\Ai\Gateway;
+namespace Laravel\Ai\Gateway\Anthropic;
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\PreparesStorableFiles;
 use Laravel\Ai\Responses\FileResponse;
 use Laravel\Ai\Responses\StoredFileResponse;
 
 class AnthropicFileGateway implements FileGateway
 {
-    use Concerns\HandlesRateLimiting;
-    use Concerns\PreparesStorableFiles;
+    use HandlesRateLimiting;
+    use PreparesStorableFiles;
 
     /**
      * Get a file by its ID.

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -82,8 +82,10 @@ class AnthropicGateway implements Gateway
                 }
 
                 if ($status === 529) {
-                    throw ProviderOverloadedException::forProvider(
-                        $providerName, $e->getCode(), $e
+                    throw new ProviderOverloadedException(
+                        'AI provider ['.$providerName.'] is overloaded.',
+                        $e->getCode(),
+                        $e,
                     );
                 }
 

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -4,8 +4,6 @@ namespace Laravel\Ai\Gateway\Anthropic;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -17,7 +15,6 @@ use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
@@ -28,6 +25,7 @@ use LogicException;
 class AnthropicGateway implements Gateway
 {
     use Concerns\BuildsTextRequests;
+    use Concerns\CreatesAnthropicClient;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;
     use Concerns\MapsMessages;
@@ -56,7 +54,13 @@ class AnthropicGateway implements Gateway
         ?int $timeout = null,
     ): TextResponse {
         $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
         );
 
         $response = $this->withRateLimitHandling(
@@ -68,7 +72,15 @@ class AnthropicGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $body);
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $body,
+        );
     }
 
     /**
@@ -86,7 +98,13 @@ class AnthropicGateway implements Gateway
         ?int $timeout = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
         );
 
         $body['stream'] = true;
@@ -99,15 +117,21 @@ class AnthropicGateway implements Gateway
         );
 
         yield from $this->processTextStream(
-            $invocationId, $provider, $model, $tools, $schema, $options,
-            $response->getBody(), $body,
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $body,
         );
     }
 
     /**
      * Generate an image.
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     public function generateImage(
         ImageProvider $provider,
@@ -124,7 +148,7 @@ class AnthropicGateway implements Gateway
     /**
      * Generate audio from the given text.
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -140,7 +164,7 @@ class AnthropicGateway implements Gateway
     /**
      * Generate text from the given audio.
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     public function generateTranscription(
         TranscriptionProvider $provider,
@@ -156,7 +180,7 @@ class AnthropicGateway implements Gateway
     /**
      * Generate embeddings for the given inputs.
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     public function generateEmbeddings(
         EmbeddingProvider $provider,
@@ -166,20 +190,5 @@ class AnthropicGateway implements Gateway
         int $timeout = 30,
     ): EmbeddingsResponse {
         throw new LogicException('Anthropic does not support embeddings.');
-    }
-
-    /**
-     * Get an HTTP client for the Anthropic API.
-     */
-    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
-    {
-        return Http::baseUrl('https://api.anthropic.com/v1')
-            ->withHeaders([
-                'x-api-key' => $provider->providerCredentials()['key'],
-                'anthropic-version' => '2023-06-01',
-                'anthropic-beta' => 'web-fetch-2025-09-10',
-            ])
-            ->timeout($timeout ?? 60)
-            ->throw();
     }
 }

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -82,10 +82,8 @@ class AnthropicGateway implements Gateway
                 }
 
                 if ($status === 529) {
-                    throw new ProviderOverloadedException(
-                        "Anthropic [{$providerName}]: The API is temporarily overloaded.",
-                        code: $e->getCode(),
-                        previous: $e,
+                    throw ProviderOverloadedException::forProvider(
+                        $providerName, $e->getCode(), $e
                     );
                 }
 

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Ai\Gateway\Anthropic;
 
+use Closure;
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\RequestException;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -11,7 +13,9 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
-use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -31,13 +35,73 @@ class AnthropicGateway implements Gateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
-    use HandlesRateLimiting;
     use InvokesTools;
     use ParsesServerSentEvents;
+
+    /**
+     * Patterns that indicate an insufficient credits or quota error.
+     *
+     * @var list<string>
+     */
+    protected static array $insufficientCreditPatterns = [
+        'credit balance',
+        'insufficient',
+        'quota exceeded',
+        'exceeded your current quota',
+        'billing',
+    ];
 
     public function __construct(protected Dispatcher $events)
     {
         $this->initializeToolCallbacks();
+    }
+
+    /**
+     * Execute a callback with Anthropic-specific exception handling.
+     *
+     * Translates HTTP 429, 529, and insufficient credit errors into
+     * failoverable exceptions matching the Prism gateway behavior.
+     *
+     * @template T
+     *
+     * @param  Closure(): T  $callback
+     * @return T
+     */
+    protected function withRateLimitHandling(string $providerName, Closure $callback): mixed
+    {
+        try {
+            return $callback();
+        } catch (RequestException $e) {
+            if ($e->response !== null) {
+                $status = $e->response->status();
+
+                if ($status === 429) {
+                    throw RateLimitedException::forProvider(
+                        $providerName, $e->getCode(), $e
+                    );
+                }
+
+                if ($status === 529) {
+                    throw new ProviderOverloadedException(
+                        'AI provider ['.$providerName.'] is overloaded.',
+                        code: $e->getCode(),
+                        previous: $e,
+                    );
+                }
+
+                $message = strtolower($e->response->json('error.message', ''));
+
+                foreach (static::$insufficientCreditPatterns as $pattern) {
+                    if (str_contains($message, $pattern)) {
+                        throw InsufficientCreditsException::forProvider(
+                            $providerName, $e->getCode(), $e
+                        );
+                    }
+                }
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\Gateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\ImageResponse;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use LogicException;
+
+class AnthropicGateway implements Gateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesRateLimiting;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+        );
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('messages', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $body);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+        );
+
+        $body['stream'] = true;
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('messages', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId, $provider, $model, $tools, $schema, $options,
+            $response->getBody(), $body,
+        );
+    }
+
+    /**
+     * Generate an image.
+     *
+     * @throws \LogicException
+     */
+    public function generateImage(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments = [],
+        ?string $size = null,
+        ?string $quality = null,
+        ?int $timeout = null,
+    ): ImageResponse {
+        throw new LogicException('Anthropic does not support image generation.');
+    }
+
+    /**
+     * Generate audio from the given text.
+     *
+     * @throws \LogicException
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        throw new LogicException('Anthropic does not support audio generation.');
+    }
+
+    /**
+     * Generate text from the given audio.
+     *
+     * @throws \LogicException
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+    ): TranscriptionResponse {
+        throw new LogicException('Anthropic does not support transcription.');
+    }
+
+    /**
+     * Generate embeddings for the given inputs.
+     *
+     * @throws \LogicException
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
+        throw new LogicException('Anthropic does not support embeddings.');
+    }
+
+    /**
+     * Get an HTTP client for the Anthropic API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl('https://api.anthropic.com/v1')
+            ->withHeaders([
+                'x-api-key' => $provider->providerCredentials()['key'],
+                'anthropic-version' => '2023-06-01',
+                'anthropic-beta' => 'web-fetch-2025-09-10',
+            ])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+}

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -83,7 +83,7 @@ class AnthropicGateway implements Gateway
 
                 if ($status === 529) {
                     throw new ProviderOverloadedException(
-                        'AI provider ['.$providerName.'] is overloaded.',
+                        "Anthropic [{$providerName}]: The API is temporarily overloaded.",
                         code: $e->getCode(),
                         previous: $e,
                     );

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -82,10 +82,8 @@ class AnthropicGateway implements Gateway
                 }
 
                 if ($status === 529) {
-                    throw new ProviderOverloadedException(
-                        'AI provider ['.$providerName.'] is overloaded.',
-                        $e->getCode(),
-                        $e,
+                    throw ProviderOverloadedException::forProvider(
+                        $providerName, $e->getCode(), $e
                     );
                 }
 

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    /**
+     * Build the request body for the Anthropic Messages API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessages($messages),
+            'max_tokens' => $options?->maxTokens ?? 64_000,
+        ];
+
+        if (filled($instructions)) {
+            $body['system'] = $instructions;
+        }
+
+        if (filled($tools) || filled($schema)) {
+            $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
+
+            if (filled($schema)) {
+                $mappedTools[] = $this->buildStructuredOutputTool($schema);
+
+                // When both regular tools and schema are present, force the model
+                // to always use a tool. It will pick the real tool when needed,
+                // then output_structured_data when done. When only structured
+                // output exists, force the specific tool directly.
+                $body['tool_choice'] = filled($tools)
+                    ? ['type' => 'any']
+                    : ['type' => 'tool', 'name' => 'output_structured_data'];
+            } elseif (filled($mappedTools)) {
+                $body['tool_choice'] = ['type' => 'auto'];
+            }
+
+            if (filled($mappedTools)) {
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
+        $providerOptions = $options?->providerOptions(Lab::Anthropic);
+
+        if (! is_null($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the synthetic tool definition for structured output.
+     */
+    protected function buildStructuredOutputTool(array $schema): array
+    {
+        $objectSchema = new ObjectSchema($schema);
+
+        $schemaArray = $objectSchema->toSchema();
+
+        return [
+            'name' => 'output_structured_data',
+            'description' => 'Output the structured data matching the required schema.',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => (object) ($schemaArray['properties'] ?? []),
+                'required' => $schemaArray['required'] ?? [],
+            ],
+        ];
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -32,6 +32,7 @@ trait BuildsTextRequests
         }
 
         $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
+
         $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
 
         if (filled($schema) && $this->supportsNativeStructuredOutput($provider)) {
@@ -68,6 +69,7 @@ trait BuildsTextRequests
      * Determine the tool_choice strategy for the request.
      *
      * Thinking mode only supports "auto" -- forced tool selection causes an API error.
+     *
      * Without thinking: structured-only forces the synthetic tool, tools+schema uses "any".
      */
     protected function resolveToolChoice(?array $schema, array $tools, array $providerOptions): array

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -32,30 +32,39 @@ trait BuildsTextRequests
         }
 
         $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
+        $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
 
         if (filled($schema)) {
             $mappedTools[] = $this->buildStructuredOutputTool($schema);
-
-            // When both regular tools and schema are present, force the model
-            // to always use a tool. It will pick the real tool when needed,
-            // then output_structured_data when done. When only structured
-            // output exists, force the specific tool directly.
-            $body['tool_choice'] = filled($tools)
-                ? ['type' => 'any']
-                : ['type' => 'tool', 'name' => 'output_structured_data'];
-        } elseif (filled($mappedTools)) {
-            $body['tool_choice'] = ['type' => 'auto'];
         }
 
         if (filled($mappedTools)) {
             $body['tools'] = $mappedTools;
+            $body['tool_choice'] = $this->resolveToolChoice($schema, $tools, $providerOptions);
         }
 
         if ($options?->temperature !== null) {
             $body['temperature'] = $options->temperature;
         }
 
-        return array_merge($body, $options?->providerOptions(Lab::Anthropic) ?? []);
+        return array_merge($body, $providerOptions);
+    }
+
+    /**
+     * Determine the tool_choice strategy for the request.
+     *
+     * Thinking mode only supports "auto" -- forced tool selection causes an API error.
+     * Without thinking: structured-only forces the synthetic tool, tools+schema uses "any".
+     */
+    protected function resolveToolChoice(?array $schema, array $tools, array $providerOptions): array
+    {
+        if (! filled($schema) || isset($providerOptions['thinking'])) {
+            return ['type' => 'auto'];
+        }
+
+        return filled($tools)
+            ? ['type' => 'any']
+            : ['type' => 'tool', 'name' => 'output_structured_data'];
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -34,13 +34,27 @@ trait BuildsTextRequests
         $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
         $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
 
-        if (filled($schema)) {
-            $mappedTools[] = $this->buildStructuredOutputTool($schema);
-        }
+        if (filled($schema) && $this->supportsNativeStructuredOutput($provider)) {
+            $body['output_config'] = [
+                'format' => [
+                    'type' => 'json_schema',
+                    'schema' => (new ObjectSchema($schema))->toSchema(),
+                ],
+            ];
 
-        if (filled($mappedTools)) {
-            $body['tools'] = $mappedTools;
-            $body['tool_choice'] = $this->resolveToolChoice($schema, $tools, $providerOptions);
+            if (filled($mappedTools)) {
+                $body['tools'] = $mappedTools;
+                $body['tool_choice'] = ['type' => 'auto'];
+            }
+        } else {
+            if (filled($schema)) {
+                $mappedTools[] = $this->buildStructuredOutputTool($schema);
+            }
+
+            if (filled($mappedTools)) {
+                $body['tools'] = $mappedTools;
+                $body['tool_choice'] = $this->resolveToolChoice($schema, $tools, $providerOptions);
+            }
         }
 
         if ($options?->temperature !== null) {
@@ -65,6 +79,16 @@ trait BuildsTextRequests
         return filled($tools)
             ? ['type' => 'any']
             : ['type' => 'tool', 'name' => 'output_structured_data'];
+    }
+
+    /**
+     * Determine if the provider supports native structured output via output_config.
+     */
+    protected function supportsNativeStructuredOutput(Provider $provider): bool
+    {
+        $beta = $provider->additionalConfiguration()['anthropic_beta'] ?? '';
+
+        return str_contains($beta, 'structured-outputs');
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -31,39 +31,31 @@ trait BuildsTextRequests
             $body['system'] = $instructions;
         }
 
-        if (filled($tools) || filled($schema)) {
-            $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
+        $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
 
-            if (filled($schema)) {
-                $mappedTools[] = $this->buildStructuredOutputTool($schema);
+        if (filled($schema)) {
+            $mappedTools[] = $this->buildStructuredOutputTool($schema);
 
-                // When both regular tools and schema are present, force the model
-                // to always use a tool. It will pick the real tool when needed,
-                // then output_structured_data when done. When only structured
-                // output exists, force the specific tool directly.
-                $body['tool_choice'] = filled($tools)
-                    ? ['type' => 'any']
-                    : ['type' => 'tool', 'name' => 'output_structured_data'];
-            } elseif (filled($mappedTools)) {
-                $body['tool_choice'] = ['type' => 'auto'];
-            }
-
-            if (filled($mappedTools)) {
-                $body['tools'] = $mappedTools;
-            }
+            // When both regular tools and schema are present, force the model
+            // to always use a tool. It will pick the real tool when needed,
+            // then output_structured_data when done. When only structured
+            // output exists, force the specific tool directly.
+            $body['tool_choice'] = filled($tools)
+                ? ['type' => 'any']
+                : ['type' => 'tool', 'name' => 'output_structured_data'];
+        } elseif (filled($mappedTools)) {
+            $body['tool_choice'] = ['type' => 'auto'];
         }
 
-        if (! is_null($options?->temperature)) {
+        if (filled($mappedTools)) {
+            $body['tools'] = $mappedTools;
+        }
+
+        if ($options?->temperature !== null) {
             $body['temperature'] = $options->temperature;
         }
 
-        $providerOptions = $options?->providerOptions(Lab::Anthropic);
-
-        if (! is_null($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        return $body;
+        return array_merge($body, $options?->providerOptions(Lab::Anthropic) ?? []);
     }
 
     /**
@@ -71,9 +63,7 @@ trait BuildsTextRequests
      */
     protected function buildStructuredOutputTool(array $schema): array
     {
-        $objectSchema = new ObjectSchema($schema);
-
-        $schemaArray = $objectSchema->toSchema();
+        $schemaArray = (new ObjectSchema($schema))->toSchema();
 
         return [
             'name' => 'output_structured_data',

--- a/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
+++ b/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesAnthropicClient
+{
+    /**
+     * Get an HTTP client for the Anthropic API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $config = $provider->additionalConfiguration();
+
+        $headers = [
+            'x-api-key' => $provider->providerCredentials()['key'],
+            'anthropic-version' => $config['version'] ?? '2023-06-01',
+            'anthropic-beta' => $config['anthropic_beta'] ?? 'web-fetch-2025-09-10',
+        ];
+
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withHeaders($headers)
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the Anthropic API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.anthropic.com/v1', '/');
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -411,7 +411,7 @@ trait HandlesTextStreaming
 
         $requestBody['messages'][] = [
             'role' => 'assistant',
-            'content' => array_values($responseContent),
+            'content' => $this->ensureToolInputIsObject(array_values($responseContent)),
         ];
 
         $requestBody['messages'][] = [

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -46,11 +46,16 @@ trait HandlesTextStreaming
         $streamStartEmitted = false;
         $textStartEmitted = false;
         $reasoningStartEmitted = false;
+
         $currentText = '';
-        $pendingToolCalls = [];
-        $currentToolIndex = -1;
         $currentBlockType = '';
+        $currentToolIndex = -1;
+        $pendingToolCalls = [];
         $responseContent = [];
+
+        $inputTokens = 0;
+        $cacheCreationTokens = 0;
+        $cacheReadTokens = 0;
         $usage = null;
         $stopReason = '';
 
@@ -71,6 +76,11 @@ trait HandlesTextStreaming
 
             if ($type === 'message_start' && ! $streamStartEmitted) {
                 $streamStartEmitted = true;
+
+                $messageStartUsage = $data['message']['usage'] ?? [];
+                $inputTokens = $messageStartUsage['input_tokens'] ?? 0;
+                $cacheCreationTokens = $messageStartUsage['cache_creation_input_tokens'] ?? 0;
+                $cacheReadTokens = $messageStartUsage['cache_read_input_tokens'] ?? 0;
 
                 yield (new StreamStart(
                     $this->generateEventId(),
@@ -266,8 +276,10 @@ trait HandlesTextStreaming
                 $deltaUsage = $data['usage'] ?? [];
 
                 $usage = new Usage(
-                    0,
+                    $inputTokens,
                     $deltaUsage['output_tokens'] ?? 0,
+                    $cacheCreationTokens,
+                    $cacheReadTokens,
                 );
             }
         }

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,398 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Process an Anthropic streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        array $requestBody = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $reasoningId = '';
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $reasoningStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $currentToolIndex = -1;
+        $currentBlockType = '';
+        $responseContent = [];
+        $usage = null;
+        $stopReason = '';
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            $type = $data['type'] ?? '';
+
+            if ($type === 'error') {
+                yield (new Error(
+                    $this->generateEventId(),
+                    $data['error']['type'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            if ($type === 'message_start' && ! $streamStartEmitted) {
+                $streamStartEmitted = true;
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    $data['message']['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                continue;
+            }
+
+            if ($type === 'content_block_start') {
+                $blockType = $data['content_block']['type'] ?? '';
+                $currentBlockType = $blockType;
+
+                if ($blockType === 'text') {
+                    if (! $textStartEmitted) {
+                        $textStartEmitted = true;
+
+                        yield (new TextStart(
+                            $this->generateEventId(),
+                            $messageId,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+                } elseif ($blockType === 'thinking') {
+                    if (! $reasoningStartEmitted) {
+                        $reasoningStartEmitted = true;
+                        $reasoningId = $this->generateEventId();
+
+                        yield (new ReasoningStart(
+                            $this->generateEventId(),
+                            $reasoningId,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+                } elseif ($blockType === 'tool_use') {
+                    $currentToolIndex++;
+
+                    $pendingToolCalls[$currentToolIndex] = [
+                        'id' => $data['content_block']['id'] ?? '',
+                        'name' => $data['content_block']['name'] ?? '',
+                        'arguments' => '',
+                    ];
+                } elseif (in_array($blockType, ['web_search_tool_result', 'server_tool_use', 'web_search_tool_use'])) {
+                    yield (new ProviderToolEvent(
+                        $this->generateEventId(),
+                        $data['content_block']['id'] ?? '',
+                        $blockType,
+                        $data['content_block'] ?? [],
+                        'started',
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                // Track content blocks for tool loop replay...
+                if (isset($data['content_block'])) {
+                    $responseContent[$data['index'] ?? count($responseContent)] = $data['content_block'];
+                }
+
+                continue;
+            }
+
+            if ($type === 'content_block_delta') {
+                $deltaType = $data['delta']['type'] ?? '';
+
+                if ($deltaType === 'text_delta') {
+                    $textDelta = (string) ($data['delta']['text'] ?? '');
+
+                    if ($textDelta !== '') {
+                        if (! $textStartEmitted) {
+                            $textStartEmitted = true;
+
+                            yield (new TextStart(
+                                $this->generateEventId(),
+                                $messageId,
+                                time(),
+                            ))->withInvocationId($invocationId);
+                        }
+
+                        $currentText .= $textDelta;
+
+                        yield (new TextDelta(
+                            $this->generateEventId(),
+                            $messageId,
+                            $textDelta,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+                } elseif ($deltaType === 'thinking_delta') {
+                    $delta = (string) ($data['delta']['thinking'] ?? '');
+
+                    if ($delta !== '') {
+                        if (! $reasoningStartEmitted) {
+                            $reasoningStartEmitted = true;
+                            $reasoningId = $this->generateEventId();
+
+                            yield (new ReasoningStart(
+                                $this->generateEventId(),
+                                $reasoningId,
+                                time(),
+                            ))->withInvocationId($invocationId);
+                        }
+
+                        yield (new ReasoningDelta(
+                            $this->generateEventId(),
+                            $reasoningId,
+                            $delta,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+                } elseif ($deltaType === 'input_json_delta') {
+                    $partial = $data['delta']['partial_json'] ?? '';
+
+                    if ($currentToolIndex >= 0 && isset($pendingToolCalls[$currentToolIndex])) {
+                        $pendingToolCalls[$currentToolIndex]['arguments'] .= $partial;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($type === 'content_block_stop') {
+                if ($currentBlockType === 'text' && $textStartEmitted) {
+                    yield (new TextEnd(
+                        $this->generateEventId(),
+                        $messageId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+
+                    $textStartEmitted = false;
+                } elseif ($currentBlockType === 'thinking' && $reasoningStartEmitted) {
+                    yield (new ReasoningEnd(
+                        $this->generateEventId(),
+                        $reasoningId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+
+                    $reasoningStartEmitted = false;
+                    $reasoningId = '';
+                } elseif ($currentBlockType === 'tool_use' && $currentToolIndex >= 0 && isset($pendingToolCalls[$currentToolIndex])) {
+                    $call = $pendingToolCalls[$currentToolIndex];
+                    $parsedArguments = json_decode($call['arguments'] ?: '{}', true) ?? [];
+
+                    $index = $data['index'] ?? $currentToolIndex;
+
+                    if (isset($responseContent[$index])) {
+                        $responseContent[$index]['input'] = $parsedArguments;
+                    }
+
+                    // Store parsed arguments to avoid re-decoding in mapStreamToolCalls...
+                    $pendingToolCalls[$currentToolIndex]['parsed_arguments'] = $parsedArguments;
+
+                    yield (new ToolCallEvent(
+                        $this->generateEventId(),
+                        new ToolCall(
+                            $call['id'],
+                            $call['name'],
+                            $parsedArguments,
+                            $call['id'],
+                        ),
+                        time(),
+                    ))->withInvocationId($invocationId);
+                } elseif (in_array($currentBlockType, ['web_search_tool_result', 'server_tool_use', 'web_search_tool_use'])) {
+                    $index = $data['index'] ?? count($responseContent) - 1;
+
+                    yield (new ProviderToolEvent(
+                        $this->generateEventId(),
+                        $responseContent[$index]['id'] ?? '',
+                        $currentBlockType,
+                        $responseContent[$index] ?? [],
+                        'completed',
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                $currentBlockType = '';
+
+                continue;
+            }
+
+            if ($type === 'message_delta') {
+                $stopReason = $data['delta']['stop_reason'] ?? '';
+                $deltaUsage = $data['usage'] ?? [];
+
+                $usage = new Usage(
+                    0,
+                    $deltaUsage['output_tokens'] ?? 0,
+                );
+            }
+        }
+
+        if (filled($pendingToolCalls) && $stopReason === 'tool_use') {
+            yield from $this->handleStreamingToolCalls(
+                $invocationId, $provider, $model, $tools, $schema, $options,
+                $pendingToolCalls, $responseContent, $requestBody,
+                $depth, $maxSteps,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            'stop',
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $pendingToolCalls,
+        array $responseContent,
+        array $requestBody,
+        int $depth,
+        ?int $maxSteps,
+    ): Generator {
+        $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+        $toolResults = [];
+
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+            $requestBody['messages'][] = [
+                'role' => 'assistant',
+                'content' => array_values($responseContent),
+            ];
+
+            $toolResultContent = [];
+
+            foreach ($toolResults as $result) {
+                $toolResultContent[] = [
+                    'type' => 'tool_result',
+                    'tool_use_id' => $result->id,
+                    'content' => $this->serializeToolResultOutput($result->result),
+                ];
+            }
+
+            $requestBody['messages'][] = [
+                'role' => 'user',
+                'content' => $toolResultContent,
+            ];
+
+            $requestBody['stream'] = true;
+
+            $response = $this->withRateLimitHandling(
+                $provider->name(),
+                fn () => $this->client($provider)
+                    ->withOptions(['stream' => true])
+                    ->post('messages', $requestBody),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId, $provider, $model, $tools, $schema, $options,
+                $response->getBody(), $requestBody, $depth + 1, $maxSteps,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $tc) => new ToolCall(
+            $tc['id'] ?? '',
+            $tc['name'] ?? '',
+            $tc['parsed_arguments'] ?? json_decode($tc['arguments'] ?? '{}', true) ?? [],
+            $tc['id'] ?? null,
+        ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -8,7 +8,9 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -49,6 +51,10 @@ trait HandlesTextStreaming
 
         $currentText = '';
         $currentBlockType = '';
+        $currentBlockIndex = -1;
+        $currentBlockText = '';
+        $currentThinkingText = '';
+        $currentSignature = '';
         $currentToolIndex = -1;
         $pendingToolCalls = [];
         $responseContent = [];
@@ -124,12 +130,18 @@ trait HandlesTextStreaming
             if ($type === 'content_block_start') {
                 $blockType = $data['content_block']['type'] ?? '';
                 $currentBlockType = $blockType;
+                $currentBlockIndex = $data['index'] ?? count($responseContent);
 
                 if ($blockType === 'text') {
+                    $currentBlockText = '';
+
                     if ($event = $emitTextStart()) {
                         yield $event;
                     }
                 } elseif ($blockType === 'thinking') {
+                    $currentThinkingText = '';
+                    $currentSignature = '';
+
                     if ($event = $emitReasoningStart()) {
                         yield $event;
                     }
@@ -181,6 +193,7 @@ trait HandlesTextStreaming
                         }
 
                         $currentText .= $textDelta;
+                        $currentBlockText .= $textDelta;
 
                         yield (new TextDelta(
                             $this->generateEventId(),
@@ -197,10 +210,25 @@ trait HandlesTextStreaming
                             yield $event;
                         }
 
+                        $currentThinkingText .= $delta;
+
                         yield (new ReasoningDelta(
                             $this->generateEventId(),
                             $reasoningId,
                             $delta,
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+                } elseif ($deltaType === 'signature_delta') {
+                    $currentSignature .= (string) ($data['delta']['signature'] ?? '');
+                } elseif ($deltaType === 'citations_delta' && $currentBlockType === 'text') {
+                    $citationData = $data['delta']['citation'] ?? null;
+
+                    if ($citationData && ($citationData['type'] ?? '') === 'web_search_result_location') {
+                        yield (new CitationEvent(
+                            $this->generateEventId(),
+                            $messageId,
+                            new UrlCitation($citationData['url'] ?? '', $citationData['title'] ?? null),
                             time(),
                         ))->withInvocationId($invocationId);
                     }
@@ -217,6 +245,10 @@ trait HandlesTextStreaming
 
             if ($type === 'content_block_stop') {
                 if ($currentBlockType === 'text' && $textStartEmitted) {
+                    if (isset($responseContent[$currentBlockIndex])) {
+                        $responseContent[$currentBlockIndex]['text'] = $currentBlockText;
+                    }
+
                     yield (new TextEnd(
                         $this->generateEventId(),
                         $messageId,
@@ -225,6 +257,11 @@ trait HandlesTextStreaming
 
                     $textStartEmitted = false;
                 } elseif ($currentBlockType === 'thinking' && $reasoningStartEmitted) {
+                    if (isset($responseContent[$currentBlockIndex])) {
+                        $responseContent[$currentBlockIndex]['thinking'] = $currentThinkingText;
+                        $responseContent[$currentBlockIndex]['signature'] = $currentSignature;
+                    }
+
                     yield (new ReasoningEnd(
                         $this->generateEventId(),
                         $reasoningId,

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -59,6 +59,35 @@ trait HandlesTextStreaming
         $usage = null;
         $stopReason = '';
 
+        $emitTextStart = function () use (&$textStartEmitted, $messageId, $invocationId) {
+            if ($textStartEmitted) {
+                return null;
+            }
+
+            $textStartEmitted = true;
+
+            return (new TextStart(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
+        };
+
+        $emitReasoningStart = function () use (&$reasoningStartEmitted, &$reasoningId, $invocationId) {
+            if ($reasoningStartEmitted) {
+                return null;
+            }
+
+            $reasoningStartEmitted = true;
+            $reasoningId = $this->generateEventId();
+
+            return (new ReasoningStart(
+                $this->generateEventId(),
+                $reasoningId,
+                time(),
+            ))->withInvocationId($invocationId);
+        };
+
         foreach ($this->parseServerSentEvents($streamBody) as $data) {
             $type = $data['type'] ?? '';
 
@@ -97,25 +126,12 @@ trait HandlesTextStreaming
                 $currentBlockType = $blockType;
 
                 if ($blockType === 'text') {
-                    if (! $textStartEmitted) {
-                        $textStartEmitted = true;
-
-                        yield (new TextStart(
-                            $this->generateEventId(),
-                            $messageId,
-                            time(),
-                        ))->withInvocationId($invocationId);
+                    if ($event = $emitTextStart()) {
+                        yield $event;
                     }
                 } elseif ($blockType === 'thinking') {
-                    if (! $reasoningStartEmitted) {
-                        $reasoningStartEmitted = true;
-                        $reasoningId = $this->generateEventId();
-
-                        yield (new ReasoningStart(
-                            $this->generateEventId(),
-                            $reasoningId,
-                            time(),
-                        ))->withInvocationId($invocationId);
+                    if ($event = $emitReasoningStart()) {
+                        yield $event;
                     }
                 } elseif ($blockType === 'tool_use') {
                     $currentToolIndex++;
@@ -160,14 +176,8 @@ trait HandlesTextStreaming
                     $textDelta = (string) ($data['delta']['text'] ?? '');
 
                     if ($textDelta !== '') {
-                        if (! $textStartEmitted) {
-                            $textStartEmitted = true;
-
-                            yield (new TextStart(
-                                $this->generateEventId(),
-                                $messageId,
-                                time(),
-                            ))->withInvocationId($invocationId);
+                        if ($event = $emitTextStart()) {
+                            yield $event;
                         }
 
                         $currentText .= $textDelta;
@@ -183,15 +193,8 @@ trait HandlesTextStreaming
                     $delta = (string) ($data['delta']['thinking'] ?? '');
 
                     if ($delta !== '') {
-                        if (! $reasoningStartEmitted) {
-                            $reasoningStartEmitted = true;
-                            $reasoningId = $this->generateEventId();
-
-                            yield (new ReasoningStart(
-                                $this->generateEventId(),
-                                $reasoningId,
-                                time(),
-                            ))->withInvocationId($invocationId);
+                        if ($event = $emitReasoningStart()) {
+                            yield $event;
                         }
 
                         yield (new ReasoningDelta(
@@ -358,56 +361,52 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $requestBody['messages'][] = [
-                'role' => 'assistant',
-                'content' => array_values($responseContent),
-            ];
-
-            $toolResultContent = [];
-
-            foreach ($toolResults as $result) {
-                $toolResultContent[] = [
-                    'type' => 'tool_result',
-                    'tool_use_id' => $result->id,
-                    'content' => $this->serializeToolResultOutput($result->result),
-                ];
-            }
-
-            $requestBody['messages'][] = [
-                'role' => 'user',
-                'content' => $toolResultContent,
-            ];
-
-            $requestBody['stream'] = true;
-
-            $response = $this->withRateLimitHandling(
-                $provider->name(),
-                fn () => $this->client($provider)
-                    ->withOptions(['stream' => true])
-                    ->post('messages', $requestBody),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $requestBody,
-                $depth + 1,
-                $maxSteps,
-            );
-        } else {
+        if ($depth + 1 >= ($maxSteps ?? round(count($tools) * 1.5))) {
             yield (new StreamEnd(
                 $this->generateEventId(),
                 'stop',
                 new Usage(0, 0),
                 time(),
             ))->withInvocationId($invocationId);
+
+            return;
         }
+
+        $requestBody['messages'][] = [
+            'role' => 'assistant',
+            'content' => array_values($responseContent),
+        ];
+
+        $requestBody['messages'][] = [
+            'role' => 'user',
+            'content' => array_map(fn (ToolResult $result) => [
+                'type' => 'tool_result',
+                'tool_use_id' => $result->id,
+                'content' => $this->serializeToolResultOutput($result->result),
+            ], $toolResults),
+        ];
+
+        $requestBody['stream'] = true;
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)
+                ->withOptions(['stream' => true])
+                ->post('messages', $requestBody),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $requestBody,
+            $depth + 1,
+            $maxSteps,
+        );
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -115,13 +115,22 @@ trait HandlesTextStreaming
                         'name' => $data['content_block']['name'] ?? '',
                         'arguments' => '',
                     ];
-                } elseif (in_array($blockType, ['web_search_tool_result', 'server_tool_use', 'web_search_tool_use'])) {
+                } elseif ($blockType === 'server_tool_use') {
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
                         $data['content_block']['id'] ?? '',
                         $blockType,
                         $data['content_block'] ?? [],
                         'started',
+                        time(),
+                    ))->withInvocationId($invocationId);
+                } elseif ($this->isProviderToolResultBlock($blockType)) {
+                    yield (new ProviderToolEvent(
+                        $this->generateEventId(),
+                        $data['content_block']['tool_use_id'] ?? $data['content_block']['id'] ?? '',
+                        $blockType,
+                        $data['content_block'] ?? [],
+                        'result_received',
                         time(),
                     ))->withInvocationId($invocationId);
                 }
@@ -182,7 +191,7 @@ trait HandlesTextStreaming
                             time(),
                         ))->withInvocationId($invocationId);
                     }
-                } elseif ($deltaType === 'input_json_delta') {
+                } elseif ($deltaType === 'input_json_delta' && $currentBlockType === 'tool_use') {
                     $partial = $data['delta']['partial_json'] ?? '';
 
                     if ($currentToolIndex >= 0 && isset($pendingToolCalls[$currentToolIndex])) {
@@ -234,7 +243,7 @@ trait HandlesTextStreaming
                         ),
                         time(),
                     ))->withInvocationId($invocationId);
-                } elseif (in_array($currentBlockType, ['web_search_tool_result', 'server_tool_use', 'web_search_tool_use'])) {
+                } elseif ($currentBlockType === 'server_tool_use') {
                     $index = $data['index'] ?? count($responseContent) - 1;
 
                     yield (new ProviderToolEvent(
@@ -265,9 +274,17 @@ trait HandlesTextStreaming
 
         if (filled($pendingToolCalls) && $stopReason === 'tool_use') {
             yield from $this->handleStreamingToolCalls(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $pendingToolCalls, $responseContent, $requestBody,
-                $depth, $maxSteps,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $pendingToolCalls,
+                $responseContent,
+                $requestBody,
+                $depth,
+                $maxSteps,
             );
 
             return;
@@ -329,7 +346,7 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
             $requestBody['messages'][] = [
                 'role' => 'assistant',
                 'content' => array_values($responseContent),
@@ -360,8 +377,16 @@ trait HandlesTextStreaming
             );
 
             yield from $this->processTextStream(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $requestBody, $depth + 1, $maxSteps,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $requestBody,
+                $depth + 1,
+                $maxSteps,
             );
         } else {
             yield (new StreamEnd(
@@ -386,6 +411,14 @@ trait HandlesTextStreaming
             $tc['parsed_arguments'] ?? json_decode($tc['arguments'] ?? '{}', true) ?? [],
             $tc['id'] ?? null,
         ), array_values($toolCalls));
+    }
+
+    /**
+     * Determine if the given block type is a provider tool result.
+     */
+    protected function isProviderToolResultBlock(string $blockType): bool
+    {
+        return str_ends_with($blockType, '_tool_result');
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -53,7 +53,7 @@ trait MapsAttachments
                     'type' => 'image',
                     'source' => [
                         'type' => 'base64',
-                        'media_type' => $attachment->mime,
+                        'media_type' => $attachment->mimeType(),
                         'data' => base64_encode(file_get_contents($attachment->path)),
                     ],
                 ],
@@ -61,7 +61,7 @@ trait MapsAttachments
                     'type' => 'image',
                     'source' => [
                         'type' => 'base64',
-                        'media_type' => 'image/png',
+                        'media_type' => $attachment->mimeType(),
                         'data' => base64_encode(
                             Storage::disk($attachment->disk)->get($attachment->path)
                         ),
@@ -86,7 +86,7 @@ trait MapsAttachments
                     'type' => 'document',
                     'source' => [
                         'type' => 'base64',
-                        'media_type' => 'application/octet-stream',
+                        'media_type' => $attachment->mimeType(),
                         'data' => base64_encode(file_get_contents($attachment->path)),
                     ],
                 ],
@@ -101,7 +101,7 @@ trait MapsAttachments
                     'type' => 'document',
                     'source' => [
                         'type' => 'base64',
-                        'media_type' => 'application/octet-stream',
+                        'media_type' => $attachment->mimeType(),
                         'data' => base64_encode(
                             Storage::disk($attachment->disk)->get($attachment->path)
                         ),

--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalDocument;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\ProviderDocument;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredDocument;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to Anthropic content blocks.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof ProviderImage => [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'file',
+                        'file_id' => $attachment->id,
+                    ],
+                ],
+                $attachment instanceof Base64Image => [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => $attachment->mime,
+                        'data' => $attachment->base64,
+                    ],
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'url',
+                        'url' => $attachment->url,
+                    ],
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => $attachment->mime,
+                        'data' => base64_encode(file_get_contents($attachment->path)),
+                    ],
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => 'image/png',
+                        'data' => base64_encode(
+                            Storage::disk($attachment->disk)->get($attachment->path)
+                        ),
+                    ],
+                ],
+                $attachment instanceof ProviderDocument => [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'file',
+                        'file_id' => $attachment->id,
+                    ],
+                ],
+                $attachment instanceof Base64Document => [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => $attachment->mime,
+                        'data' => $attachment->base64,
+                    ],
+                ],
+                $attachment instanceof LocalDocument => [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => 'application/octet-stream',
+                        'data' => base64_encode(file_get_contents($attachment->path)),
+                    ],
+                ],
+                $attachment instanceof RemoteDocument => [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'url',
+                        'url' => $attachment->url,
+                    ],
+                ],
+                $attachment instanceof StoredDocument => [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => 'application/octet-stream',
+                        'data' => base64_encode(
+                            Storage::disk($attachment->disk)->get($attachment->path)
+                        ),
+                    ],
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'image',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => $attachment->getClientMimeType(),
+                        'data' => base64_encode($attachment->get()),
+                    ],
+                ],
+                $attachment instanceof UploadedFile => [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => $attachment->getClientMimeType(),
+                        'data' => base64_encode($attachment->get()),
+                    ],
+                ],
+                default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -26,7 +26,7 @@ trait MapsAttachments
     protected function mapAttachments(Collection $attachments): array
     {
         return $attachments->map(function (File|UploadedFile $attachment) {
-            return match (true) {
+            $mapped = match (true) {
                 $attachment instanceof ProviderImage => [
                     'type' => 'image',
                     'source' => [
@@ -125,6 +125,12 @@ trait MapsAttachments
                 ],
                 default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
             };
+
+            if (($mapped['type'] ?? '') === 'document' && $attachment instanceof File && filled($attachment->name)) {
+                $mapped['title'] = $attachment->name;
+            }
+
+            return $mapped;
         })->all();
     }
 

--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -25,13 +25,7 @@ trait MapsAttachments
      */
     protected function mapAttachments(Collection $attachments): array
     {
-        return $attachments->map(function ($attachment) {
-            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
-                throw new InvalidArgumentException(
-                    'Unsupported attachment type ['.get_class($attachment).']'
-                );
-            }
-
+        return $attachments->map(function (File|UploadedFile $attachment) {
             return match (true) {
                 $attachment instanceof ProviderImage => [
                     'type' => 'image',

--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -55,9 +55,9 @@ trait MapsMessages
     protected function mapAssistantMessage(AssistantMessage|Message $message, array &$mapped): void
     {
         $content = [];
+        $hasToolCalls = $message instanceof AssistantMessage && $message->toolCalls->isNotEmpty();
 
-        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
-            // Add thinking blocks before tool calls...
+        if ($hasToolCalls) {
             $thinkingBlocks = $message->toolCalls
                 ->whereNotNull('reasoningId')
                 ->unique('reasoningId')
@@ -80,7 +80,7 @@ trait MapsMessages
             ];
         }
 
-        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+        if ($hasToolCalls) {
             foreach ($message->toolCalls as $toolCall) {
                 $content[] = [
                     'type' => 'tool_use',

--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to Anthropic Messages API format.
+     */
+    protected function mapMessages(array $messages): array
+    {
+        $mapped = [];
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $mapped),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $mapped),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $mapped),
+            };
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a user message to Anthropic format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$mapped): void
+    {
+        $content = [
+            ['type' => 'text', 'text' => $message->content],
+        ];
+
+        if ($message instanceof UserMessage && $message->attachments->isNotEmpty()) {
+            $content = array_merge($this->mapAttachments($message->attachments), $content);
+        }
+
+        $mapped[] = [
+            'role' => 'user',
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * Map an assistant message to Anthropic format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$mapped): void
+    {
+        $content = [];
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            // Add thinking blocks before tool calls...
+            $thinkingBlocks = $message->toolCalls
+                ->whereNotNull('reasoningId')
+                ->unique('reasoningId')
+                ->map(fn ($toolCall) => [
+                    'type' => 'thinking',
+                    'thinking' => is_array($toolCall->reasoningSummary)
+                        ? implode("\n", array_column($toolCall->reasoningSummary, 'text'))
+                        : ($toolCall->reasoningSummary ?? ''),
+                ])
+                ->values()
+                ->all();
+
+            array_push($content, ...$thinkingBlocks);
+        }
+
+        if (filled($message->content)) {
+            $content[] = [
+                'type' => 'text',
+                'text' => $message->content,
+            ];
+        }
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            foreach ($message->toolCalls as $toolCall) {
+                $content[] = [
+                    'type' => 'tool_use',
+                    'id' => $toolCall->id,
+                    'name' => $toolCall->name,
+                    'input' => $toolCall->arguments,
+                ];
+            }
+        }
+
+        if (filled($content)) {
+            $mapped[] = [
+                'role' => 'assistant',
+                'content' => $content,
+            ];
+        }
+    }
+
+    /**
+     * Map a tool result message to Anthropic format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$mapped): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        $content = [];
+
+        foreach ($message->toolResults as $toolResult) {
+            $content[] = [
+                'type' => 'tool_result',
+                'tool_use_id' => $toolResult->id,
+                'content' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+
+        $mapped[] = [
+            'role' => 'user',
+            'content' => $content,
+        ];
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/MapsTools.php
+++ b/src/Gateway/Anthropic/Concerns/MapsTools.php
@@ -40,29 +40,20 @@ trait MapsTools
     {
         $schema = $tool->schema(new JsonSchemaTypeFactory);
 
-        $definition = [
-            'name' => class_basename($tool),
-            'description' => (string) $tool->description(),
-        ];
+        $inputSchema = ['type' => 'object', 'properties' => (object) []];
 
         if (filled($schema)) {
-            $objectSchema = new ObjectSchema($schema);
+            $schemaArray = (new ObjectSchema($schema))->toSchema();
 
-            $schemaArray = $objectSchema->toSchema();
-
-            $definition['input_schema'] = [
-                'type' => 'object',
-                'properties' => (object) ($schemaArray['properties'] ?? []),
-                'required' => $schemaArray['required'] ?? [],
-            ];
-        } else {
-            $definition['input_schema'] = [
-                'type' => 'object',
-                'properties' => (object) [],
-            ];
+            $inputSchema['properties'] = (object) ($schemaArray['properties'] ?? []);
+            $inputSchema['required'] = $schemaArray['required'] ?? [];
         }
 
-        return $definition;
+        return [
+            'name' => class_basename($tool),
+            'description' => (string) $tool->description(),
+            'input_schema' => $inputSchema,
+        ];
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/MapsTools.php
+++ b/src/Gateway/Anthropic/Concerns/MapsTools.php
@@ -11,6 +11,7 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
+use LogicException;
 use RuntimeException;
 
 trait MapsTools
@@ -64,7 +65,7 @@ trait MapsTools
         return match (true) {
             $tool instanceof WebFetch => $this->mapWebFetchTool($tool, $provider),
             $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
-            default => [],
+            default => throw new LogicException('Provider tool ['.get_class($tool).'] is not supported by Anthropic.'),
         };
     }
 

--- a/src/Gateway/Anthropic/Concerns/MapsTools.php
+++ b/src/Gateway/Anthropic/Concerns/MapsTools.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebFetch;
+use Laravel\Ai\Providers\Tools\WebSearch;
+use RuntimeException;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to Anthropic tool definitions.
+     */
+    protected function mapTools(array $tools, Provider $provider): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                $mapped[] = $this->mapProviderTool($tool, $provider);
+            } elseif ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to an Anthropic tool definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $definition = [
+            'name' => class_basename($tool),
+            'description' => (string) $tool->description(),
+        ];
+
+        if (filled($schema)) {
+            $objectSchema = new ObjectSchema($schema);
+
+            $schemaArray = $objectSchema->toSchema();
+
+            $definition['input_schema'] = [
+                'type' => 'object',
+                'properties' => (object) ($schemaArray['properties'] ?? []),
+                'required' => $schemaArray['required'] ?? [],
+            ];
+        } else {
+            $definition['input_schema'] = [
+                'type' => 'object',
+                'properties' => (object) [],
+            ];
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Map a provider tool to an Anthropic provider tool definition.
+     */
+    protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
+    {
+        return match (true) {
+            $tool instanceof WebFetch => $this->mapWebFetchTool($tool, $provider),
+            $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
+            default => [],
+        };
+    }
+
+    /**
+     * Map a web fetch tool to an Anthropic server-side tool definition.
+     */
+    protected function mapWebFetchTool(WebFetch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebFetch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web fetch.');
+        }
+
+        return [
+            'type' => 'web_fetch_20250910',
+            'name' => 'web_fetch',
+            ...$provider->webFetchToolOptions($tool),
+        ];
+    }
+
+    /**
+     * Map a web search tool to an Anthropic server-side tool definition.
+     */
+    protected function mapWebSearchTool(WebSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
+        }
+
+        return [
+            'type' => 'web_search_20250305',
+            'name' => 'web_search',
+            ...$provider->webSearchToolOptions($tool),
+        ];
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -124,6 +124,10 @@ trait ParsesTextResponses
         if ($structured || $hasStructuredToolCall) {
             $structuredData = $this->extractStructuredOutput($content);
 
+            if (empty($structuredData) && filled($text)) {
+                $structuredData = json_decode($text, true) ?? [];
+            }
+
             return (new StructuredTextResponse(
                 $structuredData,
                 json_encode($structuredData) ?: '',
@@ -329,7 +333,7 @@ trait ParsesTextResponses
     protected function extractFinishReason(array $data): FinishReason
     {
         return match ($data['stop_reason'] ?? '') {
-            'end_turn' => FinishReason::Stop,
+            'end_turn', 'stop_sequence' => FinishReason::Stop,
             'tool_use' => FinishReason::ToolCalls,
             'max_tokens' => FinishReason::Length,
             default => FinishReason::Unknown,

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -1,0 +1,390 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\UrlCitation;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Validate the Anthropic response data.
+     *
+     * @throws \Laravel\Ai\Exceptions\AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || ($data['type'] ?? '') === 'error') {
+            throw new AiException(sprintf(
+                'Anthropic Error: [%s] %s',
+                $data['error']['type'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown Anthropic error.',
+            ));
+        }
+    }
+
+    /**
+     * Parse the Anthropic response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        array $requestBody = [],
+    ): TextResponse {
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            $requestBody,
+            maxSteps: $options?->maxSteps,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        array $requestBody,
+        int $depth = 0,
+        ?int $maxSteps = null,
+    ): TextResponse {
+        $model = $data['model'] ?? '';
+        $content = $data['content'] ?? [];
+
+        $text = $this->extractText($content);
+        $toolCalls = $this->extractToolCalls($content);
+        $citations = $this->extractCitations($content);
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->extractFinishReason($data);
+
+        $step = new Step(
+            $text,
+            $toolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model, $citations),
+        );
+
+        $steps->push($step);
+
+        $assistantMessage = new AssistantMessage($text, collect($toolCalls));
+
+        $messages->push($assistantMessage);
+
+        $realToolCalls = array_filter($toolCalls, fn (ToolCall $tc) => $tc->name !== 'output_structured_data');
+        $hasStructuredToolCall = count($realToolCalls) < count($toolCalls);
+
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($realToolCalls) &&
+            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+            $toolResults = $this->executeToolCalls($realToolCalls, $tools);
+
+            $steps->pop();
+
+            $steps->push(new Step(
+                $text,
+                $toolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model, $citations),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $data, $provider, $structured, $tools, $schema,
+                $steps, $messages, $requestBody, $toolResults,
+                $depth + 1, $maxSteps,
+            );
+        }
+
+        if ($structured || $hasStructuredToolCall) {
+            $structuredData = $this->extractStructuredOutput($content);
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                json_encode($structuredData) ?: '',
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model, $citations),
+            ))->withToolCallsAndResults(
+                toolCalls: $steps->flatMap(fn (Step $s) => $s->toolCalls),
+                toolResults: $steps->flatMap(fn (Step $s) => $s->toolResults),
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model, $citations),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        array $previousData,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        array $requestBody,
+        array $toolResults,
+        int $depth,
+        ?int $maxSteps,
+    ): TextResponse {
+        $requestBody['messages'][] = [
+            'role' => 'assistant',
+            'content' => $this->ensureToolInputIsObject($previousData['content'] ?? []),
+        ];
+
+        $toolResultContent = [];
+
+        foreach ($toolResults as $result) {
+            $toolResultContent[] = [
+                'type' => 'tool_result',
+                'tool_use_id' => $result->id,
+                'content' => $this->serializeToolResultOutput($result->result),
+            ];
+        }
+
+        $requestBody['messages'][] = [
+            'role' => 'user',
+            'content' => $toolResultContent,
+        ];
+
+        unset($requestBody['stream']);
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('messages', $requestBody),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data, $provider, $structured, $tools, $schema,
+            $steps, $messages, $requestBody, $depth, $maxSteps,
+        );
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+
+    /**
+     * Extract the text content from Anthropic content blocks.
+     */
+    protected function extractText(array $content): string
+    {
+        $texts = [];
+
+        foreach ($content as $block) {
+            if (($block['type'] ?? '') === 'text') {
+                $texts[] = $block['text'] ?? '';
+            }
+        }
+
+        return implode('', $texts);
+    }
+
+    /**
+     * Extract tool calls from Anthropic content blocks.
+     *
+     * @return array<ToolCall>
+     */
+    protected function extractToolCalls(array $content): array
+    {
+        $toolCalls = [];
+
+        foreach ($content as $block) {
+            if (($block['type'] ?? '') === 'tool_use') {
+                $toolCalls[] = new ToolCall(
+                    $block['id'] ?? '',
+                    $block['name'] ?? '',
+                    $block['input'] ?? [],
+                    $block['id'] ?? null,
+                );
+            }
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * Extract citations from Anthropic content blocks.
+     */
+    protected function extractCitations(array $content): Collection
+    {
+        $citations = new Collection;
+
+        foreach ($content as $block) {
+            if (($block['type'] ?? '') === 'web_search_tool_result') {
+                foreach ($block['search_results'] ?? [] as $result) {
+                    $citations->push(new UrlCitation(
+                        $result['url'] ?? '',
+                        $result['title'] ?? null,
+                    ));
+                }
+            }
+
+            // Also check for citations within text block annotations...
+            if (($block['type'] ?? '') === 'text') {
+                foreach ($block['citations'] ?? [] as $citation) {
+                    if (($citation['type'] ?? '') === 'web_search_result_location') {
+                        $citations->push(new UrlCitation(
+                            $citation['url'] ?? '',
+                            $citation['title'] ?? null,
+                        ));
+                    }
+                }
+            }
+        }
+
+        return $citations->unique('url')->values();
+    }
+
+    /**
+     * Extract usage data from the Anthropic response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+
+        return new Usage(
+            $usage['input_tokens'] ?? 0,
+            $usage['output_tokens'] ?? 0,
+            $usage['cache_creation_input_tokens'] ?? 0,
+            $usage['cache_read_input_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract and map the finish reason from the Anthropic response.
+     */
+    protected function extractFinishReason(array $data): FinishReason
+    {
+        return match ($data['stop_reason'] ?? '') {
+            'end_turn' => FinishReason::Stop,
+            'tool_use' => FinishReason::ToolCalls,
+            'max_tokens' => FinishReason::Length,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Extract structured output from the synthetic tool call.
+     */
+    protected function extractStructuredOutput(array $content): array
+    {
+        foreach ($content as $block) {
+            if (($block['type'] ?? '') === 'tool_use' && ($block['name'] ?? '') === 'output_structured_data') {
+                return $block['input'] ?? [];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Ensure tool_use content blocks have their input cast to object for JSON serialization.
+     */
+    protected function ensureToolInputIsObject(array $content): array
+    {
+        return array_map(function (array $block) {
+            if (($block['type'] ?? '') === 'tool_use') {
+                $block['input'] = (object) ($block['input'] ?? []);
+            }
+
+            return $block;
+        }, $content);
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -24,7 +24,7 @@ trait ParsesTextResponses
     /**
      * Validate the Anthropic response data.
      *
-     * @throws \Laravel\Ai\Exceptions\AiException
+     * @throws AiException
      */
     protected function validateTextResponse(array $data): void
     {
@@ -85,49 +85,39 @@ trait ParsesTextResponses
         $citations = $this->extractCitations($content);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data);
-
-        $step = new Step(
-            $text,
-            $toolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model, $citations),
-        );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($toolCalls));
-
-        $messages->push($assistantMessage);
+        $meta = new Meta($provider->name(), $model, $citations);
 
         $realToolCalls = array_filter($toolCalls, fn (ToolCall $tc) => $tc->name !== 'output_structured_data');
         $hasStructuredToolCall = count($realToolCalls) < count($toolCalls);
+        $toolResults = [];
 
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($realToolCalls) &&
-            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+        $shouldContinue = $finishReason === FinishReason::ToolCalls
+            && filled($realToolCalls)
+            && $depth + 1 < ($maxSteps ?? round(count($tools) * 1.5));
+
+        if ($shouldContinue) {
             $toolResults = $this->executeToolCalls($realToolCalls, $tools);
+        }
 
-            $steps->pop();
+        $steps->push(new Step($text, $toolCalls, $toolResults, $finishReason, $usage, $meta));
 
-            $steps->push(new Step(
-                $text,
-                $toolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model, $citations),
-            ));
+        $messages->push(new AssistantMessage($text, collect($toolCalls)));
 
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
+        if ($shouldContinue) {
+            $messages->push(new ToolResultMessage(collect($toolResults)));
 
             return $this->continueWithToolResults(
-                $data, $provider, $structured, $tools, $schema,
-                $steps, $messages, $requestBody, $toolResults,
-                $depth + 1, $maxSteps,
+                $data,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $requestBody,
+                $toolResults,
+                $depth + 1,
+                $maxSteps,
             );
         }
 
@@ -138,7 +128,7 @@ trait ParsesTextResponses
                 $structuredData,
                 json_encode($structuredData) ?: '',
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
+                $meta,
             ))->withToolCallsAndResults(
                 toolCalls: $steps->flatMap(fn (Step $s) => $s->toolCalls),
                 toolResults: $steps->flatMap(fn (Step $s) => $s->toolResults),
@@ -148,7 +138,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
+            $meta,
         ))->withMessages($messages)->withSteps($steps);
     }
 
@@ -232,8 +222,16 @@ trait ParsesTextResponses
         $this->validateTextResponse($data);
 
         return $this->processResponse(
-            $data, $provider, $structured, $tools, $schema,
-            $steps, $messages, $requestBody, $depth, $maxSteps,
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $requestBody,
+            $depth,
+            $maxSteps,
         );
     }
 
@@ -242,11 +240,11 @@ trait ParsesTextResponses
      */
     protected function serializeToolResultOutput(mixed $output): string
     {
-        if (is_string($output)) {
-            return $output;
-        }
-
-        return is_array($output) ? json_encode($output) : strval($output);
+        return match (true) {
+            is_string($output) => $output,
+            is_array($output) => json_encode($output),
+            default => strval($output),
+        };
     }
 
     /**
@@ -254,15 +252,9 @@ trait ParsesTextResponses
      */
     protected function extractText(array $content): string
     {
-        $texts = [];
+        $textBlocks = array_filter($content, fn (array $block) => ($block['type'] ?? '') === 'text');
 
-        foreach ($content as $block) {
-            if (($block['type'] ?? '') === 'text') {
-                $texts[] = $block['text'] ?? '';
-            }
-        }
-
-        return implode('', $texts);
+        return implode('', array_column($textBlocks, 'text'));
     }
 
     /**
@@ -272,20 +264,14 @@ trait ParsesTextResponses
      */
     protected function extractToolCalls(array $content): array
     {
-        $toolCalls = [];
+        $toolUseBlocks = array_filter($content, fn (array $block) => ($block['type'] ?? '') === 'tool_use');
 
-        foreach ($content as $block) {
-            if (($block['type'] ?? '') === 'tool_use') {
-                $toolCalls[] = new ToolCall(
-                    $block['id'] ?? '',
-                    $block['name'] ?? '',
-                    $block['input'] ?? [],
-                    $block['id'] ?? null,
-                );
-            }
-        }
-
-        return $toolCalls;
+        return array_values(array_map(fn (array $block) => new ToolCall(
+            $block['id'] ?? '',
+            $block['name'] ?? '',
+            $block['input'] ?? [],
+            $block['id'] ?? null,
+        ), $toolUseBlocks));
     }
 
     /**
@@ -296,7 +282,9 @@ trait ParsesTextResponses
         $citations = new Collection;
 
         foreach ($content as $block) {
-            if (($block['type'] ?? '') === 'web_search_tool_result') {
+            $blockType = $block['type'] ?? '';
+
+            if ($blockType === 'web_search_tool_result') {
                 foreach ($block['search_results'] ?? [] as $result) {
                     $citations->push(new UrlCitation(
                         $result['url'] ?? '',
@@ -305,8 +293,7 @@ trait ParsesTextResponses
                 }
             }
 
-            // Also check for citations within text block annotations...
-            if (($block['type'] ?? '') === 'text') {
+            if ($blockType === 'text') {
                 foreach ($block['citations'] ?? [] as $citation) {
                     if (($citation['type'] ?? '') === 'web_search_result_location') {
                         $citations->push(new UrlCitation(

--- a/src/Gateway/Concerns/ParsesServerSentEvents.php
+++ b/src/Gateway/Concerns/ParsesServerSentEvents.php
@@ -11,37 +11,48 @@ trait ParsesServerSentEvents
      */
     protected function parseServerSentEvents($streamBody): Generator
     {
+        while (! $streamBody->eof()) {
+            $line = trim($this->readLine($streamBody));
+
+            if ($line === '' || ! str_starts_with($line, 'data:')) {
+                continue;
+            }
+
+            $data = trim(substr($line, 5));
+
+            if ($data === '[DONE]') {
+                return;
+            }
+
+            $decoded = json_decode($data, true);
+
+            if (json_last_error() === JSON_ERROR_NONE && $decoded !== null) {
+                yield $decoded;
+            }
+        }
+    }
+
+    /**
+     * Read a single line from the stream, byte by byte, to prevent event batching.
+     */
+    protected function readLine($streamBody): string
+    {
         $buffer = '';
 
         while (! $streamBody->eof()) {
-            $buffer .= $streamBody->read(8192);
+            $byte = $streamBody->read(1);
 
-            while (($pos = strpos($buffer, "\n")) !== false) {
-                $line = substr($buffer, 0, $pos);
-                $buffer = substr($buffer, $pos + 1);
+            if ($byte === '') {
+                return $buffer;
+            }
 
-                $line = trim($line);
+            $buffer .= $byte;
 
-                if ($line === '') {
-                    continue;
-                }
-
-                if (! str_starts_with($line, 'data:')) {
-                    continue;
-                }
-
-                $data = trim(substr($line, 5));
-
-                if ($data === '[DONE]') {
-                    return;
-                }
-
-                $decoded = json_decode($data, true);
-
-                if (json_last_error() === JSON_ERROR_NONE && $decoded !== null) {
-                    yield $decoded;
-                }
+            if ($byte === "\n") {
+                break;
             }
         }
+
+        return $buffer;
     }
 }

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -24,7 +24,7 @@ trait ParsesTextResponses
     /**
      * Validate the OpenAI response data.
      *
-     * @throws \Laravel\Ai\Exceptions\AiException
+     * @throws AiException
      */
     protected function validateTextResponse(array $data): void
     {

--- a/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
+++ b/src/Gateway/Prism/Concerns/AddsToolsToPrismRequests.php
@@ -119,7 +119,6 @@ trait AddsToolsToPrismRequests
             : throw new RuntimeException('Provider ['.$provider->name().'] does not support web fetch.');
 
         return match ($provider->driver()) {
-            'anthropic' => new PrismProviderTool('web_fetch_20250910', 'web_fetch', options: $options),
             'gemini' => new PrismProviderTool('url_context'),
         };
     }
@@ -134,7 +133,6 @@ trait AddsToolsToPrismRequests
             : throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
 
         return match ($provider->driver()) {
-            'anthropic' => new PrismProviderTool('web_search_20250305', 'web_search', options: $options),
             'gemini' => new PrismProviderTool('google_search'),
             'openai' => new PrismProviderTool('web_search', options: $options),
         };

--- a/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
+++ b/src/Gateway/Prism/Concerns/CreatesPrismTextRequests.php
@@ -6,7 +6,6 @@ use Laravel\Ai\Contracts\Prompt;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
-use Laravel\Ai\Providers\AnthropicProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\Provider;
 use Prism\Prism\Facades\Prism;
@@ -64,22 +63,6 @@ trait CreatesPrismTextRequests
             Lab::tryFrom($provider->driver()) ?? $provider->driver()
         );
 
-        if ($provider instanceof AnthropicProvider) {
-            $providerOptions = array_filter([
-                'use_tool_calling' => $schema ? true : null,
-            ]);
-
-            // Merge agent provider options (agent options can override defaults)...
-            if (! is_null($agentProviderOptions)) {
-                $providerOptions = array_merge($providerOptions, $agentProviderOptions);
-            }
-
-            return $request
-                ->withProviderOptions($providerOptions)
-                ->withMaxTokens($options?->maxTokens ?? 64_000);
-        }
-
-        // For non-Anthropic providers, apply agent provider options if available...
         if (! is_null($agentProviderOptions)) {
             $request = $request->withProviderOptions($agentProviderOptions);
         }
@@ -101,9 +84,6 @@ trait CreatesPrismTextRequests
             $model,
             array_filter([
                 ...$provider->additionalConfiguration(),
-                ...($provider->driver() === 'anthropic')
-                   ? ['anthropic_beta' => 'web-fetch-2025-09-10']
-                   : [],
                 'api_key' => $provider->providerCredentials()['key'],
             ]),
         );

--- a/src/Gateway/Prism/PrismException.php
+++ b/src/Gateway/Prism/PrismException.php
@@ -42,10 +42,9 @@ class PrismException
         }
 
         if ($e instanceof PrismProviderOverloadedException) {
-            throw new ProviderOverloadedException(
-                'AI provider ['.$provider->name().'] is overloaded.',
-                code: $e->getCode(),
-                previous: $e->getPrevious());
+            throw ProviderOverloadedException::forProvider(
+                $provider->name(), $e->getCode(), $e->getPrevious()
+            );
         }
 
         if (str_starts_with($e->getMessage(), 'Calling ') &&

--- a/src/Gateway/Prism/PrismException.php
+++ b/src/Gateway/Prism/PrismException.php
@@ -42,9 +42,10 @@ class PrismException
         }
 
         if ($e instanceof PrismProviderOverloadedException) {
-            throw ProviderOverloadedException::forProvider(
-                $provider->name(), $e->getCode(), $e->getPrevious()
-            );
+            throw new ProviderOverloadedException(
+                'AI provider ['.$provider->name().'] is overloaded.',
+                code: $e->getCode(),
+                previous: $e->getPrevious());
         }
 
         if (str_starts_with($e->getMessage(), 'Calling ') &&

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -382,7 +382,7 @@ class PrismGateway implements Gateway
     protected static function toPrismProvider(Provider $provider): PrismProvider
     {
         return match ($provider->driver()) {
-            'anthropic' => PrismProvider::Anthropic,
+
             'azure' => PrismProvider::OpenAI,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -382,7 +382,6 @@ class PrismGateway implements Gateway
     protected static function toPrismProvider(Provider $provider): PrismProvider
     {
         return match ($provider->driver()) {
-
             'azure' => PrismProvider::OpenAI,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,

--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -7,7 +7,7 @@ use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
-use Laravel\Ai\Gateway\AnthropicFileGateway;
+use Laravel\Ai\Gateway\Anthropic\AnthropicFileGateway;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -2,17 +2,16 @@
 
 namespace Laravel\Ai\Providers;
 
-use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
 
 class OpenRouterProvider extends Provider implements EmbeddingProvider, TextProvider
 {
+    use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
-    use Concerns\GeneratesEmbeddings;
-    use Concerns\HasEmbeddingGateway;
-
 
     /**
      * Get the name of the default text model.

--- a/tests/Feature/Agents/ProviderOptionsWithToolsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsWithToolsAgent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+use Tests\Feature\Tools\FixedNumberGenerator;
+
+class ProviderOptionsWithToolsAgent implements Agent, HasProviderOptions, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that generates numbers.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new FixedNumberGenerator,
+        ];
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Anthropic => [
+                'thinking' => [
+                    'type' => 'enabled',
+                    'budget_tokens' => 10000,
+                ],
+            ],
+            Lab::OpenAI => [
+                'reasoning' => [
+                    'effort' => 'high',
+                ],
+                'frequency_penalty' => 0.5,
+            ],
+            default => [],
+        };
+    }
+}

--- a/tests/Feature/Agents/StructuredWithThinkingAgent.php
+++ b/tests/Feature/Agents/StructuredWithThinkingAgent.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+class StructuredWithThinkingAgent implements Agent, HasProviderOptions, HasStructuredOutput
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that uses structured output.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->required(),
+            'age' => $schema->integer()->required(),
+        ];
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Anthropic => [
+                'thinking' => [
+                    'type' => 'enabled',
+                    'budget_tokens' => 10000,
+                ],
+            ],
+            default => [],
+        };
+    }
+}

--- a/tests/Feature/Providers/Anthropic/AnthropicTestCase.php
+++ b/tests/Feature/Providers/Anthropic/AnthropicTestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+abstract class AnthropicTestCase extends TestCase
+{
+    protected function fakeTextResponse(string $text = 'Hello'): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [['type' => 'text', 'text' => $text]],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeToolCallResponse(string $toolName = 'FixedNumberGenerator'): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_tool_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_123',
+                'name' => $toolName,
+                'input' => (object) [],
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeStructuredResponse(array $data): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_123',
+                'name' => 'output_structured_data',
+                'input' => $data,
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Anthropic/BaseUrlTest.php
+++ b/tests/Feature/Providers/Anthropic/BaseUrlTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+
+class BaseUrlTest extends AnthropicTestCase
+{
+    public function test_anthropic_requests_use_the_configured_base_url(): void
+    {
+        config(['ai.providers.anthropic.url' => 'https://custom-proxy.example.com/v1']);
+
+        Http::fake([
+            'custom-proxy.example.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://custom-proxy.example.com/v1/messages';
+        });
+    }
+
+    public function test_anthropic_requests_fall_back_to_the_default_base_url(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.anthropic.com/v1/messages';
+        });
+    }
+}

--- a/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Feature\Agents\AssistantAgent;
+
+class ErrorHandlingTest extends AnthropicTestCase
+{
+    public function test_http_error_response_throws_request_exception(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'type' => 'error',
+                'error' => [
+                    'type' => 'invalid_request_error',
+                    'message' => 'max_tokens: must be at least 1',
+                ],
+            ], 400),
+        ]);
+
+        $this->expectException(RequestException::class);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+    }
+
+    public function test_rate_limit_response_throws_rate_limited_exception(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'type' => 'error',
+                'error' => [
+                    'type' => 'rate_limit_error',
+                    'message' => 'Rate limit exceeded',
+                ],
+            ], 429),
+        ]);
+
+        $this->expectException(RateLimitedException::class);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+    }
+
+    public function test_error_in_200_response_throws_ai_exception(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'type' => 'error',
+                'error' => [
+                    'type' => 'api_error',
+                    'message' => 'Internal server error',
+                ],
+            ], 200),
+        ]);
+
+        $this->expectException(AiException::class);
+        $this->expectExceptionMessage('api_error');
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+    }
+}

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ToolUsingAgent;
+
+class MessageMappingTest extends AnthropicTestCase
+{
+    public function test_user_message_maps_to_anthropic_format(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'What is Laravel?',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $messages = $request->data()['messages'];
+            $userMessage = $messages[0];
+
+            return $userMessage['role'] === 'user'
+                && $userMessage['content'][0]['type'] === 'text'
+                && $userMessage['content'][0]['text'] === 'What is Laravel?';
+        });
+    }
+
+    public function test_tool_result_follow_up_maps_assistant_and_tool_result_messages(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'anthropic',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpMessages = $recorded[1][0]->data()['messages'];
+
+        $assistantMsg = null;
+        $toolResultMsg = null;
+
+        foreach ($followUpMessages as $msg) {
+            if ($msg['role'] === 'assistant') {
+                foreach ($msg['content'] ?? [] as $block) {
+                    if (($block['type'] ?? '') === 'tool_use') {
+                        $assistantMsg = $msg;
+                    }
+                }
+            }
+
+            if ($msg['role'] === 'user') {
+                foreach ($msg['content'] ?? [] as $block) {
+                    if (($block['type'] ?? '') === 'tool_result') {
+                        $toolResultMsg = $msg;
+                    }
+                }
+            }
+        }
+
+        $this->assertNotNull($assistantMsg, 'Follow-up should include assistant message');
+        $this->assertNotNull($toolResultMsg, 'Follow-up should include tool result message');
+
+        $toolUseBlock = collect($assistantMsg['content'])->firstWhere('type', 'tool_use');
+        $this->assertSame('FixedNumberGenerator', $toolUseBlock['name']);
+        $this->assertArrayHasKey('input', $toolUseBlock);
+
+        $toolResultBlock = collect($toolResultMsg['content'])->firstWhere('type', 'tool_result');
+        $this->assertSame($toolUseBlock['id'], $toolResultBlock['tool_use_id']);
+        $this->assertNotEmpty($toolResultBlock['content']);
+    }
+
+    public function test_system_instructions_are_not_in_messages_array(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            foreach ($body['messages'] as $message) {
+                if ($message['role'] === 'system') {
+                    return false;
+                }
+            }
+
+            return isset($body['system']) && is_string($body['system']);
+        });
+    }
+}

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -2,9 +2,13 @@
 
 namespace Tests\Feature\Providers\Anthropic;
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\Base64Document;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\ToolUsingAgent;
+
+use function Laravel\Ai\agent;
 
 class MessageMappingTest extends AnthropicTestCase
 {
@@ -80,6 +84,55 @@ class MessageMappingTest extends AnthropicTestCase
         $toolResultBlock = collect($toolResultMsg['content'])->firstWhere('type', 'tool_result');
         $this->assertSame($toolUseBlock['id'], $toolResultBlock['tool_use_id']);
         $this->assertNotEmpty($toolResultBlock['content']);
+    }
+
+    public function test_base64_pdf_document_maps_to_document_content_block(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('I see a PDF'),
+        ]);
+
+        $pdf = new Base64Document(base64_encode('fake-pdf-content'), 'application/pdf');
+
+        agent('You are helpful.')->prompt(
+            'What is in this PDF?',
+            attachments: [$pdf],
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $content = $request->data()['messages'][0]['content'];
+            $docBlock = $content[0];
+
+            return $docBlock['type'] === 'document'
+                && $docBlock['source']['type'] === 'base64'
+                && $docBlock['source']['media_type'] === 'application/pdf'
+                && $docBlock['source']['data'] === base64_encode('fake-pdf-content');
+        });
+    }
+
+    public function test_uploaded_pdf_file_maps_to_document_content_block(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('I see a PDF'),
+        ]);
+
+        $file = UploadedFile::fake()->create('report.pdf', 100, 'application/pdf');
+
+        agent('You are helpful.')->prompt(
+            'What is in this file?',
+            attachments: [$file],
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $content = $request->data()['messages'][0]['content'];
+            $docBlock = $content[0];
+
+            return $docBlock['type'] === 'document'
+                && $docBlock['source']['type'] === 'base64'
+                && $docBlock['source']['media_type'] === 'application/pdf';
+        });
     }
 
     public function test_system_instructions_are_not_in_messages_array(): void

--- a/tests/Feature/Providers/Anthropic/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Anthropic/ProviderOptionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+
+class ProviderOptionsTest extends AnthropicTestCase
+{
+    public function test_provider_options_are_included_in_anthropic_request_body(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new ProviderOptionsAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return isset($body['thinking'])
+                && $body['thinking']['type'] === 'enabled'
+                && $body['thinking']['budget_tokens'] === 10000;
+        });
+    }
+
+    public function test_request_body_does_not_contain_provider_options_when_agent_does_not_implement_interface(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            return ! isset($request->data()['thinking']);
+        });
+    }
+
+    public function test_provider_options_are_persisted_in_tool_call_follow_up_requests(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = (new ProviderOptionsWithToolsAgent)->prompt(
+            'Generate a random number',
+            provider: 'anthropic',
+        );
+
+        $this->assertSame('The number is 72019', $response->text);
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $firstBody = $recorded[0][0]->data();
+        $this->assertSame('enabled', $firstBody['thinking']['type']);
+        $this->assertSame(10000, $firstBody['thinking']['budget_tokens']);
+
+        $secondBody = $recorded[1][0]->data();
+        $this->assertArrayHasKey('thinking', $secondBody);
+        $this->assertSame('enabled', $secondBody['thinking']['type']);
+        $this->assertSame(10000, $secondBody['thinking']['budget_tokens']);
+    }
+}

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Providers\Anthropic;
 use Illuminate\Support\Facades\Http;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\StructuredAgent;
+use Tests\Feature\Agents\StructuredWithThinkingAgent;
 use Tests\Feature\Agents\ToolUsingAgent;
 
 class RequestMappingTest extends AnthropicTestCase
@@ -191,6 +192,34 @@ class RequestMappingTest extends AnthropicTestCase
 
         $this->assertSame(25, $response->usage->promptTokens);
         $this->assertSame(15, $response->usage->completionTokens);
+    }
+
+    public function test_structured_output_with_thinking_uses_auto_tool_choice(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Taylor', 'age' => 30]),
+        ]);
+
+        (new StructuredWithThinkingAgent)->prompt(
+            'Tell me about Taylor',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            $hasStructuredTool = false;
+
+            foreach ($body['tools'] ?? [] as $tool) {
+                if ($tool['name'] === 'output_structured_data') {
+                    $hasStructuredTool = true;
+                }
+            }
+
+            return $hasStructuredTool
+                && $body['tool_choice']['type'] === 'auto'
+                && $body['thinking']['type'] === 'enabled';
+        });
     }
 
     public function test_structured_response_is_correctly_parsed(): void

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\StructuredAgent;
+use Tests\Feature\Agents\ToolUsingAgent;
+
+class RequestMappingTest extends AnthropicTestCase
+{
+    public function test_request_includes_model_and_messages(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('Laravel is great'),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'What is Laravel?',
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-6',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return $request->url() === 'https://api.anthropic.com/v1/messages'
+                && $body['model'] === 'claude-sonnet-4-6'
+                && $body['messages'][0]['role'] === 'user'
+                && $body['messages'][0]['content'][0]['text'] === 'What is Laravel?';
+        });
+    }
+
+    public function test_system_instructions_are_sent_as_top_level_system_field(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return isset($body['system'])
+                && is_string($body['system'])
+                && str_contains($body['system'], 'helpful');
+        });
+    }
+
+    public function test_max_tokens_defaults_to_64000(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            return $request->data()['max_tokens'] === 64000;
+        });
+    }
+
+    public function test_tools_with_structured_output_use_tool_choice_any(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('The number is 42'),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return isset($body['tools'])
+                && count($body['tools']) > 0
+                && $body['tool_choice']['type'] === 'any';
+        });
+    }
+
+    public function test_request_without_tools_excludes_tool_fields(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return ! isset($body['tools'])
+                && ! isset($body['tool_choice']);
+        });
+    }
+
+    public function test_structured_output_uses_synthetic_tool(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Taylor', 'age' => 30]),
+        ]);
+
+        (new StructuredAgent)->prompt(
+            'Tell me about Taylor',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            $hasStructuredTool = false;
+
+            foreach ($body['tools'] ?? [] as $tool) {
+                if ($tool['name'] === 'output_structured_data') {
+                    $hasStructuredTool = true;
+                }
+            }
+
+            return $hasStructuredTool
+                && $body['tool_choice']['type'] === 'tool'
+                && $body['tool_choice']['name'] === 'output_structured_data';
+        });
+    }
+
+    public function test_request_sends_correct_authentication_headers(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('x-api-key')
+                && $request->hasHeader('anthropic-version', '2023-06-01');
+        });
+    }
+
+    public function test_response_text_is_correctly_parsed(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('Laravel is a PHP framework'),
+        ]);
+
+        $response = (new AssistantAgent)->prompt(
+            'What is Laravel?',
+            provider: 'anthropic',
+        );
+
+        $this->assertSame('Laravel is a PHP framework', $response->text);
+    }
+
+    public function test_response_usage_is_correctly_parsed(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'id' => 'msg_123',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [['type' => 'text', 'text' => 'Hello']],
+                'stop_reason' => 'end_turn',
+                'usage' => [
+                    'input_tokens' => 25,
+                    'output_tokens' => 15,
+                    'cache_creation_input_tokens' => 5,
+                    'cache_read_input_tokens' => 3,
+                ],
+            ]),
+        ]);
+
+        $response = (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        $this->assertSame(25, $response->usage->promptTokens);
+        $this->assertSame(15, $response->usage->completionTokens);
+    }
+
+    public function test_structured_response_is_correctly_parsed(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Taylor', 'age' => 30]),
+        ]);
+
+        $response = (new StructuredAgent)->prompt(
+            'Tell me about Taylor',
+            provider: 'anthropic',
+        );
+
+        $this->assertSame('Taylor', $response->structured['name']);
+        $this->assertSame(30, $response->structured['age']);
+    }
+}

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -262,6 +262,46 @@ class StreamingTest extends AnthropicTestCase
         ];
     }
 
+    public function test_streaming_captures_input_tokens_from_message_start(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    [
+                        'type' => 'message_start',
+                        'message' => [
+                            'id' => 'msg_1',
+                            'model' => 'claude-sonnet-4-6',
+                            'role' => 'assistant',
+                            'content' => [],
+                            'usage' => [
+                                'input_tokens' => 42,
+                                'output_tokens' => 0,
+                                'cache_creation_input_tokens' => 100,
+                                'cache_read_input_tokens' => 50,
+                            ],
+                        ],
+                    ],
+                    $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'Hello']),
+                    $this->contentBlockStop(0),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+        $this->assertSame(42, $streamEnd->usage->promptTokens);
+        $this->assertSame(10, $streamEnd->usage->completionTokens);
+        $this->assertSame(100, $streamEnd->usage->cacheWriteInputTokens);
+        $this->assertSame(50, $streamEnd->usage->cacheReadInputTokens);
+    }
+
     protected function messageDelta(string $stopReason, int $outputTokens): array
     {
         return [

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+
+class StreamingTest extends AnthropicTestCase
+{
+    public function test_streaming_emits_text_events(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'Hello']),
+                    $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => ' world']),
+                    $this->contentBlockStop(0),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertInstanceOf(StreamStart::class, $events[0]);
+        $this->assertInstanceOf(TextStart::class, $events[1]);
+        $this->assertInstanceOf(TextDelta::class, $events[2]);
+        $this->assertSame('Hello', $events[2]->delta);
+        $this->assertInstanceOf(TextDelta::class, $events[3]);
+        $this->assertSame(' world', $events[3]->delta);
+        $this->assertInstanceOf(TextEnd::class, $events[4]);
+        $this->assertInstanceOf(StreamEnd::class, $events[5]);
+    }
+
+    public function test_streaming_handles_tool_calls(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->messageStart(),
+                        $this->contentBlockStart(0, ['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'FixedNumberGenerator', 'input' => '']),
+                        $this->contentBlockDelta(0, ['type' => 'input_json_delta', 'partial_json' => '{}']),
+                        $this->contentBlockStop(0),
+                        $this->messageDelta('tool_use', 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response([
+                    'id' => 'msg_2',
+                    'type' => 'message',
+                    'role' => 'assistant',
+                    'model' => 'claude-sonnet-4-6',
+                    'content' => [['type' => 'text', 'text' => 'The number is 72019']],
+                    'stop_reason' => 'end_turn',
+                    'usage' => ['input_tokens' => 20, 'output_tokens' => 10],
+                ]),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+
+        $this->assertNotEmpty($toolCallEvents);
+        $this->assertSame('FixedNumberGenerator', $toolCallEvents[0]->toolCall->name);
+        $this->assertSame('toolu_1', $toolCallEvents[0]->toolCall->id);
+    }
+
+    public function test_streaming_handles_thinking_blocks(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'thinking', 'thinking' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'thinking_delta', 'thinking' => 'Let me think...']),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(1, ['type' => 'text_delta', 'text' => 'Answer']),
+                    $this->contentBlockStop(1),
+                    $this->messageDelta('end_turn', 15),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $types = array_map(fn ($e) => $e::class, $events);
+
+        $this->assertContains(ReasoningStart::class, $types);
+        $this->assertContains(ReasoningDelta::class, $types);
+        $this->assertContains(ReasoningEnd::class, $types);
+
+        $reasoningDelta = array_values(array_filter($events, fn ($e) => $e instanceof ReasoningDelta))[0];
+        $this->assertSame('Let me think...', $reasoningDelta->delta);
+    }
+
+    public function test_streaming_handles_server_tool_use(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'server_tool_use', 'id' => 'srvtoolu_1', 'name' => 'web_search']),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(1, ['type' => 'text_delta', 'text' => 'Result']),
+                    $this->contentBlockStop(1),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $providerEvents = array_values(array_filter($events, fn ($e) => $e instanceof ProviderToolEvent));
+
+        $this->assertCount(2, $providerEvents);
+        $this->assertSame('started', $providerEvents[0]->status);
+        $this->assertSame('completed', $providerEvents[1]->status);
+        $this->assertSame('srvtoolu_1', $providerEvents[0]->itemId);
+    }
+
+    public function test_streaming_handles_provider_tool_results(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'web_search_tool_result', 'tool_use_id' => 'srvtoolu_1', 'search_results' => []]),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(1, ['type' => 'text_delta', 'text' => 'Found it']),
+                    $this->contentBlockStop(1),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $providerEvents = array_values(array_filter($events, fn ($e) => $e instanceof ProviderToolEvent));
+
+        $this->assertNotEmpty($providerEvents);
+        $this->assertSame('result_received', $providerEvents[0]->status);
+        $this->assertSame('web_search_tool_result', $providerEvents[0]->type);
+    }
+
+    public function test_streaming_error_event_stops_stream(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    ['type' => 'error', 'error' => ['type' => 'overloaded_error', 'message' => 'Server overloaded']],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(Error::class, $events[0]);
+        $this->assertSame('overloaded_error', $events[0]->type);
+        $this->assertSame('Server overloaded', $events[0]->message);
+    }
+
+    /**
+     * Collect all stream events from the agent's stream response.
+     */
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream(
+            'Hello',
+            provider: 'anthropic',
+        );
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            $lines[] = 'data: '.json_encode($event);
+        }
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+
+    protected function messageStart(): array
+    {
+        return [
+            'type' => 'message_start',
+            'message' => [
+                'id' => 'msg_1',
+                'model' => 'claude-sonnet-4-6',
+                'role' => 'assistant',
+                'content' => [],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 0],
+            ],
+        ];
+    }
+
+    protected function contentBlockStart(int $index, array $contentBlock): array
+    {
+        return [
+            'type' => 'content_block_start',
+            'index' => $index,
+            'content_block' => $contentBlock,
+        ];
+    }
+
+    protected function contentBlockDelta(int $index, array $delta): array
+    {
+        return [
+            'type' => 'content_block_delta',
+            'index' => $index,
+            'delta' => $delta,
+        ];
+    }
+
+    protected function contentBlockStop(int $index): array
+    {
+        return [
+            'type' => 'content_block_stop',
+            'index' => $index,
+        ];
+    }
+
+    protected function messageDelta(string $stopReason, int $outputTokens): array
+    {
+        return [
+            'type' => 'message_delta',
+            'delta' => ['stop_reason' => $stopReason],
+            'usage' => ['output_tokens' => $outputTokens],
+        ];
+    }
+}

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ToolUsingAgent;
+
+class ToolCallLoopTest extends AnthropicTestCase
+{
+    public function test_tool_calls_trigger_follow_up_request(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a random number',
+            provider: 'anthropic',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = $recorded[1][0]->data();
+
+        $hasAssistantWithToolUse = false;
+        $hasToolResult = false;
+
+        foreach ($followUpBody['messages'] as $message) {
+            if ($message['role'] === 'assistant') {
+                foreach ($message['content'] as $block) {
+                    if (($block['type'] ?? '') === 'tool_use') {
+                        $hasAssistantWithToolUse = true;
+                    }
+                }
+            }
+
+            if ($message['role'] === 'user') {
+                foreach ($message['content'] ?? [] as $block) {
+                    if (($block['type'] ?? '') === 'tool_result') {
+                        $hasToolResult = true;
+                    }
+                }
+            }
+        }
+
+        $this->assertTrue($hasAssistantWithToolUse, 'Follow-up request should include assistant message with tool_use block');
+        $this->assertTrue($hasToolResult, 'Follow-up request should include user message with tool_result block');
+    }
+
+    public function test_max_steps_limits_tool_call_depth(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeTextResponse('Done'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate numbers',
+            provider: 'anthropic',
+        );
+
+        $recorded = Http::recorded();
+
+        // ToolUsingAgent has 1 tool + structured output tool = 2 tools
+        // maxSteps = round(2 * 1.5) = 3
+        // So max 3 requests before stopping (initial + 2 follow-ups)
+        $this->assertLessThanOrEqual(3, count($recorded));
+    }
+
+    /**
+     * Create a tool call response with unique IDs for use in sequences.
+     */
+    protected function fakeUniqueToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_tool_'.uniqid(),
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_'.uniqid(),
+                'name' => 'FixedNumberGenerator',
+                'input' => (object) [],
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -3,7 +3,11 @@
 namespace Tests\Feature\Providers\Anthropic;
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\FileSearch;
+use LogicException;
 use Tests\Feature\Agents\ToolUsingAgent;
+
+use function Laravel\Ai\agent;
 
 class ToolMappingTest extends AnthropicTestCase
 {
@@ -32,6 +36,24 @@ class ToolMappingTest extends AnthropicTestCase
 
             return false;
         });
+    }
+
+    public function test_unsupported_provider_tool_throws_logic_exception(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('is not supported by Anthropic');
+
+        agent(
+            'Test unsupported tool',
+            tools: [new FileSearch(['store_1'])],
+        )->prompt(
+            'Search for something',
+            provider: 'anthropic',
+        );
     }
 
     public function test_empty_schema_still_includes_input_schema_with_type_object(): void

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Providers\Anthropic;
+
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ToolUsingAgent;
+
+class ToolMappingTest extends AnthropicTestCase
+{
+    public function test_tool_parameters_are_not_wrapped_in_schema_definition(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('The number is 42'),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $tools = $request->data()['tools'] ?? [];
+
+            foreach ($tools as $tool) {
+                if ($tool['name'] === 'FixedNumberGenerator') {
+                    $properties = (array) ($tool['input_schema']['properties'] ?? []);
+
+                    return $tool['input_schema']['type'] === 'object'
+                        && ! isset($properties['schema_definition']);
+                }
+            }
+
+            return false;
+        });
+    }
+
+    public function test_empty_schema_still_includes_input_schema_with_type_object(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('The number is 42'),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $tools = $request->data()['tools'] ?? [];
+
+            foreach ($tools as $tool) {
+                if ($tool['name'] === 'FixedNumberGenerator') {
+                    return isset($tool['input_schema'])
+                        && $tool['input_schema']['type'] === 'object'
+                        && isset($tool['input_schema']['properties']);
+                }
+            }
+
+            return false;
+        });
+    }
+}

--- a/tests/Unit/Gateway/Concerns/ParsesServerSentEventsTest.php
+++ b/tests/Unit/Gateway/Concerns/ParsesServerSentEventsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Gateway\Concerns;
+
+use Generator;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use PHPUnit\Framework\TestCase;
+
+class ParsesServerSentEventsTest extends TestCase
+{
+    protected function parser(): object
+    {
+        return new class
+        {
+            use ParsesServerSentEvents;
+
+            public function parse($streamBody): Generator
+            {
+                return $this->parseServerSentEvents($streamBody);
+            }
+        };
+    }
+
+    public function test_reads_stream_byte_by_byte_to_prevent_event_batching(): void
+    {
+        $payload = implode("\n\n", [
+            'data: {"type":"message_start"}',
+            'data: {"type":"content_block_delta","delta":{"text":"Hello"}}',
+            'data: {"type":"content_block_delta","delta":{"text":" world"}}',
+            'data: {"type":"message_delta"}',
+        ])."\n\n";
+
+        $stream = new FakeStream($payload);
+
+        iterator_to_array($this->parser()->parse($stream));
+
+        $this->assertSame(1, $stream->maxReadSize, 'Parser must read byte-by-byte to prevent SSE event batching.');
+    }
+
+    public function test_yields_each_event_before_reading_next_events_data(): void
+    {
+        $payload = "data: {\"type\":\"event_1\"}\n\ndata: {\"type\":\"event_2\"}\n\ndata: {\"type\":\"event_3\"}\n\n";
+
+        $stream = new FakeStream($payload);
+        $generator = $this->parser()->parse($stream);
+
+        $first = $generator->current();
+        $this->assertSame('event_1', $first['type']);
+        $this->assertFalse($stream->fullyConsumed(), 'Events must be yielded progressively, not after buffering the entire stream.');
+
+        $generator->next();
+        $second = $generator->current();
+        $this->assertSame('event_2', $second['type']);
+        $this->assertFalse($stream->fullyConsumed(), 'Stream should not be fully consumed after yielding only two events.');
+
+        $generator->next();
+        $third = $generator->current();
+        $this->assertSame('event_3', $third['type']);
+    }
+}
+
+/**
+ * A fake PSR-7-compatible stream that tracks read behavior.
+ */
+class FakeStream
+{
+    private int $position = 0;
+
+    public int $maxReadSize = 0;
+
+    public function __construct(private readonly string $data) {}
+
+    public function read(int $length): string
+    {
+        if ($length > $this->maxReadSize) {
+            $this->maxReadSize = $length;
+        }
+
+        $chunk = substr($this->data, $this->position, $length);
+        $this->position += strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function eof(): bool
+    {
+        return $this->position >= strlen($this->data);
+    }
+
+    public function fullyConsumed(): bool
+    {
+        return $this->position >= strlen($this->data);
+    }
+}

--- a/tests/Unit/Gateway/Prism/PrismStreamEventTest.php
+++ b/tests/Unit/Gateway/Prism/PrismStreamEventTest.php
@@ -3,10 +3,12 @@
 namespace Tests\Unit\Gateway\Prism;
 
 use Laravel\Ai\Gateway\Prism\PrismStreamEvent;
+use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use PHPUnit\Framework\TestCase;
 use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Streaming\Events\ErrorEvent;
 use Prism\Prism\Streaming\Events\StreamEndEvent;
 use Prism\Prism\Streaming\Events\ThinkingCompleteEvent;
 use Prism\Prism\ValueObjects\Usage;
@@ -79,7 +81,7 @@ class PrismStreamEventTest extends TestCase
 
     public function test_error_event_maps_correctly(): void
     {
-        $event = new \Prism\Prism\Streaming\Events\ErrorEvent(
+        $event = new ErrorEvent(
             id: 'event-5',
             timestamp: 1234567890,
             errorType: 'server_error',
@@ -90,9 +92,9 @@ class PrismStreamEventTest extends TestCase
 
         $result = PrismStreamEvent::toLaravelStreamEvent('invocation-1', $event, 'openai', 'gpt-4');
 
-        $this->assertInstanceOf(\Laravel\Ai\Streaming\Events\Error::class, $result);
+        $this->assertInstanceOf(Error::class, $result);
 
-        /** @var \Laravel\Ai\Streaming\Events\Error $result */
+        /** @var Error $result */
         $this->assertEquals('event-5', $result->id);
         $this->assertEquals('server_error', $result->type);
         $this->assertEquals('Something went wrong', $result->message);


### PR DESCRIPTION
Similar to the OpenAI gateway change, this removes the Prism PHP dependency for the Anthropic provider and implements the Messages API directly as part of the AI SDK. This makes it much easier to iterate on Anthropic-specific features without going through an intermediary.

### Approach

- Introduces `AnthropicGateway` with trait-based concerns for request building, message/tool/attachment mapping, response parsing, and streaming
- Handles extended thinking with proper signature preservation for multi-turn tool-call replay
- Supports native `output_config` structured output when the `structured-outputs` beta is enabled, with a synthetic tool fallback
- Covers streaming SSE events including `signature_delta`, `citations_delta`, and provider tool events
- Includes 36 tests covering request mapping, tool mapping, message mapping, streaming, tool call loops, provider options, error handling, and base URL configuration

> [!WARNING]
> `Laravel\Ai\Gateway\AnthropicFileGateway` has been moved to `Laravel\Ai\Gateway\Anthropic\AnthropicFileGateway`. Code referencing the old FQCN will need to be updated.