### PR TITLE
[0.x] Sync conversation state to StreamableAgentResponse after streaming

### DIFF
--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -152,5 +152,11 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         foreach ($this->thenCallbacks as $callback) {
             call_user_func($callback, $this->streamedResponse);
         }
+
+        // Sync conversation state from the streamed response back to the
+        // streamable wrapper so callers can access the conversation ID
+        // after iterating through the stream events.
+        $this->conversationId ??= $this->streamedResponse->conversationId;
+        $this->conversationUser ??= $this->streamedResponse->conversationUser;
     }
 }


### PR DESCRIPTION
Fixes #336

`StreamableAgentResponse::conversationId` is always `null` after iterating a streaming conversational agent.

The `RememberConversation` middleware sets conversation state on the inner `StreamedAgentResponse` via `thenCallbacks`, but the outer `StreamableAgentResponse` that the caller holds is never updated.

This adds two lines after `thenCallbacks` complete in `getIterator()` to sync the state back:

```php
$this->conversationId ??= $this->streamedResponse->conversationId;
$this->conversationUser ??= $this->streamedResponse->conversationUser;
```

**Before:** `$stream->conversationId` returns `null` after streaming.
**After:** `$stream->conversationId` returns the conversation UUID, matching `prompt()` behavior.