### PR TITLE
[0.x] Fix PrismTool dropping arguments when provider uses 'input' key

### DIFF
--- a/src/Gateway/Prism/PrismTool.php
+++ b/src/Gateway/Prism/PrismTool.php
@@ -40,10 +40,12 @@ class PrismTool extends Tool
     public static function toLaravelToolCall(PrismToolCall|array $toolCall): ToolCall
     {
         if (is_array($toolCall)) {
+            $arguments = $toolCall['arguments'] ?? $toolCall['input'] ?? [];
+
             return new ToolCall(
                 $toolCall['id'] ?? '',
                 $toolCall['name'] ?? '',
-                static::normalizeArguments($toolCall['arguments']['schema_definition'] ?? $toolCall['arguments'] ?? []),
+                static::normalizeArguments(is_array($arguments) ? ($arguments['schema_definition'] ?? $arguments) : $arguments),
                 $toolCall['resultId'] ?? null,
                 $toolCall['reasoningId'] ?? null,
                 $toolCall['reasoningSummary'] ?? null,
@@ -68,10 +70,12 @@ class PrismTool extends Tool
     public static function toLaravelToolResult(PrismToolResult|array $toolResult): ToolResult
     {
         if (is_array($toolResult)) {
+            $args = $toolResult['args'] ?? $toolResult['input'] ?? [];
+
             return new ToolResult(
                 $toolResult['toolCallId'] ?? $toolResult['tool_call_id'] ?? '',
                 $toolResult['toolName'] ?? $toolResult['tool_name'] ?? '',
-                static::normalizeArguments($toolResult['args']['schema_definition'] ?? $toolResult['args'] ?? []),
+                static::normalizeArguments(is_array($args) ? ($args['schema_definition'] ?? $args) : $args),
                 $toolResult['result'] ?? '',
                 $toolResult['toolCallResultId'] ?? $toolResult['tool_call_result_id'] ?? null,
             );


### PR DESCRIPTION
Fixes #291

## Summary

Some AI providers (notably Anthropic) send tool call arguments under the \`input\` key instead of \`arguments\`. \`PrismTool::toLaravelToolCall()\` and \`toLaravelToolResult()\` only check for \`arguments\`, silently dropping all arguments when \`input\` is used.

### The Bug

```php
// Tool call from Anthropic uses 'input' key
$toolCall = [
    'id' => 'call_123',
    'name' => 'search',
    'input' => '{"query": "Laravel AI"}',  // 'input' not 'arguments'
];

$result = PrismTool::toLaravelToolCall($toolCall);
$result->arguments; // [] — all arguments silently lost
```

### The Fix

Check \`input\` as a fallback when \`arguments\` is not present:

```php
// Before
$toolCall['arguments']['schema_definition'] ?? $toolCall['arguments'] ?? []

// After
$arguments = $toolCall['arguments'] ?? $toolCall['input'] ?? [];
```

Applied to both \`toLaravelToolCall()\` and \`toLaravelToolResult()\`.

### Consistency

This follows the same pattern used in PR #326 which fixed the identical issue in \`DatabaseConversationStore\`.

### Changes

- \`src/Gateway/Prism/PrismTool.php\` — Add \`input\` key fallback in both methods