### PR TITLE
Throw helpful error when ai.default config is an array

### DIFF
--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -458,10 +458,7 @@ class AiManager extends MultipleInstanceManager
         }
 
         if (is_array($default)) {
-            throw new InvalidArgumentException(sprintf(
-                'The "ai.default" config value must be a string provider name or a Lab enum; got array. Did you mean \'default\' => \'%s\'?',
-                is_string($first = reset($default)) && $first !== '' ? $first : 'anthropic',
-            ));
+            throw new InvalidArgumentException('The "ai.default" config value must be a string provider name or a Lab enum, not an array.');
         }
 
         return $default;

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\MultipleInstanceManager;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
@@ -452,7 +453,18 @@ class AiManager extends MultipleInstanceManager
     {
         $default = $this->app['config']['ai.default'];
 
-        return $default instanceof Lab ? $default->value : $default;
+        if ($default instanceof Lab) {
+            return $default->value;
+        }
+
+        if (is_array($default)) {
+            throw new InvalidArgumentException(sprintf(
+                'The "ai.default" config value must be a string provider name or a Lab enum; got array. Did you mean \'default\' => \'%s\'?',
+                is_string($first = reset($default)) && $first !== '' ? $first : 'anthropic',
+            ));
+        }
+
+        return $default;
     }
 
     /**

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -23,6 +23,7 @@ use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\QueuedAgentResponse;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
+use InvalidArgumentException;
 use ReflectionClass;
 use RuntimeException;
 
@@ -188,9 +189,18 @@ trait Promptable
             }
         }
 
-        return Provider::formatProviderAndModelList(
-            $provider ?? config('ai.default'), $model
-        );
+        $resolved = $provider ?? config('ai.default');
+
+        if (is_array($resolved) && array_intersect(array_keys($resolved), ['text', 'image', 'audio', 'transcription', 'embedding', 'reranking'])) {
+            $first = reset($resolved);
+
+            throw new InvalidArgumentException(sprintf(
+                'The "ai.default" config value must be a string provider name or a Lab enum; got array. Did you mean \'default\' => \'%s\'?',
+                is_string($first) && $first !== '' ? $first : 'anthropic',
+            ));
+        }
+
+        return Provider::formatProviderAndModelList($resolved, $model);
     }
 
     /**

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -192,12 +192,7 @@ trait Promptable
         $resolved = $provider ?? config('ai.default');
 
         if (is_array($resolved) && array_intersect(array_keys($resolved), ['text', 'image', 'audio', 'transcription', 'embedding', 'reranking'])) {
-            $first = reset($resolved);
-
-            throw new InvalidArgumentException(sprintf(
-                'The "ai.default" config value must be a string provider name or a Lab enum; got array. Did you mean \'default\' => \'%s\'?',
-                is_string($first) && $first !== '' ? $first : 'anthropic',
-            ));
+            throw new InvalidArgumentException('The "ai.default" config value must be a string provider name or a Lab enum, not an array.');
         }
 
         return Provider::formatProviderAndModelList($resolved, $model);

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Enums\Lab;
 
@@ -59,6 +60,21 @@ abstract class Provider
 
         if (is_string($providers)) {
             return [$providers => $model];
+        }
+
+        $capabilityKeys = ['text', 'image', 'images', 'audio', 'transcription', 'embedding', 'embeddings', 'reranking'];
+
+        if ($matched = array_intersect(array_keys($providers), $capabilityKeys)) {
+            $key = (string) reset($matched);
+            $value = $providers[$key];
+
+            throw new InvalidArgumentException(sprintf(
+                'The provider list uses the unsupported capability-keyed format ["%s" => "%s"]. Use a string provider name (e.g. \'%s\'), a Lab enum, or a failover list keyed by provider name (e.g. [\'%s\' => \'model-name\']).',
+                $key,
+                is_string($value) ? $value : 'provider',
+                is_string($value) && $value !== '' ? $value : 'anthropic',
+                is_string($value) && $value !== '' ? $value : 'anthropic',
+            ));
         }
 
         return (new Collection($providers))->mapWithKeys(function ($value, $key) {

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -4,7 +4,6 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
-use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Enums\Lab;
 
@@ -60,21 +59,6 @@ abstract class Provider
 
         if (is_string($providers)) {
             return [$providers => $model];
-        }
-
-        $capabilityKeys = ['text', 'image', 'images', 'audio', 'transcription', 'embedding', 'embeddings', 'reranking'];
-
-        if ($matched = array_intersect(array_keys($providers), $capabilityKeys)) {
-            $key = (string) reset($matched);
-            $value = $providers[$key];
-
-            throw new InvalidArgumentException(sprintf(
-                'The provider list uses the unsupported capability-keyed format ["%s" => "%s"]. Use a string provider name (e.g. \'%s\'), a Lab enum, or a failover list keyed by provider name (e.g. [\'%s\' => \'model-name\']).',
-                $key,
-                is_string($value) ? $value : 'provider',
-                is_string($value) && $value !== '' ? $value : 'anthropic',
-                is_string($value) && $value !== '' ? $value : 'anthropic',
-            ));
         }
 
         return (new Collection($providers))->mapWithKeys(function ($value, $key) {

--- a/tests/Feature/AiManagerDefaultConfigTest.php
+++ b/tests/Feature/AiManagerDefaultConfigTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\OpenAiProvider;
+use Laravel\Ai\Providers\Provider;
+
+test('string default works', function () {
+    config(['ai.default' => 'openai']);
+
+    expect(Ai::textProvider())->toBeInstanceOf(OpenAiProvider::class);
+});
+
+test('array default throws helpful error', function () {
+    config(['ai.default' => ['text' => 'anthropic']]);
+
+    expect(fn () => Ai::textProvider())
+        ->toThrow(InvalidArgumentException::class, "'default' => 'anthropic'");
+});
+
+test('capability keyed provider list throws helpful error', function () {
+    expect(fn () => Provider::formatProviderAndModelList(['text' => 'anthropic']))
+        ->toThrow(InvalidArgumentException::class, 'capability-keyed format');
+});
+
+test('failover provider list still works', function () {
+    expect(Provider::formatProviderAndModelList(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'gpt-4']))
+        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'gpt-4']);
+});

--- a/tests/Feature/AiManagerDefaultConfigTest.php
+++ b/tests/Feature/AiManagerDefaultConfigTest.php
@@ -1,25 +1,28 @@
 <?php
 
-use Laravel\Ai\Ai;
-use Laravel\Ai\Providers\OpenAiProvider;
+use Laravel\Ai\AiManager;
 use Laravel\Ai\Providers\Provider;
+
+use function Laravel\Ai\agent;
 
 test('string default works', function () {
     config(['ai.default' => 'openai']);
 
-    expect(Ai::textProvider())->toBeInstanceOf(OpenAiProvider::class);
+    expect(app(AiManager::class)->getDefaultInstance())->toBe('openai');
 });
 
-test('array default throws helpful error', function () {
+test('array default via Ai facade throws helpful error', function () {
     config(['ai.default' => ['text' => 'anthropic']]);
 
-    expect(fn () => Ai::textProvider())
+    expect(fn () => app(AiManager::class)->getDefaultInstance())
         ->toThrow(InvalidArgumentException::class, "'default' => 'anthropic'");
 });
 
-test('capability keyed provider list throws helpful error', function () {
-    expect(fn () => Provider::formatProviderAndModelList(['text' => 'anthropic']))
-        ->toThrow(InvalidArgumentException::class, 'capability-keyed format');
+test('array default via agent prompt throws helpful error', function () {
+    config(['ai.default' => ['text' => 'anthropic']]);
+
+    expect(fn () => agent(instructions: 'test')->prompt('hello'))
+        ->toThrow(InvalidArgumentException::class, "'default' => 'anthropic'");
 });
 
 test('failover provider list still works', function () {

--- a/tests/Feature/AiManagerDefaultConfigTest.php
+++ b/tests/Feature/AiManagerDefaultConfigTest.php
@@ -15,14 +15,14 @@ test('array default via Ai facade throws helpful error', function () {
     config(['ai.default' => ['text' => 'anthropic']]);
 
     expect(fn () => app(AiManager::class)->getDefaultInstance())
-        ->toThrow(InvalidArgumentException::class, "'default' => 'anthropic'");
+        ->toThrow(InvalidArgumentException::class, 'must be a string provider name or a Lab enum, not an array');
 });
 
 test('array default via agent prompt throws helpful error', function () {
     config(['ai.default' => ['text' => 'anthropic']]);
 
     expect(fn () => agent(instructions: 'test')->prompt('hello'))
-        ->toThrow(InvalidArgumentException::class, "'default' => 'anthropic'");
+        ->toThrow(InvalidArgumentException::class, 'must be a string provider name or a Lab enum, not an array');
 });
 
 test('failover provider list still works', function () {


### PR DESCRIPTION
When `config('ai.default')` is set to an array shape like `['text' => 'anthropic']` (a format that was never published in `config/ai.php` but appears in some user setups), the SDK currently surfaces a confusing `"Instance driver [text] is not supported"` error. The published config has always been a plain string (`'default' => 'openai'`), so the array shape is misuse — but the existing error gives the user no signal that their config is the problem.

Fixes #289
