### PR TITLE
fix: use correct file extension for audio transcription uploads

### DIFF
--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -286,9 +286,6 @@ class OpenAiGateway implements Gateway
 
     /**
      * Determine the appropriate filename for the audio file based on its MIME type.
-     *
-     * OpenAI's transcription API infers the audio format from the filename extension,
-     * not the Content-Type header, so the extension must match the actual audio format.
      */
     protected function audioFilename(TranscribableAudio $audio): string
     {

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -258,7 +258,7 @@ class OpenAiGateway implements Gateway
         $response = $this->withRateLimitHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)
-                ->attach('file', $audio->content(), 'audio.mp3', ['Content-Type' => $audio->mimeType()])
+                ->attach('file', $audio->content(), $this->audioFilename($audio), ['Content-Type' => $audio->mimeType()])
                 ->post('audio/transcriptions', array_filter([
                     'model' => $model,
                     'language' => $language,
@@ -282,6 +282,32 @@ class OpenAiGateway implements Gateway
             ),
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Determine the appropriate filename for the audio file based on its MIME type.
+     *
+     * OpenAI's transcription API infers the audio format from the filename extension,
+     * not the Content-Type header, so the extension must match the actual audio format.
+     */
+    protected function audioFilename(TranscribableAudio $audio): string
+    {
+        if ($audio instanceof \Laravel\Ai\Contracts\Files\HasName && $audio->name()) {
+            return $audio->name();
+        }
+
+        $extension = match ($audio->mimeType()) {
+            'audio/webm' => 'webm',
+            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
+            'audio/wav', 'audio/x-wav' => 'wav',
+            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/mpeg', 'audio/mp3' => 'mp3',
+            'audio/mpga' => 'mpga',
+            default => 'mp3',
+        };
+
+        return "audio.{$extension}";
     }
 
     /**

--- a/tests/Unit/Gateway/OpenAi/AudioFilenameTest.php
+++ b/tests/Unit/Gateway/OpenAi/AudioFilenameTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Gateway\OpenAi;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Files\Base64Audio;
+use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class AudioFilenameTest extends TestCase
+{
+    protected function callAudioFilename(TranscribableAudio $audio): string
+    {
+        $dispatcher = new class implements Dispatcher
+        {
+            public function listen($events, $listener = null) {}
+
+            public function hasListeners($eventName) {}
+
+            public function subscribe($subscriber) {}
+
+            public function until($event, $payload = []) {}
+
+            public function dispatch($event, $payload = [], $halt = false) {}
+
+            public function push($event, $payload = []) {}
+
+            public function flush($event) {}
+
+            public function forget($event) {}
+
+            public function forgetPushed() {}
+        };
+
+        $gateway = new OpenAiGateway($dispatcher);
+
+        $method = new ReflectionMethod($gateway, 'audioFilename');
+
+        return $method->invoke($gateway, $audio);
+    }
+
+    public function test_webm_audio_gets_webm_extension(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/webm');
+
+        $this->assertEquals('audio.webm', $this->callAudioFilename($audio));
+    }
+
+    public function test_ogg_audio_gets_ogg_extension(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/ogg');
+
+        $this->assertEquals('audio.ogg', $this->callAudioFilename($audio));
+    }
+
+    public function test_wav_audio_gets_wav_extension(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/wav');
+
+        $this->assertEquals('audio.wav', $this->callAudioFilename($audio));
+    }
+
+    public function test_m4a_audio_gets_m4a_extension(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/m4a');
+
+        $this->assertEquals('audio.m4a', $this->callAudioFilename($audio));
+    }
+
+    public function test_flac_audio_gets_flac_extension(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/flac');
+
+        $this->assertEquals('audio.flac', $this->callAudioFilename($audio));
+    }
+
+    public function test_mp3_audio_gets_mp3_extension(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/mpeg');
+
+        $this->assertEquals('audio.mp3', $this->callAudioFilename($audio));
+    }
+
+    public function test_unknown_mime_defaults_to_mp3(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), 'audio/unknown');
+
+        $this->assertEquals('audio.mp3', $this->callAudioFilename($audio));
+    }
+
+    public function test_null_mime_defaults_to_mp3(): void
+    {
+        $audio = new Base64Audio(base64_encode('fake'), null);
+
+        $this->assertEquals('audio.mp3', $this->callAudioFilename($audio));
+    }
+
+    public function test_custom_name_via_as_method_is_respected(): void
+    {
+        $audio = (new Base64Audio(base64_encode('fake'), 'audio/webm'))->as('my-recording.webm');
+
+        $this->assertEquals('my-recording.webm', $this->callAudioFilename($audio));
+    }
+}


### PR DESCRIPTION
OpenAI's transcription API infers the audio format from the filename extension, not the Content-Type header. The hardcoded 'audio.mp3' filename causes uploads in other formats (notably webm, the default format for browser MediaRecorder) to fail with:

    "Audio file might be corrupted or unsupported"

This change derives the filename extension from the audio's MIME type, and respects any custom name set via the as() method.

Ref: https://community.openai.com/t/whisper-error-400-unrecognized-file-format/563474