### PR TITLE
Add Groq gateway for Chat Completions API

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -87,6 +87,7 @@ return [
         'groq' => [
             'driver' => 'groq',
             'key' => env('GROQ_API_KEY'),
+            'url' => env('GROQ_URL', 'https://api.groq.com/openai/v1'),
         ],
 
         'jina' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -351,7 +351,6 @@ class AiManager extends MultipleInstanceManager
     public function createGroqDriver(array $config): GroqProvider
     {
         return new GroqProvider(
-            new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -30,8 +30,8 @@ trait BuildsTextRequests
             $mappedTools = $this->mapTools($tools);
 
             if (filled($mappedTools)) {
-                $body['tools'] = $mappedTools;
                 $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
             }
         }
 

--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    /**
+     * Build the request body for the Chat Completions API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessagesToChat($messages, $instructions),
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tools'] = $mappedTools;
+                $body['tool_choice'] = 'auto';
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat($schema);
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the response format options for structured output.
+     */
+    protected function buildResponseFormat(array $schema): array
+    {
+        $objectSchema = new ObjectSchema($schema);
+
+        $schemaArray = $objectSchema->toSchema();
+
+        return [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => $schemaArray['name'] ?? 'schema_definition',
+                'schema' => Arr::except($schemaArray, ['name']),
+                'strict' => true,
+            ],
+        ];
+    }
+}

--- a/src/Gateway/Groq/Concerns/CreatesGroqClient.php
+++ b/src/Gateway/Groq/Concerns/CreatesGroqClient.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesGroqClient
+{
+    /**
+     * Get an HTTP client for the Groq API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the Groq API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.groq.com/openai/v1', '/');
+    }
+}

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Process a Chat Completions streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        array $priorChatMessages = [],
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $usage = null;
+        $finishReason = null;
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            if (isset($data['error'])) {
+                yield (new Error(
+                    $this->generateEventId(),
+                    $data['error']['code'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            $choice = $data['choices'][0] ?? null;
+
+            if (! $choice) {
+                // Usage-only chunk (final)...
+                if (isset($data['usage'])) {
+                    $usage = new Usage(
+                        $data['usage']['prompt_tokens'] ?? 0,
+                        $data['usage']['completion_tokens'] ?? 0,
+                    );
+                }
+
+                continue;
+            }
+
+            $delta = $choice['delta'] ?? [];
+
+            // Emit StreamStart on first chunk...
+            if (! $streamStartEmitted) {
+                $streamStartEmitted = true;
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    $data['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            // Text content delta...
+            if (isset($delta['content']) && $delta['content'] !== '') {
+                if (! $textStartEmitted) {
+                    $textStartEmitted = true;
+
+                    yield (new TextStart(
+                        $this->generateEventId(),
+                        $messageId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                $currentText .= $delta['content'];
+
+                yield (new TextDelta(
+                    $this->generateEventId(),
+                    $messageId,
+                    $delta['content'],
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            // Tool call deltas (accumulated by index)...
+            if (isset($delta['tool_calls'])) {
+                foreach ($delta['tool_calls'] as $tcDelta) {
+                    $idx = $tcDelta['index'];
+
+                    if (! isset($pendingToolCalls[$idx])) {
+                        $pendingToolCalls[$idx] = [
+                            'id' => $tcDelta['id'] ?? '',
+                            'name' => $tcDelta['function']['name'] ?? '',
+                            'arguments' => '',
+                        ];
+                    }
+
+                    if (isset($tcDelta['function']['arguments'])) {
+                        $pendingToolCalls[$idx]['arguments'] .= $tcDelta['function']['arguments'];
+                    }
+                }
+            }
+
+            // Check finish reason...
+            if (isset($choice['finish_reason']) && $choice['finish_reason'] !== null) {
+                $finishReason = $choice['finish_reason'];
+            }
+
+            // Usage in final chunk...
+            if (isset($data['usage'])) {
+                $usage = new Usage(
+                    $data['usage']['prompt_tokens'] ?? 0,
+                    $data['usage']['completion_tokens'] ?? 0,
+                );
+            }
+        }
+
+        // Close text if it was started...
+        if ($textStartEmitted) {
+            yield (new TextEnd(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        // Handle tool calls...
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
+            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+            foreach ($mappedToolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield from $this->handleStreamingToolCalls(
+                $invocationId, $provider, $model, $tools, $schema, $options,
+                $mappedToolCalls, $currentText, $instructions, $originalMessages,
+                $depth, $maxSteps, $priorChatMessages,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            'stop',
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $mappedToolCalls,
+        string $currentText,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        array $priorChatMessages,
+    ): Generator {
+        $toolResults = [];
+
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+            // Build the assistant message with tool calls for this round...
+            $assistantMsg = ['role' => 'assistant'];
+
+            if (filled($currentText)) {
+                $assistantMsg['content'] = $currentText;
+            }
+
+            $assistantMsg['tool_calls'] = array_map(
+                fn (ToolCall $tc) => $this->serializeToolCallToChat($tc), $mappedToolCalls
+            );
+
+            // Build tool result messages for this round...
+            $toolResultMessages = [];
+
+            foreach ($toolResults as $toolResult) {
+                $toolResultMessages[] = [
+                    'role' => 'tool',
+                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                    'content' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+
+            // Accumulate this round's messages for future rounds...
+            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
+
+            // Rebuild full conversation: original messages + all accumulated rounds...
+            $chatMessages = [
+                ...$this->mapMessagesToChat($originalMessages, $instructions),
+                ...$updatedPriorMessages,
+            ];
+
+            $body = [
+                'model' => $model,
+                'messages' => $chatMessages,
+                'stream' => true,
+                'stream_options' => ['include_usage' => true],
+            ];
+
+            if (filled($tools)) {
+                $mappedTools = $this->mapTools($tools);
+
+                if (filled($mappedTools)) {
+                    $body['tools'] = $mappedTools;
+                    $body['tool_choice'] = 'auto';
+                }
+            }
+
+            if (filled($schema)) {
+                $body['response_format'] = $this->buildResponseFormat($schema);
+            }
+
+            $response = $this->withRateLimitHandling(
+                $provider->name(),
+                fn () => $this->client($provider)
+                    ->withOptions(['stream' => true])
+                    ->post('chat/completions', $body),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId, $provider, $model, $tools, $schema, $options,
+                $response->getBody(), $instructions, $originalMessages,
+                $depth + 1, $maxSteps, $updatedPriorMessages,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $tc) => new ToolCall(
+            $tc['id'] ?? '',
+            $tc['name'] ?? '',
+            json_decode($tc['arguments'] ?? '{}', true) ?? [],
+            $tc['id'] ?? null,
+        ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+}

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -279,6 +279,12 @@ trait HandlesTextStreaming
                 $body['response_format'] = $this->buildResponseFormat($schema);
             }
 
+            $providerOptions = $options?->providerOptions($provider->driver());
+
+            if (filled($providerOptions)) {
+                $body = array_merge($body, $providerOptions);
+            }
+
             $response = $this->withRateLimitHandling(
                 $provider->name(),
                 fn () => $this->client($provider)

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -157,9 +157,19 @@ trait HandlesTextStreaming
             }
 
             yield from $this->handleStreamingToolCalls(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $mappedToolCalls, $currentText, $instructions, $originalMessages,
-                $depth, $maxSteps, $priorChatMessages,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $mappedToolCalls,
+                $currentText,
+                $instructions,
+                $originalMessages,
+                $depth,
+                $maxSteps,
+                $priorChatMessages,
             );
 
             return;
@@ -229,7 +239,7 @@ trait HandlesTextStreaming
             }
 
             $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $tc) => $this->serializeToolCallToChat($tc), $mappedToolCalls
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
             );
 
             $toolResultMessages = [];
@@ -277,9 +287,18 @@ trait HandlesTextStreaming
             );
 
             yield from $this->processTextStream(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $instructions, $originalMessages,
-                $depth + 1, $maxSteps, $updatedPriorMessages,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $updatedPriorMessages,
             );
         } else {
             yield (new StreamEnd(
@@ -298,11 +317,11 @@ trait HandlesTextStreaming
      */
     protected function mapStreamToolCalls(array $toolCalls): array
     {
-        return array_map(fn (array $tc) => new ToolCall(
-            $tc['id'] ?? '',
-            $tc['name'] ?? '',
-            json_decode($tc['arguments'] ?? '{}', true) ?? [],
-            $tc['id'] ?? null,
+        return array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['name'] ?? '',
+            json_decode($toolCall['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
         ), array_values($toolCalls));
     }
 

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -63,7 +63,6 @@ trait HandlesTextStreaming
             $choice = $data['choices'][0] ?? null;
 
             if (! $choice) {
-                // Usage-only chunk (final)...
                 if (isset($data['usage'])) {
                     $usage = new Usage(
                         $data['usage']['prompt_tokens'] ?? 0,
@@ -76,7 +75,6 @@ trait HandlesTextStreaming
 
             $delta = $choice['delta'] ?? [];
 
-            // Emit StreamStart on first chunk...
             if (! $streamStartEmitted) {
                 $streamStartEmitted = true;
 
@@ -88,7 +86,6 @@ trait HandlesTextStreaming
                 ))->withInvocationId($invocationId);
             }
 
-            // Text content delta...
             if (isset($delta['content']) && $delta['content'] !== '') {
                 if (! $textStartEmitted) {
                     $textStartEmitted = true;
@@ -110,7 +107,6 @@ trait HandlesTextStreaming
                 ))->withInvocationId($invocationId);
             }
 
-            // Tool call deltas (accumulated by index)...
             if (isset($delta['tool_calls'])) {
                 foreach ($delta['tool_calls'] as $tcDelta) {
                     $idx = $tcDelta['index'];
@@ -129,12 +125,10 @@ trait HandlesTextStreaming
                 }
             }
 
-            // Check finish reason...
             if (isset($choice['finish_reason']) && $choice['finish_reason'] !== null) {
                 $finishReason = $choice['finish_reason'];
             }
 
-            // Usage in final chunk...
             if (isset($data['usage'])) {
                 $usage = new Usage(
                     $data['usage']['prompt_tokens'] ?? 0,
@@ -143,7 +137,6 @@ trait HandlesTextStreaming
             }
         }
 
-        // Close text if it was started...
         if ($textStartEmitted) {
             yield (new TextEnd(
                 $this->generateEventId(),
@@ -152,7 +145,6 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        // Handle tool calls...
         if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
             $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -230,7 +222,6 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
-            // Build the assistant message with tool calls for this round...
             $assistantMsg = ['role' => 'assistant'];
 
             if (filled($currentText)) {
@@ -241,7 +232,6 @@ trait HandlesTextStreaming
                 fn (ToolCall $tc) => $this->serializeToolCallToChat($tc), $mappedToolCalls
             );
 
-            // Build tool result messages for this round...
             $toolResultMessages = [];
 
             foreach ($toolResults as $toolResult) {
@@ -252,10 +242,8 @@ trait HandlesTextStreaming
                 ];
             }
 
-            // Accumulate this round's messages for future rounds...
             $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
 
-            // Rebuild full conversation: original messages + all accumulated rounds...
             $chatMessages = [
                 ...$this->mapMessagesToChat($originalMessages, $instructions),
                 ...$updatedPriorMessages,
@@ -272,8 +260,8 @@ trait HandlesTextStreaming
                 $mappedTools = $this->mapTools($tools);
 
                 if (filled($mappedTools)) {
-                    $body['tools'] = $mappedTools;
                     $body['tool_choice'] = 'auto';
+                    $body['tools'] = $mappedTools;
                 }
             }
 

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -231,7 +231,7 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
             $assistantMsg = ['role' => 'assistant'];
 
             if (filled($currentText)) {

--- a/src/Gateway/Groq/Concerns/MapsAttachments.php
+++ b/src/Gateway/Groq/Concerns/MapsAttachments.php
@@ -6,10 +6,15 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\ProviderDocument;
+use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
 
 trait MapsAttachments
@@ -45,9 +50,41 @@ trait MapsAttachments
                         Storage::disk($attachment->disk)->get($attachment->path)
                     )],
                 ],
+                $attachment instanceof ProviderDocument => array_filter([
+                    'type' => 'input_file',
+                    'file_id' => $attachment->id,
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof Base64Document => array_filter([
+                    'type' => 'input_file',
+                    'file_data' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof LocalDocument => array_filter([
+                    'type' => 'input_file',
+                    'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(file_get_contents($attachment->path)),
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof RemoteDocument => array_filter([
+                    'type' => 'input_file',
+                    'file_url' => $attachment->url,
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof StoredDocument => array_filter([
+                    'type' => 'input_file',
+                    'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
+                    'filename' => $attachment->name(),
+                ]),
                 $attachment instanceof UploadedFile && $this->isImage($attachment) => [
                     'type' => 'image_url',
                     'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
+                ],
+                $attachment instanceof UploadedFile => [
+                    'type' => 'input_file',
+                    'file_data' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
+                    'filename' => $attachment->getClientOriginalName(),
                 ],
                 default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
             };

--- a/src/Gateway/Groq/Concerns/MapsAttachments.php
+++ b/src/Gateway/Groq/Concerns/MapsAttachments.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to Chat Completions content parts.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof Base64Image => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.$attachment->base64],
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => $attachment->url],
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.base64_encode(file_get_contents($attachment->path))],
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:image/png;base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    )],
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
+                ],
+                default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/Groq/Concerns/MapsAttachments.php
+++ b/src/Gateway/Groq/Concerns/MapsAttachments.php
@@ -6,15 +6,10 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
-use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\File;
-use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\LocalImage;
-use Laravel\Ai\Files\ProviderDocument;
-use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
-use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
 
 trait MapsAttachments
@@ -42,51 +37,19 @@ trait MapsAttachments
                 ],
                 $attachment instanceof LocalImage => [
                     'type' => 'image_url',
-                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.base64_encode(file_get_contents($attachment->path))],
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(file_get_contents($attachment->path))],
                 ],
                 $attachment instanceof StoredImage => [
                     'type' => 'image_url',
-                    'image_url' => ['url' => 'data:image/png;base64,'.base64_encode(
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(
                         Storage::disk($attachment->disk)->get($attachment->path)
                     )],
                 ],
-                $attachment instanceof ProviderDocument => array_filter([
-                    'type' => 'input_file',
-                    'file_id' => $attachment->id,
-                    'filename' => $attachment->name(),
-                ]),
-                $attachment instanceof Base64Document => array_filter([
-                    'type' => 'input_file',
-                    'file_data' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
-                    'filename' => $attachment->name(),
-                ]),
-                $attachment instanceof LocalDocument => array_filter([
-                    'type' => 'input_file',
-                    'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(file_get_contents($attachment->path)),
-                    'filename' => $attachment->name(),
-                ]),
-                $attachment instanceof RemoteDocument => array_filter([
-                    'type' => 'input_file',
-                    'file_url' => $attachment->url,
-                    'filename' => $attachment->name(),
-                ]),
-                $attachment instanceof StoredDocument => array_filter([
-                    'type' => 'input_file',
-                    'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(
-                        Storage::disk($attachment->disk)->get($attachment->path)
-                    ),
-                    'filename' => $attachment->name(),
-                ]),
                 $attachment instanceof UploadedFile && $this->isImage($attachment) => [
                     'type' => 'image_url',
                     'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
                 ],
-                $attachment instanceof UploadedFile => [
-                    'type' => 'input_file',
-                    'file_data' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
-                    'filename' => $attachment->getClientOriginalName(),
-                ],
-                default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
+                default => throw new InvalidArgumentException('Groq does not support document attachments. Only image attachments are supported.'),
             };
         })->all();
     }

--- a/src/Gateway/Groq/Concerns/MapsMessages.php
+++ b/src/Gateway/Groq/Concerns/MapsMessages.php
@@ -109,7 +109,7 @@ trait MapsMessages
             'type' => 'function',
             'function' => [
                 'name' => $toolCall->name,
-                'arguments' => json_encode($toolCall->arguments),
+                'arguments' => json_encode($toolCall->arguments ?: (object) []),
             ],
         ];
     }

--- a/src/Gateway/Groq/Concerns/MapsMessages.php
+++ b/src/Gateway/Groq/Concerns/MapsMessages.php
@@ -43,22 +43,22 @@ trait MapsMessages
      */
     protected function mapUserMessage(UserMessage|Message $message, array &$chatMessages): void
     {
-        if ($message instanceof UserMessage && $message->attachments->isNotEmpty()) {
-            $content = [
-                ['type' => 'text', 'text' => $message->content],
-                ...$this->mapAttachments($message->attachments),
-            ];
-
-            $chatMessages[] = [
-                'role' => 'user',
-                'content' => $content,
-            ];
-        } else {
+        if (! $message instanceof UserMessage || $message->attachments->isEmpty()) {
             $chatMessages[] = [
                 'role' => 'user',
                 'content' => $message->content,
             ];
+
+            return;
         }
+
+        $chatMessages[] = [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => $message->content],
+                ...$this->mapAttachments($message->attachments),
+            ],
+        ];
     }
 
     /**
@@ -74,7 +74,7 @@ trait MapsMessages
 
         if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
             $msg['tool_calls'] = $message->toolCalls->map(
-                fn (ToolCall $tc) => $this->serializeToolCallToChat($tc)
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
             )->all();
         }
 
@@ -102,14 +102,14 @@ trait MapsMessages
     /**
      * Serialize a tool call DTO to Chat Completions array format.
      */
-    protected function serializeToolCallToChat(ToolCall $tc): array
+    protected function serializeToolCallToChat(ToolCall $toolCall): array
     {
         return [
-            'id' => $tc->resultId ?? $tc->id,
+            'id' => $toolCall->resultId ?? $toolCall->id,
             'type' => 'function',
             'function' => [
-                'name' => $tc->name,
-                'arguments' => json_encode($tc->arguments),
+                'name' => $toolCall->name,
+                'arguments' => json_encode($toolCall->arguments),
             ],
         ];
     }

--- a/src/Gateway/Groq/Concerns/MapsMessages.php
+++ b/src/Gateway/Groq/Concerns/MapsMessages.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to Chat Completions messages format.
+     */
+    protected function mapMessagesToChat(array $messages, ?string $instructions = null): array
+    {
+        $chatMessages = [];
+
+        if (filled($instructions)) {
+            $chatMessages[] = [
+                'role' => 'system',
+                'content' => $instructions,
+            ];
+        }
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $chatMessages),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $chatMessages),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $chatMessages),
+            };
+        }
+
+        return $chatMessages;
+    }
+
+    /**
+     * Map a user message to Chat Completions format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$chatMessages): void
+    {
+        if ($message instanceof UserMessage && $message->attachments->isNotEmpty()) {
+            $content = [
+                ['type' => 'text', 'text' => $message->content],
+                ...$this->mapAttachments($message->attachments),
+            ];
+
+            $chatMessages[] = [
+                'role' => 'user',
+                'content' => $content,
+            ];
+        } else {
+            $chatMessages[] = [
+                'role' => 'user',
+                'content' => $message->content,
+            ];
+        }
+    }
+
+    /**
+     * Map an assistant message to Chat Completions format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$chatMessages): void
+    {
+        $msg = ['role' => 'assistant'];
+
+        if (filled($message->content)) {
+            $msg['content'] = $message->content;
+        }
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            $msg['tool_calls'] = $message->toolCalls->map(
+                fn (ToolCall $tc) => $this->serializeToolCallToChat($tc)
+            )->all();
+        }
+
+        $chatMessages[] = $msg;
+    }
+
+    /**
+     * Map a tool result message to Chat Completions format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        foreach ($message->toolResults as $toolResult) {
+            $chatMessages[] = [
+                'role' => 'tool',
+                'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                'content' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+    }
+
+    /**
+     * Serialize a tool call DTO to Chat Completions array format.
+     */
+    protected function serializeToolCallToChat(ToolCall $tc): array
+    {
+        return [
+            'id' => $tc->resultId ?? $tc->id,
+            'type' => 'function',
+            'function' => [
+                'name' => $tc->name,
+                'arguments' => json_encode($tc->arguments),
+            ],
+        ];
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+}

--- a/src/Gateway/Groq/Concerns/MapsTools.php
+++ b/src/Gateway/Groq/Concerns/MapsTools.php
@@ -37,27 +37,22 @@ trait MapsTools
     {
         $schema = $tool->schema(new JsonSchemaTypeFactory);
 
-        $function = [
-            'name' => class_basename($tool),
-            'description' => (string) $tool->description(),
-        ];
-
-        if (filled($schema)) {
-            $objectSchema = new ObjectSchema($schema);
-
-            $schemaArray = $objectSchema->toSchema();
-
-            $function['parameters'] = [
-                'type' => 'object',
-                'properties' => $schemaArray['properties'] ?? [],
-                'required' => $schemaArray['required'] ?? [],
-                'additionalProperties' => false,
-            ];
-        }
+        $schemaArray = filled($schema)
+            ? (new ObjectSchema($schema))->toSchema()
+            : [];
 
         return [
             'type' => 'function',
-            'function' => $function,
+            'function' => [
+                'name' => class_basename($tool),
+                'description' => (string) $tool->description(),
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $schemaArray['properties'] ?? (object) [],
+                    'required' => $schemaArray['required'] ?? [],
+                    'additionalProperties' => false,
+                ],
+            ],
         ];
     }
 }

--- a/src/Gateway/Groq/Concerns/MapsTools.php
+++ b/src/Gateway/Groq/Concerns/MapsTools.php
@@ -6,6 +6,7 @@ use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Tools\ProviderTool;
+use RuntimeException;
 
 trait MapsTools
 {
@@ -18,7 +19,7 @@ trait MapsTools
 
         foreach ($tools as $tool) {
             if ($tool instanceof ProviderTool) {
-                continue;
+                throw new RuntimeException('Groq does not support ['.class_basename($tool).'] provider tools.');
             }
 
             if ($tool instanceof Tool) {

--- a/src/Gateway/Groq/Concerns/MapsTools.php
+++ b/src/Gateway/Groq/Concerns/MapsTools.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to Chat Completions function definitions.
+     */
+    protected function mapTools(array $tools): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                continue;
+            }
+
+            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to a Chat Completions function definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $function = [
+            'name' => class_basename($tool),
+            'description' => (string) $tool->description(),
+        ];
+
+        if (filled($schema)) {
+            $objectSchema = new ObjectSchema($schema);
+
+            $schemaArray = $objectSchema->toSchema();
+
+            $function['parameters'] = [
+                'type' => 'object',
+                'properties' => $schemaArray['properties'] ?? [],
+                'required' => $schemaArray['required'] ?? [],
+                'additionalProperties' => false,
+            ];
+        }
+
+        return [
+            'type' => 'function',
+            'function' => $function,
+        ];
+    }
+}

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq\Concerns;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Validate the Groq response data.
+     *
+     * @throws \Laravel\Ai\Exceptions\AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || isset($data['error'])) {
+            throw new AiException(sprintf(
+                'Groq Error: [%s] %s',
+                $data['error']['type'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown Groq error.',
+            ));
+        }
+    }
+
+    /**
+     * Parse the Groq response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?string $instructions = null,
+        array $originalMessages = [],
+    ): TextResponse {
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            instructions: $instructions,
+            originalMessages: $originalMessages,
+            maxSteps: $options?->maxSteps,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+    ): TextResponse {
+        $choice = $data['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+        $model = $data['model'] ?? '';
+
+        $text = $message['content'] ?? '';
+        $rawToolCalls = $message['tool_calls'] ?? [];
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->extractFinishReason($choice);
+
+        $mappedToolCalls = array_map(fn (array $tc) => new ToolCall(
+            $tc['id'] ?? '',
+            $tc['function']['name'] ?? '',
+            json_decode($tc['function']['arguments'] ?? '{}', true) ?? [],
+            $tc['id'] ?? null,
+        ), $rawToolCalls);
+
+        $step = new Step(
+            $text,
+            $mappedToolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model),
+        );
+
+        $steps->push($step);
+
+        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+
+        $messages->push($assistantMessage);
+
+        // Execute tool calls...
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($mappedToolCalls) &&
+            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+
+            // Update step with tool results...
+            $steps->pop();
+
+            $steps->push(new Step(
+                $text,
+                $mappedToolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $model, $provider, $structured, $tools, $schema, $steps, $messages,
+                $instructions, $originalMessages, $depth + 1, $maxSteps,
+            );
+        }
+
+        // Build final response...
+        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
+        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
+
+        if ($structured) {
+            $structuredData = json_decode($text, true) ?? [];
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                $text,
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model),
+            ))->withToolCallsAndResults(
+                toolCalls: $allToolCalls,
+                toolResults: $allToolResults,
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        string $model,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+    ): TextResponse {
+        // Rebuild full conversation history for Chat Completions...
+        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
+
+        // Append accumulated assistant and tool result messages...
+        foreach ($messages as $msg) {
+            if ($msg instanceof AssistantMessage) {
+                $mapped = ['role' => 'assistant'];
+
+                if (filled($msg->content)) {
+                    $mapped['content'] = $msg->content;
+                }
+
+                if ($msg->toolCalls->isNotEmpty()) {
+                    $mapped['tool_calls'] = $msg->toolCalls->map(
+                        fn (ToolCall $tc) => $this->serializeToolCallToChat($tc)
+                    )->all();
+                }
+
+                $chatMessages[] = $mapped;
+            } elseif ($msg instanceof ToolResultMessage) {
+                foreach ($msg->toolResults as $toolResult) {
+                    $chatMessages[] = [
+                        'role' => 'tool',
+                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                        'content' => $this->serializeToolResultOutput($toolResult->result),
+                    ];
+                }
+            }
+        }
+
+        $body = [
+            'model' => $model,
+            'messages' => $chatMessages,
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tools'] = $mappedTools;
+                $body['tool_choice'] = 'auto';
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat($schema);
+        }
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data, $provider, $structured, $tools, $schema, $steps, $messages,
+            $instructions, $originalMessages, $depth, $maxSteps,
+        );
+    }
+
+    /**
+     * Extract usage data from the response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+
+        return new Usage(
+            $usage['prompt_tokens'] ?? 0,
+            $usage['completion_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract and map the finish reason from the response.
+     */
+    protected function extractFinishReason(array $choice): FinishReason
+    {
+        return match ($choice['finish_reason'] ?? '') {
+            'stop' => FinishReason::Stop,
+            'tool_calls' => FinishReason::ToolCalls,
+            'length' => FinishReason::Length,
+            'content_filter' => FinishReason::ContentFilter,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+}

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -112,7 +112,7 @@ trait ParsesTextResponses
 
         if ($finishReason === FinishReason::ToolCalls &&
             filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
 
             $steps->pop();

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -110,13 +110,11 @@ trait ParsesTextResponses
 
         $messages->push($assistantMessage);
 
-        // Execute tool calls...
         if ($finishReason === FinishReason::ToolCalls &&
             filled($mappedToolCalls) &&
             $steps->count() < ($maxSteps ?? count($tools) * 2)) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
 
-            // Update step with tool results...
             $steps->pop();
 
             $steps->push(new Step(
@@ -138,7 +136,6 @@ trait ParsesTextResponses
             );
         }
 
-        // Build final response...
         $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
         $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
 
@@ -211,10 +208,8 @@ trait ParsesTextResponses
         int $depth,
         ?int $maxSteps,
     ): TextResponse {
-        // Rebuild full conversation history for Chat Completions...
         $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
 
-        // Append accumulated assistant and tool result messages...
         foreach ($messages as $msg) {
             if ($msg instanceof AssistantMessage) {
                 $mapped = ['role' => 'assistant'];
@@ -250,8 +245,8 @@ trait ParsesTextResponses
             $mappedTools = $this->mapTools($tools);
 
             if (filled($mappedTools)) {
-                $body['tools'] = $mappedTools;
                 $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
             }
         }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -88,11 +88,11 @@ trait ParsesTextResponses
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($choice);
 
-        $mappedToolCalls = array_map(fn (array $tc) => new ToolCall(
-            $tc['id'] ?? '',
-            $tc['function']['name'] ?? '',
-            json_decode($tc['function']['arguments'] ?? '{}', true) ?? [],
-            $tc['id'] ?? null,
+        $mappedToolCalls = array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['function']['name'] ?? '',
+            json_decode($toolCall['function']['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
         $step = new Step(
@@ -131,8 +131,17 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $model, $provider, $structured, $tools, $schema, $steps, $messages,
-                $instructions, $originalMessages, $depth + 1, $maxSteps,
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
             );
         }
 
@@ -220,7 +229,7 @@ trait ParsesTextResponses
 
                 if ($msg->toolCalls->isNotEmpty()) {
                     $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $tc) => $this->serializeToolCallToChat($tc)
+                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
                     )->all();
                 }
 
@@ -264,8 +273,17 @@ trait ParsesTextResponses
         $this->validateTextResponse($data);
 
         return $this->processResponse(
-            $data, $provider, $structured, $tools, $schema, $steps, $messages,
-            $instructions, $originalMessages, $depth, $maxSteps,
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $instructions,
+            $originalMessages,
+            $depth,
+            $maxSteps,
         );
     }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -60,6 +60,7 @@ trait ParsesTextResponses
             instructions: $instructions,
             originalMessages: $originalMessages,
             maxSteps: $options?->maxSteps,
+            options: $options,
         );
     }
 
@@ -78,6 +79,7 @@ trait ParsesTextResponses
         array $originalMessages = [],
         int $depth = 0,
         ?int $maxSteps = null,
+        ?TextGenerationOptions $options = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -142,6 +144,7 @@ trait ParsesTextResponses
                 $originalMessages,
                 $depth + 1,
                 $maxSteps,
+                $options,
             );
         }
 
@@ -216,6 +219,7 @@ trait ParsesTextResponses
         array $originalMessages,
         int $depth,
         ?int $maxSteps,
+        ?TextGenerationOptions $options = null,
     ): TextResponse {
         $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
 
@@ -263,6 +267,12 @@ trait ParsesTextResponses
             $body['response_format'] = $this->buildResponseFormat($schema);
         }
 
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
         $response = $this->withRateLimitHandling(
             $provider->name(),
             fn () => $this->client($provider)->post('chat/completions', $body),
@@ -284,6 +294,7 @@ trait ParsesTextResponses
             $originalMessages,
             $depth,
             $maxSteps,
+            $options,
         );
     }
 

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -4,20 +4,18 @@ namespace Laravel\Ai\Gateway\Groq;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\TextResponse;
 
 class GroqGateway implements TextGateway
 {
     use Concerns\BuildsTextRequests;
+    use Concerns\CreatesGroqClient;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;
     use Concerns\MapsMessages;
@@ -96,16 +94,5 @@ class GroqGateway implements TextGateway
             $invocationId, $provider, $model, $tools, $schema, $options,
             $response->getBody(), $instructions, $messages,
         );
-    }
-
-    /**
-     * Get an HTTP client for the Groq API.
-     */
-    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
-    {
-        return Http::baseUrl('https://api.groq.com/openai/v1')
-            ->withToken($provider->providerCredentials()['key'])
-            ->timeout($timeout ?? 60)
-            ->throw();
     }
 }

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Groq;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\TextResponse;
+
+class GroqGateway implements TextGateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesRateLimiting;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+        );
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse(
+            $data, $provider, filled($schema), $tools, $schema, $options,
+            $instructions, $messages,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+        );
+
+        $body['stream'] = true;
+        $body['stream_options'] = ['include_usage' => true];
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('chat/completions', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId, $provider, $model, $tools, $schema, $options,
+            $response->getBody(), $instructions, $messages,
+        );
+    }
+
+    /**
+     * Get an HTTP client for the Groq API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl('https://api.groq.com/openai/v1')
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+}

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -44,7 +44,13 @@ class GroqGateway implements TextGateway
         ?int $timeout = null,
     ): TextResponse {
         $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
         );
 
         $response = $this->withRateLimitHandling(
@@ -57,8 +63,14 @@ class GroqGateway implements TextGateway
         $this->validateTextResponse($data);
 
         return $this->parseTextResponse(
-            $data, $provider, filled($schema), $tools, $schema, $options,
-            $instructions, $messages,
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $instructions,
+            $messages,
         );
     }
 
@@ -77,7 +89,13 @@ class GroqGateway implements TextGateway
         ?int $timeout = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
         );
 
         $body['stream'] = true;
@@ -91,8 +109,15 @@ class GroqGateway implements TextGateway
         );
 
         yield from $this->processTextStream(
-            $invocationId, $provider, $model, $tools, $schema, $options,
-            $response->getBody(), $instructions, $messages,
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $instructions,
+            $messages,
         );
     }
 }

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -386,7 +386,6 @@ class PrismGateway implements Gateway
             'azure' => PrismProvider::OpenAI,
             'deepseek' => PrismProvider::DeepSeek,
             'gemini' => PrismProvider::Gemini,
-            'groq' => PrismProvider::Groq,
             'mistral' => PrismProvider::Mistral,
             'ollama' => PrismProvider::Ollama,
             'openai' => PrismProvider::OpenAI,

--- a/src/Providers/GroqProvider.php
+++ b/src/Providers/GroqProvider.php
@@ -2,13 +2,29 @@
 
 namespace Laravel\Ai\Providers;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Groq\GroqGateway;
 
 class GroqProvider extends Provider implements TextProvider
 {
     use Concerns\GeneratesText;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
+
+    public function __construct(
+        protected array $config,
+        protected Dispatcher $events,
+    ) {}
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new GroqGateway($this->events);
+    }
 
     /**
      * Get the name of the default text model.

--- a/src/Providers/GroqProvider.php
+++ b/src/Providers/GroqProvider.php
@@ -13,10 +13,10 @@ class GroqProvider extends Provider implements TextProvider
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
 
-    public function __construct(
-        protected array $config,
-        protected Dispatcher $events,
-    ) {}
+    public function __construct(protected array $config, protected Dispatcher $events)
+    {
+        //
+    }
 
     /**
      * Get the provider's text gateway.

--- a/tests/Feature/Agents/ProviderOptionsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsAgent.php
@@ -34,6 +34,10 @@ class ProviderOptionsAgent implements Agent, HasProviderOptions
                     'budget_tokens' => 10000,
                 ],
             ],
+            Lab::Groq => [
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
+            ],
             default => [],
         };
     }

--- a/tests/Feature/Agents/ProviderOptionsWithToolsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsWithToolsAgent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+use Tests\Feature\Tools\FixedNumberGenerator;
+
+class ProviderOptionsWithToolsAgent implements Agent, HasProviderOptions, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that generates numbers.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new FixedNumberGenerator,
+        ];
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::OpenAI => [
+                'reasoning' => [
+                    'effort' => 'high',
+                ],
+                'frequency_penalty' => 0.5,
+            ],
+            Lab::Groq => [
+                'frequency_penalty' => 0.5,
+            ],
+            default => [],
+        };
+    }
+}

--- a/tests/Feature/Providers/Groq/BaseUrlTest.php
+++ b/tests/Feature/Providers/Groq/BaseUrlTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class BaseUrlTest extends TestCase
+{
+    protected string $customUrl = 'http://localhost:1234/v1';
+
+    public function test_groq_text_requests_use_the_configured_base_url(): void
+    {
+        $this->configureGroqProvider($this->customUrl);
+
+        Http::fake([
+            '*' => Http::response([
+                'id' => 'chatcmpl-123',
+                'object' => 'chat.completion',
+                'model' => 'openai/gpt-oss-20b',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello from local model',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 1,
+                    'completion_tokens' => 1,
+                ],
+            ]),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'groq');
+
+        $this->assertSame('Hello from local model', $response->text);
+
+        Http::assertSentCount(1);
+        $this->assertRequestSent('POST', "{$this->customUrl}/chat/completions");
+    }
+
+    public function test_groq_requests_fall_back_to_the_default_base_url(): void
+    {
+        $this->configureGroqProvider();
+
+        Http::fake([
+            '*' => Http::response([
+                'id' => 'chatcmpl-456',
+                'object' => 'chat.completion',
+                'model' => 'openai/gpt-oss-20b',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello from Groq',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 1,
+                    'completion_tokens' => 1,
+                ],
+            ]),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'groq');
+
+        $this->assertSame('Hello from Groq', $response->text);
+
+        Http::assertSentCount(1);
+        $this->assertRequestSent('POST', 'https://api.groq.com/openai/v1/chat/completions');
+    }
+
+    protected function configureGroqProvider(?string $url = null): void
+    {
+        config(['ai.providers.groq' => array_filter([
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+            'url' => $url,
+        ])]);
+    }
+
+    protected function assertRequestSent(string $method, string $url): void
+    {
+        Http::assertSent(fn (Request $request) => $request->method() === $method
+            && $request->url() === $url);
+    }
+}

--- a/tests/Feature/Providers/Groq/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Groq/ProviderOptionsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ProviderOptionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_provider_options_are_included_in_groq_request_body(): void
+    {
+        Http::fake([
+            '*' => $this->fakeGroqResponse('Hello'),
+        ]);
+
+        (new ProviderOptionsAgent)->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'frequency_penalty') === 0.5
+                && data_get($body, 'presence_penalty') === 0.3;
+        });
+    }
+
+    public function test_request_body_does_not_contain_provider_options_when_agent_does_not_implement_interface(): void
+    {
+        Http::fake([
+            '*' => $this->fakeGroqResponse('Hello'),
+        ]);
+
+        agent()->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('reasoning', $body)
+                && ! array_key_exists('frequency_penalty', $body)
+                && ! array_key_exists('presence_penalty', $body);
+        });
+    }
+
+    protected function fakeGroqResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Groq/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Groq/ProviderOptionsTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
 use Tests\TestCase;
 
 use function Laravel\Ai\agent;
@@ -53,6 +54,55 @@ class ProviderOptionsTest extends TestCase
                 && ! array_key_exists('frequency_penalty', $body)
                 && ! array_key_exists('presence_penalty', $body);
         });
+    }
+
+    public function test_provider_options_are_persisted_in_tool_call_follow_up_requests(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeGroqToolCallResponse(),
+                $this->fakeGroqResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ProviderOptionsWithToolsAgent)->prompt('Give me a number', provider: 'groq');
+
+        $requests = Http::recorded(fn (Request $r) => true);
+
+        $this->assertGreaterThanOrEqual(2, count($requests));
+
+        $followUpBody = json_decode($requests[1][0]->body(), true);
+
+        $this->assertSame(0.5, data_get($followUpBody, 'frequency_penalty'));
+    }
+
+    protected function fakeGroqToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
     }
 
     protected function fakeGroqResponse(string $text): PromiseInterface

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\AttributeAgent;
+use Tests\Feature\Agents\StructuredAgent;
+use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class RequestMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_request_includes_model_and_messages(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        agent()->prompt('Hi there', provider: 'groq', model: 'llama-3.3-70b-versatile');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['model'] === 'llama-3.3-70b-versatile'
+                && count($body['messages']) >= 1
+                && collect($body['messages'])->contains(fn ($m) => $m['role'] === 'user' && $m['content'] === 'Hi there');
+        });
+    }
+
+    public function test_system_instructions_are_sent_as_system_message(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        (new AssistantAgent)->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+            return $systemMsg !== null
+                && str_contains($systemMsg['content'], 'helpful assistant');
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_included_when_set_via_attributes(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        (new AttributeAgent)->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'temperature') === 0.7
+                && data_get($body, 'max_completion_tokens') === 4096;
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_excluded_when_not_set(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('temperature', $body)
+                && ! array_key_exists('max_completion_tokens', $body);
+        });
+    }
+
+    public function test_tools_include_tool_choice_auto(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('42')]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['tool_choice'] === 'auto'
+                && is_array($body['tools'])
+                && count($body['tools']) > 0;
+        });
+    }
+
+    public function test_request_without_tools_excludes_tool_fields(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('tools', $body)
+                && ! array_key_exists('tool_choice', $body);
+        });
+    }
+
+    public function test_structured_output_includes_json_schema_response_format(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('{"symbol": "Au"}')]);
+
+        (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $format = data_get($body, 'response_format');
+
+            return $format['type'] === 'json_schema'
+                && isset($format['json_schema']['name'])
+                && isset($format['json_schema']['schema'])
+                && $format['json_schema']['strict'] === true;
+        });
+    }
+
+    public function test_request_without_schema_excludes_response_format(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('response_format', $body);
+        });
+    }
+
+    public function test_streaming_request_includes_stream_options(): void
+    {
+        Http::fake(['*' => Http::response("data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n")]);
+
+        $stream = agent()->stream('Hello', provider: 'groq');
+
+        // Consume the stream
+        foreach ($stream as $event) {
+            //
+        }
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['stream'] === true
+                && data_get($body, 'stream_options.include_usage') === true;
+        });
+    }
+
+    public function test_request_sends_bearer_token_authorization(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_response_text_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('Laravel is great')]);
+
+        $response = agent()->prompt('Tell me about Laravel', provider: 'groq');
+
+        $this->assertSame('Laravel is great', $response->text);
+        $this->assertSame('groq', $response->meta->provider);
+    }
+
+    public function test_response_usage_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello'],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ])]);
+
+        $response = agent()->prompt('Hello', provider: 'groq');
+
+        $this->assertSame(10, $response->usage->promptTokens);
+        $this->assertSame(5, $response->usage->completionTokens);
+    }
+
+    public function test_structured_response_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeGroqResponse('{"symbol": "Au"}')]);
+
+        $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'groq');
+
+        $this->assertSame('Au', $response->structured['symbol']);
+    }
+
+    protected function fakeGroqResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Groq/ToolMappingTest.php
+++ b/tests/Feature/Providers/Groq/ToolMappingTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ToolMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_tool_with_parameters_includes_correct_schema(): void
+    {
+        Http::fake([
+            '*' => $this->fakeGroqResponse('42'),
+        ]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return $function['parameters']['type'] === 'object'
+                && array_key_exists('min', $function['parameters']['properties'])
+                && array_key_exists('max', $function['parameters']['properties'])
+                && in_array('min', $function['parameters']['required'])
+                && in_array('max', $function['parameters']['required'])
+                && $function['parameters']['additionalProperties'] === false;
+        });
+    }
+
+    public function test_tool_with_empty_schema_includes_parameters(): void
+    {
+        Http::fake([
+            '*' => $this->fakeGroqResponse('72019'),
+        ]);
+
+        agent(tools: [new FixedNumberGenerator])->prompt('Give me a random number', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return array_key_exists('parameters', $function)
+                && $function['parameters']['type'] === 'object'
+                && $function['parameters']['properties'] === []
+                && $function['parameters']['required'] === []
+                && $function['parameters']['additionalProperties'] === false;
+        });
+    }
+
+    public function test_tool_parameters_are_not_wrapped_in_schema_definition(): void
+    {
+        Http::fake([
+            '*' => $this->fakeGroqResponse('done'),
+        ]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'groq');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return ! array_key_exists('schema_definition', $function['parameters']['properties'] ?? [])
+                && ! in_array('schema_definition', $function['parameters']['required'] ?? []);
+        });
+    }
+
+    protected function fakeGroqResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Gateway/Groq/ToolMappingTest.php
+++ b/tests/Unit/Gateway/Groq/ToolMappingTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit\Gateway\Groq;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\Groq\Concerns\MapsTools;
+use Laravel\Ai\Tools\Request;
+use PHPUnit\Framework\TestCase;
+
+class ToolMappingTest extends TestCase
+{
+    public function test_tool_parameters_are_not_wrapped_in_schema_definition(): void
+    {
+        $mapper = new class
+        {
+            use MapsTools;
+
+            public function map(array $tools): array
+            {
+                return $this->mapTools($tools);
+            }
+        };
+
+        $tool = new class implements Tool
+        {
+            public function description(): string
+            {
+                return 'Creates a new lead';
+            }
+
+            public function handle(Request $request): string
+            {
+                return 'done';
+            }
+
+            public function schema(\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array
+            {
+                return [
+                    'name' => $schema->string()->required()->description('full customer name'),
+                    'email' => $schema->string()->nullable(),
+                    'phone_number' => $schema->string()->required()->description("customer's phone number"),
+                ];
+            }
+        };
+
+        $mapped = $mapper->map([$tool]);
+
+        $parameters = $mapped[0]['function']['parameters'];
+
+        // The parameters should have direct properties, not wrapped in schema_definition (fixes #239, #342)
+        $this->assertArrayNotHasKey('schema_definition', $parameters['properties'] ?? []);
+        $this->assertNotContains('schema_definition', $parameters['required'] ?? []);
+        $this->assertArrayHasKey('name', $parameters['properties']);
+        $this->assertArrayHasKey('email', $parameters['properties']);
+        $this->assertArrayHasKey('phone_number', $parameters['properties']);
+        $this->assertContains('name', $parameters['required']);
+        $this->assertContains('phone_number', $parameters['required']);
+        $this->assertEquals('object', $parameters['type']);
+        $this->assertFalse($parameters['additionalProperties']);
+    }
+
+    public function test_tool_with_empty_schema_includes_parameters(): void
+    {
+        $mapper = new class
+        {
+            use MapsTools;
+
+            public function map(array $tools): array
+            {
+                return $this->mapTools($tools);
+            }
+        };
+
+        $tool = new class implements Tool
+        {
+            public function description(): string
+            {
+                return 'A tool with no parameters';
+            }
+
+            public function handle(Request $request): string
+            {
+                return 'done';
+            }
+
+            public function schema(\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array
+            {
+                return [];
+            }
+        };
+
+        $mapped = $mapper->map([$tool]);
+
+        $function = $mapped[0]['function'];
+
+        $this->assertArrayHasKey('parameters', $function);
+        $this->assertEquals('object', $function['parameters']['type']);
+        $this->assertEquals([], $function['parameters']['required']);
+        $this->assertFalse($function['parameters']['additionalProperties']);
+    }
+}


### PR DESCRIPTION
The AI SDK currently depends on Prism PHP as a middleware layer for Groq text generation. This creates a bottleneck where any bug fix or new feature must first land in Prism before the SDK can adopt it. This replaces the Prism dependency for Groq with a direct gateway, giving the SDK full ownership of its Groq integration.

### Approach

- Implements a new `GroqGateway` that calls the Groq Chat Completions API directly, following the same trait-based composition pattern established by the OpenAI gateway migration
- Handles synchronous text generation, streaming with SSE parsing, multi-round tool call loops with full conversation history replay, structured output via JSON schema, image attachments, and provider options forwarding
- Updates `GroqProvider` to lazily initialize its own gateway (like `CohereProvider`), removing the `PrismGateway` dependency from `AiManager`
- No public API changes — the `Ai` facade, agents, tools, and all user-facing interfaces remain identical

https://console.groq.com/docs/api-reference#chat-create