### PR TITLE
[0.x] Fix HasTools::tools() return type to accept ProviderTool

### DIFF
--- a/src/Contracts/HasTools.php
+++ b/src/Contracts/HasTools.php
@@ -7,7 +7,7 @@ interface HasTools
     /**
      * Get the tools available to the agent.
      *
-     * @return Tool[]
+     * @return array<Tool|\Laravel\Ai\Providers\Tools\ProviderTool>
      */
     public function tools(): iterable;
 }

--- a/src/Contracts/HasTools.php
+++ b/src/Contracts/HasTools.php
@@ -2,12 +2,14 @@
 
 namespace Laravel\Ai\Contracts;
 
+use Laravel\Ai\Providers\Tools\ProviderTool;
+
 interface HasTools
 {
     /**
      * Get the tools available to the agent.
      *
-     * @return array<Tool|\Laravel\Ai\Providers\Tools\ProviderTool>
+     * @return array<Tool|ProviderTool>
      */
     public function tools(): iterable;
 }


### PR DESCRIPTION
Fixes #297

## Summary

`HasTools::tools()` declares its return type as `@return Tool[]`, but `ProviderTool` (used by `WebSearch`, `WebFetch`, `FileSearch`) does not implement the `Tool` interface. This causes PHPStan errors when agents return provider tools:

```
Method MyAgent::tools() should return array<Laravel\Ai\Contracts\Tool>
but returns array<int, Laravel\Ai\Providers\Tools\WebSearch>.
```

### The Fix

Widen the docblock return type to accept both `Tool` and `ProviderTool`:

```php
// Before
@return Tool[]

// After
@return array<Tool|\Laravel\Ai\Providers\Tools\ProviderTool>
```

This allows agents to mix custom tools with provider tools without static analysis errors:

```php
public function tools(): array
{
    return [
        new MyCustomTool,     // implements Tool ✅
        new WebSearch,        // extends ProviderTool ✅
    ];
}
```

### Changes

- `src/Contracts/HasTools.php` — Widen `@return` type