### PR TITLE
Refactor: 🔄 Centralize multi-step tool loop into StepLoop; gateways become single-turn adapters

### DIFF
--- a/src/Contracts/Gateway/TextGateway.php
+++ b/src/Contracts/Gateway/TextGateway.php
@@ -2,23 +2,28 @@
 
 namespace Laravel\Ai\Contracts\Gateway;
 
-use Closure;
 use Generator;
 use Illuminate\JsonSchema\Types\Type;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\Message;
-use Laravel\Ai\Responses\TextResponse;
 
 interface TextGateway
 {
     /**
-     * Generate text representing the next message in a conversation.
+     * Generate text for a single LLM turn.
+     *
+     * Gateways make exactly one LLM call and return the raw result.
+     * The multi-step tool loop is handled by the orchestrator.
      *
      * @param  Message[]  $messages
      * @param  Tool[]  $tools
      * @param  array<string, Type>|null  $schema
+     * @param  string|null  $previousResponseId  Opaque provider response ID from a prior turn for stateful continuation.
+     * @param  StepContext|null  $context  Per-call orchestration hints (e.g. is-final-step).
      */
     public function generateText(
         TextProvider $provider,
@@ -29,14 +34,21 @@ interface TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse;
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse;
 
     /**
-     * Stream text representing the next message in a conversation.
+     * Stream text for a single LLM turn.
+     *
+     * Gateways stream events for exactly one LLM call.
+     * The multi-step tool loop is handled by the orchestrator.
      *
      * @param  Message[]  $messages
      * @param  Tool[]  $tools
      * @param  array<string, Type>|null  $schema
+     * @param  string|null  $previousResponseId  Opaque provider response ID from a prior turn for stateful continuation.
+     * @param  StepContext|null  $context  Per-call orchestration hints (e.g. is-final-step).
      */
     public function streamText(
         string $invocationId,
@@ -48,10 +60,7 @@ interface TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator;
-
-    /**
-     * Specify callbacks that should be invoked when tools are invoking / invoked.
-     */
-    public function onToolInvocation(Closure $invoking, Closure $invoked): self;
 }

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -12,13 +12,13 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use LogicException;
 
@@ -32,13 +32,9 @@ class AnthropicGateway implements Gateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -52,7 +48,9 @@ class AnthropicGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $body = $this->buildTextRequestBody(
             $provider,
             $model,
@@ -63,25 +61,29 @@ class AnthropicGateway implements Gateway
             $options,
         );
 
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('messages', $body),
-        );
+        $maxPauseTurnResumes = $options?->maxSteps ?? 5;
 
-        $data = $response->json();
+        for ($depth = 0; $depth < $maxPauseTurnResumes; $depth++) {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)->post('messages', $body),
+            );
 
-        $this->validateTextResponse($data);
+            $data = $response->json();
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $body,
-            $timeout,
-        );
+            $this->validateTextResponse($data);
+
+            if (($data['stop_reason'] ?? '') !== 'pause_turn') {
+                return $this->parseTextResponse($data, $provider, filled($schema));
+            }
+
+            $body['messages'][] = [
+                'role' => 'assistant',
+                'content' => $this->ensureToolInputIsObject($data['content'] ?? []),
+            ];
+        }
+
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -97,6 +99,8 @@ class AnthropicGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
             $provider,
@@ -110,24 +114,12 @@ class AnthropicGateway implements Gateway
 
         $body['stream'] = true;
 
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)
-                ->withOptions(['stream' => true])
-                ->post('messages', $body),
-        );
-
-        yield from $this->processTextStream(
+        yield from $this->processTextStreamWithPauseTurnResume(
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
             $body,
-            0,
-            null,
+            $options,
             $timeout,
         );
     }

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -70,12 +70,6 @@ class AnthropicGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        if (($data['stop_reason'] ?? '') === 'pause_turn') {
-            return $this->continueFromPauseTurn(
-                $data, $provider, filled($schema), $body, $options, $timeout,
-            );
-        }
-
         return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
@@ -107,13 +101,18 @@ class AnthropicGateway implements Gateway
 
         $body['stream'] = true;
 
-        yield from $this->resumeFromPauseTurn(
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('messages', $body),
+        );
+
+        yield from $this->processTextStream(
             $invocationId,
             $provider,
             $model,
-            $body,
-            $options,
-            $timeout,
+            $response->getBody(),
         );
     }
 

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -61,26 +61,19 @@ class AnthropicGateway implements Gateway
             $options,
         );
 
-        $maxPauseTurnResumes = $options?->maxSteps ?? 5;
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('messages', $body),
+        );
 
-        for ($depth = 0; $depth < $maxPauseTurnResumes; $depth++) {
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)->post('messages', $body),
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        if (($data['stop_reason'] ?? '') === 'pause_turn') {
+            return $this->continueFromPauseTurn(
+                $data, $provider, filled($schema), $body, $options, $timeout,
             );
-
-            $data = $response->json();
-
-            $this->validateTextResponse($data);
-
-            if (($data['stop_reason'] ?? '') !== 'pause_turn') {
-                return $this->parseTextResponse($data, $provider, filled($schema));
-            }
-
-            $body['messages'][] = [
-                'role' => 'assistant',
-                'content' => $this->ensureToolInputIsObject($data['content'] ?? []),
-            ];
         }
 
         return $this->parseTextResponse($data, $provider, filled($schema));
@@ -114,7 +107,7 @@ class AnthropicGateway implements Gateway
 
         $body['stream'] = true;
 
-        yield from $this->processTextStreamWithPauseTurnResume(
+        yield from $this->resumeFromPauseTurn(
             $invocationId,
             $provider,
             $model,

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -8,7 +8,6 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
@@ -23,44 +22,83 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process an Anthropic streaming response and yield Laravel stream events.
+     * Stream with automatic pause_turn resume — a provider-internal server-tool
+     * continuation that is transparent to the caller / StepLoop.
+     */
+    protected function processTextStreamWithPauseTurnResume(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $requestBody,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+    ): Generator {
+        $maxResumes = $options?->maxSteps ?? 5;
+
+        for ($depth = 0; $depth < $maxResumes; $depth++) {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)
+                    ->withOptions(['stream' => true])
+                    ->post('messages', $requestBody),
+            );
+
+            $responseContent = [];
+            $stopReason = '';
+            $bufferedStreamEnd = null;
+
+            foreach ($this->processTextStream($invocationId, $provider, $model, $response->getBody(), $responseContent, $stopReason) as $event) {
+                if ($event instanceof StreamEnd) {
+                    $bufferedStreamEnd = $event;
+                } else {
+                    yield $event;
+                }
+            }
+
+            if ($stopReason !== 'pause_turn') {
+                if ($bufferedStreamEnd) {
+                    yield $bufferedStreamEnd;
+                }
+
+                return;
+            }
+
+            $requestBody['messages'][] = [
+                'role' => 'assistant',
+                'content' => $this->ensureToolInputIsObject(array_values($responseContent)),
+            ];
+        }
+    }
+
+    /**
+     * Process an Anthropic streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        array $requestBody = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
+        array &$outResponseContent = [],
+        string &$outStopReason = '',
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $reasoningId = '';
         $streamStartEmitted = false;
         $textStartEmitted = false;
         $reasoningStartEmitted = false;
 
-        $currentText = '';
         $currentBlockType = '';
-        $currentBlockIndex = -1;
-        $currentBlockText = '';
         $currentThinkingText = '';
         $currentSignature = '';
         $currentToolIndex = -1;
         $currentServerToolInput = '';
         $pendingToolCalls = [];
         $responseContent = [];
+        $currentServerToolBlock = [];
 
         $inputTokens = 0;
         $cacheCreationTokens = 0;
@@ -133,11 +171,10 @@ trait HandlesTextStreaming
             if ($type === 'content_block_start') {
                 $blockType = $data['content_block']['type'] ?? '';
                 $currentBlockType = $blockType;
-                $currentBlockIndex = $data['index'] ?? count($responseContent);
+                $index = $data['index'] ?? count($responseContent);
+                $responseContent[$index] = $data['content_block'] ?? [];
 
                 if ($blockType === 'text') {
-                    $currentBlockText = '';
-
                     if ($event = $emitTextStart()) {
                         yield $event;
                     }
@@ -158,12 +195,13 @@ trait HandlesTextStreaming
                     ];
                 } elseif ($blockType === 'server_tool_use') {
                     $currentServerToolInput = '';
+                    $currentServerToolBlock = $data['content_block'] ?? [];
 
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
-                        $data['content_block']['id'] ?? '',
+                        $currentServerToolBlock['id'] ?? '',
                         $blockType,
-                        $data['content_block'] ?? [],
+                        $currentServerToolBlock,
                         'started',
                         time(),
                     ))->withInvocationId($invocationId);
@@ -178,11 +216,6 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
                 }
 
-                // Track content blocks for tool loop replay...
-                if (isset($data['content_block'])) {
-                    $responseContent[$data['index'] ?? count($responseContent)] = $data['content_block'];
-                }
-
                 continue;
             }
 
@@ -193,12 +226,14 @@ trait HandlesTextStreaming
                     $textDelta = (string) ($data['delta']['text'] ?? '');
 
                     if ($textDelta !== '') {
+                        $blockIndex = $data['index'] ?? array_key_last($responseContent);
+                        if ($blockIndex !== null && isset($responseContent[$blockIndex])) {
+                            $responseContent[$blockIndex]['text'] = ($responseContent[$blockIndex]['text'] ?? '').$textDelta;
+                        }
+
                         if ($event = $emitTextStart()) {
                             yield $event;
                         }
-
-                        $currentText .= $textDelta;
-                        $currentBlockText .= $textDelta;
 
                         yield (new TextDelta(
                             $this->generateEventId(),
@@ -252,10 +287,6 @@ trait HandlesTextStreaming
 
             if ($type === 'content_block_stop') {
                 if ($currentBlockType === 'text' && $textStartEmitted) {
-                    if (isset($responseContent[$currentBlockIndex])) {
-                        $responseContent[$currentBlockIndex]['text'] = $currentBlockText;
-                    }
-
                     yield (new TextEnd(
                         $this->generateEventId(),
                         $messageId,
@@ -264,11 +295,6 @@ trait HandlesTextStreaming
 
                     $textStartEmitted = false;
                 } elseif ($currentBlockType === 'thinking' && $reasoningStartEmitted) {
-                    if (isset($responseContent[$currentBlockIndex])) {
-                        $responseContent[$currentBlockIndex]['thinking'] = $currentThinkingText;
-                        $responseContent[$currentBlockIndex]['signature'] = $currentSignature;
-                    }
-
                     yield (new ReasoningEnd(
                         $this->generateEventId(),
                         $reasoningId,
@@ -281,40 +307,43 @@ trait HandlesTextStreaming
                     $call = $pendingToolCalls[$currentToolIndex];
                     $parsedArguments = json_decode($call['arguments'] ?: '{}', true) ?? [];
 
-                    $index = $data['index'] ?? $currentToolIndex;
-
-                    if (isset($responseContent[$index])) {
-                        $responseContent[$index]['input'] = $parsedArguments;
+                    // Don't emit the synthetic structured output tool call as a real tool call.
+                    if ($call['name'] !== 'output_structured_data') {
+                        yield (new ToolCallEvent(
+                            $this->generateEventId(),
+                            new ToolCall(
+                                $call['id'],
+                                $call['name'],
+                                $parsedArguments,
+                                $call['id'],
+                                reasoningSummary: $currentThinkingText !== '' ? [$currentThinkingText] : null,
+                                reasoningSignature: $currentSignature ?: null,
+                            ),
+                            time(),
+                        ))->withInvocationId($invocationId);
                     }
-
-                    // Store parsed arguments to avoid re-decoding in mapStreamToolCalls...
-                    $pendingToolCalls[$currentToolIndex]['parsed_arguments'] = $parsedArguments;
-
-                    yield (new ToolCallEvent(
-                        $this->generateEventId(),
-                        new ToolCall(
-                            $call['id'],
-                            $call['name'],
-                            $parsedArguments,
-                            $call['id'],
-                        ),
-                        time(),
-                    ))->withInvocationId($invocationId);
                 } elseif ($currentBlockType === 'server_tool_use') {
-                    $index = $data['index'] ?? count($responseContent) - 1;
+                    $blockIndex = $data['index'] ?? array_key_last($responseContent);
 
-                    if ($currentServerToolInput !== '' && isset($responseContent[$index])) {
-                        $responseContent[$index]['input'] = json_decode($currentServerToolInput, true) ?? [];
+                    if ($currentServerToolInput !== '') {
+                        $decodedInput = json_decode($currentServerToolInput, true) ?? [];
+                        $currentServerToolBlock['input'] = $decodedInput;
+
+                        if ($blockIndex !== null && isset($responseContent[$blockIndex])) {
+                            $responseContent[$blockIndex]['input'] = $decodedInput;
+                        }
                     }
 
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
-                        $responseContent[$index]['id'] ?? '',
+                        $currentServerToolBlock['id'] ?? '',
                         $currentBlockType,
-                        $responseContent[$index] ?? [],
+                        $currentServerToolBlock,
                         'completed',
                         time(),
                     ))->withInvocationId($invocationId);
+
+                    $currentServerToolBlock = [];
                 }
 
                 $currentBlockType = '';
@@ -335,42 +364,8 @@ trait HandlesTextStreaming
             }
         }
 
-        if (filled($pendingToolCalls) && $stopReason === 'tool_use') {
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $pendingToolCalls,
-                $responseContent,
-                $requestBody,
-                $depth,
-                $maxSteps,
-                $timeout,
-            );
-
-            return;
-        }
-
-        if ($stopReason === 'pause_turn' && $depth + 1 < ($maxSteps ?? 5)) {
-            yield from $this->resumeFromPauseTurn(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $responseContent,
-                $requestBody,
-                $depth,
-                $maxSteps,
-                $timeout,
-            );
-
-            return;
-        }
+        $outResponseContent = $responseContent;
+        $outStopReason = $stopReason;
 
         yield (new StreamEnd(
             $this->generateEventId(),
@@ -378,165 +373,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $pendingToolCalls,
-        array $responseContent,
-        array $requestBody,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
-
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 >= ($maxSteps ?? round(count($tools) * 1.5))) {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                FinishReason::ToolCalls->value,
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-
-            return;
-        }
-
-        $requestBody['messages'][] = [
-            'role' => 'assistant',
-            'content' => $this->ensureToolInputIsObject(array_values($responseContent)),
-        ];
-
-        $requestBody['messages'][] = [
-            'role' => 'user',
-            'content' => array_map(fn (ToolResult $result) => [
-                'type' => 'tool_result',
-                'tool_use_id' => $result->id,
-                'content' => $this->serializeToolResultOutput($result->result),
-            ], $toolResults),
-        ];
-
-        $requestBody['stream'] = true;
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)
-                ->withOptions(['stream' => true])
-                ->post('messages', $requestBody),
-        );
-
-        yield from $this->processTextStream(
-            $invocationId,
-            $provider,
-            $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
-            $requestBody,
-            $depth + 1,
-            $maxSteps,
-            $timeout,
-        );
-    }
-
-    /**
-     * Resume a paused server-side loop by replaying the assistant response
-     * as-is and continuing to stream the follow-up response.
-     */
-    protected function resumeFromPauseTurn(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $responseContent,
-        array $requestBody,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $requestBody['messages'][] = [
-            'role' => 'assistant',
-            'content' => $this->ensureToolInputIsObject(array_values($responseContent)),
-        ];
-
-        $requestBody['stream'] = true;
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)
-                ->withOptions(['stream' => true])
-                ->post('messages', $requestBody),
-        );
-
-        yield from $this->processTextStream(
-            $invocationId,
-            $provider,
-            $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
-            $requestBody,
-            $depth + 1,
-            $maxSteps,
-            $timeout,
-        );
-    }
-
-    /**
-     * Map raw streaming tool call data to ToolCall DTOs.
-     *
-     * @return array<ToolCall>
-     */
-    protected function mapStreamToolCalls(array $toolCalls): array
-    {
-        return array_map(fn (array $tc) => new ToolCall(
-            $tc['id'] ?? '',
-            $tc['name'] ?? '',
-            $tc['parsed_arguments'] ?? json_decode($tc['arguments'] ?? '{}', true) ?? [],
-            $tc['id'] ?? null,
-        ), array_values($toolCalls));
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -26,10 +26,10 @@ use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 trait HandlesTextStreaming
 {
     /**
-     * Stream with automatic pause_turn resume — a provider-internal server-tool
-     * continuation that is transparent to the caller / StepLoop.
+     * Resume a paused server-side loop by replaying the assistant response
+     * as-is and continuing to stream the follow-up response.
      */
-    protected function processTextStreamWithPauseTurnResume(
+    protected function resumeFromPauseTurn(
         string $invocationId,
         Provider $provider,
         string $model,

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -38,14 +38,16 @@ trait HandlesTextStreaming
         $textStartEmitted = false;
         $reasoningStartEmitted = false;
 
+        $currentText = '';
         $currentBlockType = '';
+        $currentBlockIndex = -1;
+        $currentBlockText = '';
         $currentThinkingText = '';
         $currentSignature = '';
         $currentToolIndex = -1;
         $currentServerToolInput = '';
         $pendingToolCalls = [];
         $responseContent = [];
-        $currentServerToolBlock = [];
 
         $inputTokens = 0;
         $cacheCreationTokens = 0;
@@ -118,10 +120,11 @@ trait HandlesTextStreaming
             if ($type === 'content_block_start') {
                 $blockType = $data['content_block']['type'] ?? '';
                 $currentBlockType = $blockType;
-                $index = $data['index'] ?? count($responseContent);
-                $responseContent[$index] = $data['content_block'] ?? [];
+                $currentBlockIndex = $data['index'] ?? count($responseContent);
 
                 if ($blockType === 'text') {
+                    $currentBlockText = '';
+
                     if ($event = $emitTextStart()) {
                         yield $event;
                     }
@@ -142,13 +145,12 @@ trait HandlesTextStreaming
                     ];
                 } elseif ($blockType === 'server_tool_use') {
                     $currentServerToolInput = '';
-                    $currentServerToolBlock = $data['content_block'] ?? [];
 
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
-                        $currentServerToolBlock['id'] ?? '',
+                        $data['content_block']['id'] ?? '',
                         $blockType,
-                        $currentServerToolBlock,
+                        $data['content_block'] ?? [],
                         'started',
                         time(),
                     ))->withInvocationId($invocationId);
@@ -163,6 +165,10 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
                 }
 
+                if (isset($data['content_block'])) {
+                    $responseContent[$data['index'] ?? count($responseContent)] = $data['content_block'];
+                }
+
                 continue;
             }
 
@@ -173,14 +179,12 @@ trait HandlesTextStreaming
                     $textDelta = (string) ($data['delta']['text'] ?? '');
 
                     if ($textDelta !== '') {
-                        $blockIndex = $data['index'] ?? array_key_last($responseContent);
-                        if ($blockIndex !== null && isset($responseContent[$blockIndex])) {
-                            $responseContent[$blockIndex]['text'] = ($responseContent[$blockIndex]['text'] ?? '').$textDelta;
-                        }
-
                         if ($event = $emitTextStart()) {
                             yield $event;
                         }
+
+                        $currentText .= $textDelta;
+                        $currentBlockText .= $textDelta;
 
                         yield (new TextDelta(
                             $this->generateEventId(),
@@ -234,6 +238,10 @@ trait HandlesTextStreaming
 
             if ($type === 'content_block_stop') {
                 if ($currentBlockType === 'text' && $textStartEmitted) {
+                    if (isset($responseContent[$currentBlockIndex])) {
+                        $responseContent[$currentBlockIndex]['text'] = $currentBlockText;
+                    }
+
                     yield (new TextEnd(
                         $this->generateEventId(),
                         $messageId,
@@ -242,6 +250,11 @@ trait HandlesTextStreaming
 
                     $textStartEmitted = false;
                 } elseif ($currentBlockType === 'thinking' && $reasoningStartEmitted) {
+                    if (isset($responseContent[$currentBlockIndex])) {
+                        $responseContent[$currentBlockIndex]['thinking'] = $currentThinkingText;
+                        $responseContent[$currentBlockIndex]['signature'] = $currentSignature;
+                    }
+
                     yield (new ReasoningEnd(
                         $this->generateEventId(),
                         $reasoningId,
@@ -254,43 +267,41 @@ trait HandlesTextStreaming
                     $call = $pendingToolCalls[$currentToolIndex];
                     $parsedArguments = json_decode($call['arguments'] ?: '{}', true) ?? [];
 
-                    // Don't emit the synthetic structured output tool call as a real tool call.
-                    if ($call['name'] !== 'output_structured_data') {
-                        yield (new ToolCallEvent(
-                            $this->generateEventId(),
-                            new ToolCall(
-                                $call['id'],
-                                $call['name'],
-                                $parsedArguments,
-                                $call['id'],
-                                reasoningSummary: $currentThinkingText !== '' ? [$currentThinkingText] : null,
-                                reasoningSignature: $currentSignature ?: null,
-                            ),
-                            time(),
-                        ))->withInvocationId($invocationId);
+                    $index = $data['index'] ?? $currentToolIndex;
+
+                    if (isset($responseContent[$index])) {
+                        $responseContent[$index]['input'] = $parsedArguments;
                     }
+
+                    $pendingToolCalls[$currentToolIndex]['parsed_arguments'] = $parsedArguments;
+
+                    yield (new ToolCallEvent(
+                        $this->generateEventId(),
+                        new ToolCall(
+                            $call['id'],
+                            $call['name'],
+                            $parsedArguments,
+                            $call['id'],
+                            reasoningSummary: $currentThinkingText !== '' ? [$currentThinkingText] : null,
+                            reasoningSignature: $currentSignature ?: null,
+                        ),
+                        time(),
+                    ))->withInvocationId($invocationId);
                 } elseif ($currentBlockType === 'server_tool_use') {
-                    $blockIndex = $data['index'] ?? array_key_last($responseContent);
+                    $index = $data['index'] ?? count($responseContent) - 1;
 
-                    if ($currentServerToolInput !== '') {
-                        $decodedInput = json_decode($currentServerToolInput, true) ?? [];
-                        $currentServerToolBlock['input'] = $decodedInput;
-
-                        if ($blockIndex !== null && isset($responseContent[$blockIndex])) {
-                            $responseContent[$blockIndex]['input'] = $decodedInput;
-                        }
+                    if ($currentServerToolInput !== '' && isset($responseContent[$index])) {
+                        $responseContent[$index]['input'] = json_decode($currentServerToolInput, true) ?? [];
                     }
 
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
-                        $currentServerToolBlock['id'] ?? '',
+                        $responseContent[$index]['id'] ?? '',
                         $currentBlockType,
-                        $currentServerToolBlock,
+                        $responseContent[$index] ?? [],
                         'completed',
                         time(),
                     ))->withInvocationId($invocationId);
-
-                    $currentServerToolBlock = [];
                 }
 
                 $currentBlockType = '';

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -4,9 +4,7 @@ namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
-use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
@@ -26,55 +24,6 @@ use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 trait HandlesTextStreaming
 {
     /**
-     * Resume a paused server-side loop by replaying the assistant response
-     * as-is and continuing to stream the follow-up response.
-     */
-    protected function resumeFromPauseTurn(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $requestBody,
-        ?TextGenerationOptions $options,
-        ?int $timeout,
-    ): Generator {
-        $maxResumes = $options?->maxSteps ?? 5;
-
-        for ($depth = 0; $depth < $maxResumes; $depth++) {
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('messages', $requestBody),
-            );
-
-            $responseContent = [];
-            $stopReason = '';
-            $bufferedStreamEnd = null;
-
-            foreach ($this->processTextStream($invocationId, $provider, $model, $response->getBody(), $responseContent, $stopReason) as $event) {
-                if ($event instanceof StreamEnd) {
-                    $bufferedStreamEnd = $event;
-                } else {
-                    yield $event;
-                }
-            }
-
-            if ($stopReason !== 'pause_turn') {
-                if ($bufferedStreamEnd) {
-                    yield $bufferedStreamEnd;
-                }
-
-                return;
-            }
-
-            $requestBody['messages'][] = [
-                'role' => 'assistant',
-                'content' => $this->ensureToolInputIsObject(array_values($responseContent)),
-            ];
-        }
-    }
-
-    /**
      * Process an Anthropic streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
@@ -82,8 +31,6 @@ trait HandlesTextStreaming
         Provider $provider,
         string $model,
         $streamBody,
-        array &$outResponseContent = [],
-        string &$outStopReason = '',
     ): Generator {
         $messageId = $this->generateEventId();
         $reasoningId = '';
@@ -364,14 +311,12 @@ trait HandlesTextStreaming
             }
         }
 
-        $outResponseContent = $responseContent;
-        $outStopReason = $stopReason;
-
         yield (new StreamEnd(
             $this->generateEventId(),
             $this->extractFinishReason(['stop_reason' => $stopReason])->value,
             $usage ?? new Usage(0, 0),
             time(),
+            providerContentBlocks: $responseContent,
         ))->withInvocationId($invocationId);
     }
 

--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -67,19 +67,33 @@ trait MapsMessages
         $hasToolCalls = $message instanceof AssistantMessage && $message->toolCalls->isNotEmpty();
 
         if ($hasToolCalls) {
-            $thinkingBlocks = $message->toolCalls
-                ->whereNotNull('reasoningId')
-                ->unique('reasoningId')
-                ->map(fn ($toolCall) => [
-                    'type' => 'thinking',
-                    'thinking' => is_array($toolCall->reasoningSummary)
-                        ? implode("\n", array_column($toolCall->reasoningSummary, 'text'))
-                        : ($toolCall->reasoningSummary ?? ''),
-                ])
-                ->values()
-                ->all();
+            $firstToolCall = $message->toolCalls->first();
 
-            array_push($content, ...$thinkingBlocks);
+            if ($firstToolCall?->reasoningSignature !== null) {
+                $thinkingText = is_array($firstToolCall->reasoningSummary)
+                    ? implode("\n", $firstToolCall->reasoningSummary)
+                    : ($firstToolCall->reasoningSummary ?? '');
+
+                $content[] = [
+                    'type' => 'thinking',
+                    'thinking' => $thinkingText,
+                    'signature' => $firstToolCall->reasoningSignature,
+                ];
+            } elseif ($message->toolCalls->whereNotNull('reasoningId')->isNotEmpty()) {
+                $thinkingBlocks = $message->toolCalls
+                    ->whereNotNull('reasoningId')
+                    ->unique('reasoningId')
+                    ->map(fn ($toolCall) => [
+                        'type' => 'thinking',
+                        'thinking' => is_array($toolCall->reasoningSummary)
+                            ? implode("\n", array_column($toolCall->reasoningSummary, 'text'))
+                            : ($toolCall->reasoningSummary ?? ''),
+                    ])
+                    ->values()
+                    ->all();
+
+                array_push($content, ...$thinkingBlocks);
+            }
         }
 
         if (filled($message->content)) {
@@ -92,7 +106,7 @@ trait MapsMessages
         if ($hasToolCalls) {
             foreach ($message->toolCalls as $toolCall) {
                 $content[] = [
-                    'type' => 'tool_use',
+                    'type' => $toolCall->providerExecuted ? 'server_tool_use' : 'tool_use',
                     'id' => $toolCall->id,
                     'name' => $toolCall->name,
                     'input' => $toolCall->arguments ?: (object) [],
@@ -131,5 +145,31 @@ trait MapsMessages
             'role' => 'user',
             'content' => $content,
         ];
+    }
+
+    /**
+     * Serialize a tool result output value to a string suitable for the API.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        return match (true) {
+            is_string($output) => $output,
+            is_array($output) => json_encode($output),
+            default => strval($output),
+        };
+    }
+
+    /**
+     * Ensure tool_use and server_tool_use input fields are objects for the API.
+     */
+    protected function ensureToolInputIsObject(array $content): array
+    {
+        return array_map(function (array $block) {
+            if (in_array($block['type'] ?? '', ['tool_use', 'server_tool_use'], true)) {
+                $block['input'] = (object) ($block['input'] ?? []);
+            }
+
+            return $block;
+        }, $content);
     }
 }

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -5,7 +5,6 @@ namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\SingleTurnResponse;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
@@ -79,45 +78,6 @@ trait ParsesTextResponses
             structured: $structuredData,
             providerContentBlocks: $content,
         );
-    }
-
-    /**
-     * Continue the conversation after a pause_turn stop reason by replaying
-     * the assistant response as-is so the server can resume its turn.
-     */
-    protected function continueFromPauseTurn(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $requestBody,
-        ?TextGenerationOptions $options,
-        ?int $timeout,
-    ): SingleTurnResponse {
-        $maxResumes = $options?->maxSteps ?? 5;
-
-        for ($depth = 0; $depth < $maxResumes; $depth++) {
-            $requestBody['messages'][] = [
-                'role' => 'assistant',
-                'content' => $this->ensureToolInputIsObject($data['content'] ?? []),
-            ];
-
-            unset($requestBody['stream']);
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)->post('messages', $requestBody),
-            );
-
-            $data = $response->json();
-
-            $this->validateTextResponse($data);
-
-            if (($data['stop_reason'] ?? '') !== 'pause_turn') {
-                return $this->parseTextResponse($data, $provider, $structured);
-            }
-        }
-
-        return $this->parseTextResponse($data, $provider, $structured);
     }
 
     /**
@@ -208,6 +168,7 @@ trait ParsesTextResponses
         return match ($data['stop_reason'] ?? '') {
             'end_turn', 'stop_sequence' => FinishReason::Stop,
             'tool_use' => FinishReason::ToolCalls,
+            'pause_turn' => FinishReason::Continue,
             'max_tokens' => FinishReason::Length,
             default => FinishReason::Unknown,
         };

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -3,21 +3,14 @@
 namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -38,48 +31,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Anthropic response data into a TextResponse.
+     * Parse a single Anthropic response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        array $requestBody = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            $requestBody,
-            maxSteps: $options?->maxSteps,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $requestBody,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $model = $data['model'] ?? '';
         $content = $data['content'] ?? [];
 
@@ -88,63 +46,15 @@ trait ParsesTextResponses
         $citations = $this->extractCitations($content);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data);
-        $meta = new Meta($provider->name(), $model, $citations);
+        $thinking = $this->extractThinking($content);
 
-        $realToolCalls = array_filter($toolCalls, fn (ToolCall $tc) => $tc->name !== 'output_structured_data');
+        $realToolCalls = $this->attachThinkingToToolCalls(
+            array_values(array_filter($toolCalls, fn (ToolCall $tc) => $tc->name !== 'output_structured_data')),
+            $thinking,
+        );
         $hasStructuredToolCall = count($realToolCalls) < count($toolCalls);
-        $toolResults = [];
 
-        $stopReason = $data['stop_reason'] ?? '';
-
-        $shouldContinue = $finishReason === FinishReason::ToolCalls
-            && filled($realToolCalls)
-            && $depth + 1 < ($maxSteps ?? round(count($tools) * 1.5));
-
-        $shouldResumePauseTurn = $stopReason === 'pause_turn'
-            && $depth + 1 < ($maxSteps ?? 5);
-
-        if ($shouldContinue) {
-            $toolResults = $this->executeToolCalls($realToolCalls, $tools);
-        }
-
-        $steps->push(new Step($text, $toolCalls, $toolResults, $finishReason, $usage, $meta));
-
-        $messages->push(new AssistantMessage($text, collect($toolCalls), $content));
-
-        if ($shouldResumePauseTurn) {
-            return $this->continueFromPauseTurn(
-                $data,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $requestBody,
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        }
-
-        if ($shouldContinue) {
-            $messages->push(new ToolResultMessage(collect($toolResults)));
-
-            return $this->continueWithToolResults(
-                $data,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $requestBody,
-                $toolResults,
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        }
+        $structuredData = null;
 
         if ($structured || $hasStructuredToolCall) {
             $structuredData = $this->extractStructuredOutput($content);
@@ -152,178 +62,22 @@ trait ParsesTextResponses
             if (empty($structuredData) && filled($text)) {
                 $structuredData = json_decode($text, true) ?? [];
             }
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                json_encode($structuredData) ?: '',
-                $this->combineUsage($steps),
-                $meta,
-            ))->withToolCallsAndResults(
-                toolCalls: $steps->flatMap(fn (Step $s) => $s->toolCalls),
-                toolResults: $steps->flatMap(fn (Step $s) => $s->toolResults),
-            )->withSteps($steps);
         }
 
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            $meta,
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
+        // If the only tool calls were the synthetic structured output, this is really a stop.
+        if ($finishReason === FinishReason::ToolCalls && empty($realToolCalls)) {
+            $finishReason = FinishReason::Stop;
         }
 
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        array $previousData,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $requestBody,
-        array $toolResults,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): TextResponse {
-        $requestBody['messages'][] = [
-            'role' => 'assistant',
-            'content' => $this->ensureToolInputIsObject($previousData['content'] ?? []),
-        ];
-
-        $toolResultContent = [];
-
-        foreach ($toolResults as $result) {
-            $toolResultContent[] = [
-                'type' => 'tool_result',
-                'tool_use_id' => $result->id,
-                'content' => $this->serializeToolResultOutput($result->result),
-            ];
-        }
-
-        $requestBody['messages'][] = [
-            'role' => 'user',
-            'content' => $toolResultContent,
-        ];
-
-        unset($requestBody['stream']);
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('messages', $requestBody),
+        return new SingleTurnResponse(
+            text: $hasStructuredToolCall && ! empty($structuredData) ? (json_encode($structuredData) ?: '') : $text,
+            toolCalls: $realToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model, $citations),
+            structured: $structuredData,
+            providerContentBlocks: $content,
         );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $requestBody,
-            $depth,
-            $maxSteps,
-            $timeout,
-        );
-    }
-
-    /**
-     * Continue the conversation after a pause_turn stop reason by replaying
-     * the assistant response as-is so the server can resume its turn.
-     */
-    protected function continueFromPauseTurn(
-        array $previousData,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $requestBody,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): TextResponse {
-        $requestBody['messages'][] = [
-            'role' => 'assistant',
-            'content' => $this->ensureToolInputIsObject($previousData['content'] ?? []),
-        ];
-
-        unset($requestBody['stream']);
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('messages', $requestBody),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $requestBody,
-            $depth,
-            $maxSteps,
-            $timeout,
-        );
-    }
-
-    /**
-     * Serialize a tool result output value to a string.
-     */
-    protected function serializeToolResultOutput(mixed $output): string
-    {
-        return match (true) {
-            is_string($output) => $output,
-            is_array($output) => json_encode($output),
-            default => strval($output),
-        };
     }
 
     /**
@@ -343,13 +97,17 @@ trait ParsesTextResponses
      */
     protected function extractToolCalls(array $content): array
     {
-        $toolUseBlocks = array_filter($content, fn (array $block) => ($block['type'] ?? '') === 'tool_use');
+        $toolUseBlocks = array_filter(
+            $content,
+            fn (array $block) => in_array($block['type'] ?? '', ['tool_use', 'server_tool_use'], true),
+        );
 
         return array_values(array_map(fn (array $block) => new ToolCall(
             $block['id'] ?? '',
             $block['name'] ?? '',
             $block['input'] ?? [],
             $block['id'] ?? null,
+            providerExecuted: ($block['type'] ?? '') === 'server_tool_use',
         ), $toolUseBlocks));
     }
 
@@ -430,27 +188,43 @@ trait ParsesTextResponses
     }
 
     /**
-     * Ensure tool_use and server_tool_use content blocks have their input cast to object for JSON serialization.
+     * Extract thinking blocks (text + signature) from Anthropic content.
+     *
+     * @return array{text: string, signature: string}|null
      */
-    protected function ensureToolInputIsObject(array $content): array
+    protected function extractThinking(array $content): ?array
     {
-        return array_map(function (array $block) {
-            if (in_array($block['type'] ?? '', ['tool_use', 'server_tool_use'], true)) {
-                $block['input'] = (object) ($block['input'] ?? []);
+        foreach ($content as $block) {
+            if (($block['type'] ?? '') === 'thinking' && isset($block['signature'])) {
+                return [
+                    'text' => $block['thinking'] ?? '',
+                    'signature' => $block['signature'],
+                ];
             }
+        }
 
-            return $block;
-        }, $content);
+        return null;
     }
 
     /**
-     * Combine usage across all steps.
+     * Attach thinking data (text + signature) to all tool calls for replay.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @return array<ToolCall>
      */
-    protected function combineUsage(Collection $steps): Usage
+    protected function attachThinkingToToolCalls(array $toolCalls, ?array $thinking): array
     {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
+        if ($thinking === null || empty($toolCalls)) {
+            return $toolCalls;
+        }
+
+        return array_map(fn (ToolCall $tc) => new ToolCall(
+            $tc->id,
+            $tc->name,
+            $tc->arguments,
+            $tc->resultId,
+            reasoningSummary: [$thinking['text']],
+            reasoningSignature: $thinking['signature'],
+        ), $toolCalls);
     }
 }

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
@@ -78,6 +79,45 @@ trait ParsesTextResponses
             structured: $structuredData,
             providerContentBlocks: $content,
         );
+    }
+
+    /**
+     * Continue the conversation after a pause_turn stop reason by replaying
+     * the assistant response as-is so the server can resume its turn.
+     */
+    protected function continueFromPauseTurn(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $requestBody,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+    ): SingleTurnResponse {
+        $maxResumes = $options?->maxSteps ?? 5;
+
+        for ($depth = 0; $depth < $maxResumes; $depth++) {
+            $requestBody['messages'][] = [
+                'role' => 'assistant',
+                'content' => $this->ensureToolInputIsObject($data['content'] ?? []),
+            ];
+
+            unset($requestBody['stream']);
+
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)->post('messages', $requestBody),
+            );
+
+            $data = $response->json();
+
+            $this->validateTextResponse($data);
+
+            if (($data['stop_reason'] ?? '') !== 'pause_turn') {
+                return $this->parseTextResponse($data, $provider, $structured);
+            }
+        }
+
+        return $this->parseTextResponse($data, $provider, $structured);
     }
 
     /**

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -15,7 +15,6 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\AzureOpenAi\Concerns\CreatesAzureOpenAiClient;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\OpenAi\Concerns\BuildsTextRequests;
 use Laravel\Ai\Gateway\OpenAi\Concerns\HandlesTextStreaming;
@@ -23,6 +22,8 @@ use Laravel\Ai\Gateway\OpenAi\Concerns\MapsAttachments;
 use Laravel\Ai\Gateway\OpenAi\Concerns\MapsMessages;
 use Laravel\Ai\Gateway\OpenAi\Concerns\MapsTools;
 use Laravel\Ai\Gateway\OpenAi\Concerns\ParsesTextResponses;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -30,7 +31,6 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Tools\ToolNameResolver;
 use LogicException;
 
@@ -40,17 +40,13 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
     use CreatesAzureOpenAiClient;
     use HandlesFailoverErrors;
     use HandlesTextStreaming;
-    use InvokesTools;
     use MapsAttachments;
     use MapsMessages;
     use MapsTools;
     use ParsesServerSentEvents;
     use ParsesTextResponses;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -64,16 +60,12 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
+        $body = $previousResponseId
+            ? $this->buildContinuationBody($previousResponseId, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -84,7 +76,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -100,16 +92,12 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        $body = $previousResponseId
+            ? $this->buildContinuationBody($previousResponseId, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $body['stream'] = true;
 
@@ -124,13 +112,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            0,
-            null,
-            $timeout,
         );
     }
 

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -15,7 +15,8 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Gateway\Bedrock\Concerns\CreatesBedrockClient;
 use Laravel\Ai\Gateway\Bedrock\Concerns\MapsAttachments;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
@@ -25,17 +26,12 @@ use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 use Laravel\Ai\Tools\ToolNameResolver;
 use stdClass;
 use Throwable;
@@ -44,15 +40,9 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
 {
     use CreatesBedrockClient;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use MapsAttachments;
 
     protected const STRUCTURED_OUTPUT_TOOL = 'structured_output';
-
-    public function __construct()
-    {
-        $this->initializeToolCallbacks();
-    }
 
     /**
      * {@inheritdoc}
@@ -66,129 +56,80 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $client = $this->createBedrockClient($provider, $timeout);
-        $conversationMessages = $this->formatMessages($messages);
-        $maxSteps = $this->resolveMaxSteps($tools, $options);
         $schemaTools = $schema ? $this->buildSchemaTools($schema, $tools) : null;
         $formattedTools = $schemaTools === null && ! empty($tools) ? $this->formatTools($tools) : null;
 
-        $allToolCalls = [];
-        $allToolResults = [];
-        $finalOutput = '';
-        $totalInputTokens = 0;
-        $totalOutputTokens = 0;
-        $step = 0;
-        $responseMessages = new Collection;
-        $steps = new Collection;
-        $meta = new Meta($provider->name(), $model);
+        $parameters = $this->buildConverseParameters(
+            $model,
+            $instructions,
+            $this->formatMessages($messages),
+            $schemaTools,
+            $formattedTools,
+            empty($tools),
+            $options,
+            isFinalStep: $context?->isFinalStep ?? false,
+        );
 
-        while ($step < $maxSteps) {
-            $parameters = $this->buildConverseParameters(
-                $model,
-                $instructions,
-                $conversationMessages,
-                $schemaTools,
-                $formattedTools,
-                empty($tools),
-                $options,
-                isFinalStep: ($step + 1) >= $maxSteps,
+        try {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $client->converse($parameters),
             );
 
-            try {
-                $response = $this->withErrorHandling(
-                    $provider->name(),
-                    fn () => $client->converse($parameters),
-                );
-
-                $result = $response->toArray();
-            } catch (Throwable $e) {
-                throw BedrockException::toAiException($e, $provider->name(), $model);
-            }
-
-            $stepInputTokens = $result['usage']['inputTokens'] ?? 0;
-            $stepOutputTokens = $result['usage']['outputTokens'] ?? 0;
-            $totalInputTokens += $stepInputTokens;
-            $totalOutputTokens += $stepOutputTokens;
-
-            $output = '';
-            $toolCalls = [];
-
-            foreach ($result['output']['message']['content'] ?? [] as $block) {
-                if (isset($block['text'])) {
-                    $output .= $block['text'];
-
-                    continue;
-                }
-
-                if (! isset($block['toolUse'])) {
-                    continue;
-                }
-
-                if ($schemaTools && $block['toolUse']['name'] === self::STRUCTURED_OUTPUT_TOOL) {
-                    $finalOutput = json_encode($block['toolUse']['input'] ?? []);
-
-                    continue;
-                }
-
-                $toolCalls[] = new ToolCall(
-                    $block['toolUse']['toolUseId'],
-                    $block['toolUse']['name'],
-                    $block['toolUse']['input'] ?? [],
-                );
-            }
-
-            if (! $schemaTools) {
-                $finalOutput = $output;
-            }
-
-            $step++;
-            $stepUsage = new Usage($stepInputTokens, $stepOutputTokens);
-            $finishReason = $this->extractFinishReason($result);
-
-            $responseMessages->push(new AssistantMessage($output, new Collection($toolCalls)));
-
-            if (empty($toolCalls)) {
-                if ($schemaTools && $finishReason === FinishReason::ToolCalls) {
-                    $finishReason = FinishReason::Stop;
-                }
-
-                $steps->push(new Step($output, $toolCalls, [], $finishReason, $stepUsage, $meta));
-
-                break;
-            }
-
-            $allToolCalls = array_merge($allToolCalls, $toolCalls);
-            $conversationMessages[] = $this->buildAssistantConversationMessage($output, $toolCalls);
-
-            $toolResults = $this->executeToolCalls($tools, $toolCalls);
-            $allToolResults = array_merge($allToolResults, $toolResults);
-
-            $steps->push(new Step($output, $toolCalls, $toolResults, $finishReason, $stepUsage, $meta));
-
-            if (! empty($toolResults)) {
-                $conversationMessages[] = $this->buildToolResultConversationMessage($toolResults);
-                $responseMessages->push(new ToolResultMessage(new Collection($toolResults)));
-            }
+            $result = $response->toArray();
+        } catch (Throwable $e) {
+            throw BedrockException::toAiException($e, $provider->name(), $model);
         }
 
-        $usage = new Usage($totalInputTokens, $totalOutputTokens);
+        $text = '';
+        $toolCalls = [];
+        $structured = null;
 
-        if ($schema) {
-            $structured = json_decode($finalOutput, true);
+        foreach ($result['output']['message']['content'] ?? [] as $block) {
+            if (isset($block['text'])) {
+                $text .= $block['text'];
 
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                $structured = [];
+                continue;
             }
 
-            return (new StructuredTextResponse($structured, $finalOutput, $usage, $meta))
-                ->withToolCallsAndResults(new Collection($allToolCalls), new Collection($allToolResults))
-                ->withSteps($steps);
+            if (! isset($block['toolUse'])) {
+                continue;
+            }
+
+            if ($schemaTools && $block['toolUse']['name'] === self::STRUCTURED_OUTPUT_TOOL) {
+                $structured = $block['toolUse']['input'] ?? [];
+
+                continue;
+            }
+
+            $toolCalls[] = new ToolCall(
+                $block['toolUse']['toolUseId'],
+                $block['toolUse']['name'],
+                $block['toolUse']['input'] ?? [],
+            );
         }
 
-        return (new TextResponse($finalOutput, $usage, $meta))
-            ->withMessages($responseMessages)
-            ->withSteps($steps);
+        $finishReason = $this->extractFinishReason($result);
+
+        if ($schemaTools && $finishReason === FinishReason::ToolCalls && empty($toolCalls)) {
+            $finishReason = FinishReason::Stop;
+        }
+
+        return new SingleTurnResponse(
+            text: $structured !== null ? json_encode($structured) : $text,
+            toolCalls: $toolCalls,
+            finishReason: $finishReason,
+            usage: new Usage(
+                $result['usage']['inputTokens'] ?? 0,
+                $result['usage']['outputTokens'] ?? 0,
+            ),
+            meta: new Meta($provider->name(), $model),
+            structured: $structured,
+        );
     }
 
     /**
@@ -204,160 +145,145 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $client = $this->createBedrockClient($provider, $timeout);
-        $conversationMessages = $this->formatMessages($messages);
-        $maxSteps = $this->resolveMaxSteps($tools, $options);
         $schemaTools = $schema ? $this->buildSchemaTools($schema, $tools) : null;
         $formattedTools = $schemaTools === null && ! empty($tools) ? $this->formatTools($tools) : null;
 
+        $parameters = $this->buildConverseParameters(
+            $model,
+            $instructions,
+            $this->formatMessages($messages),
+            $schemaTools,
+            $formattedTools,
+            empty($tools),
+            $options,
+            isFinalStep: $context?->isFinalStep ?? false,
+        );
+
+        try {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $client->converseStream($parameters),
+            );
+        } catch (Throwable $e) {
+            throw BedrockException::toAiException($e, $provider->name(), $model);
+        }
+
         $messageId = (string) Str::uuid();
         $timestamp = time();
+        $pendingToolCalls = [];
+        $currentBlockIndex = null;
+        $stopReason = 'end_turn';
         $totalInputTokens = 0;
         $totalOutputTokens = 0;
-        $step = 0;
 
-        while ($step < $maxSteps) {
-            $parameters = $this->buildConverseParameters(
-                $model,
-                $instructions,
-                $conversationMessages,
-                $schemaTools,
-                $formattedTools,
-                empty($tools),
-                $options,
-                isFinalStep: ($step + 1) >= $maxSteps,
-            );
+        foreach ($response['stream'] as $event) {
+            if (isset($event['contentBlockStart'])) {
+                $currentBlockIndex = $event['contentBlockStart']['contentBlockIndex'] ?? 0;
+                $start = $event['contentBlockStart']['start'] ?? [];
 
-            try {
-                $response = $this->withErrorHandling(
-                    $provider->name(),
-                    fn () => $client->converseStream($parameters),
-                );
-            } catch (Throwable $e) {
-                throw BedrockException::toAiException($e, $provider->name(), $model);
-            }
-
-            $assistantText = '';
-            $pendingToolCalls = [];
-            $currentBlockIndex = null;
-            $stopReason = 'stop';
-
-            foreach ($response['stream'] as $event) {
-                if (isset($event['contentBlockStart'])) {
-                    $currentBlockIndex = $event['contentBlockStart']['contentBlockIndex'] ?? 0;
-                    $start = $event['contentBlockStart']['start'] ?? [];
-
-                    if (isset($start['toolUse'])) {
-                        $pendingToolCalls[$currentBlockIndex] = [
-                            'id' => $start['toolUse']['toolUseId'] ?? '',
-                            'name' => $start['toolUse']['name'] ?? '',
-                            'input' => '',
-                        ];
-                    }
-
-                    continue;
+                if (isset($start['toolUse'])) {
+                    $pendingToolCalls[$currentBlockIndex] = [
+                        'id' => $start['toolUse']['toolUseId'] ?? '',
+                        'name' => $start['toolUse']['name'] ?? '',
+                        'input' => '',
+                    ];
                 }
 
-                if (isset($event['contentBlockDelta'])) {
-                    $index = $event['contentBlockDelta']['contentBlockIndex'] ?? $currentBlockIndex;
-                    $delta = $event['contentBlockDelta']['delta'] ?? [];
+                continue;
+            }
 
-                    if (isset($delta['text'])) {
-                        $assistantText .= $delta['text'];
+            if (isset($event['contentBlockDelta'])) {
+                $index = $event['contentBlockDelta']['contentBlockIndex'] ?? $currentBlockIndex;
+                $delta = $event['contentBlockDelta']['delta'] ?? [];
 
-                        yield (new TextDelta(
-                            (string) Str::uuid(),
-                            $messageId,
-                            $delta['text'],
-                            $timestamp,
-                        ))->withInvocationId($invocationId);
-                    } elseif (isset($delta['toolUse']['input'], $pendingToolCalls[$index])) {
-                        $pendingToolCalls[$index]['input'] .= $delta['toolUse']['input'];
-                    }
-
-                    continue;
+                if (isset($delta['text'])) {
+                    yield (new TextDelta(
+                        (string) Str::uuid(),
+                        $messageId,
+                        $delta['text'],
+                        $timestamp,
+                    ))->withInvocationId($invocationId);
+                } elseif (isset($delta['toolUse']['input'], $pendingToolCalls[$index])) {
+                    $pendingToolCalls[$index]['input'] .= $delta['toolUse']['input'];
                 }
 
-                if (isset($event['messageStop'])) {
-                    $stopReason = $event['messageStop']['stopReason'] ?? 'stop';
-
-                    continue;
-                }
-
-                if (isset($event['metadata']['usage'])) {
-                    $totalInputTokens += $event['metadata']['usage']['inputTokens'] ?? 0;
-                    $totalOutputTokens += $event['metadata']['usage']['outputTokens'] ?? 0;
-                }
+                continue;
             }
 
-            $toolCalls = [];
-            $structuredOutput = null;
+            if (isset($event['messageStop'])) {
+                $stopReason = $event['messageStop']['stopReason'] ?? 'end_turn';
 
-            foreach ($pendingToolCalls as $pending) {
-                $arguments = json_decode($pending['input'] !== '' ? $pending['input'] : '{}', true) ?? [];
-
-                if ($schemaTools && $pending['name'] === self::STRUCTURED_OUTPUT_TOOL) {
-                    $structuredOutput = json_encode($arguments);
-
-                    continue;
-                }
-
-                $toolCalls[] = new ToolCall($pending['id'], $pending['name'], $arguments);
+                continue;
             }
 
-            $step++;
+            if (isset($event['metadata']['usage'])) {
+                $totalInputTokens += $event['metadata']['usage']['inputTokens'] ?? 0;
+                $totalOutputTokens += $event['metadata']['usage']['outputTokens'] ?? 0;
+            }
+        }
 
-            if ($structuredOutput !== null) {
-                yield (new TextDelta(
-                    (string) Str::uuid(),
-                    $messageId,
-                    $structuredOutput,
-                    $timestamp,
-                ))->withInvocationId($invocationId);
+        $toolCalls = [];
+        $structuredOutput = null;
+
+        foreach ($pendingToolCalls as $pending) {
+            $arguments = json_decode($pending['input'] !== '' ? $pending['input'] : '{}', true) ?? [];
+
+            if ($schemaTools && $pending['name'] === self::STRUCTURED_OUTPUT_TOOL) {
+                $structuredOutput = json_encode($arguments);
+
+                continue;
             }
 
-            if (empty($toolCalls)) {
-                break;
-            }
+            $toolCalls[] = new ToolCall($pending['id'], $pending['name'], $arguments);
+        }
 
-            $conversationMessages[] = $this->buildAssistantConversationMessage($assistantText, $toolCalls);
+        if ($structuredOutput !== null) {
+            yield (new TextDelta(
+                (string) Str::uuid(),
+                $messageId,
+                $structuredOutput,
+                $timestamp,
+            ))->withInvocationId($invocationId);
+        }
 
-            foreach ($toolCalls as $toolCall) {
-                yield (new ToolCallEvent(
-                    (string) Str::uuid(),
-                    $toolCall,
-                    $timestamp,
-                ))->withInvocationId($invocationId);
-            }
+        foreach ($toolCalls as $toolCall) {
+            yield (new ToolCallEvent(
+                (string) Str::uuid(),
+                $toolCall,
+                $timestamp,
+            ))->withInvocationId($invocationId);
+        }
 
-            $toolResults = $this->executeToolCalls($tools, $toolCalls);
+        $finishReason = $this->extractFinishReason(['stopReason' => $stopReason]);
 
-            foreach ($toolResults as $toolResult) {
-                yield (new ToolResultEvent(
-                    (string) Str::uuid(),
-                    $toolResult,
-                    true,
-                    null,
-                    $timestamp,
-                ))->withInvocationId($invocationId);
-            }
-
-            if (! empty($toolResults)) {
-                $conversationMessages[] = $this->buildToolResultConversationMessage($toolResults);
-            }
-
-            if ($stopReason !== 'tool_use') {
-                break;
-            }
+        if ($schemaTools && $finishReason === FinishReason::ToolCalls && empty($toolCalls)) {
+            $finishReason = FinishReason::Stop;
         }
 
         yield (new StreamEnd(
             $messageId,
-            'stop',
+            $finishReason->value,
             new Usage($totalInputTokens, $totalOutputTokens),
             $timestamp,
         ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Extract and map the finish reason from the Bedrock Converse response.
+     */
+    protected function extractFinishReason(array $data): FinishReason
+    {
+        return match ($data['stopReason'] ?? '') {
+            'end_turn', 'stop_sequence' => FinishReason::Stop,
+            'tool_use' => FinishReason::ToolCalls,
+            'max_tokens' => FinishReason::Length,
+            'content_filtered', 'guardrail_intervened' => FinishReason::ContentFilter,
+            default => FinishReason::Unknown,
+        };
     }
 
     /**
@@ -459,34 +385,6 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
     }
 
     /**
-     * Resolve the maximum number of steps for the given tools and options.
-     *
-     * @param  array<Tool>  $tools
-     */
-    protected function resolveMaxSteps(array $tools, ?TextGenerationOptions $options): int
-    {
-        if (empty($tools)) {
-            return 1;
-        }
-
-        return (int) ($options?->maxSteps ?? round(count($tools) * 1.5));
-    }
-
-    /**
-     * Extract and map the finish reason from the Bedrock Converse response.
-     */
-    protected function extractFinishReason(array $data): FinishReason
-    {
-        return match ($data['stopReason'] ?? '') {
-            'end_turn', 'stop_sequence' => FinishReason::Stop,
-            'tool_use' => FinishReason::ToolCalls,
-            'max_tokens' => FinishReason::Length,
-            'content_filtered', 'guardrail_intervened' => FinishReason::ContentFilter,
-            default => FinishReason::Unknown,
-        };
-    }
-
-    /**
      * Build the request parameters for the Bedrock Converse API.
      *
      * @param  array<string, mixed>|null  $schemaTools
@@ -541,48 +439,6 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             'temperature' => $options->temperature,
             'topP' => $options->topP,
         ]);
-    }
-
-    /**
-     * Build the assistant conversation message block combining text and tool calls.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     */
-    protected function buildAssistantConversationMessage(string $text, array $toolCalls): array
-    {
-        return [
-            'role' => 'assistant',
-            'content' => array_merge(
-                $text !== '' ? [['text' => $text]] : [],
-                array_map(fn (ToolCall $toolCall) => [
-                    'toolUse' => [
-                        'toolUseId' => $toolCall->id,
-                        'name' => $toolCall->name,
-                        'input' => $toolCall->arguments ?: new stdClass,
-                    ],
-                ], $toolCalls),
-            ),
-        ];
-    }
-
-    /**
-     * Build the user conversation message block carrying tool results.
-     *
-     * @param  array<ToolResult>  $toolResults
-     */
-    protected function buildToolResultConversationMessage(array $toolResults): array
-    {
-        return [
-            'role' => 'user',
-            'content' => array_map(fn (ToolResult $toolResult) => [
-                'toolResult' => [
-                    'toolUseId' => $toolResult->id,
-                    'content' => [
-                        ['text' => is_string($toolResult->result) ? $toolResult->result : json_encode($toolResult->result)],
-                    ],
-                ],
-            ], $toolResults),
-        ];
     }
 
     /**
@@ -746,43 +602,5 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             ])
             ->values()
             ->all();
-    }
-
-    /**
-     * Execute the tool calls against the provided tools and collect results.
-     *
-     * @param  array<Tool>  $tools
-     * @param  array<ToolCall>  $toolCalls
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $tools, array $toolCalls): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                $results[] = new ToolResult(
-                    $toolCall->id,
-                    $toolCall->name,
-                    $toolCall->arguments,
-                    'Error: Tool "'.$toolCall->name.'" not found.',
-                );
-
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-            );
-        }
-
-        return $results;
     }
 }

--- a/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
@@ -3,12 +3,9 @@
 namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -20,37 +17,24 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process a Chat Completions streaming response and yield Laravel stream events.
+     * Process a DeepSeek streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $reasoningId = '';
         $inReasoning = false;
         $currentReasoning = '';
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $usage = null;
         $finishReason = null;
@@ -136,8 +120,6 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
                 }
 
-                $currentText .= $delta['content'];
-
                 yield (new TextDelta(
                     $this->generateEventId(),
                     $messageId,
@@ -199,26 +181,6 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-                $currentReasoning,
-            );
-
-            return;
         }
 
         yield (new StreamEnd(
@@ -227,158 +189,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-        string $currentReasoning = '',
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = ['role' => 'assistant'];
-
-            if (filled($currentText)) {
-                $assistantMsg['content'] = $currentText;
-            }
-
-            if (filled($currentReasoning)) {
-                $assistantMsg['reasoning_content'] = $currentReasoning;
-            }
-
-            $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-            );
-
-            $toolResultMessages = [];
-
-            foreach ($toolResults as $toolResult) {
-                $toolResultMessages[] = [
-                    'role' => 'tool',
-                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                    'content' => $this->serializeToolResultOutput($toolResult->result),
-                ];
-            }
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat(
-                    $originalMessages,
-                    $this->composeInstructions($instructions, $schema),
-                ),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = [
-                'model' => $model,
-                'messages' => $chatMessages,
-                'stream' => true,
-                'stream_options' => ['include_usage' => true],
-            ];
-
-            if (filled($tools)) {
-                $mappedTools = $this->mapTools($tools);
-
-                if (filled($mappedTools)) {
-                    $body['tool_choice'] = 'auto';
-                    $body['tools'] = $mappedTools;
-                }
-            }
-
-            if (filled($schema)) {
-                $body['response_format'] = $this->buildResponseFormat();
-            }
-
-            if (! is_null($options?->maxTokens)) {
-                $body['max_completion_tokens'] = $options->maxTokens;
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('chat/completions', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
     }
 
     /**

--- a/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
@@ -183,11 +183,19 @@ trait HandlesTextStreaming
             }
         }
 
+        $streamProviderContentBlocks = [];
+
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls' && filled($currentReasoning)) {
+            $streamProviderContentBlocks['reasoning_content'] = $currentReasoning;
+        }
+
         yield (new StreamEnd(
             $this->generateEventId(),
             $this->extractFinishReason(['finish_reason' => $finishReason ?? ''])->value,
             $usage ?? new Usage(0, 0),
             time(),
+            null,
+            $streamProviderContentBlocks,
         ))->withInvocationId($invocationId);
     }
 

--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -2,22 +2,13 @@
 
 namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -38,57 +29,17 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the DeepSeek response data into a TextResponse.
-     */
-    protected function parseTextResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
+     * Parse a single DeepSeek response into a SingleTurnResponse.
      *
      * DeepSeek thinking-mode responses can include `reasoning_content` on each
      * choice's message. We capture it into `providerContentBlocks`; the message
      * mapper only replays it for assistant messages that include tool calls.
      */
-    protected function processResponse(
+    protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
@@ -105,206 +56,21 @@ trait ParsesTextResponses
             $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
-        );
-
-        $steps->push($step);
-
         $providerContentBlocks = [];
+
         if (filled($message['reasoning_content'] ?? null)) {
             $providerContentBlocks['reasoning_content'] = $message['reasoning_content'];
         }
 
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls), $providerContentBlocks);
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat(
-            $originalMessages,
-            $this->composeInstructions($instructions, $schema),
-        );
-
-        foreach ($messages as $msg) {
-            match (true) {
-                $msg instanceof AssistantMessage => $this->mapAssistantMessage($msg, $chatMessages),
-                $msg instanceof ToolResultMessage => $this->mapToolResultMessage($msg, $chatMessages),
-                default => null,
-            };
-        }
-
-        $body = [
-            'model' => $model,
-            'messages' => $chatMessages,
-        ];
-
-        if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
-
-            if (filled($mappedTools)) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
-        }
-
-        if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat();
-        }
-
-        if (! is_null($options?->maxTokens)) {
-            $body['max_completion_tokens'] = $options->maxTokens;
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            responseId: null,
+            providerContentBlocks: $providerContentBlocks,
         );
     }
 
@@ -336,16 +102,5 @@ trait ParsesTextResponses
             'content_filter' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/DeepSeek/DeepSeekGateway.php
+++ b/src/Gateway/DeepSeek/DeepSeekGateway.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Responses\TextResponse;
 
 class DeepSeekGateway implements TextGateway
 {
@@ -22,13 +22,9 @@ class DeepSeekGateway implements TextGateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -42,7 +38,9 @@ class DeepSeekGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $body = $this->buildTextRequestBody(
             $provider,
             $model,
@@ -62,17 +60,7 @@ class DeepSeekGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -88,6 +76,8 @@ class DeepSeekGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
             $provider,
@@ -113,16 +103,7 @@ class DeepSeekGateway implements TextGateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
         );
     }
 }

--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -10,13 +10,10 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -32,8 +29,6 @@ use function Laravel\Ai\ulid;
 
 class FakeTextGateway implements TextGateway
 {
-    use InvokesTools;
-
     protected int $currentResponseIndex = 0;
 
     protected bool $preventStrayPrompts = false;
@@ -56,7 +51,9 @@ class FakeTextGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $message = (new Collection($messages))->last(function ($message) {
             return $message instanceof UserMessage;
         });
@@ -66,51 +63,43 @@ class FakeTextGateway implements TextGateway
         );
 
         if ($response instanceof ToolCall) {
-            return $this->handleFakeToolCalls(
-                $response,
-                $provider,
-                $model,
-                $message->content,
-                $message->attachments,
-                $schema,
-                $tools,
+            return new SingleTurnResponse(
+                '',
+                [$response],
+                FinishReason::ToolCalls,
+                new Usage,
+                new Meta($provider->name(), $model),
             );
         }
 
-        return $response;
-    }
-
-    /**
-     * Execute a faked tool call and return the next fake response.
-     */
-    protected function handleFakeToolCalls(
-        ToolCall $toolCall,
-        TextProvider $provider,
-        string $model,
-        string $prompt,
-        Collection $attachments,
-        ?array $schema,
-        array $tools,
-    ): TextResponse {
-        $this->initializeToolCallbacks();
-
-        $toolResults = new Collection;
-
-        if ($tool = $this->findTool($toolCall->name, $tools)) {
-            $toolResults->push(new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $this->executeTool($tool, $toolCall->arguments),
-                $toolCall->resultId,
-            ));
+        if ($response instanceof StructuredTextResponse) {
+            return new SingleTurnResponse(
+                $response->text,
+                [],
+                FinishReason::Stop,
+                $response->usage,
+                $response->meta,
+                structured: $response->structured,
+            );
         }
 
-        return $this->nextResponse($provider, $model, $prompt, $attachments, $schema)
-            ->withMessages(new Collection([
-                new AssistantMessage('', new Collection([$toolCall])),
-                new ToolResultMessage($toolResults),
-            ]));
+        if ($response instanceof TextResponse) {
+            return new SingleTurnResponse(
+                $response->text,
+                [],
+                FinishReason::Stop,
+                $response->usage,
+                $response->meta,
+            );
+        }
+
+        return new SingleTurnResponse(
+            (string) $response,
+            [],
+            FinishReason::Stop,
+            new Usage,
+            new Meta($provider->name(), $model),
+        );
     }
 
     /**
@@ -128,6 +117,8 @@ class FakeTextGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $messageId = ulid();
 
@@ -143,7 +134,9 @@ class FakeTextGateway implements TextGateway
             $provider, $model, $message->content, $message->attachments, $schema
         );
 
-        $events = Str::of($fakeResponse->text)
+        $text = $fakeResponse instanceof TextResponse ? $fakeResponse->text : (string) $fakeResponse;
+
+        $events = Str::of($text)
             ->explode(' ')
             ->map(fn ($word, $index) => new TextDelta(
                 ulid(),
@@ -214,17 +207,6 @@ class FakeTextGateway implements TextGateway
             ),
             default => $response,
         };
-    }
-
-    /**
-     * Specify callbacks that should be invoked when tools are invoking / invoked.
-     */
-    public function onToolInvocation(Closure $invoking, Closure $invoked): self
-    {
-        $this->invokingToolCallback = $invoking;
-        $this->toolInvokedCallback = $invoked;
-
-        return $this;
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -4,9 +4,7 @@ namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -18,37 +16,24 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process a Gemini streaming response and yield Laravel stream events.
+     * Process a Gemini streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        array $contents = [],
-        ?string $instructions = null,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $reasoningId = '';
         $streamStartEmitted = false;
         $textStartEmitted = false;
         $inReasoning = false;
-        $currentText = '';
         $pendingToolCalls = [];
-        $modelParts = [];
         $usage = null;
         $data = [];
 
@@ -81,7 +66,6 @@ trait HandlesTextStreaming
 
             foreach ($parts as $part) {
                 if (isset($part['text']) && $this->isThinkingPart($part)) {
-                    $modelParts[] = $part;
                     $delta = $part['text'];
 
                     if ($delta !== '') {
@@ -108,8 +92,6 @@ trait HandlesTextStreaming
                 }
 
                 if (isset($part['text'])) {
-                    $modelParts[] = $part;
-
                     if ($inReasoning) {
                         $inReasoning = false;
 
@@ -135,8 +117,6 @@ trait HandlesTextStreaming
                             ))->withInvocationId($invocationId);
                         }
 
-                        $currentText .= $textDelta;
-
                         yield (new TextDelta(
                             $this->generateEventId(),
                             $messageId,
@@ -150,7 +130,6 @@ trait HandlesTextStreaming
 
                 if (isset($part['functionCall'])) {
                     $pendingToolCalls[] = $part['functionCall'];
-                    $modelParts[] = $part;
 
                     continue;
                 }
@@ -181,21 +160,22 @@ trait HandlesTextStreaming
 
         // Handle pending tool calls...
         if (filled($pendingToolCalls)) {
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $pendingToolCalls,
-                $contents,
-                $instructions,
-                $modelParts,
-                $depth,
-                $maxSteps,
-                $timeout,
-            );
+            $mappedToolCalls = $this->mapToolCalls($pendingToolCalls);
+
+            foreach ($mappedToolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'tool_calls',
+                $usage ?? new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
 
             return;
         }
@@ -206,102 +186,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $pendingToolCalls,
-        array $contents,
-        ?string $instructions,
-        array $modelParts,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $mappedToolCalls = $this->mapToolCalls($pendingToolCalls);
-
-        // Emit tool call events...
-        foreach ($mappedToolCalls as $toolCall) {
-            yield (new ToolCallEvent(
-                $this->generateEventId(),
-                $toolCall,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $contents[] = ['role' => 'model', 'parts' => $this->sanitizeRequestParts($this->excludeThinkingParts($modelParts))];
-            $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
-
-            $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post("models/{$model}:streamGenerateContent?alt=sse", $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $contents,
-                $instructions,
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -4,21 +4,14 @@ namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -39,56 +32,14 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Gemini response data into a TextResponse.
+     * Parse a single Gemini response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         string $model,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        array $contents = [],
-        ?string $instructions = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $model,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            $contents,
-            $instructions,
-            $options,
-            maxSteps: $options?->maxSteps,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        string $model,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $contents,
-        ?string $instructions,
-        ?TextGenerationOptions $options,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $candidate = $data['candidates'][0] ?? [];
         $parts = $candidate['content']['parts'] ?? [];
 
@@ -97,143 +48,16 @@ trait ParsesTextResponses
         $citations = $this->extractCitations($data);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data, $rawToolCalls);
-
         $mappedToolCalls = $this->mapToolCalls($rawToolCalls);
-        $meta = new Meta($provider->name(), $model, $citations);
-        $toolResults = [];
 
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-        }
-
-        $steps->push(new Step($text, $mappedToolCalls, $toolResults, $finishReason, $usage, $meta));
-
-        if (filled($toolResults)) {
-            $messages->push(new ToolResultMessage(collect($toolResults)));
-
-            $contents[] = ['role' => 'model', 'parts' => $this->sanitizeRequestParts($this->excludeThinkingParts($parts))];
-            $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $contents,
-                $instructions,
-                $options,
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            return (new StructuredTextResponse(
-                json_decode($text, true) ?? [],
-                $text,
-                $this->combineUsage($steps),
-                $meta,
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            $meta,
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by resending the full history.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $contents,
-        ?string $instructions,
-        ?TextGenerationOptions $options,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $model,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $contents,
-            $instructions,
-            $options,
-            $depth,
-            $maxSteps,
-            $timeout,
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model, $citations),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            responseId: null,
         );
     }
 
@@ -243,41 +67,6 @@ trait ParsesTextResponses
     protected function isThinkingPart(array $part): bool
     {
         return $part['thought'] ?? false;
-    }
-
-    /**
-     * Sanitize functionCall parts so they can be sent back to Gemini as conversation history.
-     */
-    protected function sanitizeRequestParts(array $parts): array
-    {
-        return array_map(function (array $part) {
-            if (! isset($part['functionCall'])) {
-                return $part;
-            }
-
-            $functionCall = ['name' => $part['functionCall']['name'] ?? ''];
-
-            $args = $part['functionCall']['args'] ?? null;
-
-            if (filled($args)) {
-                $functionCall['args'] = $args;
-            }
-
-            $part['functionCall'] = $functionCall;
-
-            return $part;
-        }, $parts);
-    }
-
-    /**
-     * Filter out thinking parts from the response, keeping only text and functionCall parts.
-     */
-    protected function excludeThinkingParts(array $parts): array
-    {
-        return array_values(array_filter(
-            $parts,
-            fn (array $part) => ! $this->isThinkingPart($part),
-        ));
     }
 
     /**
@@ -412,16 +201,5 @@ trait ParsesTextResponses
             'SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'MALFORMED_FUNCTION_CALL' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -14,9 +14,10 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -25,7 +26,6 @@ use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use RuntimeException;
 
@@ -39,14 +39,10 @@ class GeminiGateway implements Gateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
     use WrapsPcmAudio;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -60,8 +56,10 @@ class GeminiGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
-        [$body, $contents] = $this->buildTextRequestBody(
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
+        [$body] = $this->buildTextRequestBody(
             $provider, $instructions, $messages, $tools, $schema, $options,
         );
 
@@ -79,12 +77,6 @@ class GeminiGateway implements Gateway
             $provider,
             $model,
             filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $contents,
-            $instructions,
-            $timeout,
         );
     }
 
@@ -101,8 +93,10 @@ class GeminiGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
-        [$body, $contents] = $this->buildTextRequestBody(
+        [$body] = $this->buildTextRequestBody(
             $provider, $instructions, $messages, $tools, $schema, $options,
         );
 
@@ -117,15 +111,7 @@ class GeminiGateway implements Gateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            $contents,
-            $instructions,
-            0,
-            null,
-            $timeout,
         );
     }
 

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -3,12 +3,9 @@
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -17,34 +14,21 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process a Chat Completions streaming response and yield Laravel stream events.
+     * Process a Chat Completions streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $usage = null;
         $finishReason = null;
@@ -98,8 +82,6 @@ trait HandlesTextStreaming
                         time(),
                     ))->withInvocationId($invocationId);
                 }
-
-                $currentText .= $delta['content'];
 
                 yield (new TextDelta(
                     $this->generateEventId(),
@@ -157,25 +139,6 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-            );
-
-            return;
         }
 
         yield (new StreamEnd(
@@ -184,153 +147,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = ['role' => 'assistant'];
-
-            if (filled($currentText)) {
-                $assistantMsg['content'] = $currentText;
-            }
-
-            $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-            );
-
-            $toolResultMessages = [];
-
-            foreach ($toolResults as $toolResult) {
-                $toolResultMessages[] = [
-                    'role' => 'tool',
-                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                    'content' => $this->serializeToolResultOutput($toolResult->result),
-                ];
-            }
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
-            $hasTools = filled($mappedTools);
-            $inlineSchema = $hasTools && filled($schema);
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat(
-                    $originalMessages,
-                    $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
-                ),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = [
-                'model' => $model,
-                'messages' => $chatMessages,
-                'stream' => true,
-                'stream_options' => ['include_usage' => true],
-            ];
-
-            if ($hasTools) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
-
-            if (filled($schema) && ! $inlineSchema) {
-                $body['response_format'] = $this->buildResponseFormat($schema);
-            }
-
-            if (! is_null($options?->maxTokens)) {
-                $body['max_completion_tokens'] = $options->maxTokens;
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('chat/completions', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
     }
 
     /**

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -2,22 +2,13 @@
 
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -38,53 +29,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Groq response data into a TextResponse.
+     * Parse a single Groq response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
@@ -101,219 +52,13 @@ trait ParsesTextResponses
             $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
-        );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
-        $hasTools = filled($mappedTools);
-        $inlineSchema = $hasTools && filled($schema);
-
-        $chatMessages = $this->mapMessagesToChat(
-            $originalMessages,
-            $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
-        );
-
-        foreach ($messages as $msg) {
-            if ($msg instanceof AssistantMessage) {
-                $mapped = ['role' => 'assistant'];
-
-                if (filled($msg->content)) {
-                    $mapped['content'] = $msg->content;
-                }
-
-                if ($msg->toolCalls->isNotEmpty()) {
-                    $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
-                    )->all();
-                }
-
-                $chatMessages[] = $mapped;
-            } elseif ($msg instanceof ToolResultMessage) {
-                foreach ($msg->toolResults as $toolResult) {
-                    $chatMessages[] = [
-                        'role' => 'tool',
-                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                        'content' => $this->serializeToolResultOutput($toolResult->result),
-                    ];
-                }
-            }
-        }
-
-        $body = [
-            'model' => $model,
-            'messages' => $chatMessages,
-        ];
-
-        if ($hasTools) {
-            $body['tool_choice'] = 'auto';
-            $body['tools'] = $mappedTools;
-        }
-
-        if (filled($schema) && ! $inlineSchema) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
-        }
-
-        if (! is_null($options?->maxTokens)) {
-            $body['max_completion_tokens'] = $options->maxTokens;
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
         );
     }
 
@@ -342,16 +87,5 @@ trait ParsesTextResponses
             'content_filter' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Responses\TextResponse;
 
 class GroqGateway implements TextGateway
 {
@@ -22,13 +22,9 @@ class GroqGateway implements TextGateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -42,7 +38,9 @@ class GroqGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $body = $this->buildTextRequestBody(
             $provider,
             $model,
@@ -62,17 +60,7 @@ class GroqGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -88,6 +76,8 @@ class GroqGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
             $provider,
@@ -113,16 +103,7 @@ class GroqGateway implements TextGateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
         );
     }
 }

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -4,10 +4,8 @@ namespace Laravel\Ai\Gateway\Mistral\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -16,34 +14,21 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process a Chat Completions streaming response and yield Laravel stream events.
+     * Process a Chat Completions streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $usage = null;
         $finishReason = null;
@@ -97,8 +82,6 @@ trait HandlesTextStreaming
                         time(),
                     ))->withInvocationId($invocationId);
                 }
-
-                $currentText .= $delta['content'];
 
                 yield (new TextDelta(
                     $this->generateEventId(),
@@ -156,25 +139,6 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-            );
-
-            return;
         }
 
         yield (new StreamEnd(
@@ -183,122 +147,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = ['role' => 'assistant'];
-
-            if (filled($currentText)) {
-                $assistantMsg['content'] = $currentText;
-            }
-
-            $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-            );
-
-            $toolResultMessages = [];
-
-            foreach ($toolResults as $toolResult) {
-                $toolResultMessages[] = [
-                    'role' => 'tool',
-                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                    'content' => $this->serializeToolResultOutput($toolResult->result),
-                ];
-            }
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat($originalMessages, $instructions),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = $this->applyTextOptions([
-                'model' => $model,
-                'messages' => $chatMessages,
-                'stream' => true,
-                'stream_options' => ['include_usage' => true],
-            ], $provider, $tools, $schema, $options);
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('chat/completions', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
     }
 
     /**

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -2,21 +2,13 @@
 
 namespace Laravel\Ai\Gateway\Mistral\Concerns;
 
-use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -37,53 +29,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Mistral response data into a TextResponse.
+     * Parse a single Mistral response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
@@ -100,188 +52,13 @@ trait ParsesTextResponses
             $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
-        );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
-
-        foreach ($messages as $msg) {
-            if ($msg instanceof AssistantMessage) {
-                $mapped = ['role' => 'assistant'];
-
-                if (filled($msg->content)) {
-                    $mapped['content'] = $msg->content;
-                }
-
-                if ($msg->toolCalls->isNotEmpty()) {
-                    $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
-                    )->all();
-                }
-
-                $chatMessages[] = $mapped;
-            } elseif ($msg instanceof ToolResultMessage) {
-                foreach ($msg->toolResults as $toolResult) {
-                    $chatMessages[] = [
-                        'role' => 'tool',
-                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                        'content' => $this->serializeToolResultOutput($toolResult->result),
-                    ];
-                }
-            }
-        }
-
-        $body = $this->applyTextOptions([
-            'model' => $model,
-            'messages' => $chatMessages,
-        ], $provider, $tools, $schema, $options);
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
         );
     }
 
@@ -310,16 +87,5 @@ trait ParsesTextResponses
             'content_filter' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -13,14 +13,14 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
 
 class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGateway
@@ -33,13 +33,9 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -53,7 +49,9 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $body = $this->buildTextRequestBody(
             $provider,
             $model,
@@ -73,17 +71,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -99,6 +87,8 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
             $provider,
@@ -124,13 +114,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            $instructions,
-            $messages,
-            timeout: $timeout,
         );
     }
 

--- a/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
@@ -4,10 +4,8 @@ namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -16,34 +14,21 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process an Ollama NDJSON streaming response and yield Laravel stream events.
+     * Process an Ollama NDJSON streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $usage = null;
         $lastData = [];
@@ -87,8 +72,6 @@ trait HandlesTextStreaming
                         time(),
                     ))->withInvocationId($invocationId);
                 }
-
-                $currentText .= $content;
 
                 yield (new TextDelta(
                     $this->generateEventId(),
@@ -183,25 +166,6 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-            );
-
-            return;
         }
 
         yield (new StreamEnd(
@@ -210,119 +174,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = [
-                'role' => 'assistant',
-                'content' => $currentText,
-                'tool_calls' => array_map(
-                    fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-                ),
-            ];
-
-            $toolResultMessages = array_map(fn (ToolResult $toolResult) => [
-                'role' => 'tool',
-                'tool_name' => $toolResult->name,
-                'content' => $this->serializeToolResultOutput($toolResult->result),
-            ], $toolResults);
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat($originalMessages, $instructions),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = $this->buildChatRequestBody(
-                $provider,
-                $model,
-                $chatMessages,
-                $tools,
-                $schema,
-                $options,
-                stream: true,
-            );
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('api/chat', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
     }
 
     /**

--- a/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
@@ -2,22 +2,14 @@
 
 namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -37,53 +29,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Ollama response data into a TextResponse.
+     * Parse a single Ollama response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $message = $data['message'] ?? [];
         $model = $data['model'] ?? '';
 
@@ -103,79 +55,20 @@ trait ParsesTextResponses
             );
         }, $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
+        // Ollama sometimes reports done_reason "stop" even when tool_calls are populated;
+        // force ToolCalls so the step loop continues and executes them.
+        if (filled($mappedToolCalls)) {
+            $finishReason = FinishReason::ToolCalls;
+        }
+
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
         );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if (filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
     }
 
     /**
@@ -188,118 +81,6 @@ trait ParsesTextResponses
         }
 
         return json_decode($arguments ?? '{}', true) ?? [];
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
-
-        foreach ($messages as $msg) {
-            if ($msg instanceof AssistantMessage) {
-                $mapped = [
-                    'role' => 'assistant',
-                    'content' => $msg->content ?? '',
-                ];
-
-                if ($msg->toolCalls->isNotEmpty()) {
-                    $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
-                    )->all();
-                }
-
-                $chatMessages[] = $mapped;
-            } elseif ($msg instanceof ToolResultMessage) {
-                foreach ($msg->toolResults as $toolResult) {
-                    $chatMessages[] = [
-                        'role' => 'tool',
-                        'tool_name' => $toolResult->name,
-                        'content' => $this->serializeToolResultOutput($toolResult->result),
-                    ];
-                }
-            }
-        }
-
-        $body = $this->buildChatRequestBody(
-            $provider,
-            $model,
-            $chatMessages,
-            $tools,
-            $schema,
-            $options,
-        );
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('api/chat', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
-        );
     }
 
     /**
@@ -324,16 +105,5 @@ trait ParsesTextResponses
             'length' => FinishReason::Length,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -10,11 +10,11 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 class OllamaGateway implements EmbeddingGateway, TextGateway
 {
@@ -26,12 +26,8 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -45,7 +41,9 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $body = $this->buildTextRequestBody(
             $provider,
             $model,
@@ -65,17 +63,7 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -91,6 +79,8 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
             $provider,
@@ -115,16 +105,7 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
         );
     }
 

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 
@@ -27,6 +28,45 @@ trait BuildsTextRequests
 
         $body = ['model' => $model, 'input' => $input];
 
+        return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Build a lightweight continuation body using previous_response_id.
+     *
+     * Only sends tool results as input instead of replaying the full conversation.
+     */
+    protected function buildContinuationBody(
+        string $previousResponseId,
+        string $model,
+        array $messages,
+        array $tools,
+        Provider $provider,
+        ?array $schema,
+        ?TextGenerationOptions $options = null,
+    ): array {
+        $body = [
+            'model' => $model,
+            'previous_response_id' => $previousResponseId,
+            'input' => $this->extractToolResultsInput($messages),
+        ];
+
+        return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Apply options shared by full requests and previous_response_id continuations.
+     *
+     * Keeps tool_choice, tools, structured output, sampling, and provider extras in one place
+     * so continuation requests cannot drift from the initial request shape.
+     */
+    protected function mergeSharedResponsesRequestOptions(
+        array $body,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        Provider $provider,
+    ): array {
         if (filled($tools)) {
             $body['tool_choice'] = 'auto';
             $body['tools'] = $this->mapTools($tools, $provider);
@@ -54,6 +94,32 @@ trait BuildsTextRequests
         }
 
         return $body;
+    }
+
+    /**
+     * Extract tool result items from the trailing messages for a continuation request.
+     *
+     * The orchestrator appends AssistantMessage + ToolResultMessage at the end of
+     * the messages array after each tool-call turn. For continuation, we only need
+     * the function_call_output items from the last ToolResultMessage.
+     */
+    protected function extractToolResultsInput(array $messages): array
+    {
+        $input = [];
+
+        $lastMessage = end($messages);
+
+        if ($lastMessage instanceof ToolResultMessage) {
+            foreach ($lastMessage->toolResults as $toolResult) {
+                $input[] = [
+                    'type' => 'function_call_output',
+                    'call_id' => $toolResult->resultId,
+                    'output' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -3,14 +3,9 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Attributes\Strict;
-use Laravel\Ai\Enums\Lab;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
@@ -23,33 +18,23 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process an OpenAI streaming response and yield Laravel stream events.
+     * Process an OpenAI streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
-        $responseId = '';
         $reasoningId = '';
+        $responseId = null;
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $reasoningItems = [];
         $usage = null;
@@ -72,7 +57,7 @@ trait HandlesTextStreaming
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
                 $streamStartEmitted = true;
-                $responseId = $data['response']['id'] ?? '';
+                $responseId = $data['response']['id'] ?? null;
 
                 yield (new StreamStart(
                     $this->generateEventId(),
@@ -97,8 +82,6 @@ trait HandlesTextStreaming
                             time(),
                         ))->withInvocationId($invocationId);
                     }
-
-                    $currentText .= $textDelta;
 
                     yield (new TextDelta(
                         $this->generateEventId(),
@@ -283,158 +266,13 @@ trait HandlesTextStreaming
             }
         }
 
-        if (filled($pendingToolCalls)) {
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $responseId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $pendingToolCalls,
-                $currentText,
-                $reasoningItems,
-                $depth,
-                $maxSteps,
-                $timeout,
-            );
-
-            return;
-        }
-
         yield (new StreamEnd(
             $this->generateEventId(),
             $this->extractFinishReason($responseData)->value,
             $usage ?? new Usage(0, 0),
             time(),
+            $responseId,
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        string $responseId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $pendingToolCalls,
-        string $currentText,
-        array $reasoningItems,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
-
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-                'stream' => true,
-            ];
-
-            if (filled($tools)) {
-                $body['tools'] = $this->mapTools($tools, $provider);
-            }
-
-            if (filled($schema)) {
-                $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-                'max_output_tokens' => $options?->maxTokens,
-            ]));
-
-            $providerOptions = $options?->providerOptions(
-                Lab::tryFrom($provider->driver()) ?? $provider->driver()
-            );
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('responses', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-    }
-
-    /**
-     * Map raw streaming tool call data to ToolCall DTOs.
-     *
-     * @return array<ToolCall>
-     */
-    protected function mapStreamToolCalls(array $toolCalls): array
-    {
-        return array_map(fn (array $tc) => new ToolCall(
-            $tc['id'] ?? '',
-            $tc['name'] ?? '',
-            json_decode($tc['arguments'] ?? '{}', true) ?? [],
-            $tc['call_id'] ?? null,
-            $tc['reasoning_id'] ?? null,
-            $tc['reasoning_summary'] ?? null,
-        ), array_values($toolCalls));
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -128,4 +128,16 @@ trait MapsMessages
             ];
         }
     }
+
+    /**
+     * Serialize a tool result output value to a string suitable for the API.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
 }

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -2,25 +2,15 @@
 
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Laravel\Ai\Attributes\Strict;
-use Laravel\Ai\Contracts\Tool;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -51,48 +41,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the OpenAI response data into a TextResponse.
+     * Parse a single OpenAI response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $responseId = $data['id'] ?? '';
+    ): SingleTurnResponse {
         $output = $data['output'] ?? [];
         $model = $data['model'] ?? '';
 
@@ -104,205 +59,15 @@ trait ParsesTextResponses
         // Associate reasoning with tool calls...
         $mappedToolCalls = $this->mapToolCallsWithReasoning($output);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model, $citations),
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model, $citations),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            responseId: $data['id'] ?? null,
         );
-
-        $steps->push($step);
-
-        // Build assistant message for conversation context...
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        // Execute tool calls...
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            // Update step with tool results...
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model, $citations),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $responseId,
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $toolResults,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $responseId,
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $toolResults,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = [
-            'model' => $model,
-            'previous_response_id' => $responseId,
-            'input' => $this->buildToolResultsInput($toolResults),
-        ];
-
-        if (filled($tools)) {
-            $body['tools'] = $this->mapTools($tools, $provider);
-        }
-
-        if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-            'max_output_tokens' => $options?->maxTokens,
-        ]));
-
-        $providerOptions = $options?->providerOptions(
-            Lab::tryFrom($provider->driver()) ?? $provider->driver()
-        );
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('responses', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
-    }
-
-    /**
-     * Build the input array containing only tool results for a follow-up request.
-     *
-     * @param  array<ToolResult>  $toolResults
-     */
-    protected function buildToolResultsInput(array $toolResults): array
-    {
-        $input = [];
-
-        foreach ($toolResults as $result) {
-            $input[] = [
-                'type' => 'function_call_output',
-                'call_id' => $result->resultId,
-                'output' => $this->serializeToolResultOutput($result->result),
-            ];
-        }
-
-        return $input;
-    }
-
-    /**
-     * Serialize a tool result output value to a string.
-     */
-    protected function serializeToolResultOutput(mixed $output): string
-    {
-        if (is_string($output)) {
-            return $output;
-        }
-
-        return is_array($output) ? json_encode($output) : strval($output);
     }
 
     /**
@@ -419,16 +184,5 @@ trait ParsesTextResponses
         }
 
         return $toolCalls;
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -20,8 +20,9 @@ use Laravel\Ai\Files\Image;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -30,7 +31,6 @@ use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use LogicException;
 
@@ -44,13 +44,9 @@ class OpenAiGateway implements Gateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -64,10 +60,12 @@ class OpenAiGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
-        );
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
+        $body = $previousResponseId
+            ? $this->buildContinuationBody($previousResponseId, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -78,7 +76,7 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -94,10 +92,12 @@ class OpenAiGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
-        );
+        $body = $previousResponseId
+            ? $this->buildContinuationBody($previousResponseId, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $body['stream'] = true;
 
@@ -112,13 +112,7 @@ class OpenAiGateway implements Gateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            0,
-            null,
-            $timeout,
         );
     }
 

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -3,12 +3,9 @@
 namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -17,34 +14,21 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process a Chat Completions streaming response and yield Laravel stream events.
+     * Process an OpenRouter streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $usage = null;
         $finishReason = null;
@@ -66,13 +50,7 @@ trait HandlesTextStreaming
 
             if (! $choice) {
                 if (isset($data['usage'])) {
-                    $usage = new Usage(
-                        $data['usage']['prompt_tokens'] ?? 0,
-                        $data['usage']['completion_tokens'] ?? 0,
-                        cacheWriteInputTokens: $data['usage']['prompt_tokens_details']['cache_write_tokens'] ?? 0,
-                        cacheReadInputTokens: $data['usage']['prompt_tokens_details']['cached_tokens'] ?? 0,
-                        reasoningTokens: $data['usage']['completion_tokens_details']['reasoning_tokens'] ?? 0,
-                    );
+                    $usage = $this->extractUsage($data);
                 }
 
                 continue;
@@ -117,8 +95,6 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
                 }
 
-                $currentText .= $delta['content'];
-
                 yield (new TextDelta(
                     $this->generateEventId(),
                     $messageId,
@@ -150,13 +126,7 @@ trait HandlesTextStreaming
             }
 
             if (isset($data['usage'])) {
-                $usage = new Usage(
-                    $data['usage']['prompt_tokens'] ?? 0,
-                    $data['usage']['completion_tokens'] ?? 0,
-                    cacheWriteInputTokens: $data['usage']['prompt_tokens_details']['cache_write_tokens'] ?? 0,
-                    cacheReadInputTokens: $data['usage']['prompt_tokens_details']['cached_tokens'] ?? 0,
-                    reasoningTokens: $data['usage']['completion_tokens_details']['reasoning_tokens'] ?? 0,
-                );
+                $usage = $this->extractUsage($data);
             }
         }
 
@@ -178,25 +148,6 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-            );
-
-            return;
         }
 
         yield (new StreamEnd(
@@ -205,150 +156,6 @@ trait HandlesTextStreaming
             $usage ?? new Usage(0, 0),
             time(),
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = ['role' => 'assistant'];
-
-            if (filled($currentText)) {
-                $assistantMsg['content'] = $currentText;
-            }
-
-            $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-            );
-
-            $toolResultMessages = [];
-
-            foreach ($toolResults as $toolResult) {
-                $toolResultMessages[] = [
-                    'role' => 'tool',
-                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                    'content' => $this->serializeToolResultOutput($toolResult->result),
-                ];
-            }
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat($originalMessages, $instructions),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = [
-                'model' => $model,
-                'messages' => $chatMessages,
-                'stream' => true,
-                'stream_options' => ['include_usage' => true],
-            ];
-
-            if (filled($tools)) {
-                $mappedTools = $this->mapTools($tools);
-
-                if (filled($mappedTools)) {
-                    $body['tool_choice'] = 'auto';
-                    $body['tools'] = $mappedTools;
-                }
-            }
-
-            if (filled($schema)) {
-                $body['response_format'] = $this->buildResponseFormat($schema);
-            }
-
-            if (! is_null($options?->maxTokens)) {
-                $body['max_tokens'] = $options->maxTokens;
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('chat/completions', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
     }
 
     /**

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -2,22 +2,13 @@
 
 namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -31,60 +22,20 @@ trait ParsesTextResponses
         if (! $data || isset($data['error'])) {
             throw new AiException(sprintf(
                 'OpenRouter Error: [%s] %s',
-                $data['error']['type'] ?? $data['error']['code'] ?? 'unknown',
+                $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown OpenRouter error.',
             ));
         }
     }
 
     /**
-     * Parse the OpenRouter response data into a TextResponse.
+     * Parse a single OpenRouter response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): SingleTurnResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
@@ -101,216 +52,13 @@ trait ParsesTextResponses
             $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
-        );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
-
-        foreach ($messages as $msg) {
-            if ($msg instanceof AssistantMessage) {
-                $mapped = ['role' => 'assistant'];
-
-                if (filled($msg->content)) {
-                    $mapped['content'] = $msg->content;
-                }
-
-                if ($msg->toolCalls->isNotEmpty()) {
-                    $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
-                    )->all();
-                }
-
-                $chatMessages[] = $mapped;
-            } elseif ($msg instanceof ToolResultMessage) {
-                foreach ($msg->toolResults as $toolResult) {
-                    $chatMessages[] = [
-                        'role' => 'tool',
-                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                        'content' => $this->serializeToolResultOutput($toolResult->result),
-                    ];
-                }
-            }
-        }
-
-        $body = [
-            'model' => $model,
-            'messages' => $chatMessages,
-        ];
-
-        if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
-
-            if (filled($mappedTools)) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
-        }
-
-        if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
-        }
-
-        if (! is_null($options?->maxTokens)) {
-            $body['max_tokens'] = $options->maxTokens;
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
         );
     }
 
@@ -342,16 +90,5 @@ trait ParsesTextResponses
             'content_filter' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -15,9 +15,10 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -25,7 +26,6 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use LogicException;
 
@@ -39,14 +39,10 @@ class OpenRouterGateway implements Gateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
     use WrapsPcmAudio;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -60,7 +56,9 @@ class OpenRouterGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
         $body = $this->buildTextRequestBody(
             $provider,
             $model,
@@ -80,17 +78,7 @@ class OpenRouterGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -106,6 +94,8 @@ class OpenRouterGateway implements Gateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
         $body = $this->buildTextRequestBody(
             $provider,
@@ -131,16 +121,7 @@ class OpenRouterGateway implements Gateway
             $invocationId,
             $provider,
             $model,
-            $tools,
-            $schema,
-            $options,
             $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
         );
     }
 

--- a/src/Gateway/SingleTurnResponse.php
+++ b/src/Gateway/SingleTurnResponse.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\Usage;
+
+class SingleTurnResponse implements Arrayable, JsonSerializable
+{
+    /**
+     * @param  ToolCall[]  $toolCalls
+     * @param  array<string, mixed>|null  $structured  Parsed structured output from the provider.
+     * @param  string|null  $responseId  Provider-specific response ID for stateful continuation (e.g. OpenAI previous_response_id).
+     * @param  array<int, array<string, mixed>>  $providerContentBlocks  Raw provider content blocks for verbatim replay (e.g. Anthropic server_tool_use).
+     */
+    public function __construct(
+        public string $text,
+        public array $toolCalls,
+        public FinishReason $finishReason,
+        public Usage $usage,
+        public Meta $meta,
+        public ?array $structured = null,
+        public ?string $responseId = null,
+        public array $providerContentBlocks = [],
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'text' => $this->text,
+            'tool_calls' => array_map(fn (ToolCall $tc) => $tc->toArray(), $this->toolCalls),
+            'finish_reason' => $this->finishReason->value,
+            'usage' => $this->usage->toArray(),
+            'meta' => $this->meta->toArray(),
+            'structured' => $this->structured,
+        ];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Gateway/StepContext.php
+++ b/src/Gateway/StepContext.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+/**
+ * Per-call context passed from the orchestrator (StepLoop) to the gateway.
+ *
+ * Lets the orchestrator hint provider-specific behavior the gateway alone can't infer —
+ * e.g. that this is the final step in a tool loop, so a provider with synthetic
+ * structured-output tooling (Bedrock) can force its toolChoice on this turn.
+ */
+final class StepContext
+{
+    public function __construct(
+        public readonly int $stepNumber = 0,
+        public readonly bool $isFinalStep = false,
+    ) {}
+}

--- a/src/Gateway/StepLoop.php
+++ b/src/Gateway/StepLoop.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+class StepLoop
+{
+    use InvokesTools;
+
+    public function __construct(
+        protected TextGateway $gateway,
+        protected Dispatcher $events,
+    ) {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * Run the multi-step tool loop, returning a fully resolved TextResponse.
+     *
+     * @param  Tool[]  $tools
+     * @param  array<string, mixed>|null  $schema
+     */
+    public function generate(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+    ): TextResponse {
+        $steps = new Collection;
+        $allMessages = $messages;
+        $maxSteps = $options?->maxSteps ?? (count($tools) > 0 ? (int) round(count($tools) * 1.5) : 1);
+        $previousResponseId = null;
+        $lastResult = null;
+
+        for ($step = 0; $step < $maxSteps; $step++) {
+            $stepContext = new StepContext(
+                stepNumber: $step,
+                isFinalStep: $step + 1 >= $maxSteps,
+            );
+
+            $lastResult = $this->gateway->generateText(
+                $provider, $model, $instructions, $allMessages, $tools, $schema, $options, $timeout, $previousResponseId, $stepContext,
+            );
+
+            if ($lastResult->finishReason !== FinishReason::ToolCalls || empty($lastResult->toolCalls)) {
+                $steps->push($this->buildStep($lastResult));
+
+                $allMessages[] = new AssistantMessage(
+                    $lastResult->text,
+                    new Collection($lastResult->toolCalls),
+                    $lastResult->providerContentBlocks,
+                );
+
+                break;
+            }
+
+            $toolResults = $this->executeToolCalls($lastResult->toolCalls, $tools);
+
+            $steps->push($this->buildStep($lastResult, $toolResults));
+
+            $allMessages[] = new AssistantMessage(
+                $lastResult->text,
+                new Collection($lastResult->toolCalls),
+                $lastResult->providerContentBlocks,
+            );
+
+            $allMessages[] = new ToolResultMessage(new Collection($toolResults));
+
+            $previousResponseId = $lastResult->responseId;
+        }
+
+        return $this->buildFinalResponse(
+            $steps, $allMessages, count($messages), $lastResult,
+        );
+    }
+
+    /**
+     * Stream the multi-step tool loop, yielding events for each turn.
+     *
+     * @param  Tool[]  $tools
+     * @param  array<string, mixed>|null  $schema
+     */
+    public function stream(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+    ): Generator {
+        $allMessages = $messages;
+        $maxSteps = $options?->maxSteps ?? (count($tools) > 0 ? (int) round(count($tools) * 1.5) : 1);
+        $previousResponseId = null;
+
+        for ($step = 0; $step < $maxSteps; $step++) {
+            $pendingToolCalls = [];
+            $currentText = '';
+            $streamResponseId = null;
+
+            $stepContext = new StepContext(
+                stepNumber: $step,
+                isFinalStep: $step + 1 >= $maxSteps,
+            );
+
+            foreach ($this->gateway->streamText($invocationId, $provider, $model, $instructions, $allMessages, $tools, $schema, $options, $timeout, $previousResponseId, $stepContext) as $event) {
+                yield $event;
+
+                if ($event instanceof ToolCallEvent) {
+                    $pendingToolCalls[] = $event->toolCall;
+                }
+
+                if ($event instanceof TextDelta) {
+                    $currentText .= $event->delta;
+                }
+
+                if ($event instanceof StreamEnd) {
+                    $streamResponseId = $event->responseId;
+                    break;
+                }
+            }
+
+            if (empty($pendingToolCalls)) {
+                break;
+            }
+
+            $toolResults = $this->executeToolCalls($pendingToolCalls, $tools);
+
+            foreach ($toolResults as $toolResult) {
+                $event = (new ToolResultEvent(
+                    strtolower((string) Str::uuid7()),
+                    $toolResult,
+                    true,
+                    null,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                yield $event;
+            }
+
+            $allMessages[] = new AssistantMessage(
+                $currentText,
+                new Collection($pendingToolCalls),
+            );
+
+            $allMessages[] = new ToolResultMessage(new Collection($toolResults));
+
+            $previousResponseId = $streamResponseId;
+        }
+    }
+
+    /**
+     * Execute tool calls against the tool registry.
+     *
+     * @param  ToolCall[]  $toolCalls
+     * @param  Tool[]  $tools
+     * @return ToolResult[]
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Build a Step from a single-turn response.
+     *
+     * @param  ToolResult[]  $toolResults
+     */
+    protected function buildStep(SingleTurnResponse $result, array $toolResults = []): Step
+    {
+        return new Step(
+            $result->text,
+            $result->toolCalls,
+            $toolResults,
+            $result->finishReason,
+            $result->usage,
+            $result->meta,
+        );
+    }
+
+    /**
+     * Build the final TextResponse from accumulated steps and messages.
+     */
+    protected function buildFinalResponse(
+        Collection $steps,
+        array $allMessages,
+        int $originalMessageCount,
+        ?SingleTurnResponse $lastResult,
+    ): TextResponse {
+        $finalStep = $steps->last();
+
+        $totalUsage = $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage,
+        );
+
+        $newMessages = (new Collection(array_slice($allMessages, $originalMessageCount)))->values();
+
+        if ($lastResult?->structured !== null && $finalStep instanceof Step) {
+            return (new StructuredTextResponse(
+                $lastResult->structured,
+                $finalStep->text,
+                $totalUsage,
+                $finalStep->meta,
+            ))->withToolCallsAndResults(
+                toolCalls: $steps->flatMap(fn (Step $s) => $s->toolCalls),
+                toolResults: $steps->flatMap(fn (Step $s) => $s->toolResults),
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $finalStep->text,
+            $totalUsage,
+            $finalStep->meta,
+        ))->withMessages($newMessages)->withSteps($steps);
+    }
+}

--- a/src/Gateway/StepLoop.php
+++ b/src/Gateway/StepLoop.php
@@ -196,6 +196,7 @@ class StepLoop
             $allMessages[] = new AssistantMessage(
                 $currentText,
                 new Collection($pendingToolCalls),
+                $streamProviderContentBlocks,
             );
 
             $allMessages[] = new ToolResultMessage(new Collection($toolResults));

--- a/src/Gateway/StepLoop.php
+++ b/src/Gateway/StepLoop.php
@@ -53,7 +53,7 @@ class StepLoop
     ): TextResponse {
         $steps = new Collection;
         $allMessages = $messages;
-        $maxSteps = $options?->maxSteps ?? (count($tools) > 0 ? (int) round(count($tools) * 1.5) : 1);
+        $maxSteps = $options?->maxSteps ?? (count($tools) > 0 ? (int) round(count($tools) * 1.5) : 5);
         $previousResponseId = null;
         $lastResult = null;
 
@@ -66,6 +66,18 @@ class StepLoop
             $lastResult = $this->gateway->generateText(
                 $provider, $model, $instructions, $allMessages, $tools, $schema, $options, $timeout, $previousResponseId, $stepContext,
             );
+
+            if ($lastResult->finishReason === FinishReason::Continue) {
+                $steps->push($this->buildStep($lastResult));
+
+                $allMessages[] = new AssistantMessage(
+                    $lastResult->text,
+                    new Collection($lastResult->toolCalls),
+                    $lastResult->providerContentBlocks,
+                );
+
+                continue;
+            }
 
             if ($lastResult->finishReason !== FinishReason::ToolCalls || empty($lastResult->toolCalls)) {
                 $steps->push($this->buildStep($lastResult));
@@ -117,13 +129,15 @@ class StepLoop
         ?int $timeout,
     ): Generator {
         $allMessages = $messages;
-        $maxSteps = $options?->maxSteps ?? (count($tools) > 0 ? (int) round(count($tools) * 1.5) : 1);
+        $maxSteps = $options?->maxSteps ?? (count($tools) > 0 ? (int) round(count($tools) * 1.5) : 5);
         $previousResponseId = null;
 
         for ($step = 0; $step < $maxSteps; $step++) {
             $pendingToolCalls = [];
             $currentText = '';
             $streamResponseId = null;
+            $streamFinishReason = null;
+            $streamProviderContentBlocks = [];
 
             $stepContext = new StepContext(
                 stepNumber: $step,
@@ -143,8 +157,22 @@ class StepLoop
 
                 if ($event instanceof StreamEnd) {
                     $streamResponseId = $event->responseId;
+                    $streamFinishReason = FinishReason::tryFrom($event->reason);
+                    $streamProviderContentBlocks = $event->providerContentBlocks;
                     break;
                 }
+            }
+
+            if ($streamFinishReason === FinishReason::Continue) {
+                $allMessages[] = new AssistantMessage(
+                    $currentText,
+                    new Collection($pendingToolCalls),
+                    $streamProviderContentBlocks,
+                );
+
+                $previousResponseId = $streamResponseId;
+
+                continue;
             }
 
             if (empty($pendingToolCalls)) {

--- a/src/Gateway/Xai/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Xai/Concerns/BuildsTextRequests.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway\Xai\Concerns;
 use Illuminate\Support\Arr;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 
@@ -26,6 +27,45 @@ trait BuildsTextRequests
 
         $body = ['model' => $model, 'input' => $input];
 
+        return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Build a lightweight continuation body using previous_response_id.
+     *
+     * Only sends tool results as input instead of replaying the full conversation.
+     */
+    protected function buildContinuationBody(
+        string $previousResponseId,
+        string $model,
+        array $messages,
+        array $tools,
+        Provider $provider,
+        ?array $schema,
+        ?TextGenerationOptions $options = null,
+    ): array {
+        $body = [
+            'model' => $model,
+            'previous_response_id' => $previousResponseId,
+            'input' => $this->extractToolResultsInput($messages),
+        ];
+
+        return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Apply options shared by full requests and previous_response_id continuations.
+     *
+     * Keeps tool_choice, tools, structured output, sampling, and provider extras in one place
+     * so continuation requests cannot drift from the initial request shape.
+     */
+    protected function mergeSharedResponsesRequestOptions(
+        array $body,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        Provider $provider,
+    ): array {
         if (filled($tools)) {
             $body['tool_choice'] = 'auto';
             $body['tools'] = $this->mapTools($tools, $provider);
@@ -53,6 +93,32 @@ trait BuildsTextRequests
         }
 
         return $body;
+    }
+
+    /**
+     * Extract tool result items from the trailing messages for a continuation request.
+     *
+     * The orchestrator appends AssistantMessage + ToolResultMessage at the end of
+     * the messages array after each tool-call turn. For continuation, we only need
+     * the function_call_output items from the last ToolResultMessage.
+     */
+    protected function extractToolResultsInput(array $messages): array
+    {
+        $input = [];
+
+        $lastMessage = end($messages);
+
+        if ($lastMessage instanceof ToolResultMessage) {
+            foreach ($lastMessage->toolResults as $toolResult) {
+                $input[] = [
+                    'type' => 'function_call_output',
+                    'call_id' => $toolResult->resultId,
+                    'output' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -3,13 +3,9 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Enums\Lab;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
@@ -22,33 +18,23 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process an xAI streaming response and yield Laravel stream events.
+     * Process an xAI streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
-        $responseId = '';
+        $responseId = null;
         $reasoningId = '';
         $streamStartEmitted = false;
         $textStartEmitted = false;
-        $currentText = '';
         $pendingToolCalls = [];
         $reasoningItems = [];
         $usage = null;
@@ -71,7 +57,7 @@ trait HandlesTextStreaming
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
                 $streamStartEmitted = true;
-                $responseId = $data['response']['id'] ?? '';
+                $responseId = $data['response']['id'] ?? null;
 
                 yield (new StreamStart(
                     $this->generateEventId(),
@@ -96,8 +82,6 @@ trait HandlesTextStreaming
                             time(),
                         ))->withInvocationId($invocationId);
                     }
-
-                    $currentText .= $textDelta;
 
                     yield (new TextDelta(
                         $this->generateEventId(),
@@ -282,140 +266,13 @@ trait HandlesTextStreaming
             }
         }
 
-        if (filled($pendingToolCalls)) {
-            yield from $this->handleStreamingToolCalls(
-                $invocationId, $responseId, $provider, $model, $tools, $schema, $options,
-                $pendingToolCalls, $currentText, $reasoningItems,
-                $depth, $maxSteps, $timeout,
-            );
-
-            return;
-        }
-
         yield (new StreamEnd(
             $this->generateEventId(),
             $this->extractFinishReason($responseData)->value,
             $usage ?? new Usage(0, 0),
             time(),
+            $responseId,
         ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        string $responseId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $pendingToolCalls,
-        string $currentText,
-        array $reasoningItems,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
-
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-                'stream' => true,
-            ];
-
-            if (filled($tools)) {
-                $body['tools'] = $this->mapTools($tools, $provider);
-            }
-
-            if (filled($schema)) {
-                $body['text'] = $this->buildSchemaFormat($schema);
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-                'max_output_tokens' => $options?->maxTokens,
-            ]));
-
-            $providerOptions = $options?->providerOptions(
-                Lab::tryFrom($provider->driver()) ?? $provider->driver()
-            );
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('responses', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $depth + 1, $maxSteps, $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-    }
-
-    /**
-     * Map raw streaming tool call data to ToolCall DTOs.
-     *
-     * @return array<ToolCall>
-     */
-    protected function mapStreamToolCalls(array $toolCalls): array
-    {
-        return array_map(fn (array $tc) => new ToolCall(
-            $tc['id'] ?? '',
-            $tc['name'] ?? '',
-            json_decode($tc['arguments'] ?? '{}', true) ?? [],
-            $tc['call_id'] ?? null,
-            $tc['reasoning_id'] ?? null,
-            $tc['reasoning_summary'] ?? null,
-        ), array_values($toolCalls));
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/MapsMessages.php
+++ b/src/Gateway/Xai/Concerns/MapsMessages.php
@@ -128,4 +128,16 @@ trait MapsMessages
             ];
         }
     }
+
+    /**
+     * Serialize a tool result output value to a string suitable for the API.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
 }

--- a/src/Gateway/Xai/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Xai/Concerns/ParsesTextResponses.php
@@ -2,24 +2,15 @@
 
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\SingleTurnResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -50,48 +41,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the xAI response data into a TextResponse.
+     * Parse a single xAI response into a SingleTurnResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $responseId = $data['id'] ?? '';
+    ): SingleTurnResponse {
         $output = $data['output'] ?? [];
         $model = $data['model'] ?? '';
 
@@ -102,190 +58,15 @@ trait ParsesTextResponses
 
         $mappedToolCalls = $this->mapToolCallsWithReasoning($output);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model, $citations),
+        return new SingleTurnResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model, $citations),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            responseId: $data['id'] ?? null,
         );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model, $citations),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options, $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $responseId,
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $toolResults,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = [
-            'model' => $model,
-            'previous_response_id' => $responseId,
-            'input' => $this->buildToolResultsInput($toolResults),
-        ];
-
-        if (filled($tools)) {
-            $body['tools'] = $this->mapTools($tools, $provider);
-        }
-
-        if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema);
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-            'max_output_tokens' => $options?->maxTokens,
-        ]));
-
-        $providerOptions = $options?->providerOptions(
-            Lab::tryFrom($provider->driver()) ?? $provider->driver()
-        );
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('responses', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
-    }
-
-    /**
-     * Build the input array containing only tool results for a follow-up request.
-     *
-     * @param  array<ToolResult>  $toolResults
-     */
-    protected function buildToolResultsInput(array $toolResults): array
-    {
-        $input = [];
-
-        foreach ($toolResults as $result) {
-            $input[] = [
-                'type' => 'function_call_output',
-                'call_id' => $result->resultId,
-                'output' => $this->serializeToolResultOutput($result->result),
-            ];
-        }
-
-        return $input;
-    }
-
-    /**
-     * Serialize a tool result output value to a string.
-     */
-    protected function serializeToolResultOutput(mixed $output): string
-    {
-        if (is_string($output)) {
-            return $output;
-        }
-
-        return is_array($output) ? json_encode($output) : strval($output);
     }
 
     /**
@@ -402,16 +183,5 @@ trait ParsesTextResponses
         }
 
         return $toolCalls;
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Responses\TextResponse;
 
 class XaiGateway implements TextGateway
 {
@@ -22,13 +22,9 @@ class XaiGateway implements TextGateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
@@ -42,10 +38,12 @@ class XaiGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
-        );
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
+    ): SingleTurnResponse {
+        $body = $previousResponseId
+            ? $this->buildContinuationBody($previousResponseId, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -56,7 +54,7 @@ class XaiGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
@@ -72,10 +70,12 @@ class XaiGateway implements TextGateway
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $previousResponseId = null,
+        ?StepContext $context = null,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
-        );
+        $body = $previousResponseId
+            ? $this->buildContinuationBody($previousResponseId, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $body['stream'] = true;
 
@@ -87,9 +87,10 @@ class XaiGateway implements TextGateway
         );
 
         yield from $this->processTextStream(
-            $invocationId, $provider, $model, $tools, $schema, $options,
+            $invocationId,
+            $provider,
+            $model,
             $response->getBody(),
-            timeout: $timeout,
         );
     }
 }

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -18,6 +18,7 @@ use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Gateway\StepLoop;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Middleware\RememberConversation;
@@ -56,11 +57,11 @@ trait GeneratesText
                     new UserMessage($prompt->prompt, $prompt->attachments->all()),
                 ];
 
-                $this->listenForToolInvocations($invocationId, $agent);
+                $loop = $this->createStepLoop($invocationId, $agent);
 
                 $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
 
-                $response = $this->textGateway()->generateText(
+                $response = $loop->generate(
                     $this,
                     $prompt->model,
                     (string) $agent->instructions(),
@@ -125,11 +126,13 @@ trait GeneratesText
     }
 
     /**
-     * Listen for gateway tool invocations and dispatch events for the given agent when the tools are invoked.
+     * Create a StepLoop wired with tool invocation events.
      */
-    protected function listenForToolInvocations(string $invocationId, Agent $agent): void
+    protected function createStepLoop(string $invocationId, Agent $agent): StepLoop
     {
-        $this->textGateway()->onToolInvocation(
+        $loop = new StepLoop($this->textGateway(), $this->events);
+
+        $loop->onToolInvocation(
             invoking: function (Tool $tool, array $arguments) use ($invocationId, $agent) {
                 $this->currentToolInvocationId = (string) Str::uuid7();
 
@@ -143,5 +146,7 @@ trait GeneratesText
                 ));
             },
         );
+
+        return $loop;
     }
 }

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -52,9 +52,9 @@ trait StreamsText
                             new UserMessage($prompt->prompt, $prompt->attachments->all()),
                         ];
 
-                        $this->listenForToolInvocations($invocationId, $agent);
+                        $loop = $this->createStepLoop($invocationId, $agent);
 
-                        yield from $this->textGateway()->streamText(
+                        yield from $loop->stream(
                             $invocationId,
                             $this,
                             $prompt->model,

--- a/src/Responses/Data/FinishReason.php
+++ b/src/Responses/Data/FinishReason.php
@@ -6,6 +6,7 @@ enum FinishReason: string
 {
     case Stop = 'stop';
     case ToolCalls = 'tool_calls';
+    case Continue = 'continue';
     case Length = 'length';
     case ContentFilter = 'content_filter';
     case Error = 'error';

--- a/src/Responses/Data/ToolCall.php
+++ b/src/Responses/Data/ToolCall.php
@@ -14,6 +14,8 @@ class ToolCall implements Arrayable, JsonSerializable
         public ?string $resultId = null,
         public ?string $reasoningId = null,
         public ?array $reasoningSummary = null,
+        public ?string $reasoningSignature = null,
+        public bool $providerExecuted = false,
     ) {}
 
     /**
@@ -28,6 +30,8 @@ class ToolCall implements Arrayable, JsonSerializable
             'result_id' => $this->resultId,
             'reasoning_id' => $this->reasoningId,
             'reasoning_summary' => $this->reasoningSummary,
+            'reasoning_signature' => $this->reasoningSignature,
+            'provider_executed' => $this->providerExecuted,
         ];
     }
 

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -158,6 +158,8 @@ class DatabaseConversationStore implements ConversationStore
                             resultId: $toolCall['result_id'] ?? null,
                             reasoningId: $toolCall['reasoning_id'] ?? null,
                             reasoningSummary: $toolCall['reasoning_summary'] ?? null,
+                            reasoningSignature: $toolCall['reasoning_signature'] ?? null,
+                            providerExecuted: $toolCall['provider_executed'] ?? false,
                         ))
                     );
 

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -13,6 +13,7 @@ class StreamEnd extends StreamEvent
         public Usage $usage,
         public int $timestamp,
         public ?string $responseId = null,
+        public array $providerContentBlocks = [],
     ) {
         //
     }

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -12,6 +12,7 @@ class StreamEnd extends StreamEvent
         public string $reason,
         public Usage $usage,
         public int $timestamp,
+        public ?string $responseId = null,
     ) {
         //
     }
@@ -44,6 +45,7 @@ class StreamEnd extends StreamEvent
                 ? $this->usage->toArray()
                 : null,
             'timestamp' => $this->timestamp,
+            'response_id' => $this->responseId,
         ];
     }
 

--- a/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
@@ -205,6 +205,51 @@ test('thinking parts are excluded from tool call continuation', function () {
         if ($content['role'] === 'model') {
             foreach ($content['parts'] as $part) {
                 expect($part['thought'] ?? false)->toBeFalse('Thinking parts should be excluded from tool call continuation');
+
+                if (isset($part['text'])) {
+                    expect($part['text'])->not->toContain(
+                        'Let me think about this...',
+                        'Thinking text content must not leak into the assistant turn as a non-flagged text part'
+                    );
+                }
+            }
+        }
+    }
+});
+
+test('functionCall parts on continuation only carry name and args', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            Http::response([
+                'candidates' => [[
+                    'content' => [
+                        'parts' => [
+                            ['functionCall' => ['id' => 'call_1', 'name' => 'FixedNumberGenerator', 'args' => (object) []]],
+                        ],
+                        'role' => 'model',
+                    ],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5],
+            ]),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini');
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $followUpContents = $recorded[1][0]->data()['contents'];
+
+    foreach ($followUpContents as $content) {
+        if ($content['role'] === 'model') {
+            foreach ($content['parts'] as $part) {
+                if (isset($part['functionCall'])) {
+                    expect(array_keys($part['functionCall']))
+                        ->each->toBeIn(['name', 'args'], 'functionCall parts must not echo extraneous fields (e.g. id) back to Gemini');
+                }
             }
         }
     }

--- a/tests/Feature/Providers/OpenAi/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenAi/ProviderOptionsTest.php
@@ -61,9 +61,14 @@ test('provider options are persisted in tool call follow up requests', function 
 
     expect(count($requests))->toBeGreaterThanOrEqual(2);
 
+    $firstBody = json_decode($requests[0][0]->body(), true);
     $followUpBody = json_decode($requests[1][0]->body(), true);
 
-    expect(data_get($followUpBody, 'reasoning.effort'))->toBe('high')
+    expect(data_get($firstBody, 'tool_choice'))->toBe('auto')
+        ->and($firstBody)->toHaveKey('tools')
+        ->and(data_get($followUpBody, 'tool_choice'))->toBe('auto')
+        ->and($followUpBody)->toHaveKey('tools')
+        ->and(data_get($followUpBody, 'reasoning.effort'))->toBe('high')
         ->and(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5)
         ->and($followUpBody)->toHaveKey('previous_response_id');
 });

--- a/tests/Feature/Providers/Xai/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Xai/ProviderOptionsTest.php
@@ -59,9 +59,14 @@ test('provider options are persisted in tool call follow up requests', function 
 
     expect(count($requests))->toBeGreaterThanOrEqual(2);
 
+    $firstBody = json_decode($requests[0][0]->body(), true);
     $followUpBody = json_decode($requests[1][0]->body(), true);
 
-    expect(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5);
+    expect(data_get($firstBody, 'tool_choice'))->toBe('auto')
+        ->and($firstBody)->toHaveKey('tools')
+        ->and(data_get($followUpBody, 'tool_choice'))->toBe('auto')
+        ->and($followUpBody)->toHaveKey('tools')
+        ->and(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5);
 });
 
 function fakeXaiProviderOptionsToolCallResponse(): PromiseInterface

--- a/tests/Feature/Providers/Xai/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Xai/ToolCallLoopTest.php
@@ -77,8 +77,12 @@ test('follow up request preserves tools', function () {
 
     $recorded = Http::recorded();
 
+    $firstBody = json_decode($recorded[0][0]->body(), true);
     $followUpBody = json_decode($recorded[1][0]->body(), true);
 
-    expect($followUpBody)->toHaveKey('tools')
+    expect(data_get($firstBody, 'tool_choice'))->toBe('auto')
+        ->and($firstBody)->toHaveKey('tools')
+        ->and(data_get($followUpBody, 'tool_choice'))->toBe('auto')
+        ->and($followUpBody)->toHaveKey('tools')
         ->and($followUpBody['tools'])->not->toBeEmpty();
 });

--- a/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
@@ -56,16 +56,6 @@ function textGateway(): object
             return $this->buildInferenceConfig($options);
         }
 
-        public function callBuildAssistantConversationMessage(string $text, array $toolCalls): array
-        {
-            return $this->buildAssistantConversationMessage($text, $toolCalls);
-        }
-
-        public function callBuildToolResultConversationMessage(array $toolResults): array
-        {
-            return $this->buildToolResultConversationMessage($toolResults);
-        }
-
         public function callBuildConverseParameters(
             string $model,
             ?string $instructions,
@@ -86,11 +76,6 @@ function textGateway(): object
                 $options,
                 $isFinalStep,
             );
-        }
-
-        public function callResolveMaxSteps(array $tools, ?TextGenerationOptions $options): int
-        {
-            return $this->resolveMaxSteps($tools, $options);
         }
 
         public function callGetDocumentFormat(Document $document): string
@@ -422,56 +407,15 @@ test('build inference config includes temperature of zero', function () {
     ]);
 });
 
-test('build assistant conversation message omits text block when empty', function () {
-    $message = textGateway()->callBuildAssistantConversationMessage('', [
+test('assistant message omits text block when content is empty', function () {
+    $assistant = new AssistantMessage('', new Collection([
         new ToolCall('t-1', 'X', []),
-    ]);
+    ]));
 
-    expect($message['content'])->toHaveCount(1)
-        ->and($message['content'][0]['toolUse']['name'])->toBe('X');
-});
+    $formatted = textGateway()->callFormatMessages([$assistant]);
 
-test('build assistant conversation message includes text and tool calls', function () {
-    $message = textGateway()->callBuildAssistantConversationMessage('thinking', [
-        new ToolCall('t-1', 'X', ['a' => 1]),
-    ]);
-
-    expect($message['content'])->toEqual([
-        ['text' => 'thinking'],
-        ['toolUse' => ['toolUseId' => 't-1', 'name' => 'X', 'input' => ['a' => 1]]],
-    ]);
-});
-
-test('build tool result conversation message uses array form', function () {
-    $message = textGateway()->callBuildToolResultConversationMessage([
-        new ToolResult('t-1', 'X', [], ['out' => true]),
-    ]);
-
-    expect($message)->toEqual([
-        'role' => 'user',
-        'content' => [[
-            'toolResult' => [
-                'toolUseId' => 't-1',
-                'content' => [['text' => '{"out":true}']],
-            ],
-        ]],
-    ]);
-});
-
-test('resolve max steps returns one when no tools', function () {
-    expect(textGateway()->callResolveMaxSteps([], null))->toBe(1);
-});
-
-test('resolve max steps honors explicit option', function () {
-    $options = new TextGenerationOptions(maxSteps: 10);
-
-    expect(textGateway()->callResolveMaxSteps([new BedrockSampleTool], $options))->toBe(10);
-});
-
-test('resolve max steps falls back to tool count times one and a half', function () {
-    $tools = [new BedrockSampleTool, new BedrockSampleTool];
-
-    expect(textGateway()->callResolveMaxSteps($tools, null))->toBe(3);
+    expect($formatted[0]['content'])->toHaveCount(1)
+        ->and($formatted[0]['content'][0]['toolUse']['name'])->toBe('X');
 });
 
 test('build converse parameters attaches system instructions', function () {

--- a/tests/Unit/Gateway/StepLoopTest.php
+++ b/tests/Unit/Gateway/StepLoopTest.php
@@ -1,0 +1,327 @@
+<?php
+
+use Illuminate\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\SingleTurnResponse;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\StepLoop;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TextResponse;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+function fakeProvider(): TextProvider
+{
+    $provider = Mockery::mock(TextProvider::class);
+    $provider->shouldReceive('name')->andReturn('fake');
+    $provider->shouldReceive('driver')->andReturn('fake');
+
+    return $provider;
+}
+
+function singleTurnResponse(string $text, array $toolCalls = [], FinishReason $finishReason = FinishReason::Stop, int $inputTokens = 10, int $outputTokens = 5): SingleTurnResponse
+{
+    return new SingleTurnResponse(
+        text: $text,
+        toolCalls: $toolCalls,
+        finishReason: $finishReason,
+        usage: new Usage($inputTokens, $outputTokens),
+        meta: new Meta('fake', 'fake-model'),
+    );
+}
+
+function fakeGateway(array $responses): TextGateway
+{
+    return new class($responses) implements TextGateway
+    {
+        private int $callIndex = 0;
+
+        public int $callCount = 0;
+
+        public function __construct(private array $responses) {}
+
+        public function generateText(
+            TextProvider $provider,
+            string $model,
+            ?string $instructions,
+            array $messages = [],
+            array $tools = [],
+            ?array $schema = null,
+            ?TextGenerationOptions $options = null,
+            ?int $timeout = null,
+            ?string $previousResponseId = null,
+            ?StepContext $context = null,
+        ): SingleTurnResponse {
+            $this->callCount++;
+
+            return $this->responses[$this->callIndex++];
+        }
+
+        public function streamText(
+            string $invocationId,
+            TextProvider $provider,
+            string $model,
+            ?string $instructions,
+            array $messages = [],
+            array $tools = [],
+            ?array $schema = null,
+            ?TextGenerationOptions $options = null,
+            ?int $timeout = null,
+            ?string $previousResponseId = null,
+            ?StepContext $context = null,
+        ): Generator {
+            yield from [];
+        }
+    };
+}
+
+function createStepLoop(TextGateway $gateway): StepLoop
+{
+    return new StepLoop($gateway, new Dispatcher);
+}
+
+test('single turn with no tools returns text response', function () {
+    $gateway = fakeGateway([
+        singleTurnResponse('Hello world'),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', 'Be helpful',
+        [new UserMessage('Hi')], [], null, null, null,
+    );
+
+    expect($response)->toBeInstanceOf(TextResponse::class)
+        ->and($response->text)->toBe('Hello world')
+        ->and($gateway->callCount)->toBe(1);
+});
+
+test('tool calls trigger follow-up requests', function () {
+    $gateway = fakeGateway([
+        singleTurnResponse('', [
+            new ToolCall('call_1', 'FixedNumberGenerator', []),
+        ], FinishReason::ToolCalls),
+        singleTurnResponse('The number is 72019'),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', 'Be helpful',
+        [new UserMessage('Generate a number')],
+        [new FixedNumberGenerator],
+        null, null, null,
+    );
+
+    expect($response->text)->toBe('The number is 72019')
+        ->and($gateway->callCount)->toBe(2);
+});
+
+test('usage is aggregated across steps', function () {
+    $gateway = fakeGateway([
+        singleTurnResponse('', [
+            new ToolCall('call_1', 'FixedNumberGenerator', []),
+        ], FinishReason::ToolCalls, 100, 20),
+        singleTurnResponse('Done', [], FinishReason::Stop, 150, 30),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Go')],
+        [new FixedNumberGenerator],
+        null, null, null,
+    );
+
+    expect($response->usage->promptTokens)->toBe(250)
+        ->and($response->usage->completionTokens)->toBe(50);
+});
+
+test('max steps limits tool call depth', function () {
+    $toolCallResponse = singleTurnResponse('', [
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+    ], FinishReason::ToolCalls);
+
+    $gateway = fakeGateway([
+        $toolCallResponse,
+        $toolCallResponse,
+        $toolCallResponse,
+        $toolCallResponse,
+        $toolCallResponse,
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $options = new TextGenerationOptions(maxSteps: 3);
+
+    $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Go')],
+        [new FixedNumberGenerator],
+        null, $options, null,
+    );
+
+    expect($gateway->callCount)->toBe(3);
+});
+
+test('steps are recorded on the response', function () {
+    $gateway = fakeGateway([
+        singleTurnResponse('', [
+            new ToolCall('call_1', 'FixedNumberGenerator', []),
+        ], FinishReason::ToolCalls),
+        singleTurnResponse('Final answer'),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Go')],
+        [new FixedNumberGenerator],
+        null, null, null,
+    );
+
+    expect($response->steps)->toHaveCount(2)
+        ->and($response->steps[0]->toolCalls)->toHaveCount(1)
+        ->and($response->steps[0]->toolResults)->toHaveCount(1)
+        ->and($response->steps[0]->toolResults[0]->result)->toBe('72019')
+        ->and($response->steps[1]->text)->toBe('Final answer');
+});
+
+test('unmatched tool calls are skipped without error', function () {
+    $gateway = fakeGateway([
+        singleTurnResponse('', [
+            new ToolCall('call_1', 'NonExistentTool', []),
+        ], FinishReason::ToolCalls),
+        singleTurnResponse('Recovered'),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Go')],
+        [new FixedNumberGenerator],
+        null, null, null,
+    );
+
+    expect($response->text)->toBe('Recovered')
+        ->and($response->steps[0]->toolResults)->toBeEmpty();
+});
+
+test('structured output is passed through from final step', function () {
+    $gateway = fakeGateway([
+        new SingleTurnResponse(
+            text: '{"number": 42}',
+            toolCalls: [],
+            finishReason: FinishReason::Stop,
+            usage: new Usage(10, 5),
+            meta: new Meta('fake', 'fake-model'),
+            structured: ['number' => 42],
+        ),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Give me a number')],
+        [], ['number' => 'integer'], null, null,
+    );
+
+    expect($response->structured)->toBe(['number' => 42]);
+});
+
+test('provider-executed tool calls are not executed locally', function () {
+    $gateway = fakeGateway([
+        singleTurnResponse('', [
+            new ToolCall('srvtoolu_1', 'web_search', ['query' => 'test'], providerExecuted: true),
+            new ToolCall('call_1', 'FixedNumberGenerator', []),
+        ], FinishReason::ToolCalls),
+        singleTurnResponse('Done'),
+    ]);
+
+    $loop = createStepLoop($gateway);
+
+    $response = $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Search and compute')],
+        [new FixedNumberGenerator],
+        null, null, null,
+    );
+
+    // Only FixedNumberGenerator should have a result; web_search is provider-executed
+    expect($response->steps[0]->toolResults)->toHaveCount(1)
+        ->and($response->steps[0]->toolResults[0]->name)->toBe('FixedNumberGenerator')
+        ->and($response->steps[0]->toolCalls)->toHaveCount(2);
+});
+
+test('messages accumulate across tool loop iterations', function () {
+    $messagesPerCall = [];
+
+    $gateway = new class($messagesPerCall) implements TextGateway
+    {
+        private int $callIndex = 0;
+
+        public function __construct(private array &$messagesPerCall) {}
+
+        public function generateText(
+            TextProvider $provider,
+            string $model,
+            ?string $instructions,
+            array $messages = [],
+            array $tools = [],
+            ?array $schema = null,
+            ?TextGenerationOptions $options = null,
+            ?int $timeout = null,
+            ?string $previousResponseId = null,
+            ?StepContext $context = null,
+        ): SingleTurnResponse {
+            $this->messagesPerCall[] = count($messages);
+
+            if ($this->callIndex++ === 0) {
+                return singleTurnResponse('', [
+                    new ToolCall('call_1', 'FixedNumberGenerator', []),
+                ], FinishReason::ToolCalls);
+            }
+
+            return singleTurnResponse('Done');
+        }
+
+        public function streamText(
+            string $invocationId,
+            TextProvider $provider,
+            string $model,
+            ?string $instructions,
+            array $messages = [],
+            array $tools = [],
+            ?array $schema = null,
+            ?TextGenerationOptions $options = null,
+            ?int $timeout = null,
+            ?string $previousResponseId = null,
+            ?StepContext $context = null,
+        ): Generator {
+            yield from [];
+        }
+    };
+
+    $loop = createStepLoop($gateway);
+
+    $loop->generate(
+        fakeProvider(), 'fake-model', null,
+        [new UserMessage('Go')],
+        [new FixedNumberGenerator],
+        null, null, null,
+    );
+
+    // First call: 1 user message
+    // Second call: 1 user + 1 assistant + 1 tool result = 3
+    expect($messagesPerCall)->toBe([1, 3]);
+});

--- a/tests/Unit/Responses/Data/FinishReasonTest.php
+++ b/tests/Unit/Responses/Data/FinishReasonTest.php
@@ -5,6 +5,7 @@ use Laravel\Ai\Responses\Data\FinishReason;
 test('finish reason enum has expected cases', function () {
     expect(FinishReason::Stop->value)->toBe('stop')
         ->and(FinishReason::ToolCalls->value)->toBe('tool_calls')
+        ->and(FinishReason::Continue->value)->toBe('continue')
         ->and(FinishReason::Length->value)->toBe('length')
         ->and(FinishReason::ContentFilter->value)->toBe('content_filter')
         ->and(FinishReason::Error->value)->toBe('error')

--- a/tests/Unit/Responses/Data/ToolCallTest.php
+++ b/tests/Unit/Responses/Data/ToolCallTest.php
@@ -32,6 +32,8 @@ test('tool call to array returns all properties', function () {
         'result_id' => null,
         'reasoning_id' => null,
         'reasoning_summary' => null,
+        'reasoning_signature' => null,
+        'provider_executed' => false,
     ]);
 });
 


### PR DESCRIPTION
## Summary

This PR extracts the multi-step tool loop from individual gateways into a central `StepLoop` class, making gateways thin single-turn adapters. The net result is **thousands of lines of duplicated orchestration code** replaced by **shared loop logic** and leaner gateways.

- **`StepLoop`** (`src/Gateway/StepLoop.php`) — new central class that owns the multi-step tool loop (LLM call → tool execution → re-prompt) for both `generate` and `stream` flows. Named after the `Step` DTO it produces on each iteration.
- **`SingleTurnResponse`** (`src/Gateway/SingleTurnResponse.php`) — lean DTO representing one LLM turn, returned by all gateways. Lives under `Laravel\Ai\Gateway` (not `Responses`) because it's an internal gateway↔loop contract, never exposed to userland.
- **`StepContext`** (`src/Gateway/StepContext.php`) — small DTO passed from `StepLoop` to each gateway call, carrying per-turn orchestration hints (currently `stepNumber`, `isFinalStep`). Lets providers consume the orchestrator's terminal-step verdict without making them recompute it themselves. Today only Bedrock reads it; everyone else accepts-and-ignores.
- **All eleven gateways** (OpenAI, AzureOpenAi, Anthropic, Groq, Gemini, Mistral, xAI, DeepSeek, Ollama, OpenRouter, Bedrock) simplified to single-turn adapters — each gateway's `ParsesTextResponses` and `HandlesTextStreaming` traits drop recursive multi-step logic entirely, and Bedrock's internal `while ($step < $maxSteps)` Converse loop / `executeToolCalls` are gone too.
- **`previous_response_id`** threading for OpenAI / AzureOpenAi / xAI — `StepLoop` passes an opaque provider response ID between turns so providers that support stateful continuation can use it instead of replaying the full conversation.
- **`providerExecuted` flag on `ToolCall`** — Anthropic's `server_tool_use` blocks (web_search, web_fetch, code_execution, advisor) are now tagged when parsed and re-emitted as `server_tool_use` on replay. The step loop skips local execution for them via the existing `findTool()` → null path.
- **`providerOptions`** correctly persisted in continuation requests (addresses the fix from #340).

## A note on scope

This is a large architectural change and my first PR to this repo, so understandably there may not be trust built up yet. I'm completely fine with this serving as a **reference implementation** that maintainers can review, cherry-pick from, or rewrite as they see fit.

I raised the proposal in #347 after noticing the same orchestration logic being duplicated across new gateway PRs (#309, #311). 

I've also been contributing to [Prism](https://github.com/echolabsdev/prism) and working on client-executed tools and tool approval there ([prism-php/prism#932](https://github.com/prism-php/prism/pull/932)), which is what originally motivated this refactor - those features would only need to be implemented once in the step loop rather than in every gateway.

Happy to iterate on any feedback.

> **Note:** I have not been able to run the full integration test suite as I don't have API keys for all providers. The unit tests and feature tests with HTTP fakes all pass. Would appreciate the maintainers running the integration suite against this branch.

## Motivation

Before this change, every gateway independently implemented the same recursive multi-step tool orchestration — `ParsesTextResponses` had `processResponse` → `continueWithToolResults` → `processResponse` loops, `HandlesTextStreaming` had parallel `handleStreamingToolCalls` → `processTextStream` recursion, and Bedrock had its own bespoke `while ($step < $maxSteps)` Converse loop with internal `executeToolCalls`. This meant:

- Every new gateway (Anthropic #309, Groq #311, DeepSeek #399, Ollama, OpenRouter, Bedrock #270, AzureOpenAi #404) had to reimplement ~200–400 lines of identical orchestration logic.
- Cross-cutting concerns (telemetry, tool approval, rate limiting around tool calls) would need to be added in every gateway.
- Bug fixes to the tool loop required changes in every gateway.
- Provider-specific behaviors like Anthropic's `server_tool_use` replay, OpenAI's `previous_response_id` continuation, or Bedrock's "force structured-output tool on the final step" trick had to be hand-rolled inside each gateway's bespoke loop.

With orchestration centralized, a new gateway only needs to implement single-turn LLM communication - one `generateText()` and one `streamText()` method. The surface area becomes small enough that providers could realistically be maintained as community packages: anyone could add support for a new LLM by implementing the single-turn contract without understanding or replicating the orchestration logic. Telemetry / observability (e.g. OpenTelemetry, Arize Phoenix) can also be added in a single place - `StepLoop` - without touching any gateway.

## Changes

| Area | What changed |
|------|-------------|
| `TextGateway` contract | `generateText()` returns `SingleTurnResponse`, accepts `?string $previousResponseId` and `?StepContext $context`; `onToolInvocation()` removed |
| `StepLoop` (new) | Owns multi-step tool loop, usage aggregation, structured output handling, `previousResponseId` threading, `StepContext` construction, streaming path |
| `SingleTurnResponse` (new) | DTO returned by every gateway — text, toolCalls, finishReason, usage, meta, structured, responseId |
| `StepContext` (new) | Per-turn orchestration hints (`stepNumber`, `isFinalStep`) passed to gateways. Used by Bedrock; ignored by others |
| `ToolCall` | New `providerExecuted: bool` flag for server-side tool invocations (Anthropic server_tool_use) |
| `OpenAiGateway` | Single-turn; `ParsesTextResponses` drops ~270 lines; `BuildsTextRequests` handles `previous_response_id` |
| `AzureOpenAiGateway` | Single-turn; mirrors the OpenAI port (same trait stack, same `previousResponseId` flow). No behavior change |
| `AnthropicGateway` | Single-turn; `ParsesTextResponses` drops ~260 lines; `HandlesTextStreaming` drops ~220 lines; `providerExecuted` re-emits `server_tool_use` blocks on replay |
| `GroqGateway` | Single-turn; `ParsesTextResponses` drops ~280 lines; `HandlesTextStreaming` drops ~190 lines |
| `GeminiGateway` | Single-turn; `ParsesTextResponses` drops ~210 lines; `HandlesTextStreaming` drops ~150 lines |
| `MistralGateway` | Single-turn; `ParsesTextResponses` drops ~250 lines; `HandlesTextStreaming` drops ~160 lines |
| `XaiGateway` | Single-turn; `ParsesTextResponses` drops ~250 lines; `BuildsTextRequests` handles `previous_response_id` |
| `DeepSeekGateway` | Ported to single-turn contract |
| `OllamaGateway` | Ported to single-turn. Behavioral quirk preserved: force `FinishReason::ToolCalls` when `tool_calls` are populated regardless of `done_reason`, since Ollama can return `"stop"` alongside tool calls |
| `OpenRouterGateway` | Ported to single-turn. Behavioral quirk preserved: `finish_reason: "error"` with inline error payload → emit stream `Error` event |
| `BedrockTextGateway` | Single-turn — internal `while ($step < $maxSteps)` Converse loop, `executeToolCalls`, in-loop conversation builders all removed (~400 lines). Bedrock's Converse API has no native structured-output mode, so the existing synthetic `structured_output` tool injection is preserved. The original "force `toolChoice` to the synthetic tool *only* on the final step of the loop" optimization (which lets the model use real tools on intermediate steps) is preserved by reading `StepContext::$isFinalStep` — the only behavior the single-turn split couldn't infer locally |
| `FakeTextGateway` | Updated to match new contract |
| `GeneratesText` / `StreamsText` | Instantiate `StepLoop` and delegate; tool-invocation events wired via callbacks |
| `StreamEnd` | Gains `?string $responseId` for provider ID propagation through the streaming path |
