### PR TITLE
Fix Anthropic system prompt caching

### DIFF
--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -27,13 +27,22 @@ trait BuildsTextRequests
             'max_tokens' => $options?->maxTokens ?? 64_000,
         ];
 
+        $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
+        $cacheControl = $providerOptions['cache_control'] ?? null;
+
+        unset($providerOptions['cache_control']);
+
         if (filled($instructions)) {
-            $body['system'] = $instructions;
+            $body['system'] = filled($cacheControl)
+                ? [[
+                    'type' => 'text',
+                    'text' => $instructions,
+                    'cache_control' => $cacheControl,
+                ]]
+                : $instructions;
         }
 
         $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
-
-        $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
 
         if (filled($schema) && $this->supportsNativeStructuredOutput($provider)) {
             $body['output_config'] = [

--- a/tests/Feature/Providers/Anthropic/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Anthropic/ProviderOptionsTest.php
@@ -3,9 +3,15 @@
 namespace Tests\Feature\Providers\Anthropic;
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\ProviderOptionsAgent;
 use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Feature\Tools\FixedNumberGenerator;
 
 class ProviderOptionsTest extends AnthropicTestCase
 {
@@ -26,6 +32,29 @@ class ProviderOptionsTest extends AnthropicTestCase
             return isset($body['thinking'])
                 && $body['thinking']['type'] === 'enabled'
                 && $body['thinking']['budget_tokens'] === 10000;
+        });
+    }
+
+    public function test_cache_control_formats_system_prompt_for_anthropic(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        $this->anthropicCacheControlAgent()->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            return isset($body['system'])
+                && is_array($body['system'])
+                && $body['system'][0]['type'] === 'text'
+                && $body['system'][0]['text'] === 'You are a cacheable assistant.'
+                && $body['system'][0]['cache_control']['type'] === 'ephemeral'
+                && ! isset($body['cache_control']);
         });
     }
 
@@ -73,5 +102,97 @@ class ProviderOptionsTest extends AnthropicTestCase
         $this->assertArrayHasKey('thinking', $secondBody);
         $this->assertSame('enabled', $secondBody['thinking']['type']);
         $this->assertSame(10000, $secondBody['thinking']['budget_tokens']);
+    }
+
+    public function test_cache_control_is_preserved_in_tool_call_follow_up_requests(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = $this->anthropicCacheControlToolAgent()->prompt(
+            'Generate a random number',
+            provider: 'anthropic',
+        );
+
+        $this->assertSame('The number is 72019', $response->text);
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $firstBody = $recorded[0][0]->data();
+        $this->assertSame([
+            [
+                'type' => 'text',
+                'text' => 'You are a cacheable assistant that generates numbers.',
+                'cache_control' => ['type' => 'ephemeral'],
+            ],
+        ], $firstBody['system']);
+        $this->assertArrayNotHasKey('cache_control', $firstBody);
+
+        $secondBody = $recorded[1][0]->data();
+        $this->assertSame($firstBody['system'], $secondBody['system']);
+        $this->assertArrayNotHasKey('cache_control', $secondBody);
+    }
+
+    protected function anthropicCacheControlAgent(): Agent
+    {
+        return new class implements Agent, HasProviderOptions
+        {
+            use Promptable;
+
+            public function instructions(): string
+            {
+                return 'You are a cacheable assistant.';
+            }
+
+            public function providerOptions(Lab|string $provider): array
+            {
+                $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+                return match ($provider) {
+                    Lab::Anthropic => [
+                        'cache_control' => ['type' => 'ephemeral'],
+                    ],
+                    default => [],
+                };
+            }
+        };
+    }
+
+    protected function anthropicCacheControlToolAgent(): Agent
+    {
+        return new class implements Agent, HasProviderOptions, HasTools
+        {
+            use Promptable;
+
+            public function instructions(): string
+            {
+                return 'You are a cacheable assistant that generates numbers.';
+            }
+
+            public function tools(): iterable
+            {
+                return [
+                    new FixedNumberGenerator,
+                ];
+            }
+
+            public function providerOptions(Lab|string $provider): array
+            {
+                $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+                return match ($provider) {
+                    Lab::Anthropic => [
+                        'cache_control' => ['type' => 'ephemeral'],
+                    ],
+                    default => [],
+                };
+            }
+        };
     }
 }


### PR DESCRIPTION
Anthropic prompt caching needs the system prompt to be sent with cache metadata on the system block so agents can opt in to cached prompts.

Fixes #119

### Approach

- Format Anthropic system prompts as cached text blocks when provider options request `cache_control`
- Remove `cache_control` from the top-level Anthropic provider options so it only lands on the system prompt block
- Add coverage for the initial request and tool-loop follow-up requests
