### PR TITLE
Fix Mistral transcription with diarize()

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -307,12 +307,21 @@ class PrismGateway implements Gateway
                     ),
                 });
 
-            if ($provider->driver() === 'openai') {
-                $request->withProviderOptions(array_filter([
-                    'language' => $language,
-                    'response_format' => $diarize ? 'diarized_json' : null,
-                    'chunking_strategy' => $diarize ? 'auto' : null,
-                ]));
+            switch ($provider->driver()) {
+                case 'openai':
+                    $request->withProviderOptions(array_filter([
+                        'language' => $language,
+                        'response_format' => $diarize ? 'diarized_json' : null,
+                        'chunking_strategy' => $diarize ? 'auto' : null,
+                    ]));
+                    break;
+                case 'mistral':
+                    $request->withProviderOptions(array_filter([
+                        'diarize' => $diarize,
+                        'timestamp_granularities' => $diarize ? ['segment'] : null,
+                        'response_format' => $diarize ? 'json' : null,
+                    ]));
+                    break;
             }
 
             $response = $request->asText();
@@ -325,7 +334,7 @@ class PrismGateway implements Gateway
             (new Collection($response->additionalContent['segments'] ?? []))->map(function ($segment) {
                 return new TranscriptionSegment(
                     $segment['text'],
-                    $segment['speaker'],
+                    $segment['speaker'] ?? $segment['speaker_id'] ?? 'Unknown Speaker',
                     $segment['start'],
                     $segment['end'],
                 );


### PR DESCRIPTION
This PR fixes diarization when using the Mistral provider.

Some things to note:

- The Prism dependency also has a bug, I've also opened a PR to fix the issue: https://github.com/prism-php/prism/pull/995
- The "Unknown Speaker" fallback is necessary because until the aforementioned PR is merged in Prism, the `speaker_id` will be null.
- Mistral speaker segments use `speaker_id`, whereas OpenAI use `speaker`. That's why we still need both in the segments mapping.