### PR TITLE
[0.x] Throw early when HasStructuredOutput returns empty schema

### DIFF
--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -56,13 +56,23 @@ trait GeneratesText
 
                 $this->listenForToolInvocations($invocationId, $agent);
 
+                $schema = $agent instanceof HasStructuredOutput
+                    ? $agent->schema(new JsonSchemaTypeFactory)
+                    : null;
+
+                if ($agent instanceof HasStructuredOutput && empty($schema)) {
+                    throw new \InvalidArgumentException(
+                        'Agents implementing HasStructuredOutput must return a non-empty schema from the schema() method.'
+                    );
+                }
+
                 $response = $this->textGateway()->generateText(
                     $this,
                     $prompt->model,
                     (string) $agent->instructions(),
                     $messages,
                     $agent instanceof HasTools ? $agent->tools() : [],
-                    $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null,
+                    $schema,
                     TextGenerationOptions::forAgent($agent),
                     $prompt->timeout,
                 );


### PR DESCRIPTION
Fixes #294

## Summary

When an agent implements `HasStructuredOutput` but `schema()` returns an empty array, the SDK crashes with `Undefined property: TextResponse::$structured`.

### Root Cause

The gateway layer checks `! empty($schema)` to decide whether to return a `StructuredTextResponse` or plain `TextResponse`. But the response-wrapping layer checks `$agent instanceof HasStructuredOutput` — which is `true` regardless of schema contents. When the schema is empty:

1. Gateway returns `TextResponse` (no `->structured` property)
2. Response layer assumes `StructuredTextResponse` and accesses `->structured`
3. Crash

### The Fix

Validate the schema before calling the gateway. If an agent implements `HasStructuredOutput` but returns an empty schema, throw a clear `InvalidArgumentException`:

```php
if ($agent instanceof HasStructuredOutput && empty($schema)) {
    throw new InvalidArgumentException(
        'Agents implementing HasStructuredOutput must return a non-empty schema from the schema() method.'
    );
}
```

This turns an obscure `Undefined property` crash into a clear, actionable error message.

### Changes

- `src/Providers/Concerns/GeneratesText.php` — Validate schema before gateway call