### PR TITLE
Add Mistral gateway for direct API integration

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -99,6 +99,7 @@ return [
         'mistral' => [
             'driver' => 'mistral',
             'key' => env('MISTRAL_API_KEY'),
+            'url' => env('MISTRAL_URL', 'https://api.mistral.ai/v1'),
         ],
 
         'ollama' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -375,7 +375,6 @@ class AiManager extends MultipleInstanceManager
     public function createMistralDriver(array $config): MistralProvider
     {
         return new MistralProvider(
-            new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Gateway/Mistral/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Mistral/Concerns/BuildsTextRequests.php
@@ -26,6 +26,19 @@ trait BuildsTextRequests
             'messages' => $this->mapMessagesToChat($messages, $instructions),
         ];
 
+        return $this->applyTextOptions($body, $provider, $tools, $schema, $options);
+    }
+
+    /**
+     * Apply tools, schema, and generation options to a request body.
+     */
+    protected function applyTextOptions(
+        array $body,
+        Provider $provider,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
         if (filled($tools)) {
             $mappedTools = $this->mapTools($tools);
 

--- a/src/Gateway/Mistral/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Mistral/Concerns/BuildsTextRequests.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    /**
+     * Build the request body for the Chat Completions API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessagesToChat($messages, $instructions),
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat($schema);
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the response format options for structured output.
+     */
+    protected function buildResponseFormat(array $schema): array
+    {
+        $objectSchema = new ObjectSchema($schema);
+
+        $schemaArray = $objectSchema->toSchema();
+
+        return [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => $schemaArray['name'] ?? 'schema_definition',
+                'schema' => Arr::except($schemaArray, ['name']),
+                'strict' => true,
+            ],
+        ];
+    }
+}

--- a/src/Gateway/Mistral/Concerns/CreatesMistralClient.php
+++ b/src/Gateway/Mistral/Concerns/CreatesMistralClient.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesMistralClient
+{
+    /**
+     * Get an HTTP client for the Mistral API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the Mistral API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.mistral.ai/v1', '/');
+    }
+}

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -262,39 +262,12 @@ trait HandlesTextStreaming
                 ...$updatedPriorMessages,
             ];
 
-            $body = [
+            $body = $this->applyTextOptions([
                 'model' => $model,
                 'messages' => $chatMessages,
                 'stream' => true,
                 'stream_options' => ['include_usage' => true],
-            ];
-
-            if (filled($tools)) {
-                $mappedTools = $this->mapTools($tools);
-
-                if (filled($mappedTools)) {
-                    $body['tool_choice'] = 'auto';
-                    $body['tools'] = $mappedTools;
-                }
-            }
-
-            if (filled($schema)) {
-                $body['response_format'] = $this->buildResponseFormat($schema);
-            }
-
-            if (! is_null($options?->maxTokens)) {
-                $body['max_tokens'] = $options->maxTokens;
-            }
-
-            if (! is_null($options?->temperature)) {
-                $body['temperature'] = $options->temperature;
-            }
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
+            ], $provider, $tools, $schema, $options);
 
             $response = $this->withRateLimitHandling(
                 $provider->name(),

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -36,6 +36,7 @@ trait HandlesTextStreaming
         int $depth = 0,
         ?int $maxSteps = null,
         array $priorChatMessages = [],
+        ?int $timeout = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -170,6 +171,7 @@ trait HandlesTextStreaming
                 $depth,
                 $maxSteps,
                 $priorChatMessages,
+                $timeout,
             );
 
             return;
@@ -200,6 +202,7 @@ trait HandlesTextStreaming
         int $depth,
         ?int $maxSteps,
         array $priorChatMessages,
+        ?int $timeout = null,
     ): Generator {
         $toolResults = [];
 
@@ -279,6 +282,14 @@ trait HandlesTextStreaming
                 $body['response_format'] = $this->buildResponseFormat($schema);
             }
 
+            if (! is_null($options?->maxTokens)) {
+                $body['max_tokens'] = $options->maxTokens;
+            }
+
+            if (! is_null($options?->temperature)) {
+                $body['temperature'] = $options->temperature;
+            }
+
             $providerOptions = $options?->providerOptions($provider->driver());
 
             if (filled($providerOptions)) {
@@ -287,7 +298,7 @@ trait HandlesTextStreaming
 
             $response = $this->withRateLimitHandling(
                 $provider->name(),
-                fn () => $this->client($provider)
+                fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
                     ->post('chat/completions', $body),
             );
@@ -305,6 +316,7 @@ trait HandlesTextStreaming
                 $depth + 1,
                 $maxSteps,
                 $updatedPriorMessages,
+                $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Process a Chat Completions streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        array $priorChatMessages = [],
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $usage = null;
+        $finishReason = null;
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            if (isset($data['error'])) {
+                yield (new Error(
+                    $this->generateEventId(),
+                    $data['error']['code'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            $choice = $data['choices'][0] ?? null;
+
+            if (! $choice) {
+                if (isset($data['usage'])) {
+                    $usage = new Usage(
+                        $data['usage']['prompt_tokens'] ?? 0,
+                        $data['usage']['completion_tokens'] ?? 0,
+                    );
+                }
+
+                continue;
+            }
+
+            $delta = $choice['delta'] ?? [];
+
+            if (! $streamStartEmitted) {
+                $streamStartEmitted = true;
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    $data['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['content']) && $delta['content'] !== '') {
+                if (! $textStartEmitted) {
+                    $textStartEmitted = true;
+
+                    yield (new TextStart(
+                        $this->generateEventId(),
+                        $messageId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                $currentText .= $delta['content'];
+
+                yield (new TextDelta(
+                    $this->generateEventId(),
+                    $messageId,
+                    $delta['content'],
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['tool_calls'])) {
+                foreach ($delta['tool_calls'] as $tcDelta) {
+                    $idx = $tcDelta['index'];
+
+                    if (! isset($pendingToolCalls[$idx])) {
+                        $pendingToolCalls[$idx] = [
+                            'id' => $tcDelta['id'] ?? '',
+                            'name' => $tcDelta['function']['name'] ?? '',
+                            'arguments' => '',
+                        ];
+                    }
+
+                    if (isset($tcDelta['function']['arguments'])) {
+                        $pendingToolCalls[$idx]['arguments'] .= $tcDelta['function']['arguments'];
+                    }
+                }
+            }
+
+            if (isset($choice['finish_reason']) && $choice['finish_reason'] !== null) {
+                $finishReason = $choice['finish_reason'];
+            }
+
+            if (isset($data['usage'])) {
+                $usage = new Usage(
+                    $data['usage']['prompt_tokens'] ?? 0,
+                    $data['usage']['completion_tokens'] ?? 0,
+                );
+            }
+        }
+
+        if ($textStartEmitted) {
+            yield (new TextEnd(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
+            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+            foreach ($mappedToolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield from $this->handleStreamingToolCalls(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $mappedToolCalls,
+                $currentText,
+                $instructions,
+                $originalMessages,
+                $depth,
+                $maxSteps,
+                $priorChatMessages,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            'stop',
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $mappedToolCalls,
+        string $currentText,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        array $priorChatMessages,
+    ): Generator {
+        $toolResults = [];
+
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $assistantMsg = ['role' => 'assistant'];
+
+            if (filled($currentText)) {
+                $assistantMsg['content'] = $currentText;
+            }
+
+            $assistantMsg['tool_calls'] = array_map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
+            );
+
+            $toolResultMessages = [];
+
+            foreach ($toolResults as $toolResult) {
+                $toolResultMessages[] = [
+                    'role' => 'tool',
+                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                    'content' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+
+            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
+
+            $chatMessages = [
+                ...$this->mapMessagesToChat($originalMessages, $instructions),
+                ...$updatedPriorMessages,
+            ];
+
+            $body = [
+                'model' => $model,
+                'messages' => $chatMessages,
+                'stream' => true,
+                'stream_options' => ['include_usage' => true],
+            ];
+
+            if (filled($tools)) {
+                $mappedTools = $this->mapTools($tools);
+
+                if (filled($mappedTools)) {
+                    $body['tool_choice'] = 'auto';
+                    $body['tools'] = $mappedTools;
+                }
+            }
+
+            if (filled($schema)) {
+                $body['response_format'] = $this->buildResponseFormat($schema);
+            }
+
+            $providerOptions = $options?->providerOptions($provider->driver());
+
+            if (filled($providerOptions)) {
+                $body = array_merge($body, $providerOptions);
+            }
+
+            $response = $this->withRateLimitHandling(
+                $provider->name(),
+                fn () => $this->client($provider)
+                    ->withOptions(['stream' => true])
+                    ->post('chat/completions', $body),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $updatedPriorMessages,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['name'] ?? '',
+            json_decode($toolCall['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+}

--- a/src/Gateway/Mistral/Concerns/MapsAttachments.php
+++ b/src/Gateway/Mistral/Concerns/MapsAttachments.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to Chat Completions content parts.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof Base64Image => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.$attachment->base64],
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => $attachment->url],
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(file_get_contents($attachment->path))],
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    )],
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
+                ],
+                $attachment instanceof RemoteDocument => [
+                    'type' => 'document_url',
+                    'document_url' => $attachment->url,
+                    'document_name' => $attachment->name ?? basename($attachment->url),
+                ],
+                default => throw new InvalidArgumentException(
+                    'Mistral only supports image attachments and remote document URLs. Unsupported attachment type ['.get_class($attachment).'].'
+                ),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/Mistral/Concerns/MapsMessages.php
+++ b/src/Gateway/Mistral/Concerns/MapsMessages.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to Chat Completions messages format.
+     */
+    protected function mapMessagesToChat(array $messages, ?string $instructions = null): array
+    {
+        $chatMessages = [];
+
+        if (filled($instructions)) {
+            $chatMessages[] = [
+                'role' => 'system',
+                'content' => $instructions,
+            ];
+        }
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $chatMessages),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $chatMessages),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $chatMessages),
+            };
+        }
+
+        return $chatMessages;
+    }
+
+    /**
+     * Map a user message to Chat Completions format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof UserMessage || $message->attachments->isEmpty()) {
+            $chatMessages[] = [
+                'role' => 'user',
+                'content' => $message->content,
+            ];
+
+            return;
+        }
+
+        $chatMessages[] = [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => $message->content],
+                ...$this->mapAttachments($message->attachments),
+            ],
+        ];
+    }
+
+    /**
+     * Map an assistant message to Chat Completions format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$chatMessages): void
+    {
+        $msg = ['role' => 'assistant'];
+
+        if (filled($message->content)) {
+            $msg['content'] = $message->content;
+        }
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            $msg['tool_calls'] = $message->toolCalls->map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+            )->all();
+        }
+
+        $chatMessages[] = $msg;
+    }
+
+    /**
+     * Map a tool result message to Chat Completions format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        foreach ($message->toolResults as $toolResult) {
+            $chatMessages[] = [
+                'role' => 'tool',
+                'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                'content' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+    }
+
+    /**
+     * Serialize a tool call DTO to Chat Completions array format.
+     */
+    protected function serializeToolCallToChat(ToolCall $toolCall): array
+    {
+        return [
+            'id' => $toolCall->resultId ?? $toolCall->id,
+            'type' => 'function',
+            'function' => [
+                'name' => $toolCall->name,
+                'arguments' => json_encode($toolCall->arguments ?: (object) []),
+            ],
+        ];
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+}

--- a/src/Gateway/Mistral/Concerns/MapsTools.php
+++ b/src/Gateway/Mistral/Concerns/MapsTools.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use RuntimeException;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to Chat Completions function definitions.
+     */
+    protected function mapTools(array $tools): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                throw new RuntimeException('Mistral does not support ['.class_basename($tool).'] provider tools.');
+            }
+
+            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to a Chat Completions function definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $schemaArray = filled($schema)
+            ? (new ObjectSchema($schema))->toSchema()
+            : [];
+
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => class_basename($tool),
+                'description' => (string) $tool->description(),
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $schemaArray['properties'] ?? (object) [],
+                    'required' => $schemaArray['required'] ?? [],
+                    'additionalProperties' => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral\Concerns;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Validate the Mistral response data.
+     *
+     * @throws AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || isset($data['error']) || ($data['object'] ?? null) === 'error') {
+            throw new AiException(sprintf(
+                'Mistral Error: [%s] %s',
+                $data['error']['type'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown Mistral error.',
+            ));
+        }
+    }
+
+    /**
+     * Parse the Mistral response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?string $instructions = null,
+        array $originalMessages = [],
+    ): TextResponse {
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            instructions: $instructions,
+            originalMessages: $originalMessages,
+            maxSteps: $options?->maxSteps,
+            options: $options,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        ?TextGenerationOptions $options = null,
+    ): TextResponse {
+        $choice = $data['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+        $model = $data['model'] ?? '';
+
+        $text = $message['content'] ?? '';
+        $rawToolCalls = $message['tool_calls'] ?? [];
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->extractFinishReason($choice);
+
+        $mappedToolCalls = array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['function']['name'] ?? '',
+            json_decode($toolCall['function']['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), $rawToolCalls);
+
+        $step = new Step(
+            $text,
+            $mappedToolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model),
+        );
+
+        $steps->push($step);
+
+        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+
+        $messages->push($assistantMessage);
+
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($mappedToolCalls) &&
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+
+            $steps->pop();
+
+            $steps->push(new Step(
+                $text,
+                $mappedToolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $options,
+            );
+        }
+
+        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
+        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
+
+        if ($structured) {
+            $structuredData = json_decode($text, true) ?? [];
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                $text,
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model),
+            ))->withToolCallsAndResults(
+                toolCalls: $allToolCalls,
+                toolResults: $allToolResults,
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        string $model,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        ?TextGenerationOptions $options = null,
+    ): TextResponse {
+        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
+
+        foreach ($messages as $msg) {
+            if ($msg instanceof AssistantMessage) {
+                $mapped = ['role' => 'assistant'];
+
+                if (filled($msg->content)) {
+                    $mapped['content'] = $msg->content;
+                }
+
+                if ($msg->toolCalls->isNotEmpty()) {
+                    $mapped['tool_calls'] = $msg->toolCalls->map(
+                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+                    )->all();
+                }
+
+                $chatMessages[] = $mapped;
+            } elseif ($msg instanceof ToolResultMessage) {
+                foreach ($msg->toolResults as $toolResult) {
+                    $chatMessages[] = [
+                        'role' => 'tool',
+                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                        'content' => $this->serializeToolResultOutput($toolResult->result),
+                    ];
+                }
+            }
+        }
+
+        $body = [
+            'model' => $model,
+            'messages' => $chatMessages,
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat($schema);
+        }
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $instructions,
+            $originalMessages,
+            $depth,
+            $maxSteps,
+            $options,
+        );
+    }
+
+    /**
+     * Extract usage data from the response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+
+        return new Usage(
+            $usage['prompt_tokens'] ?? 0,
+            $usage['completion_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract and map the finish reason from the response.
+     */
+    protected function extractFinishReason(array $choice): FinishReason
+    {
+        return match ($choice['finish_reason'] ?? '') {
+            'stop' => FinishReason::Stop,
+            'tool_calls' => FinishReason::ToolCalls,
+            'length' => FinishReason::Length,
+            'content_filter' => FinishReason::ContentFilter,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+}

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -254,37 +254,10 @@ trait ParsesTextResponses
             }
         }
 
-        $body = [
+        $body = $this->applyTextOptions([
             'model' => $model,
             'messages' => $chatMessages,
-        ];
-
-        if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
-
-            if (filled($mappedTools)) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
-        }
-
-        if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
-        }
-
-        if (! is_null($options?->maxTokens)) {
-            $body['max_tokens'] = $options->maxTokens;
-        }
-
-        if (! is_null($options?->temperature)) {
-            $body['temperature'] = $options->temperature;
-        }
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
+        ], $provider, $tools, $schema, $options);
 
         $response = $this->withRateLimitHandling(
             $provider->name(),

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -48,6 +48,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?string $instructions = null,
         array $originalMessages = [],
+        ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -61,6 +62,7 @@ trait ParsesTextResponses
             originalMessages: $originalMessages,
             maxSteps: $options?->maxSteps,
             options: $options,
+            timeout: $timeout,
         );
     }
 
@@ -80,6 +82,7 @@ trait ParsesTextResponses
         int $depth = 0,
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -145,6 +148,7 @@ trait ParsesTextResponses
                 $depth + 1,
                 $maxSteps,
                 $options,
+                $timeout,
             );
         }
 
@@ -220,6 +224,7 @@ trait ParsesTextResponses
         int $depth,
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
 
@@ -267,6 +272,14 @@ trait ParsesTextResponses
             $body['response_format'] = $this->buildResponseFormat($schema);
         }
 
+        if (! is_null($options?->maxTokens)) {
+            $body['max_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
         $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {
@@ -275,7 +288,7 @@ trait ParsesTextResponses
 
         $response = $this->withRateLimitHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('chat/completions', $body),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
         );
 
         $data = $response->json();
@@ -295,6 +308,7 @@ trait ParsesTextResponses
             $depth,
             $maxSteps,
             $options,
+            $timeout,
         );
     }
 

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Mistral;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\TextResponse;
+
+class MistralGateway implements TextGateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\CreatesMistralClient;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesRateLimiting;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $instructions,
+            $messages,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $body['stream'] = true;
+        $body['stream_options'] = ['include_usage' => true];
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('chat/completions', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $instructions,
+            $messages,
+        );
+    }
+}

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -4,15 +4,26 @@ namespace Laravel\Ai\Gateway\Mistral;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Files\HasName;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Responses\TranscriptionResponse;
 
-class MistralGateway implements TextGateway
+class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesMistralClient;
@@ -71,6 +82,7 @@ class MistralGateway implements TextGateway
             $options,
             $instructions,
             $messages,
+            $timeout,
         );
     }
 
@@ -118,6 +130,96 @@ class MistralGateway implements TextGateway
             $response->getBody(),
             $instructions,
             $messages,
+            timeout: $timeout,
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('embeddings', [
+                'model' => $model,
+                'input' => $inputs,
+            ]),
+        );
+
+        $data = $response->json();
+
+        return new EmbeddingsResponse(
+            collect($data['data'] ?? [])->pluck('embedding')->all(),
+            $data['usage']['total_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+    ): TranscriptionResponse {
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->attach('file', $audio->content(), $this->audioFilename($audio), ['Content-Type' => $audio->mimeType()])
+                ->post('audio/transcriptions', array_filter([
+                    'model' => $model,
+                    'language' => $language,
+                ])),
+        );
+
+        $data = $response->json();
+
+        return new TranscriptionResponse(
+            $data['text'] ?? '',
+            collect($data['segments'] ?? [])->map(fn (array $segment) => new TranscriptionSegment(
+                $segment['text'] ?? '',
+                $segment['speaker'] ?? '',
+                $segment['start'] ?? 0,
+                $segment['end'] ?? 0,
+            )),
+            new Usage(
+                $data['usage']['prompt_tokens'] ?? 0,
+                $data['usage']['completion_tokens'] ?? 0,
+            ),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Determine the appropriate filename for the audio file based on its MIME type.
+     */
+    protected function audioFilename(TranscribableAudio $audio): string
+    {
+        if ($audio instanceof HasName && $audio->name()) {
+            return $audio->name();
+        }
+
+        $extension = match ($audio->mimeType()) {
+            'audio/webm' => 'webm',
+            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
+            'audio/wav', 'audio/x-wav' => 'wav',
+            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/mpeg', 'audio/mp3' => 'mp3',
+            'audio/mpga' => 'mpga',
+            default => 'mp3',
+        };
+
+        return "audio.{$extension}";
     }
 }

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -2,9 +2,11 @@
 
 namespace Laravel\Ai\Providers;
 
+use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\Mistral\MistralGateway;
 
 class MistralProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider
 {
@@ -15,6 +17,14 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new MistralGateway($this->events);
+    }
 
     /**
      * Get the name of the default text model.

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -21,9 +21,19 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
 
+    protected ?MistralGateway $mistralGateway = null;
+
     public function __construct(protected array $config, protected Dispatcher $events)
     {
         //
+    }
+
+    /**
+     * Get the shared Mistral gateway instance.
+     */
+    protected function mistralGateway(): MistralGateway
+    {
+        return $this->mistralGateway ??= new MistralGateway($this->events);
     }
 
     /**
@@ -31,7 +41,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function textGateway(): TextGateway
     {
-        return $this->textGateway ??= new MistralGateway($this->events);
+        return $this->mistralGateway();
     }
 
     /**
@@ -39,7 +49,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function embeddingGateway(): EmbeddingGateway
     {
-        return $this->embeddingGateway ??= new MistralGateway($this->events);
+        return $this->mistralGateway();
     }
 
     /**
@@ -47,7 +57,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function transcriptionGateway(): TranscriptionGateway
     {
-        return $this->transcriptionGateway ??= new MistralGateway($this->events);
+        return $this->mistralGateway();
     }
 
     /**

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -2,7 +2,10 @@
 
 namespace Laravel\Ai\Providers;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
@@ -18,12 +21,33 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
 
+    public function __construct(protected array $config, protected Dispatcher $events)
+    {
+        //
+    }
+
     /**
      * Get the provider's text gateway.
      */
     public function textGateway(): TextGateway
     {
         return $this->textGateway ??= new MistralGateway($this->events);
+    }
+
+    /**
+     * Get the provider's embedding gateway.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ??= new MistralGateway($this->events);
+    }
+
+    /**
+     * Get the provider's transcription gateway.
+     */
+    public function transcriptionGateway(): TranscriptionGateway
+    {
+        return $this->transcriptionGateway ??= new MistralGateway($this->events);
     }
 
     /**

--- a/tests/Feature/Agents/ProviderOptionsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsAgent.php
@@ -38,6 +38,10 @@ class ProviderOptionsAgent implements Agent, HasProviderOptions
                 'frequency_penalty' => 0.5,
                 'presence_penalty' => 0.3,
             ],
+            Lab::Mistral => [
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
+            ],
             Lab::Gemini => [
                 'thinkingConfig' => [
                     'thinkingBudget' => 10000,

--- a/tests/Feature/Agents/ProviderOptionsWithToolsAgent.php
+++ b/tests/Feature/Agents/ProviderOptionsWithToolsAgent.php
@@ -45,6 +45,9 @@ class ProviderOptionsWithToolsAgent implements Agent, HasProviderOptions, HasToo
             Lab::Groq => [
                 'frequency_penalty' => 0.5,
             ],
+            Lab::Mistral => [
+                'frequency_penalty' => 0.5,
+            ],
             Lab::Gemini => [
                 'thinkingConfig' => [
                     'thinkingBudget' => 10000,

--- a/tests/Feature/Providers/Mistral/BaseUrlTest.php
+++ b/tests/Feature/Providers/Mistral/BaseUrlTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+use function Laravel\Ai\agent;
+
+class BaseUrlTest extends MistralTestCase
+{
+    protected string $customUrl = 'http://localhost:1234/v1';
+
+    public function test_mistral_requests_use_the_configured_base_url(): void
+    {
+        $this->configureMistralProvider($this->customUrl);
+
+        Http::fake([
+            '*' => $this->fakeTextResponse('Hello from custom'),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'mistral');
+
+        $this->assertSame('Hello from custom', $response->text);
+
+        Http::assertSentCount(1);
+        $this->assertRequestSent('POST', "{$this->customUrl}/chat/completions");
+    }
+
+    public function test_mistral_requests_fall_back_to_the_default_base_url(): void
+    {
+        Http::fake([
+            '*' => $this->fakeTextResponse('Hello from Mistral'),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'mistral');
+
+        $this->assertSame('Hello from Mistral', $response->text);
+
+        Http::assertSentCount(1);
+        $this->assertRequestSent('POST', 'https://api.mistral.ai/v1/chat/completions');
+    }
+
+    protected function configureMistralProvider(?string $url = null): void
+    {
+        config(['ai.providers.mistral' => array_filter([
+            ...config('ai.providers.mistral'),
+            'key' => 'test-key',
+            'url' => $url,
+        ])]);
+    }
+
+    protected function assertRequestSent(string $method, string $url): void
+    {
+        Http::assertSent(fn (Request $request) => $request->method() === $method
+            && $request->url() === $url);
+    }
+}

--- a/tests/Feature/Providers/Mistral/EmbeddingTest.php
+++ b/tests/Feature/Providers/Mistral/EmbeddingTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+class EmbeddingTest extends MistralTestCase
+{
+    public function test_embeddings_request_includes_model_and_input(): void
+    {
+        Http::fake(['*' => $this->fakeEmbeddingsResponse()]);
+
+        Embeddings::for(['Hello world'])->generate(provider: 'mistral', model: 'mistral-embed');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['model'] === 'mistral-embed'
+                && $body['input'] === ['Hello world']
+                && $request->url() === 'https://api.mistral.ai/v1/embeddings';
+        });
+    }
+
+    public function test_embeddings_response_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeEmbeddingsResponse()]);
+
+        $response = Embeddings::for(['Hello world'])->generate(provider: 'mistral', model: 'mistral-embed');
+
+        $this->assertCount(1, $response->embeddings);
+        $this->assertCount(3, $response->embeddings[0]);
+        $this->assertSame(10, $response->tokens);
+        $this->assertSame('mistral', $response->meta->provider);
+    }
+
+    public function test_embeddings_request_sends_bearer_token(): void
+    {
+        Http::fake(['*' => $this->fakeEmbeddingsResponse()]);
+
+        Embeddings::for(['Hello'])->generate(provider: 'mistral', model: 'mistral-embed');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_multiple_inputs_return_multiple_embeddings(): void
+    {
+        Http::fake(['*' => Http::response([
+            'id' => 'embd-123',
+            'object' => 'list',
+            'model' => 'mistral-embed',
+            'data' => [
+                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+                ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+            ],
+            'usage' => ['total_tokens' => 20],
+        ])]);
+
+        $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'mistral', model: 'mistral-embed');
+
+        $this->assertCount(2, $response->embeddings);
+    }
+
+    protected function fakeEmbeddingsResponse()
+    {
+        return Http::response([
+            'id' => 'embd-123',
+            'object' => 'list',
+            'model' => 'mistral-embed',
+            'data' => [
+                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ],
+            'usage' => ['total_tokens' => 10],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Mistral/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Mistral/ErrorHandlingTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Feature\Agents\AssistantAgent;
+
+class ErrorHandlingTest extends MistralTestCase
+{
+    public function test_http_error_response_throws_request_exception(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'object' => 'error',
+                'message' => 'Invalid API key',
+                'type' => 'authentication_error',
+            ], 401),
+        ]);
+
+        $this->expectException(RequestException::class);
+
+        (new AssistantAgent)->prompt('Hi', provider: 'mistral');
+    }
+
+    public function test_rate_limit_response_throws_rate_limited_exception(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'object' => 'error',
+                'message' => 'Rate limit exceeded',
+                'type' => 'rate_limit_error',
+            ], 429),
+        ]);
+
+        $this->expectException(RateLimitedException::class);
+
+        (new AssistantAgent)->prompt('Hi', provider: 'mistral');
+    }
+
+    public function test_error_in_200_response_throws_ai_exception(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'object' => 'error',
+                'error' => [
+                    'type' => 'server_error',
+                    'message' => 'Internal server error',
+                ],
+            ], 200),
+        ]);
+
+        $this->expectException(AiException::class);
+        $this->expectExceptionMessage('Mistral Error');
+
+        (new AssistantAgent)->prompt('Hi', provider: 'mistral');
+    }
+}

--- a/tests/Feature/Providers/Mistral/MessageMappingTest.php
+++ b/tests/Feature/Providers/Mistral/MessageMappingTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ToolUsingAgent;
+
+use function Laravel\Ai\agent;
+
+class MessageMappingTest extends MistralTestCase
+{
+    public function test_user_message_maps_to_chat_format(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse()]);
+
+        (new AssistantAgent)->prompt('What is Laravel?', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $userMsg = collect($body['messages'])->firstWhere('role', 'user');
+
+            return $userMsg['content'] === 'What is Laravel?';
+        });
+    }
+
+    public function test_assistant_message_with_tool_calls_maps_correctly(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'mistral');
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+        $assistantMsg = collect($followUpBody['messages'])->firstWhere('role', 'assistant');
+        $toolMsg = collect($followUpBody['messages'])->firstWhere('role', 'tool');
+
+        $this->assertNotNull($assistantMsg, 'Follow-up should include assistant message');
+        $this->assertNotNull($toolMsg, 'Follow-up should include tool result message');
+        $this->assertNotEmpty($assistantMsg['tool_calls']);
+        $this->assertSame('FixedNumberGenerator', $assistantMsg['tool_calls'][0]['function']['name']);
+        $this->assertSame($assistantMsg['tool_calls'][0]['id'], $toolMsg['tool_call_id']);
+    }
+
+    public function test_image_attachment_maps_to_image_url(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('I see an image')]);
+
+        $image = new RemoteImage('https://example.com/image.png');
+
+        agent('You are helpful.')->prompt(
+            'What is in this image?',
+            attachments: [$image],
+            provider: 'mistral',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $content = $body['messages'][1]['content'] ?? $body['messages'][0]['content'];
+
+            if (! is_array($content)) {
+                return false;
+            }
+
+            $imageBlock = collect($content)->firstWhere('type', 'image_url');
+
+            return $imageBlock !== null
+                && $imageBlock['image_url']['url'] === 'https://example.com/image.png';
+        });
+    }
+
+    public function test_base64_image_attachment_maps_to_data_uri(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('I see an image')]);
+
+        $image = new Base64Image(base64_encode('fake-image-data'), 'image/png');
+
+        agent('You are helpful.')->prompt(
+            'What is in this image?',
+            attachments: [$image],
+            provider: 'mistral',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $content = $body['messages'][1]['content'] ?? $body['messages'][0]['content'];
+
+            if (! is_array($content)) {
+                return false;
+            }
+
+            $imageBlock = collect($content)->firstWhere('type', 'image_url');
+
+            return $imageBlock !== null
+                && str_starts_with($imageBlock['image_url']['url'], 'data:image/png;base64,');
+        });
+    }
+
+    public function test_remote_document_maps_to_document_url(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('I see a document')]);
+
+        $document = new RemoteDocument('https://example.com/report.pdf');
+
+        agent('You are helpful.')->prompt(
+            'What is in this document?',
+            attachments: [$document],
+            provider: 'mistral',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $content = $body['messages'][1]['content'] ?? $body['messages'][0]['content'];
+
+            if (! is_array($content)) {
+                return false;
+            }
+
+            $docBlock = collect($content)->firstWhere('type', 'document_url');
+
+            return $docBlock !== null
+                && $docBlock['document_url'] === 'https://example.com/report.pdf';
+        });
+    }
+
+    public function test_system_instructions_are_in_messages_array(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse()]);
+
+        (new AssistantAgent)->prompt('Hi', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+            return $systemMsg !== null
+                && str_contains($systemMsg['content'], 'helpful assistant');
+        });
+    }
+}

--- a/tests/Feature/Providers/Mistral/MistralTestCase.php
+++ b/tests/Feature/Providers/Mistral/MistralTestCase.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+abstract class MistralTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.mistral' => [
+            ...config('ai.providers.mistral'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    protected function fakeTextResponse(string $text = 'Hello'): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'mistral-medium-latest',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+
+    protected function fakeToolCallResponse(string $toolName = 'FixedNumberGenerator', ?string $callId = null): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'mistral-medium-latest',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => $callId ?? 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => $toolName,
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+
+    protected function fakeStructuredResponse(string $json = '{"symbol": "Au"}'): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'mistral-medium-latest',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $json,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Mistral/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Mistral/ProviderOptionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+
+use function Laravel\Ai\agent;
+
+class ProviderOptionsTest extends MistralTestCase
+{
+    public function test_provider_options_are_included_in_mistral_request_body(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        (new ProviderOptionsAgent)->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'frequency_penalty') === 0.5
+                && data_get($body, 'presence_penalty') === 0.3;
+        });
+    }
+
+    public function test_request_body_does_not_contain_provider_options_when_agent_does_not_implement_interface(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('frequency_penalty', $body)
+                && ! array_key_exists('presence_penalty', $body);
+        });
+    }
+
+    public function test_provider_options_are_persisted_in_tool_call_follow_up_requests(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ProviderOptionsWithToolsAgent)->prompt('Give me a number', provider: 'mistral');
+
+        $requests = Http::recorded(fn (Request $r) => true);
+
+        $this->assertGreaterThanOrEqual(2, count($requests));
+
+        $followUpBody = json_decode($requests[1][0]->body(), true);
+
+        $this->assertSame(0.5, data_get($followUpBody, 'frequency_penalty'));
+    }
+}

--- a/tests/Feature/Providers/Mistral/RequestMappingTest.php
+++ b/tests/Feature/Providers/Mistral/RequestMappingTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\AttributeAgent;
+use Tests\Feature\Agents\StructuredAgent;
+use Tests\Feature\Tools\RandomNumberGenerator;
+
+use function Laravel\Ai\agent;
+
+class RequestMappingTest extends MistralTestCase
+{
+    public function test_request_includes_model_and_messages(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        agent()->prompt('Hi there', provider: 'mistral', model: 'mistral-large-latest');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['model'] === 'mistral-large-latest'
+                && count($body['messages']) >= 1
+                && collect($body['messages'])->contains(fn ($m) => $m['role'] === 'user' && $m['content'] === 'Hi there');
+        });
+    }
+
+    public function test_system_instructions_are_sent_as_system_message(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        (new AssistantAgent)->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+            return $systemMsg !== null
+                && str_contains($systemMsg['content'], 'helpful assistant');
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_included_when_set_via_attributes(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        (new AttributeAgent)->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'temperature') === 0.7
+                && data_get($body, 'max_tokens') === 4096;
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_excluded_when_not_set(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('temperature', $body)
+                && ! array_key_exists('max_tokens', $body);
+        });
+    }
+
+    public function test_tools_include_tool_choice_auto(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('42')]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['tool_choice'] === 'auto'
+                && is_array($body['tools'])
+                && count($body['tools']) > 0;
+        });
+    }
+
+    public function test_request_without_tools_excludes_tool_fields(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('tools', $body)
+                && ! array_key_exists('tool_choice', $body);
+        });
+    }
+
+    public function test_structured_output_includes_json_schema_response_format(): void
+    {
+        Http::fake(['*' => $this->fakeStructuredResponse('{"symbol": "Au"}')]);
+
+        (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $format = data_get($body, 'response_format');
+
+            return $format['type'] === 'json_schema'
+                && isset($format['json_schema']['name'])
+                && isset($format['json_schema']['schema'])
+                && $format['json_schema']['strict'] === true;
+        });
+    }
+
+    public function test_streaming_request_includes_stream_options(): void
+    {
+        Http::fake(['*' => Http::response("data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n")]);
+
+        $stream = agent()->stream('Hello', provider: 'mistral');
+
+        foreach ($stream as $event) {
+            //
+        }
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['stream'] === true
+                && data_get($body, 'stream_options.include_usage') === true;
+        });
+    }
+
+    public function test_request_sends_bearer_token_authorization(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_response_text_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('Laravel is great')]);
+
+        $response = agent()->prompt('Tell me about Laravel', provider: 'mistral');
+
+        $this->assertSame('Laravel is great', $response->text);
+        $this->assertSame('mistral', $response->meta->provider);
+    }
+
+    public function test_response_usage_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'mistral-medium-latest',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello'],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ])]);
+
+        $response = agent()->prompt('Hello', provider: 'mistral');
+
+        $this->assertSame(10, $response->usage->promptTokens);
+        $this->assertSame(5, $response->usage->completionTokens);
+    }
+
+    public function test_structured_response_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeStructuredResponse('{"symbol": "Au"}')]);
+
+        $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'mistral');
+
+        $this->assertSame('Au', $response->structured['symbol']);
+    }
+}

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+
+use function Laravel\Ai\agent;
+
+class StreamingTest extends MistralTestCase
+{
+    public function test_streaming_emits_text_events(): void
+    {
+        Http::fake([
+            '*' => Http::response(
+                body: $this->ssePayload([
+                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hello'], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['content' => ' world'], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5]],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertInstanceOf(StreamStart::class, $events[0]);
+        $this->assertInstanceOf(TextStart::class, $events[1]);
+        $this->assertInstanceOf(TextDelta::class, $events[2]);
+        $this->assertSame('Hello', $events[2]->delta);
+        $this->assertInstanceOf(TextDelta::class, $events[3]);
+        $this->assertSame(' world', $events[3]->delta);
+        $this->assertInstanceOf(TextEnd::class, $events[4]);
+        $this->assertInstanceOf(StreamEnd::class, $events[5]);
+    }
+
+    public function test_streaming_handles_tool_calls(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_1', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
+                        ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
+                        ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5]],
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        ['id' => 'chatcmpl-456', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
+                        ['id' => 'chatcmpl-456', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 10]],
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+        $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
+
+        $this->assertNotEmpty($toolCallEvents);
+        $this->assertSame('FixedNumberGenerator', $toolCallEvents[0]->toolCall->name);
+        $this->assertNotEmpty($toolResultEvents);
+    }
+
+    public function test_streaming_captures_usage(): void
+    {
+        Http::fake([
+            '*' => Http::response(
+                body: $this->ssePayload([
+                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5]],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+        $this->assertSame(10, $streamEnd->usage->promptTokens);
+        $this->assertSame(5, $streamEnd->usage->completionTokens);
+    }
+
+    public function test_streaming_error_event_stops_stream(): void
+    {
+        Http::fake([
+            '*' => Http::response(
+                body: $this->ssePayload([
+                    ['error' => ['code' => 'server_error', 'message' => 'Internal server error']],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(Error::class, $events[0]);
+        $this->assertSame('server_error', $events[0]->type);
+        $this->assertSame('Internal server error', $events[0]->message);
+    }
+
+    /**
+     * Collect all stream events from the agent's stream response.
+     */
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream('Hello', provider: 'mistral');
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            $lines[] = 'data: '.json_encode($event);
+        }
+
+        $lines[] = 'data: [DONE]';
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+}

--- a/tests/Feature/Providers/Mistral/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Mistral/ToolCallLoopTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ToolUsingAgent;
+
+class ToolCallLoopTest extends MistralTestCase
+{
+    public function test_tool_calls_trigger_follow_up_request(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a random number',
+            provider: 'mistral',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+        $hasAssistantWithToolCalls = false;
+        $hasToolResult = false;
+
+        foreach ($followUpBody['messages'] as $message) {
+            if ($message['role'] === 'assistant' && ! empty($message['tool_calls'])) {
+                $hasAssistantWithToolCalls = true;
+            }
+
+            if ($message['role'] === 'tool') {
+                $hasToolResult = true;
+            }
+        }
+
+        $this->assertTrue($hasAssistantWithToolCalls, 'Follow-up request should include assistant message with tool_calls');
+        $this->assertTrue($hasToolResult, 'Follow-up request should include tool result message');
+    }
+
+    public function test_max_steps_limits_tool_call_depth(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+                $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+                $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+                $this->fakeTextResponse('Done'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate numbers',
+            provider: 'mistral',
+        );
+
+        $recorded = Http::recorded();
+
+        // ToolUsingAgent has 1 tool + structured output tool = 2 tools
+        // maxSteps = round(2 * 1.5) = 3
+        // So max 3 requests before stopping (initial + 2 follow-ups)
+        $this->assertLessThanOrEqual(3, count($recorded));
+    }
+
+    public function test_follow_up_request_includes_original_messages(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'mistral',
+        );
+
+        $recorded = Http::recorded();
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+        $userMsg = collect($followUpBody['messages'])->firstWhere('role', 'user');
+
+        $this->assertNotNull($userMsg, 'Follow-up should include original user message');
+    }
+}

--- a/tests/Feature/Providers/Mistral/ToolMappingTest.php
+++ b/tests/Feature/Providers/Mistral/ToolMappingTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\FileSearch;
+use RuntimeException;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Feature\Tools\RandomNumberGenerator;
+
+use function Laravel\Ai\agent;
+
+class ToolMappingTest extends MistralTestCase
+{
+    public function test_tool_with_parameters_includes_correct_schema(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('42')]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return $function['parameters']['type'] === 'object'
+                && array_key_exists('min', $function['parameters']['properties'])
+                && array_key_exists('max', $function['parameters']['properties'])
+                && in_array('min', $function['parameters']['required'])
+                && in_array('max', $function['parameters']['required'])
+                && $function['parameters']['additionalProperties'] === false;
+        });
+    }
+
+    public function test_tool_with_empty_schema_includes_parameters(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('72019')]);
+
+        agent(tools: [new FixedNumberGenerator])->prompt('Give me a random number', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return array_key_exists('parameters', $function)
+                && $function['parameters']['type'] === 'object'
+                && $function['parameters']['properties'] === []
+                && $function['parameters']['required'] === []
+                && $function['parameters']['additionalProperties'] === false;
+        });
+    }
+
+    public function test_provider_tools_throw_runtime_exception(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse()]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Mistral does not support');
+
+        agent(
+            tools: [new FileSearch(['store_1'])],
+        )->prompt('Search for something', provider: 'mistral');
+    }
+
+    public function test_tool_parameters_are_not_wrapped_in_schema_definition(): void
+    {
+        Http::fake(['*' => $this->fakeTextResponse('done')]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return ! array_key_exists('schema_definition', $function['parameters']['properties'] ?? [])
+                && ! in_array('schema_definition', $function['parameters']['required'] ?? []);
+        });
+    }
+}

--- a/tests/Feature/Providers/Mistral/TranscriptionTest.php
+++ b/tests/Feature/Providers/Mistral/TranscriptionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Transcription;
+
+class TranscriptionTest extends MistralTestCase
+{
+    public function test_transcription_request_posts_to_correct_endpoint(): void
+    {
+        Http::fake(['*' => $this->fakeTranscriptionResponse()]);
+
+        Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+            ->generate(provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://api.mistral.ai/v1/audio/transcriptions'
+                && str_contains($request->header('Content-Type')[0] ?? '', 'multipart/form-data');
+        });
+    }
+
+    public function test_transcription_response_text_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeTranscriptionResponse('Hello, world!')]);
+
+        $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+            ->generate(provider: 'mistral');
+
+        $this->assertSame('Hello, world!', $response->text);
+        $this->assertSame('mistral', $response->meta->provider);
+    }
+
+    public function test_transcription_includes_model_in_request(): void
+    {
+        Http::fake(['*' => $this->fakeTranscriptionResponse()]);
+
+        Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+            ->generate(provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            return str_contains($request->body(), 'voxtral-small-latest');
+        });
+    }
+
+    public function test_transcription_sends_language_when_provided(): void
+    {
+        Http::fake(['*' => $this->fakeTranscriptionResponse()]);
+
+        Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+            ->language('en')
+            ->generate(provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            return str_contains($request->body(), 'language')
+                && str_contains($request->body(), 'en');
+        });
+    }
+
+    public function test_transcription_sends_bearer_token(): void
+    {
+        Http::fake(['*' => $this->fakeTranscriptionResponse()]);
+
+        Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+            ->generate(provider: 'mistral');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_transcription_usage_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => Http::response([
+            'text' => 'Hello',
+            'usage' => [
+                'prompt_tokens' => 100,
+                'completion_tokens' => 50,
+            ],
+        ])]);
+
+        $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+            ->generate(provider: 'mistral');
+
+        $this->assertSame(100, $response->usage->promptTokens);
+        $this->assertSame(50, $response->usage->completionTokens);
+    }
+
+    protected function fakeTranscriptionResponse(string $text = 'Hello, world!')
+    {
+        return Http::response([
+            'text' => $text,
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
The AI SDK currently depends on Prism PHP as a middleware layer for Mistral text generation, embeddings, and transcription. This creates a bottleneck where any bug fix or new feature must first land in Prism before the SDK can adopt it. This replaces the Prism dependency for Mistral with a direct gateway, giving the SDK full ownership of its Mistral integration.

### Approach

- Implements a new `MistralGateway` that calls the Mistral Chat Completions API directly, following the same trait-based composition pattern established by the OpenAI and Groq gateway migrations
- Handles synchronous text generation, streaming with SSE parsing, multi-round tool call loops with full conversation history replay, structured output via JSON schema, image and document attachments, and provider options forwarding
- Migrates embeddings (`/embeddings`) and audio transcription (`/audio/transcriptions`) inline in the gateway, removing the last remaining Prism dependencies for Mistral
- Fixes a bug where `max_tokens`, `temperature`, and `timeout` were dropped from follow-up requests during tool call loops (same class of issue as #363)
- Updates `MistralProvider` to lazily initialize its own gateway, removing the `PrismGateway` dependency from `AiManager`
- No public API changes — the `Ai` facade, agents, tools, and all user-facing interfaces remain identical

https://docs.mistral.ai/api