### PR TITLE
Fix Mistral default transcription model

### DIFF
--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -45,7 +45,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function defaultTranscriptionModel(): string
     {
-        return $this->config['models']['transcription']['default'] ?? 'voxtral-small-latest';
+        return $this->config['models']['transcription']['default'] ?? 'voxtral-mini-latest';
     }
 
     /**


### PR DESCRIPTION
The current default in the codebase uses the `voxtral-small-latest` model, which does not support transcription. As mentioned in [the official Mistral docs](https://docs.mistral.ai/capabilities/audio/speech_to_text/offline_transcription#transcription), the only model supported in the transcription endpoint is `voxtral-mini-latest`.

I run into this issue because if you try to transcribe an audio using the current defaults, you'll get the following error:

```
HTTP request returned status code 400:
{"object":"error","message":"Invalid model: voxtral-small-latest","type":"invalid_model","param":null,"code":"1500","raw (truncated...)
```