### PR TITLE
Fix ProviderDocument OpenAI attachment mapping

### DIFF
--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -58,7 +58,6 @@ trait MapsAttachments
                 $attachment instanceof ProviderDocument => array_filter([
                     'type' => 'input_file',
                     'file_id' => $attachment->id,
-                    'filename' => $attachment->name(),
                 ]),
                 $attachment instanceof Base64Document => array_filter([
                     'type' => 'input_file',


### PR DESCRIPTION
When #324 was merged to fix missing filenames, the `filename` attribute got added to instances of ProviderDocument (where `filename` isn't supported), causing an OpenAI `400` error.