### PR TITLE
Switch Gemini structured output to response_json_schema

### DIFF
--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
-use Illuminate\Support\Arr;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -74,7 +73,7 @@ trait BuildsTextRequests
 
         if (filled($schema)) {
             $generationConfig['response_mime_type'] = 'application/json';
-            $generationConfig['response_schema'] = $this->buildResponseSchema($schema);
+            $generationConfig['response_json_schema'] = $this->buildResponseSchema($schema);
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -127,8 +126,6 @@ trait BuildsTextRequests
      */
     protected function buildResponseSchema(array $schema): array
     {
-        $objectSchema = new ObjectSchema($schema);
-
-        return Arr::except($objectSchema->toSchema(), ['additionalProperties', 'name']);
+        return (new ObjectSchema($schema))->toSchema();
     }
 }

--- a/tests/Feature/Agents/NestedStructuredAgent.php
+++ b/tests/Feature/Agents/NestedStructuredAgent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+
+class NestedStructuredAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that knows about periodic table elements.';
+    }
+
+    /**
+     * Get the structured output's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'elements' => $schema->array()->required()->items(
+                $schema->object([
+                    'atomicNumber' => $schema->integer()->required(),
+                    'symbol' => $schema->string()->required(),
+                ])
+            ),
+        ];
+    }
+}

--- a/tests/Feature/Agents/NullableStructuredAgent.php
+++ b/tests/Feature/Agents/NullableStructuredAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+
+class NullableStructuredAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that knows about periodic table elements and their properties.';
+    }
+
+    /**
+     * Get the structured output's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'symbol' => $schema->string()->required(),
+            'meltingPoint' => $schema->number()->nullable()->required(),
+            'boilingPoint' => $schema->number()->nullable()->required(),
+        ];
+    }
+}

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Responses\Data\FinishReason;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\NestedStructuredAgent;
+use Tests\Feature\Agents\NullableStructuredAgent;
 use Tests\Feature\Agents\StructuredAgent;
 use Tests\Feature\Agents\ToolUsingAgent;
 
@@ -138,7 +140,7 @@ class RequestMappingTest extends GeminiTestCase
         $this->assertSame(50, $response->usage->completionTokens);
     }
 
-    public function test_structured_output_uses_response_schema(): void
+    public function test_structured_output_uses_response_json_schema(): void
     {
         Http::fake([
             'generativelanguage.googleapis.com/*' => $this->fakeStructuredResponse(['symbol' => 'Fe']),
@@ -154,7 +156,7 @@ class RequestMappingTest extends GeminiTestCase
             $config = $body['generationConfig'] ?? [];
 
             return ($config['response_mime_type'] ?? '') === 'application/json'
-                && isset($config['response_schema']);
+                && isset($config['response_json_schema']);
         });
     }
 
@@ -213,19 +215,42 @@ class RequestMappingTest extends GeminiTestCase
         $this->assertSame('call_abc123', $toolCall->id);
     }
 
-    public function test_structured_response_schema_excludes_additional_properties(): void
+    public function test_nested_structured_output_uses_response_json_schema(): void
     {
         Http::fake([
-            'generativelanguage.googleapis.com/*' => $this->fakeStructuredResponse(['symbol' => 'Fe']),
+            'generativelanguage.googleapis.com/*' => $this->fakeStructuredResponse([
+                'elements' => [['atomicNumber' => 1, 'symbol' => 'H']],
+            ]),
         ]);
 
-        (new StructuredAgent)->prompt('Iron symbol?', provider: 'gemini');
+        (new NestedStructuredAgent)->prompt('List noble gases?', provider: 'gemini');
 
         Http::assertSent(function ($request) {
-            $schema = $request->data()['generationConfig']['response_schema'] ?? [];
+            $config = $request->data()['generationConfig'] ?? [];
 
-            return ! isset($schema['additionalProperties'])
-                && ! isset($schema['name']);
+            return isset($config['response_json_schema'])
+                && ! isset($config['response_schema']);
+        });
+    }
+
+    public function test_nullable_schema_types_are_preserved_in_response_json_schema(): void
+    {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => $this->fakeStructuredResponse([
+                'symbol' => 'He',
+                'meltingPoint' => null,
+                'boilingPoint' => -268.9,
+            ]),
+        ]);
+
+        (new NullableStructuredAgent)->prompt('Properties of Helium?', provider: 'gemini');
+
+        Http::assertSent(function ($request) {
+            $schema = $request->data()['generationConfig']['response_json_schema'] ?? [];
+            $props = $schema['properties'] ?? [];
+
+            return $props['meltingPoint']['type'] === ['number', 'null']
+                && $props['boilingPoint']['type'] === ['number', 'null'];
         });
     }
 

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -156,7 +156,8 @@ class RequestMappingTest extends GeminiTestCase
             $config = $body['generationConfig'] ?? [];
 
             return ($config['response_mime_type'] ?? '') === 'application/json'
-                && isset($config['response_json_schema']);
+                && isset($config['response_json_schema'])
+                && ! isset($config['response_schema']);
         });
     }
 
@@ -227,9 +228,13 @@ class RequestMappingTest extends GeminiTestCase
 
         Http::assertSent(function ($request) {
             $config = $request->data()['generationConfig'] ?? [];
+            $schema = $config['response_json_schema'] ?? [];
+            $itemSchema = $schema['properties']['elements']['items'] ?? [];
 
             return isset($config['response_json_schema'])
-                && ! isset($config['response_schema']);
+                && ! isset($config['response_schema'])
+                && isset($itemSchema['additionalProperties'])
+                && $itemSchema['additionalProperties'] === false;
         });
     }
 


### PR DESCRIPTION
## Summary

Switches Gemini structured output from `response_schema` to `response_json_schema`, fixing 400 errors caused by unsupported JSON Schema features in nested schemas.

`response_schema` uses Gemini's OpenAPI subset, which does not support keys like `additionalProperties` or union types (`["string", "null"]`). `response_json_schema` accepts standard JSON Schema natively, so no stripping or workarounds are needed.

## What this fixes

**Nested objects** — `ObjectSchema::toSchema()` recursively adds `additionalProperties: false` to every nested object (required by OpenAI). With `response_schema`, `Arr::except()` only stripped it from the top level, so any nested objects caused Gemini to reject the request with HTTP 400: `Unknown name "additionalProperties"`. For example:

```php
public function schema(JsonSchema $schema): array
{
    return [
        'elements' => $schema->array()->required()->items(
            $schema->object([
                'atomicNumber' => $schema->integer()->required(),
                'symbol' => $schema->string()->required(),
            ])
        ),
    ];
}
```

**Nullable types** — `->nullable()` serializes as `"type": ["number", "null"]` (JSON Schema union type). `response_schema` rejects this because it expects a single string type. This forced workarounds like sentinel values (`-1`) to represent null. For example:

```php
'meltingPoint' => $schema->number()->nullable()->required(),
```

Both issues are resolved by switching to `response_json_schema`, which accepts standard JSON Schema as-is.

## Verification

Confirmed working in production by pointing `composer.json` at this branch — nested objects and nullable types both work without workarounds.

All existing and new tests pass.

## Test plan

- [x] `test_structured_output_uses_response_json_schema` — flat schema uses new key
- [x] `test_nested_structured_output_uses_response_json_schema` — array of objects uses new key
- [x] `test_nullable_schema_types_are_preserved_in_response_json_schema` — union types preserved
- [x] Full Gemini test suite passes (21 tests)