### PR TITLE
Fix missing additionalProperties on nested objects in strict schemas

### DIFF
--- a/src/ObjectSchema.php
+++ b/src/ObjectSchema.php
@@ -41,7 +41,9 @@ class ObjectSchema extends Schema implements HasSchemaType
      */
     protected static function disableAdditionalProperties(array $schema): array
     {
-        if (($schema['type'] ?? null) === 'object') {
+        $type = $schema['type'] ?? null;
+
+        if ($type === 'object' || (is_array($type) && in_array('object', $type))) {
             $schema['additionalProperties'] = false;
 
             foreach ($schema['properties'] ?? [] as $key => $property) {

--- a/src/ObjectSchema.php
+++ b/src/ObjectSchema.php
@@ -23,8 +23,7 @@ class ObjectSchema extends Schema implements HasSchemaType
     }
 
     /**
-     * Get the array representation of the schema with additional properties
-     * disabled on all nested objects, as required by OpenAI strict mode.
+     * Get the array representation of the schema with additional properties disabled on all nested objects.
      *
      * @return array<string, mixed>
      */

--- a/src/ObjectSchema.php
+++ b/src/ObjectSchema.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Ai;
 
+use Illuminate\JsonSchema\Types\ArrayType;
 use Illuminate\JsonSchema\Types\ObjectType;
+use Illuminate\JsonSchema\Types\Type;
 use Prism\Prism\Contracts\HasSchemaType;
 
 class ObjectSchema extends Schema implements HasSchemaType
@@ -15,11 +17,45 @@ class ObjectSchema extends Schema implements HasSchemaType
         string $name = 'schema_definition',
         bool $strict = true
     ) {
+        $rootType = (new ObjectType($schema))->withoutAdditionalProperties();
+
+        static::disableAdditionalPropertiesRecursively($schema);
+
         parent::__construct(
-            schema: (new ObjectType($schema))->withoutAdditionalProperties(),
+            schema: $rootType,
             name: $name,
             strict: $strict
         );
+    }
+
+    /**
+     * Recursively disable additional properties on all nested object types.
+     *
+     * @param  array<string, Type>  $properties
+     */
+    protected static function disableAdditionalPropertiesRecursively(array $properties): void
+    {
+        foreach ($properties as $property) {
+            if ($property instanceof ObjectType) {
+                $property->withoutAdditionalProperties();
+
+                $nested = (fn () => $this->properties)->call($property);
+
+                static::disableAdditionalPropertiesRecursively($nested);
+            } elseif ($property instanceof ArrayType) {
+                $items = (fn () => $this->items)->call($property);
+
+                if ($items instanceof ObjectType) {
+                    $items->withoutAdditionalProperties();
+
+                    $nested = (fn () => $this->properties)->call($items);
+
+                    static::disableAdditionalPropertiesRecursively($nested);
+                } elseif ($items instanceof ArrayType) {
+                    static::disableAdditionalPropertiesRecursively(['items' => $items]);
+                }
+            }
+        }
     }
 
     /**

--- a/src/ObjectSchema.php
+++ b/src/ObjectSchema.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Ai;
 
-use Illuminate\JsonSchema\Types\ArrayType;
 use Illuminate\JsonSchema\Types\ObjectType;
-use Illuminate\JsonSchema\Types\Type;
 use Prism\Prism\Contracts\HasSchemaType;
 
 class ObjectSchema extends Schema implements HasSchemaType
@@ -17,45 +15,47 @@ class ObjectSchema extends Schema implements HasSchemaType
         string $name = 'schema_definition',
         bool $strict = true
     ) {
-        $rootType = (new ObjectType($schema))->withoutAdditionalProperties();
-
-        static::disableAdditionalPropertiesRecursively($schema);
-
         parent::__construct(
-            schema: $rootType,
+            schema: (new ObjectType($schema))->withoutAdditionalProperties(),
             name: $name,
             strict: $strict
         );
     }
 
     /**
-     * Recursively disable additional properties on all nested object types.
+     * Get the array representation of the schema with additional properties
+     * disabled on all nested objects, as required by OpenAI strict mode.
      *
-     * @param  array<string, Type>  $properties
+     * @return array<string, mixed>
      */
-    protected static function disableAdditionalPropertiesRecursively(array $properties): void
+    public function toSchema(): array
     {
-        foreach ($properties as $property) {
-            if ($property instanceof ObjectType) {
-                $property->withoutAdditionalProperties();
+        return static::disableAdditionalProperties(parent::toSchema());
+    }
 
-                $nested = (fn () => $this->properties)->call($property);
+    /**
+     * Recursively set "additionalProperties" to false on all object nodes.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    protected static function disableAdditionalProperties(array $schema): array
+    {
+        if (($schema['type'] ?? null) === 'object') {
+            $schema['additionalProperties'] = false;
 
-                static::disableAdditionalPropertiesRecursively($nested);
-            } elseif ($property instanceof ArrayType) {
-                $items = (fn () => $this->items)->call($property);
-
-                if ($items instanceof ObjectType) {
-                    $items->withoutAdditionalProperties();
-
-                    $nested = (fn () => $this->properties)->call($items);
-
-                    static::disableAdditionalPropertiesRecursively($nested);
-                } elseif ($items instanceof ArrayType) {
-                    static::disableAdditionalPropertiesRecursively(['items' => $items]);
+            foreach ($schema['properties'] ?? [] as $key => $property) {
+                if (is_array($property)) {
+                    $schema['properties'][$key] = static::disableAdditionalProperties($property);
                 }
             }
         }
+
+        if (is_array($schema['items'] ?? null)) {
+            $schema['items'] = static::disableAdditionalProperties($schema['items']);
+        }
+
+        return $schema;
     }
 
     /**

--- a/tests/Unit/ObjectSchemaTest.php
+++ b/tests/Unit/ObjectSchemaTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\ObjectSchema;
+use Tests\TestCase;
+
+class ObjectSchemaTest extends TestCase
+{
+    public function test_nested_objects_include_additional_properties_false(): void
+    {
+        $schema = new JsonSchemaTypeFactory;
+
+        $objectSchema = new ObjectSchema([
+            'name' => $schema->string()->required(),
+            'address' => $schema->object([
+                'street' => $schema->string()->required(),
+                'city' => $schema->string()->required(),
+            ])->required(),
+        ]);
+
+        $result = $objectSchema->toSchema();
+
+        $this->assertFalse($result['additionalProperties']);
+        $this->assertFalse($result['properties']['address']['additionalProperties']);
+    }
+
+    public function test_objects_nested_in_arrays_include_additional_properties_false(): void
+    {
+        $schema = new JsonSchemaTypeFactory;
+
+        $objectSchema = new ObjectSchema([
+            'items' => $schema->array()->items(
+                $schema->object([
+                    'action' => $schema->string()->required(),
+                    'amount' => $schema->integer()->required(),
+                ])
+            )->required(),
+        ]);
+
+        $result = $objectSchema->toSchema();
+
+        $this->assertFalse($result['additionalProperties']);
+        $this->assertFalse($result['properties']['items']['items']['additionalProperties']);
+    }
+
+    public function test_deeply_nested_objects_include_additional_properties_false(): void
+    {
+        $schema = new JsonSchemaTypeFactory;
+
+        $objectSchema = new ObjectSchema([
+            'user' => $schema->object([
+                'name' => $schema->string()->required(),
+                'contact' => $schema->object([
+                    'email' => $schema->string()->required(),
+                    'phone' => $schema->string()->required(),
+                ])->required(),
+            ])->required(),
+        ]);
+
+        $result = $objectSchema->toSchema();
+
+        $this->assertFalse($result['additionalProperties']);
+        $this->assertFalse($result['properties']['user']['additionalProperties']);
+        $this->assertFalse($result['properties']['user']['properties']['contact']['additionalProperties']);
+    }
+
+    public function test_objects_in_nested_arrays_include_additional_properties_false(): void
+    {
+        $schema = new JsonSchemaTypeFactory;
+
+        $objectSchema = new ObjectSchema([
+            'matrix' => $schema->array()->items(
+                $schema->array()->items(
+                    $schema->object([
+                        'value' => $schema->integer()->required(),
+                    ])
+                )
+            )->required(),
+        ]);
+
+        $result = $objectSchema->toSchema();
+
+        $this->assertFalse($result['properties']['matrix']['items']['items']['additionalProperties']);
+    }
+}

--- a/tests/Unit/ObjectSchemaTest.php
+++ b/tests/Unit/ObjectSchemaTest.php
@@ -84,4 +84,22 @@ class ObjectSchemaTest extends TestCase
 
         $this->assertFalse($result['properties']['matrix']['items']['items']['additionalProperties']);
     }
+
+    public function test_nullable_nested_objects_include_additional_properties_false(): void
+    {
+        $schema = new JsonSchemaTypeFactory;
+
+        $objectSchema = new ObjectSchema([
+            'name' => $schema->string()->required(),
+            'address' => $schema->object([
+                'street' => $schema->string()->required(),
+                'city' => $schema->string()->required(),
+            ])->nullable(),
+        ]);
+
+        $result = $objectSchema->toSchema();
+
+        $this->assertFalse($result['additionalProperties']);
+        $this->assertFalse($result['properties']['address']['additionalProperties']);
+    }
 }


### PR DESCRIPTION
When v0.4.0 moved OpenAI to a direct gateway, nested objects in schemas lost `additionalProperties: false` — which OpenAI strict mode requires on every object, not just the root. This caused API errors for any schema with nested objects or arrays of objects, including nullable ones.

Fixes #356

### Approach

- Post-process the serialized schema array to set `additionalProperties: false` on every object node, including nullable objects (`type: ["object", "null"]`)
- The fix lives in `ObjectSchema`, so it applies to all direct gateways (OpenAI, Groq, Anthropic) for both structured output and tool schemas