### PR TITLE
Preserve configured options in tool loop follow-up requests

### DIFF
--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -96,6 +96,7 @@ class AnthropicGateway implements Gateway
             $schema,
             $options,
             $body,
+            $timeout,
         );
     }
 
@@ -141,6 +142,9 @@ class AnthropicGateway implements Gateway
             $options,
             $response->getBody(),
             $body,
+            0,
+            null,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -40,6 +40,7 @@ trait HandlesTextStreaming
         array $requestBody = [],
         int $depth = 0,
         ?int $maxSteps = null,
+        ?int $timeout = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -337,6 +338,7 @@ trait HandlesTextStreaming
                 $requestBody,
                 $depth,
                 $maxSteps,
+                $timeout,
             );
 
             return;
@@ -365,6 +367,7 @@ trait HandlesTextStreaming
         array $requestBody,
         int $depth,
         ?int $maxSteps,
+        ?int $timeout = null,
     ): Generator {
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -427,7 +430,7 @@ trait HandlesTextStreaming
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => $this->client($provider)
+            fn () => $this->client($provider, $timeout)
                 ->withOptions(['stream' => true])
                 ->post('messages', $requestBody),
         );
@@ -443,6 +446,7 @@ trait HandlesTextStreaming
             $requestBody,
             $depth + 1,
             $maxSteps,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -48,6 +48,7 @@ trait ParsesTextResponses
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         array $requestBody = [],
+        ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -59,6 +60,7 @@ trait ParsesTextResponses
             new Collection,
             $requestBody,
             maxSteps: $options?->maxSteps,
+            timeout: $timeout,
         );
     }
 
@@ -76,6 +78,7 @@ trait ParsesTextResponses
         array $requestBody,
         int $depth = 0,
         ?int $maxSteps = null,
+        ?int $timeout = null,
     ): TextResponse {
         $model = $data['model'] ?? '';
         $content = $data['content'] ?? [];
@@ -118,6 +121,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $depth + 1,
                 $maxSteps,
+                $timeout,
             );
         }
 
@@ -193,6 +197,7 @@ trait ParsesTextResponses
         array $toolResults,
         int $depth,
         ?int $maxSteps,
+        ?int $timeout = null,
     ): TextResponse {
         $requestBody['messages'][] = [
             'role' => 'assistant',
@@ -218,7 +223,7 @@ trait ParsesTextResponses
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('messages', $requestBody),
+            fn () => $this->client($provider, $timeout)->post('messages', $requestBody),
         );
 
         $data = $response->json();
@@ -236,6 +241,7 @@ trait ParsesTextResponses
             $requestBody,
             $depth,
             $maxSteps,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -256,7 +256,7 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        if ($depth + 1 < ($maxSteps ?? count($tools) * 2)) {
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
             $contents[] = ['role' => 'model', 'parts' => $this->excludeThinkingParts($modelParts)];
             $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
 

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -181,9 +181,19 @@ trait HandlesTextStreaming
         // Handle pending tool calls...
         if (filled($pendingToolCalls)) {
             yield from $this->handleStreamingToolCalls(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $pendingToolCalls, $contents, $instructions,
-                $modelParts, $depth, $maxSteps, $timeout,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $pendingToolCalls,
+                $contents,
+                $instructions,
+                $modelParts,
+                $depth,
+                $maxSteps,
+                $timeout,
             );
 
             return;
@@ -270,9 +280,18 @@ trait HandlesTextStreaming
             );
 
             yield from $this->processTextStream(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $contents, $instructions,
-                $depth + 1, $maxSteps, $timeout,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $contents,
+                $instructions,
+                $depth + 1,
+                $maxSteps,
+                $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -37,6 +37,7 @@ trait HandlesTextStreaming
         ?string $instructions = null,
         int $depth = 0,
         ?int $maxSteps = null,
+        ?int $timeout = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -182,7 +183,7 @@ trait HandlesTextStreaming
             yield from $this->handleStreamingToolCalls(
                 $invocationId, $provider, $model, $tools, $schema, $options,
                 $pendingToolCalls, $contents, $instructions,
-                $modelParts, $depth, $maxSteps,
+                $modelParts, $depth, $maxSteps, $timeout,
             );
 
             return;
@@ -212,6 +213,7 @@ trait HandlesTextStreaming
         array $modelParts,
         int $depth,
         ?int $maxSteps,
+        ?int $timeout = null,
     ): Generator {
         $mappedToolCalls = $this->mapToolCalls($pendingToolCalls);
 
@@ -262,7 +264,7 @@ trait HandlesTextStreaming
 
             $response = $this->withRateLimitHandling(
                 $provider->name(),
-                fn () => $this->client($provider)
+                fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
                     ->post("models/{$model}:streamGenerateContent?alt=sse", $body),
             );
@@ -270,7 +272,7 @@ trait HandlesTextStreaming
             yield from $this->processTextStream(
                 $invocationId, $provider, $model, $tools, $schema, $options,
                 $response->getBody(), $contents, $instructions,
-                $depth + 1, $maxSteps,
+                $depth + 1, $maxSteps, $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -51,6 +51,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         array $contents = [],
         ?string $instructions = null,
+        ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -65,6 +66,7 @@ trait ParsesTextResponses
             $instructions,
             $options,
             maxSteps: $options?->maxSteps,
+            timeout: $timeout,
         );
     }
 
@@ -85,6 +87,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options,
         int $depth = 0,
         ?int $maxSteps = null,
+        ?int $timeout = null,
     ): TextResponse {
         $candidate = $data['candidates'][0] ?? [];
         $parts = $candidate['content']['parts'] ?? [];
@@ -119,7 +122,7 @@ trait ParsesTextResponses
             return $this->continueWithToolResults(
                 $model, $provider, $structured, $tools, $schema,
                 $steps, $messages, $contents, $instructions, $options,
-                $depth + 1, $maxSteps,
+                $depth + 1, $maxSteps, $timeout,
             );
         }
 
@@ -193,12 +196,13 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options,
         int $depth,
         ?int $maxSteps,
+        ?int $timeout = null,
     ): TextResponse {
         $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post("models/{$model}:generateContent", $body),
+            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", $body),
         );
 
         $data = $response->json();
@@ -208,7 +212,7 @@ trait ParsesTextResponses
         return $this->processResponse(
             $data, $provider, $model, $structured, $tools, $schema,
             $steps, $messages, $contents, $instructions, $options,
-            $depth, $maxSteps,
+            $depth, $maxSteps, $timeout,
         );
     }
 

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -120,9 +120,19 @@ trait ParsesTextResponses
             $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
 
             return $this->continueWithToolResults(
-                $model, $provider, $structured, $tools, $schema,
-                $steps, $messages, $contents, $instructions, $options,
-                $depth + 1, $maxSteps, $timeout,
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $contents,
+                $instructions,
+                $options,
+                $depth + 1,
+                $maxSteps,
+                $timeout,
             );
         }
 
@@ -210,9 +220,20 @@ trait ParsesTextResponses
         $this->validateTextResponse($data);
 
         return $this->processResponse(
-            $data, $provider, $model, $structured, $tools, $schema,
-            $steps, $messages, $contents, $instructions, $options,
-            $depth, $maxSteps, $timeout,
+            $data,
+            $provider,
+            $model,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $contents,
+            $instructions,
+            $options,
+            $depth,
+            $maxSteps,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -107,7 +107,7 @@ trait ParsesTextResponses
 
         if ($finishReason === FinishReason::ToolCalls &&
             filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? count($tools) * 2)) {
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
         }
 

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -73,7 +73,7 @@ class GeminiGateway implements Gateway
         $this->validateTextResponse($data);
 
         return $this->parseTextResponse(
-            $data, $provider, $model, filled($schema), $tools, $schema, $options, $contents, $instructions,
+            $data, $provider, $model, filled($schema), $tools, $schema, $options, $contents, $instructions, $timeout,
         );
     }
 
@@ -104,7 +104,7 @@ class GeminiGateway implements Gateway
 
         yield from $this->processTextStream(
             $invocationId, $provider, $model, $tools, $schema, $options,
-            $response->getBody(), $contents, $instructions,
+            $response->getBody(), $contents, $instructions, 0, null, $timeout,
         );
     }
 

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -73,7 +73,16 @@ class GeminiGateway implements Gateway
         $this->validateTextResponse($data);
 
         return $this->parseTextResponse(
-            $data, $provider, $model, filled($schema), $tools, $schema, $options, $contents, $instructions, $timeout,
+            $data,
+            $provider,
+            $model,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $contents,
+            $instructions,
+            $timeout,
         );
     }
 
@@ -103,8 +112,18 @@ class GeminiGateway implements Gateway
         );
 
         yield from $this->processTextStream(
-            $invocationId, $provider, $model, $tools, $schema, $options,
-            $response->getBody(), $contents, $instructions, 0, null, $timeout,
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $contents,
+            $instructions,
+            0,
+            null,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -282,6 +282,14 @@ trait HandlesTextStreaming
                 $body['response_format'] = $this->buildResponseFormat($schema);
             }
 
+            if (! is_null($options?->maxTokens)) {
+                $body['max_completion_tokens'] = $options->maxTokens;
+            }
+
+            if (! is_null($options?->temperature)) {
+                $body['temperature'] = $options->temperature;
+            }
+
             $providerOptions = $options?->providerOptions($provider->driver());
 
             if (filled($providerOptions)) {

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -36,6 +36,7 @@ trait HandlesTextStreaming
         int $depth = 0,
         ?int $maxSteps = null,
         array $priorChatMessages = [],
+        ?int $timeout = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -170,6 +171,7 @@ trait HandlesTextStreaming
                 $depth,
                 $maxSteps,
                 $priorChatMessages,
+                $timeout,
             );
 
             return;
@@ -200,6 +202,7 @@ trait HandlesTextStreaming
         int $depth,
         ?int $maxSteps,
         array $priorChatMessages,
+        ?int $timeout = null,
     ): Generator {
         $toolResults = [];
 
@@ -287,7 +290,7 @@ trait HandlesTextStreaming
 
             $response = $this->withRateLimitHandling(
                 $provider->name(),
-                fn () => $this->client($provider)
+                fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
                     ->post('chat/completions', $body),
             );
@@ -305,6 +308,7 @@ trait HandlesTextStreaming
                 $depth + 1,
                 $maxSteps,
                 $updatedPriorMessages,
+                $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -272,6 +272,14 @@ trait ParsesTextResponses
             $body['response_format'] = $this->buildResponseFormat($schema);
         }
 
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
         $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -23,7 +23,7 @@ trait ParsesTextResponses
     /**
      * Validate the Groq response data.
      *
-     * @throws \Laravel\Ai\Exceptions\AiException
+     * @throws AiException
      */
     protected function validateTextResponse(array $data): void
     {
@@ -48,6 +48,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?string $instructions = null,
         array $originalMessages = [],
+        ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -61,6 +62,7 @@ trait ParsesTextResponses
             originalMessages: $originalMessages,
             maxSteps: $options?->maxSteps,
             options: $options,
+            timeout: $timeout,
         );
     }
 
@@ -80,6 +82,7 @@ trait ParsesTextResponses
         int $depth = 0,
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -145,6 +148,7 @@ trait ParsesTextResponses
                 $depth + 1,
                 $maxSteps,
                 $options,
+                $timeout,
             );
         }
 
@@ -220,6 +224,7 @@ trait ParsesTextResponses
         int $depth,
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
 
@@ -275,7 +280,7 @@ trait ParsesTextResponses
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('chat/completions', $body),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
         );
 
         $data = $response->json();
@@ -295,6 +300,7 @@ trait ParsesTextResponses
             $depth,
             $maxSteps,
             $options,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -71,6 +71,7 @@ class GroqGateway implements TextGateway
             $options,
             $instructions,
             $messages,
+            $timeout,
         );
     }
 
@@ -118,6 +119,10 @@ class GroqGateway implements TextGateway
             $response->getBody(),
             $instructions,
             $messages,
+            0,
+            null,
+            [],
+            $timeout,
         );
     }
 }

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -281,9 +281,19 @@ trait HandlesTextStreaming
 
         if (filled($pendingToolCalls)) {
             yield from $this->handleStreamingToolCalls(
-                $invocationId, $responseId, $provider, $model, $tools, $schema, $options,
-                $pendingToolCalls, $currentText, $reasoningItems,
-                $depth, $maxSteps, $timeout,
+                $invocationId,
+                $responseId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $pendingToolCalls,
+                $currentText,
+                $reasoningItems,
+                $depth,
+                $maxSteps,
+                $timeout,
             );
 
             return;
@@ -387,8 +397,16 @@ trait HandlesTextStreaming
             );
 
             yield from $this->processTextStream(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $depth + 1, $maxSteps, $timeout,
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $depth + 1,
+                $maxSteps,
+                $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -38,6 +38,7 @@ trait HandlesTextStreaming
         $streamBody,
         int $depth = 0,
         ?int $maxSteps = null,
+        ?int $timeout = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -282,7 +283,7 @@ trait HandlesTextStreaming
             yield from $this->handleStreamingToolCalls(
                 $invocationId, $responseId, $provider, $model, $tools, $schema, $options,
                 $pendingToolCalls, $currentText, $reasoningItems,
-                $depth, $maxSteps,
+                $depth, $maxSteps, $timeout,
             );
 
             return;
@@ -312,6 +313,7 @@ trait HandlesTextStreaming
         array $reasoningItems,
         int $depth,
         ?int $maxSteps,
+        ?int $timeout = null,
     ): Generator {
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -371,14 +373,14 @@ trait HandlesTextStreaming
 
             $response = $this->withRateLimitHandling(
                 $provider->name(),
-                fn () => $this->client($provider)
+                fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
                     ->post('responses', $body),
             );
 
             yield from $this->processTextStream(
                 $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $depth + 1, $maxSteps,
+                $response->getBody(), $depth + 1, $maxSteps, $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -363,6 +363,14 @@ trait HandlesTextStreaming
                 $body['text'] = $this->buildSchemaFormat($schema);
             }
 
+            if (! is_null($options?->temperature)) {
+                $body['temperature'] = $options->temperature;
+            }
+
+            if (! is_null($options?->maxTokens)) {
+                $body['max_output_tokens'] = $options->maxTokens;
+            }
+
             $providerOptions = $options?->providerOptions(
                 Lab::tryFrom($provider->driver()) ?? $provider->driver()
             );

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -273,19 +273,7 @@ trait ParsesTextResponses
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
-        );
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -236,6 +236,14 @@ trait ParsesTextResponses
             $body['text'] = $this->buildSchemaFormat($schema);
         }
 
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_output_tokens'] = $options->maxTokens;
+        }
+
         $providerOptions = $options?->providerOptions(
             Lab::tryFrom($provider->driver()) ?? $provider->driver()
         );

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -143,7 +143,19 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options, $timeout,
+                $responseId,
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $toolResults,
+                $depth + 1,
+                $maxSteps,
+                $options,
+                $timeout,
             );
         }
 
@@ -261,7 +273,19 @@ trait ParsesTextResponses
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $depth,
+            $maxSteps,
+            $options,
+            $timeout,
+        );
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -58,6 +58,7 @@ trait ParsesTextResponses
         array $tools = [],
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -69,6 +70,7 @@ trait ParsesTextResponses
             new Collection,
             maxSteps: $options?->maxSteps,
             options: $options,
+            timeout: $timeout,
         );
     }
 
@@ -86,6 +88,7 @@ trait ParsesTextResponses
         int $depth = 0,
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
@@ -140,7 +143,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options,
+                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options, $timeout,
             );
         }
 
@@ -217,6 +220,7 @@ trait ParsesTextResponses
         int $depth,
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $body = [
             'model' => $model,
@@ -242,14 +246,14 @@ trait ParsesTextResponses
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('responses', $body),
+            fn () => $this->client($provider, $timeout)->post('responses', $body),
         );
 
         $data = $response->json();
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options);
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
     }
 
     /**

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -75,7 +76,7 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
     }
 
     /**
@@ -107,7 +108,7 @@ class OpenAiGateway implements Gateway
 
         yield from $this->processTextStream(
             $invocationId, $provider, $model, $tools, $schema, $options,
-            $response->getBody(),
+            $response->getBody(), 0, null, $timeout,
         );
     }
 
@@ -289,7 +290,7 @@ class OpenAiGateway implements Gateway
      */
     protected function audioFilename(TranscribableAudio $audio): string
     {
-        if ($audio instanceof \Laravel\Ai\Contracts\Files\HasName && $audio->name()) {
+        if ($audio instanceof HasName && $audio->name()) {
             return $audio->name();
         }
 

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -76,7 +76,15 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $timeout,
+        );
     }
 
     /**
@@ -107,8 +115,16 @@ class OpenAiGateway implements Gateway
         );
 
         yield from $this->processTextStream(
-            $invocationId, $provider, $model, $tools, $schema, $options,
-            $response->getBody(), 0, null, $timeout,
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            0,
+            null,
+            $timeout,
         );
     }
 

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -76,15 +76,7 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
     }
 
     /**

--- a/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
+++ b/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature\Providers;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Gateway\Groq\GroqGateway;
+use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Providers\GroqProvider;
+use Laravel\Ai\Providers\OpenAiProvider;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\TestCase;
+
+#[Temperature(0.2)]
+#[MaxTokens(1024)]
+class TextGenOptionsToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator];
+    }
+}
+
+class TextGenerationOptionsInToolLoopTest extends TestCase
+{
+    // ── OpenAI ────────────────────────────────────────────────────────
+
+    public function test_openai_temperature_and_max_tokens_are_preserved_in_tool_call_follow_up(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeOpenAiToolCallResponse(),
+                $this->fakeOpenAiTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        config(['ai.providers.openai.key' => 'test-key']);
+
+        $gateway = new OpenAiGateway(app(Dispatcher::class));
+        $manager = app(AiManager::class);
+        $manager->purge('openai');
+        $manager->extend('openai', fn ($app, array $config) => new OpenAiProvider(
+            $gateway, $config, app(Dispatcher::class),
+        ));
+
+        (new TextGenOptionsToolAgent)->prompt('Give me a number', provider: 'openai');
+
+        Http::assertSentInOrder([
+            fn (Request $request) => $request['temperature'] === 0.2
+                && $request['max_output_tokens'] === 1024,
+            fn (Request $request) => $request['temperature'] === 0.2
+                && $request['max_output_tokens'] === 1024
+                && isset($request['previous_response_id']),
+        ]);
+    }
+
+    // ── Groq ──────────────────────────────────────────────────────────
+
+    public function test_groq_temperature_and_max_tokens_are_preserved_in_tool_call_follow_up(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeGroqToolCallResponse(),
+                $this->fakeGroqTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        config(['ai.providers.groq.key' => 'test-key']);
+
+        $gateway = new GroqGateway(app(Dispatcher::class));
+        $manager = app(AiManager::class);
+        $manager->purge('groq');
+        $manager->extend('groq', function ($app, array $config) use ($gateway) {
+            $provider = new GroqProvider($config, app(Dispatcher::class));
+            $provider->useTextGateway($gateway);
+
+            return $provider;
+        });
+
+        (new TextGenOptionsToolAgent)->prompt('Give me a number', provider: 'groq');
+
+        Http::assertSentInOrder([
+            fn (Request $request) => $request['temperature'] === 0.2
+                && $request['max_completion_tokens'] === 1024,
+            fn (Request $request) => $request['temperature'] === 0.2
+                && $request['max_completion_tokens'] === 1024,
+        ]);
+    }
+
+    // ── OpenAI response helpers ───────────────────────────────────────
+
+    protected function fakeOpenAiToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_tool_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'function_call',
+                'id' => 'fc_123',
+                'call_id' => 'call_123',
+                'name' => 'FixedNumberGenerator',
+                'arguments' => '{}',
+                'status' => 'completed',
+            ]],
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeOpenAiTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [['type' => 'output_text', 'text' => $text]],
+            ]],
+            'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+        ]);
+    }
+
+    // ── Groq response helpers ─────────────────────────────────────────
+
+    protected function fakeGroqToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeGroqTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => $text],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
+++ b/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
@@ -38,8 +38,6 @@ class TextGenOptionsToolAgent implements Agent, HasTools
 
 class TextGenerationOptionsInToolLoopTest extends TestCase
 {
-    // ── OpenAI ────────────────────────────────────────────────────────
-
     public function test_openai_temperature_and_max_tokens_are_preserved_in_tool_call_follow_up(): void
     {
         Http::fake([
@@ -68,8 +66,6 @@ class TextGenerationOptionsInToolLoopTest extends TestCase
                 && isset($request['previous_response_id']),
         ]);
     }
-
-    // ── Groq ──────────────────────────────────────────────────────────
 
     public function test_groq_temperature_and_max_tokens_are_preserved_in_tool_call_follow_up(): void
     {
@@ -101,8 +97,6 @@ class TextGenerationOptionsInToolLoopTest extends TestCase
                 && $request['max_completion_tokens'] === 1024,
         ]);
     }
-
-    // ── OpenAI response helpers ───────────────────────────────────────
 
     protected function fakeOpenAiToolCallResponse(): PromiseInterface
     {
@@ -136,8 +130,6 @@ class TextGenerationOptionsInToolLoopTest extends TestCase
             'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
         ]);
     }
-
-    // ── Groq response helpers ─────────────────────────────────────────
 
     protected function fakeGroqToolCallResponse(): PromiseInterface
     {

--- a/tests/Feature/Providers/TimeoutInToolLoopTest.php
+++ b/tests/Feature/Providers/TimeoutInToolLoopTest.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace Tests\Feature\Providers;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\AiManager;
+use Laravel\Ai\Attributes\Timeout;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
+use Laravel\Ai\Gateway\Gemini\GeminiGateway;
+use Laravel\Ai\Gateway\Groq\GroqGateway;
+use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\GeminiProvider;
+use Laravel\Ai\Providers\GroqProvider;
+use Laravel\Ai\Providers\OpenAiProvider;
+use Laravel\Ai\Providers\Provider;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\TestCase;
+
+#[Timeout(300)]
+class TimeoutToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator];
+    }
+}
+
+class SpyOpenAiGateway extends OpenAiGateway
+{
+    public array $capturedTimeouts = [];
+
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $this->capturedTimeouts[] = $timeout;
+
+        return parent::client($provider, $timeout);
+    }
+}
+
+class SpyAnthropicGateway extends AnthropicGateway
+{
+    public array $capturedTimeouts = [];
+
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $this->capturedTimeouts[] = $timeout;
+
+        return parent::client($provider, $timeout);
+    }
+}
+
+class SpyGroqGateway extends GroqGateway
+{
+    public array $capturedTimeouts = [];
+
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $this->capturedTimeouts[] = $timeout;
+
+        return parent::client($provider, $timeout);
+    }
+}
+
+class SpyGeminiGateway extends GeminiGateway
+{
+    public array $capturedTimeouts = [];
+
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $this->capturedTimeouts[] = $timeout;
+
+        return parent::client($provider, $timeout);
+    }
+}
+
+class TimeoutInToolLoopTest extends TestCase
+{
+    public function test_openai_timeout_is_preserved_in_tool_call_follow_up(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeOpenAiToolCallResponse(),
+                $this->fakeOpenAiTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        config(['ai.providers.openai.key' => 'test-key']);
+
+        $spy = new SpyOpenAiGateway(app(Dispatcher::class));
+        $manager = app(AiManager::class);
+        $manager->purge('openai');
+        $manager->extend('openai', fn ($app, array $config) => new OpenAiProvider(
+            $spy, $config, app(Dispatcher::class),
+        ));
+
+        (new TimeoutToolAgent)->prompt('Give me a number', provider: 'openai');
+
+        $this->assertCount(2, $spy->capturedTimeouts);
+        $this->assertSame(300, $spy->capturedTimeouts[0]);
+        $this->assertSame(300, $spy->capturedTimeouts[1]);
+    }
+
+    public function test_anthropic_timeout_is_preserved_in_tool_call_follow_up(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                $this->fakeAnthropicToolCallResponse(),
+                $this->fakeAnthropicTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        config(['ai.providers.anthropic.key' => 'test-key']);
+
+        $spy = new SpyAnthropicGateway(app(Dispatcher::class));
+        $manager = app(AiManager::class);
+        $manager->purge('anthropic');
+        $manager->extend('anthropic', fn ($app, array $config) => new AnthropicProvider(
+            $spy, $config, app(Dispatcher::class),
+        ));
+
+        (new TimeoutToolAgent)->prompt('Give me a number', provider: 'anthropic');
+
+        $this->assertCount(2, $spy->capturedTimeouts);
+        $this->assertSame(300, $spy->capturedTimeouts[0]);
+        $this->assertSame(300, $spy->capturedTimeouts[1]);
+    }
+
+    public function test_groq_timeout_is_preserved_in_tool_call_follow_up(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeGroqToolCallResponse(),
+                $this->fakeGroqTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        config(['ai.providers.groq.key' => 'test-key']);
+
+        $spy = new SpyGroqGateway(app(Dispatcher::class));
+
+        $manager = app(AiManager::class);
+        $manager->purge('groq');
+        $manager->extend('groq', function ($app, array $config) use ($spy) {
+            $provider = new GroqProvider($config, app(Dispatcher::class));
+            $provider->useTextGateway($spy);
+
+            return $provider;
+        });
+
+        (new TimeoutToolAgent)->prompt('Give me a number', provider: 'groq');
+
+        $this->assertCount(2, $spy->capturedTimeouts);
+        $this->assertSame(300, $spy->capturedTimeouts[0]);
+        $this->assertSame(300, $spy->capturedTimeouts[1]);
+    }
+
+    public function test_gemini_timeout_is_preserved_in_tool_call_follow_up(): void
+    {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence([
+                $this->fakeGeminiToolCallResponse(),
+                $this->fakeGeminiTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        config(['ai.providers.gemini.key' => 'test-key']);
+
+        $spy = new SpyGeminiGateway(app(Dispatcher::class));
+        $manager = app(AiManager::class);
+        $manager->purge('gemini');
+        $manager->extend('gemini', fn ($app, array $config) => new GeminiProvider(
+            $spy, $config, app(Dispatcher::class),
+        ));
+
+        (new TimeoutToolAgent)->prompt('Give me a number', provider: 'gemini');
+
+        $this->assertCount(2, $spy->capturedTimeouts);
+        $this->assertSame(300, $spy->capturedTimeouts[0]);
+        $this->assertSame(300, $spy->capturedTimeouts[1]);
+    }
+
+    // OpenAI response helpers
+
+    protected function fakeOpenAiToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_tool_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'function_call',
+                'id' => 'fc_123',
+                'call_id' => 'call_123',
+                'name' => 'FixedNumberGenerator',
+                'arguments' => '{}',
+                'status' => 'completed',
+            ]],
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeOpenAiTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [['type' => 'output_text', 'text' => $text]],
+            ]],
+            'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+        ]);
+    }
+
+    // Anthropic response helpers
+
+    protected function fakeAnthropicToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_tool_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_123',
+                'name' => 'FixedNumberGenerator',
+                'input' => (object) [],
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeAnthropicTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [['type' => 'text', 'text' => $text]],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    // Groq response helpers
+
+    protected function fakeGroqToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeGroqTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => $text],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
+        ]);
+    }
+
+    // Gemini response helpers
+
+    protected function fakeGeminiToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'candidates' => [[
+                'content' => [
+                    'parts' => [[
+                        'functionCall' => [
+                            'id' => 'call_123',
+                            'name' => 'FixedNumberGenerator',
+                            'args' => (object) [],
+                        ],
+                    ]],
+                    'role' => 'model',
+                ],
+                'finishReason' => 'STOP',
+            ]],
+            'usageMetadata' => [
+                'promptTokenCount' => 10,
+                'candidatesTokenCount' => 5,
+                'totalTokenCount' => 15,
+            ],
+            'modelVersion' => 'gemini-3-flash-preview',
+        ]);
+    }
+
+    protected function fakeGeminiTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'candidates' => [[
+                'content' => [
+                    'parts' => [['text' => $text]],
+                    'role' => 'model',
+                ],
+                'finishReason' => 'STOP',
+            ]],
+            'usageMetadata' => [
+                'promptTokenCount' => 10,
+                'candidatesTokenCount' => 5,
+                'totalTokenCount' => 15,
+            ],
+            'modelVersion' => 'gemini-3-flash-preview',
+        ]);
+    }
+}

--- a/tests/Feature/Providers/TimeoutInToolLoopTest.php
+++ b/tests/Feature/Providers/TimeoutInToolLoopTest.php
@@ -193,8 +193,6 @@ class TimeoutInToolLoopTest extends TestCase
         $this->assertSame(300, $spy->capturedTimeouts[1]);
     }
 
-    // OpenAI response helpers
-
     protected function fakeOpenAiToolCallResponse(): PromiseInterface
     {
         return Http::response([
@@ -228,8 +226,6 @@ class TimeoutInToolLoopTest extends TestCase
         ]);
     }
 
-    // Anthropic response helpers
-
     protected function fakeAnthropicToolCallResponse(): PromiseInterface
     {
         return Http::response([
@@ -260,8 +256,6 @@ class TimeoutInToolLoopTest extends TestCase
             'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
         ]);
     }
-
-    // Groq response helpers
 
     protected function fakeGroqToolCallResponse(): PromiseInterface
     {
@@ -303,8 +297,6 @@ class TimeoutInToolLoopTest extends TestCase
             'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
         ]);
     }
-
-    // Gemini response helpers
 
     protected function fakeGeminiToolCallResponse(): PromiseInterface
     {


### PR DESCRIPTION
Several agent configuration options are honored for the initial API request but silently revert to provider defaults after a tool call triggers a follow-up request. This affects all four direct gateway implementations.

Fixes #359

### Approach

- Thread `$timeout` through recursive tool loop methods so follow-up HTTP requests preserve the configured timeout across OpenAI, Anthropic, Groq, and Gemini gateways
- Re-send `temperature` and `max_output_tokens`/`max_completion_tokens` in tool loop follow-up request bodies for OpenAI and Groq (Anthropic and Gemini already preserved these by reusing the original request body)
- Align Gemini's default `maxSteps` formula to `round(count($tools) * 1.5)` to match all other gateways (was `count($tools) * 2`)
- Add integration tests asserting timeout, temperature, and max tokens are preserved across both initial and follow-up requests