### PR TITLE
Add missing filename to OpenAI input_file attachment mappings

### DIFF
--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -55,28 +55,33 @@ trait MapsAttachments
                         Storage::disk($attachment->disk)->get($attachment->path)
                     ),
                 ],
-                $attachment instanceof ProviderDocument => [
+                $attachment instanceof ProviderDocument => array_filter([
                     'type' => 'input_file',
                     'file_id' => $attachment->id,
-                ],
-                $attachment instanceof Base64Document => [
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof Base64Document => array_filter([
                     'type' => 'input_file',
                     'file_data' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
-                ],
-                $attachment instanceof LocalDocument => [
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof LocalDocument => array_filter([
                     'type' => 'input_file',
-                    'file_data' => 'data:application/octet-stream;base64,'.base64_encode(file_get_contents($attachment->path)),
-                ],
-                $attachment instanceof RemoteDocument => [
+                    'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(file_get_contents($attachment->path)),
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof RemoteDocument => array_filter([
                     'type' => 'input_file',
                     'file_url' => $attachment->url,
-                ],
-                $attachment instanceof StoredDocument => [
+                    'filename' => $attachment->name(),
+                ]),
+                $attachment instanceof StoredDocument => array_filter([
                     'type' => 'input_file',
-                    'file_data' => 'data:application/octet-stream;base64,'.base64_encode(
+                    'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(
                         Storage::disk($attachment->disk)->get($attachment->path)
                     ),
-                ],
+                    'filename' => $attachment->name(),
+                ]),
                 $attachment instanceof UploadedFile && $this->isImage($attachment) => [
                     'type' => 'input_image',
                     'image_url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
@@ -84,6 +89,7 @@ trait MapsAttachments
                 $attachment instanceof UploadedFile => [
                     'type' => 'input_file',
                     'file_data' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
+                    'filename' => $attachment->getClientOriginalName(),
                 ],
                 default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
             };


### PR DESCRIPTION
The OpenAI Responses API requires a `filename` field on inline `input_file` content parts, but the SDK wasn't including it. This causes a `400: Missing required parameter` error when attaching documents like PDFs or PHP files.

Fixes #321