### PR TITLE
Apply missing providerOptions and align maxSteps in OpenAI gateway

### DIFF
--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
@@ -40,6 +41,14 @@ trait BuildsTextRequests
 
         if (! is_null($options?->temperature)) {
             $body['temperature'] = $options->temperature;
+        }
+
+        $providerOptions = $options?->providerOptions(
+            Lab::tryFrom($provider->driver()) ?? $provider->driver()
+        );
+
+        if (! is_null($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
         }
 
         return $body;

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -344,7 +344,7 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
             $body = [
                 'model' => $model,
                 'previous_response_id' => $responseId,

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -117,7 +117,7 @@ trait ParsesTextResponses
         // Execute tool calls...
         if ($finishReason === FinishReason::ToolCalls &&
             filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
 
             // Update step with tool results...

--- a/tests/Feature/OpenAiProviderOptionsTest.php
+++ b/tests/Feature/OpenAiProviderOptionsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class OpenAiProviderOptionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openai' => [
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_provider_options_are_included_in_openai_request_body(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenAiResponse('Hello'),
+        ]);
+
+        (new ProviderOptionsAgent)->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'reasoning.effort') === 'high'
+                && data_get($body, 'frequency_penalty') === 0.5
+                && data_get($body, 'presence_penalty') === 0.3;
+        });
+    }
+
+    public function test_request_body_does_not_contain_provider_options_when_agent_does_not_implement_interface(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenAiResponse('Hello'),
+        ]);
+
+        agent()->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('reasoning', $body)
+                && ! array_key_exists('frequency_penalty', $body)
+                && ! array_key_exists('presence_penalty', $body);
+        });
+    }
+
+    protected function fakeOpenAiResponse(string $text): \GuzzleHttp\Promise\PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [[
+                    'type' => 'output_text',
+                    'text' => $text,
+                ]],
+            ]],
+            'usage' => [
+                'input_tokens' => 1,
+                'output_tokens' => 1,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
When OpenAI was migrated from Prism to its own direct gateway (#275), `providerOptions` support and the `maxSteps` default multiplier were not carried over from the Prism path.

Fixes #335

### Approach

- Merge agent provider options into the OpenAI request body, matching how the Prism gateway handles them
- Align the default `maxSteps` fallback from `count($tools) * 2` to `round(count($tools) * 1.5)` to be consistent with Prism
- Add integration tests that verify provider options are sent in the HTTP request body