### PR TITLE
Respect configured OpenAI base URL and fixes #314

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -108,6 +108,7 @@ return [
         'openai' => [
             'driver' => 'openai',
             'key' => env('OPENAI_API_KEY'),
+            'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
         ],
 
         'openrouter' => [

--- a/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
+++ b/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
@@ -24,9 +24,6 @@ trait CreatesOpenAiClient
      */
     protected function baseUrl(Provider $provider): string
     {
-        $config = $provider->additionalConfiguration();
-        $url = trim((string) ($config['url'] ?? ''));
-
-        return rtrim($url !== '' ? $url : 'https://api.openai.com/v1', '/');
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.openai.com/v1', '/');
     }
 }

--- a/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
+++ b/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesOpenAiClient
+{
+    /**
+     * Get an HTTP client for the OpenAI API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the OpenAI-compatible API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        $config = $provider->additionalConfiguration();
+        $url = trim((string) ($config['url'] ?? ''));
+
+        return rtrim($url !== '' ? $url : 'https://api.openai.com/v1', '/');
+    }
+}

--- a/src/Gateway/OpenAi/OpenAiFileGateway.php
+++ b/src/Gateway/OpenAi/OpenAiFileGateway.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Ai\Gateway\OpenAi;
 
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
@@ -13,6 +12,7 @@ use Laravel\Ai\Responses\StoredFileResponse;
 
 class OpenAiFileGateway implements FileGateway
 {
+    use Concerns\CreatesOpenAiClient;
     use HandlesRateLimiting;
     use PreparesStorableFiles;
 
@@ -23,9 +23,8 @@ class OpenAiFileGateway implements FileGateway
     {
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->get("https://api.openai.com/v1/files/{$fileId}")
-                ->throw()
+            fn () => $this->client($provider)
+                ->get("files/{$fileId}")
         );
 
         return new FileResponse(
@@ -44,12 +43,11 @@ class OpenAiFileGateway implements FileGateway
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
+            fn () => $this->client($provider)
                 ->attach('file', $content, $name, ['Content-Type' => $mime])
-                ->post('https://api.openai.com/v1/files', [
+                ->post('files', [
                     'purpose' => 'user_data',
                 ])
-                ->throw()
         );
 
         return new StoredFileResponse($response->json('id'));
@@ -62,9 +60,8 @@ class OpenAiFileGateway implements FileGateway
     {
         $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->delete("https://api.openai.com/v1/files/{$fileId}")
-                ->throw()
+            fn () => $this->client($provider)
+                ->delete("files/{$fileId}")
         );
     }
 }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -4,9 +4,7 @@ namespace Laravel\Ai\Gateway\OpenAi;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
@@ -23,7 +21,6 @@ use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
@@ -37,6 +34,7 @@ use Laravel\Ai\Responses\TranscriptionResponse;
 class OpenAiGateway implements Gateway
 {
     use Concerns\BuildsTextRequests;
+    use Concerns\CreatesOpenAiClient;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;
     use Concerns\MapsMessages;
@@ -312,16 +310,5 @@ class OpenAiGateway implements Gateway
             $data['usage']['prompt_tokens'] ?? 0,
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Get an HTTP client for the OpenAI API.
-     */
-    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
-    {
-        return Http::baseUrl('https://api.openai.com/v1')
-            ->withToken($provider->providerCredentials()['key'])
-            ->timeout($timeout ?? 60)
-            ->throw();
     }
 }

--- a/src/Gateway/OpenAi/OpenAiStoreGateway.php
+++ b/src/Gateway/OpenAi/OpenAiStoreGateway.php
@@ -5,7 +5,6 @@ namespace Laravel\Ai\Gateway\OpenAi;
 use DateInterval;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
@@ -14,6 +13,7 @@ use Laravel\Ai\Store;
 
 class OpenAiStoreGateway implements StoreGateway
 {
+    use Concerns\CreatesOpenAiClient;
     use HandlesRateLimiting;
 
     /**
@@ -23,9 +23,8 @@ class OpenAiStoreGateway implements StoreGateway
     {
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->get("https://api.openai.com/v1/vector_stores/{$storeId}")
-                ->throw()
+            fn () => $this->client($provider)
+                ->get("vector_stores/{$storeId}")
         );
 
         return new Store(
@@ -55,8 +54,8 @@ class OpenAiStoreGateway implements StoreGateway
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->post('https://api.openai.com/v1/vector_stores', array_filter([
+            fn () => $this->client($provider)
+                ->post('vector_stores', array_filter([
                     'name' => $name,
                     'description' => $description,
                     'file_ids' => $fileIds?->values()->all(),
@@ -65,7 +64,6 @@ class OpenAiStoreGateway implements StoreGateway
                         'days' => $this->intervalToDays($expiresWhenIdleFor),
                     ] : null,
                 ]))
-                ->throw()
         );
 
         return $this->getStore($provider, $response->json('id'));
@@ -78,12 +76,11 @@ class OpenAiStoreGateway implements StoreGateway
     {
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->post("https://api.openai.com/v1/vector_stores/{$storeId}/files", array_filter([
+            fn () => $this->client($provider)
+                ->post("vector_stores/{$storeId}/files", array_filter([
                     'file_id' => $fileId,
                     'attributes' => filled($metadata) ? $metadata : null,
                 ]))
-                ->throw()
         );
 
         return $response->json('id');
@@ -96,9 +93,8 @@ class OpenAiStoreGateway implements StoreGateway
     {
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->delete("https://api.openai.com/v1/vector_stores/{$storeId}/files/{$documentId}")
-                ->throw()
+            fn () => $this->client($provider)
+                ->delete("vector_stores/{$storeId}/files/{$documentId}")
         );
 
         return $response->json('deleted', false);
@@ -111,9 +107,8 @@ class OpenAiStoreGateway implements StoreGateway
     {
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => Http::withToken($provider->providerCredentials()['key'])
-                ->delete("https://api.openai.com/v1/vector_stores/{$storeId}")
-                ->throw()
+            fn () => $this->client($provider)
+                ->delete("vector_stores/{$storeId}")
         );
 
         return $response->json('deleted', false);

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -2,17 +2,16 @@
 
 namespace Laravel\Ai\Providers;
 
-use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
 
 class OpenRouterProvider extends Provider implements EmbeddingProvider, TextProvider
 {
+    use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
-    use Concerns\GeneratesEmbeddings;
-    use Concerns\HasEmbeddingGateway;
-
 
     /**
      * Get the name of the default text model.

--- a/tests/Feature/OpenAiBaseUrlTest.php
+++ b/tests/Feature/OpenAiBaseUrlTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Stores;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class OpenAiBaseUrlTest extends TestCase
+{
+    public function test_openai_text_requests_use_the_configured_base_url(): void
+    {
+        $this->configureOpenAiProvider('http://localhost:1234/v1/');
+
+        Http::fake([
+            '*' => Http::response([
+                'id' => 'resp_123',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [[
+                    'type' => 'message',
+                    'status' => 'completed',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Hello from local model',
+                    ]],
+                ]],
+                'usage' => [
+                    'input_tokens' => 1,
+                    'output_tokens' => 1,
+                ],
+            ]),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'openai');
+
+        $this->assertSame('Hello from local model', $response->text);
+
+        Http::assertSentCount(1);
+        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+            && $request->url() === 'http://localhost:1234/v1/responses');
+    }
+
+    public function test_openai_file_requests_use_the_configured_base_url(): void
+    {
+        $this->configureOpenAiProvider('http://localhost:1234/v1/');
+
+        Http::fake(function (Request $request) {
+            return match ([$request->method(), $request->url()]) {
+                ['POST', 'http://localhost:1234/v1/files'] => Http::response(['id' => 'file_123']),
+                ['GET', 'http://localhost:1234/v1/files/file_123'] => Http::response(['id' => 'file_123']),
+                ['DELETE', 'http://localhost:1234/v1/files/file_123'] => Http::response(),
+                default => Http::response(['unexpected_url' => $request->url()], 500),
+            };
+        });
+
+        $stored = Files::put(
+            Document::fromString('Hello, World!', 'text/plain')->as('hello.txt'),
+            provider: 'openai',
+        );
+
+        $retrieved = Files::get($stored->id, provider: 'openai');
+
+        Files::delete($stored->id, provider: 'openai');
+
+        $this->assertSame('file_123', $stored->id);
+        $this->assertSame('file_123', $retrieved->id);
+
+        Http::assertSentCount(3);
+        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+            && $request->url() === 'http://localhost:1234/v1/files');
+        Http::assertSent(fn (Request $request) => $request->method() === 'GET'
+            && $request->url() === 'http://localhost:1234/v1/files/file_123');
+        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
+            && $request->url() === 'http://localhost:1234/v1/files/file_123');
+    }
+
+    public function test_openai_store_requests_use_the_configured_base_url(): void
+    {
+        $this->configureOpenAiProvider('http://localhost:1234/v1/');
+
+        Http::fake(function (Request $request) {
+            return match ([$request->method(), $request->url()]) {
+                ['POST', 'http://localhost:1234/v1/vector_stores'] => Http::response(['id' => 'vs_123']),
+                ['GET', 'http://localhost:1234/v1/vector_stores/vs_123'] => Http::response([
+                    'id' => 'vs_123',
+                    'name' => 'Local Store',
+                    'status' => 'completed',
+                    'file_counts' => [
+                        'completed' => 0,
+                        'in_progress' => 0,
+                        'failed' => 0,
+                    ],
+                ]),
+                ['POST', 'http://localhost:1234/v1/vector_stores/vs_123/files'] => Http::response(['id' => 'vsfile_123']),
+                ['DELETE', 'http://localhost:1234/v1/vector_stores/vs_123/files/vsfile_123'] => Http::response(['deleted' => true]),
+                ['DELETE', 'http://localhost:1234/v1/vector_stores/vs_123'] => Http::response(['deleted' => true]),
+                default => Http::response(['unexpected_url' => $request->url()], 500),
+            };
+        });
+
+        $store = Stores::create('Local Store', provider: 'openai');
+        $document = $store->add('file_123');
+        $removed = $store->remove($document->id());
+        $deleted = $store->delete();
+
+        $this->assertSame('vs_123', $store->id);
+        $this->assertSame('Local Store', $store->name);
+        $this->assertSame('vsfile_123', $document->id());
+        $this->assertTrue($removed);
+        $this->assertTrue($deleted);
+
+        Http::assertSentCount(5);
+        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+            && $request->url() === 'http://localhost:1234/v1/vector_stores');
+        Http::assertSent(fn (Request $request) => $request->method() === 'GET'
+            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123');
+        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123/files');
+        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
+            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123/files/vsfile_123');
+        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
+            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123');
+    }
+
+    public function test_openai_requests_fall_back_to_the_default_base_url(): void
+    {
+        $this->configureOpenAiProvider();
+
+        Http::fake([
+            '*' => Http::response([
+                'id' => 'resp_456',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [[
+                    'type' => 'message',
+                    'status' => 'completed',
+                    'content' => [[
+                        'type' => 'output_text',
+                        'text' => 'Hello from OpenAI',
+                    ]],
+                ]],
+                'usage' => [
+                    'input_tokens' => 1,
+                    'output_tokens' => 1,
+                ],
+            ]),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'openai');
+
+        $this->assertSame('Hello from OpenAI', $response->text);
+
+        Http::assertSentCount(1);
+        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.openai.com/v1/responses');
+    }
+
+    protected function configureOpenAiProvider(?string $url = null): void
+    {
+        $provider = config('ai.providers.openai');
+
+        $provider['key'] = 'test-key';
+
+        if ($url === null) {
+            unset($provider['url']);
+        } else {
+            $provider['url'] = $url;
+        }
+
+        config(['ai.providers.openai' => $provider]);
+    }
+}

--- a/tests/Feature/OpenAiBaseUrlTest.php
+++ b/tests/Feature/OpenAiBaseUrlTest.php
@@ -13,9 +13,11 @@ use function Laravel\Ai\agent;
 
 class OpenAiBaseUrlTest extends TestCase
 {
+    protected string $customUrl = 'http://localhost:1234/v1';
+
     public function test_openai_text_requests_use_the_configured_base_url(): void
     {
-        $this->configureOpenAiProvider('http://localhost:1234/v1/');
+        $this->configureOpenAiProvider($this->customUrl);
 
         Http::fake([
             '*' => Http::response([
@@ -42,19 +44,18 @@ class OpenAiBaseUrlTest extends TestCase
         $this->assertSame('Hello from local model', $response->text);
 
         Http::assertSentCount(1);
-        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-            && $request->url() === 'http://localhost:1234/v1/responses');
+        $this->assertRequestSent('POST', "{$this->customUrl}/responses");
     }
 
     public function test_openai_file_requests_use_the_configured_base_url(): void
     {
-        $this->configureOpenAiProvider('http://localhost:1234/v1/');
+        $this->configureOpenAiProvider($this->customUrl);
 
         Http::fake(function (Request $request) {
             return match ([$request->method(), $request->url()]) {
-                ['POST', 'http://localhost:1234/v1/files'] => Http::response(['id' => 'file_123']),
-                ['GET', 'http://localhost:1234/v1/files/file_123'] => Http::response(['id' => 'file_123']),
-                ['DELETE', 'http://localhost:1234/v1/files/file_123'] => Http::response(),
+                ['POST', "{$this->customUrl}/files"] => Http::response(['id' => 'file_123']),
+                ['GET', "{$this->customUrl}/files/file_123"] => Http::response(['id' => 'file_123']),
+                ['DELETE', "{$this->customUrl}/files/file_123"] => Http::response(),
                 default => Http::response(['unexpected_url' => $request->url()], 500),
             };
         });
@@ -72,22 +73,19 @@ class OpenAiBaseUrlTest extends TestCase
         $this->assertSame('file_123', $retrieved->id);
 
         Http::assertSentCount(3);
-        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-            && $request->url() === 'http://localhost:1234/v1/files');
-        Http::assertSent(fn (Request $request) => $request->method() === 'GET'
-            && $request->url() === 'http://localhost:1234/v1/files/file_123');
-        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
-            && $request->url() === 'http://localhost:1234/v1/files/file_123');
+        $this->assertRequestSent('POST', "{$this->customUrl}/files");
+        $this->assertRequestSent('GET', "{$this->customUrl}/files/file_123");
+        $this->assertRequestSent('DELETE', "{$this->customUrl}/files/file_123");
     }
 
     public function test_openai_store_requests_use_the_configured_base_url(): void
     {
-        $this->configureOpenAiProvider('http://localhost:1234/v1/');
+        $this->configureOpenAiProvider($this->customUrl);
 
         Http::fake(function (Request $request) {
             return match ([$request->method(), $request->url()]) {
-                ['POST', 'http://localhost:1234/v1/vector_stores'] => Http::response(['id' => 'vs_123']),
-                ['GET', 'http://localhost:1234/v1/vector_stores/vs_123'] => Http::response([
+                ['POST', "{$this->customUrl}/vector_stores"] => Http::response(['id' => 'vs_123']),
+                ['GET', "{$this->customUrl}/vector_stores/vs_123"] => Http::response([
                     'id' => 'vs_123',
                     'name' => 'Local Store',
                     'status' => 'completed',
@@ -97,9 +95,9 @@ class OpenAiBaseUrlTest extends TestCase
                         'failed' => 0,
                     ],
                 ]),
-                ['POST', 'http://localhost:1234/v1/vector_stores/vs_123/files'] => Http::response(['id' => 'vsfile_123']),
-                ['DELETE', 'http://localhost:1234/v1/vector_stores/vs_123/files/vsfile_123'] => Http::response(['deleted' => true]),
-                ['DELETE', 'http://localhost:1234/v1/vector_stores/vs_123'] => Http::response(['deleted' => true]),
+                ['POST', "{$this->customUrl}/vector_stores/vs_123/files"] => Http::response(['id' => 'vsfile_123']),
+                ['DELETE', "{$this->customUrl}/vector_stores/vs_123/files/vsfile_123"] => Http::response(['deleted' => true]),
+                ['DELETE', "{$this->customUrl}/vector_stores/vs_123"] => Http::response(['deleted' => true]),
                 default => Http::response(['unexpected_url' => $request->url()], 500),
             };
         });
@@ -116,16 +114,11 @@ class OpenAiBaseUrlTest extends TestCase
         $this->assertTrue($deleted);
 
         Http::assertSentCount(5);
-        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-            && $request->url() === 'http://localhost:1234/v1/vector_stores');
-        Http::assertSent(fn (Request $request) => $request->method() === 'GET'
-            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123');
-        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123/files');
-        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
-            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123/files/vsfile_123');
-        Http::assertSent(fn (Request $request) => $request->method() === 'DELETE'
-            && $request->url() === 'http://localhost:1234/v1/vector_stores/vs_123');
+        $this->assertRequestSent('POST', "{$this->customUrl}/vector_stores");
+        $this->assertRequestSent('GET', "{$this->customUrl}/vector_stores/vs_123");
+        $this->assertRequestSent('POST', "{$this->customUrl}/vector_stores/vs_123/files");
+        $this->assertRequestSent('DELETE', "{$this->customUrl}/vector_stores/vs_123/files/vsfile_123");
+        $this->assertRequestSent('DELETE', "{$this->customUrl}/vector_stores/vs_123");
     }
 
     public function test_openai_requests_fall_back_to_the_default_base_url(): void
@@ -157,22 +150,21 @@ class OpenAiBaseUrlTest extends TestCase
         $this->assertSame('Hello from OpenAI', $response->text);
 
         Http::assertSentCount(1);
-        Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-            && $request->url() === 'https://api.openai.com/v1/responses');
+        $this->assertRequestSent('POST', 'https://api.openai.com/v1/responses');
     }
 
     protected function configureOpenAiProvider(?string $url = null): void
     {
-        $provider = config('ai.providers.openai');
+        config(['ai.providers.openai' => array_filter([
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+            'url' => $url,
+        ])]);
+    }
 
-        $provider['key'] = 'test-key';
-
-        if ($url === null) {
-            unset($provider['url']);
-        } else {
-            $provider['url'] = $url;
-        }
-
-        config(['ai.providers.openai' => $provider]);
+    protected function assertRequestSent(string $method, string $url): void
+    {
+        Http::assertSent(fn (Request $request) => $request->method() === $method
+            && $request->url() === $url);
     }
 }


### PR DESCRIPTION
The v0.4.0 OpenAI gateway hardcoded `https://api.openai.com/v1` and ignored custom endpoints. 
This updates the text, file, and store gateway paths to use the configured base URL, with the normal OpenAI URL as fallback.

Includes regression tests for custom-url and fallback behavior.

Fixes #314 