### PR TITLE
Add missing gateway tests for Groq and OpenAI providers

### DIFF
--- a/tests/Feature/Providers/Groq/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Groq/ErrorHandlingTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\TestCase;
+
+class ErrorHandlingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_http_error_response_throws_request_exception(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::response([
+                'error' => [
+                    'type' => 'invalid_request_error',
+                    'message' => 'max_tokens: must be at least 1',
+                ],
+            ], 400),
+        ]);
+
+        $this->expectException(RequestException::class);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'groq',
+        );
+    }
+
+    public function test_rate_limit_response_throws_rate_limited_exception(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::response([
+                'error' => [
+                    'type' => 'rate_limit_error',
+                    'message' => 'Rate limit exceeded',
+                ],
+            ], 429),
+        ]);
+
+        $this->expectException(RateLimitedException::class);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'groq',
+        );
+    }
+
+    public function test_error_in_200_response_throws_ai_exception(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::response([
+                'error' => [
+                    'type' => 'api_error',
+                    'message' => 'Internal server error',
+                ],
+            ], 200),
+        ]);
+
+        $this->expectException(AiException::class);
+        $this->expectExceptionMessage('Groq Error');
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'groq',
+        );
+    }
+}

--- a/tests/Feature/Providers/Groq/MessageMappingTest.php
+++ b/tests/Feature/Providers/Groq/MessageMappingTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ToolUsingAgent;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class MessageMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_user_message_maps_to_groq_format(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => $this->fakeGroqResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'What is Laravel?',
+            provider: 'groq',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $messages = $body['messages'];
+            $userMessage = collect($messages)->firstWhere('role', 'user');
+
+            return $userMessage !== null
+                && $userMessage['content'] === 'What is Laravel?';
+        });
+    }
+
+    public function test_tool_result_follow_up_maps_assistant_and_tool_result_messages(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::sequence([
+                $this->fakeGroqToolCallResponse(),
+                $this->fakeGroqResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'groq',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+        $followUpMessages = $followUpBody['messages'];
+
+        $hasAssistantWithToolCalls = false;
+        $hasToolResult = false;
+
+        foreach ($followUpMessages as $msg) {
+            if ($msg['role'] === 'assistant' && isset($msg['tool_calls'])) {
+                $hasAssistantWithToolCalls = true;
+            }
+
+            if ($msg['role'] === 'tool') {
+                $hasToolResult = true;
+            }
+        }
+
+        $this->assertTrue($hasAssistantWithToolCalls, 'Follow-up should include assistant message with tool_calls');
+        $this->assertTrue($hasToolResult, 'Follow-up should include tool result message');
+
+        $assistantMsg = collect($followUpMessages)->last(fn ($m) => $m['role'] === 'assistant' && isset($m['tool_calls']));
+        $toolMsg = collect($followUpMessages)->last(fn ($m) => $m['role'] === 'tool');
+
+        $this->assertSame('FixedNumberGenerator', $assistantMsg['tool_calls'][0]['function']['name']);
+        $this->assertSame($assistantMsg['tool_calls'][0]['id'], $toolMsg['tool_call_id']);
+        $this->assertNotEmpty($toolMsg['content']);
+    }
+
+    public function test_image_attachment_maps_to_image_url_content_block(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => $this->fakeGroqResponse('I see an image'),
+        ]);
+
+        $image = new Base64Image(base64_encode('fake-image-data'), 'image/png');
+
+        agent('You are helpful.')->prompt(
+            'What is in this image?',
+            attachments: [$image],
+            provider: 'groq',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $userMessage = collect($body['messages'])->firstWhere('role', 'user');
+            $content = $userMessage['content'];
+
+            $imageBlock = collect($content)->firstWhere('type', 'image_url');
+
+            return $imageBlock !== null
+                && str_contains($imageBlock['image_url']['url'], 'image/png')
+                && str_contains($imageBlock['image_url']['url'], base64_encode('fake-image-data'));
+        });
+    }
+
+    public function test_document_attachments_throw_exception(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => $this->fakeGroqResponse(),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $pdf = new Base64Document(base64_encode('fake-pdf'), 'application/pdf');
+
+        agent('You are helpful.')->prompt(
+            'What is in this PDF?',
+            attachments: [$pdf],
+            provider: 'groq',
+        );
+    }
+
+    protected function fakeGroqResponse(string $text = 'Hello'): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+
+    protected function fakeGroqToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+use Tests\TestCase;
+
+class StreamingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_streaming_emits_text_events(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+                    $this->chatChunk(['content' => ' world']),
+                    $this->chatChunkFinish('stop', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+                    '[DONE]',
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertInstanceOf(StreamStart::class, $events[0]);
+        $this->assertInstanceOf(TextStart::class, $events[1]);
+        $this->assertInstanceOf(TextDelta::class, $events[2]);
+        $this->assertSame('Hello', $events[2]->delta);
+        $this->assertInstanceOf(TextDelta::class, $events[3]);
+        $this->assertSame(' world', $events[3]->delta);
+        $this->assertInstanceOf(TextEnd::class, $events[count($events) - 2]);
+        $this->assertInstanceOf(StreamEnd::class, $events[count($events) - 1]);
+    }
+
+    public function test_streaming_handles_tool_calls(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->chatChunkToolCallStart(0, 'call_1', 'FixedNumberGenerator'),
+                        $this->chatChunkToolCallDelta(0, '{}'),
+                        $this->chatChunkFinish('tool_calls', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+                        '[DONE]',
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->chatChunk(['role' => 'assistant', 'content' => 'The number is 72019']),
+                        $this->chatChunkFinish('stop', ['prompt_tokens' => 20, 'completion_tokens' => 10]),
+                        '[DONE]',
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+
+        $this->assertNotEmpty($toolCallEvents);
+        $this->assertSame('FixedNumberGenerator', $toolCallEvents[0]->toolCall->name);
+        $this->assertSame('call_1', $toolCallEvents[0]->toolCall->id);
+    }
+
+    public function test_streaming_error_event_stops_stream(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::response(
+                body: $this->ssePayload([
+                    ['error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit exceeded']],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(Error::class, $events[0]);
+        $this->assertSame('rate_limit_exceeded', $events[0]->type);
+        $this->assertSame('Rate limit exceeded', $events[0]->message);
+    }
+
+    public function test_streaming_captures_usage_from_final_chunk(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+                    $this->chatChunkFinish('stop', ['prompt_tokens' => 42, 'completion_tokens' => 10]),
+                    '[DONE]',
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+        $this->assertSame(42, $streamEnd->usage->promptTokens);
+        $this->assertSame(10, $streamEnd->usage->completionTokens);
+    }
+
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream(
+            'Hello',
+            provider: 'groq',
+        );
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            if ($event === '[DONE]') {
+                $lines[] = 'data: [DONE]';
+            } else {
+                $lines[] = 'data: '.json_encode($event);
+            }
+        }
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+
+    protected function chatChunk(array $delta, ?string $finishReason = null): array
+    {
+        return [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'delta' => $delta,
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+    }
+
+    protected function chatChunkFinish(string $finishReason, ?array $usage = null): array
+    {
+        $chunk = [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'delta' => (object) [],
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+
+        if ($usage) {
+            $chunk['usage'] = $usage;
+        }
+
+        return $chunk;
+    }
+
+    protected function chatChunkToolCallStart(int $index, string $id, string $name): array
+    {
+        return [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'id' => $id,
+                        'type' => 'function',
+                        'function' => ['name' => $name, 'arguments' => ''],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+
+    protected function chatChunkToolCallDelta(int $index, string $arguments): array
+    {
+        return [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'function' => ['arguments' => $arguments],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+}

--- a/tests/Feature/Providers/Groq/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Groq/ToolCallLoopTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Feature\Providers\Groq;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ToolUsingAgent;
+use Tests\TestCase;
+
+class ToolCallLoopTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.groq' => [
+            ...config('ai.providers.groq'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_tool_calls_trigger_follow_up_request(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::sequence([
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeGroqResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a random number',
+            provider: 'groq',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+        $hasAssistantWithToolCalls = false;
+        $hasToolResult = false;
+
+        foreach ($followUpBody['messages'] as $message) {
+            if ($message['role'] === 'assistant' && isset($message['tool_calls'])) {
+                $hasAssistantWithToolCalls = true;
+            }
+
+            if ($message['role'] === 'tool') {
+                $hasToolResult = true;
+            }
+        }
+
+        $this->assertTrue($hasAssistantWithToolCalls, 'Follow-up request should include assistant message with tool_calls');
+        $this->assertTrue($hasToolResult, 'Follow-up request should include tool result message');
+    }
+
+    public function test_max_steps_limits_tool_call_depth(): void
+    {
+        Http::fake([
+            'api.groq.com/*' => Http::sequence([
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeGroqResponse('Done'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate numbers',
+            provider: 'groq',
+        );
+
+        $recorded = Http::recorded();
+
+        // ToolUsingAgent has 1 tool + structured output tool = 2 tools
+        // maxSteps = round(2 * 1.5) = 3
+        // So max 3 requests before stopping (initial + 2 follow-ups)
+        $this->assertLessThanOrEqual(3, count($recorded));
+    }
+
+    protected function fakeGroqResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+
+    protected function fakeUniqueToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-'.uniqid(),
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_'.uniqid(),
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenAi/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/OpenAi/ErrorHandlingTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenAi;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\TestCase;
+
+class ErrorHandlingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openai' => [
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_http_error_response_throws_request_exception(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response([
+                'error' => [
+                    'type' => 'invalid_request_error',
+                    'message' => 'Invalid request: max_output_tokens must be at least 1',
+                ],
+            ], 400),
+        ]);
+
+        $this->expectException(RequestException::class);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'openai',
+        );
+    }
+
+    public function test_rate_limit_response_throws_rate_limited_exception(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response([
+                'error' => [
+                    'type' => 'rate_limit_error',
+                    'message' => 'Rate limit exceeded',
+                ],
+            ], 429),
+        ]);
+
+        $this->expectException(RateLimitedException::class);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'openai',
+        );
+    }
+
+    public function test_error_in_200_response_throws_ai_exception(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response([
+                'error' => [
+                    'type' => 'api_error',
+                    'message' => 'Internal server error',
+                ],
+            ], 200),
+        ]);
+
+        $this->expectException(AiException::class);
+        $this->expectExceptionMessage('OpenAI Error');
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'openai',
+        );
+    }
+
+    public function test_failed_status_response_throws_ai_exception(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response([
+                'id' => 'resp_123',
+                'status' => 'failed',
+                'model' => 'gpt-5.4',
+                'output' => [],
+            ], 200),
+        ]);
+
+        $this->expectException(AiException::class);
+        $this->expectExceptionMessage('OpenAI Error');
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'openai',
+        );
+    }
+}

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenAi;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\Base64Document;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ToolUsingAgent;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class MessageMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openai' => [
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_user_message_maps_to_openai_format(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => $this->fakeOpenAiResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'What is Laravel?',
+            provider: 'openai',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $input = $body['input'];
+            $userMessage = collect($input)->firstWhere('role', 'user');
+
+            return $userMessage !== null
+                && $userMessage['content'][0]['type'] === 'input_text'
+                && $userMessage['content'][0]['text'] === 'What is Laravel?';
+        });
+    }
+
+    public function test_tool_result_follow_up_uses_previous_response_id(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::sequence([
+                $this->fakeOpenAiToolCallResponse(),
+                $this->fakeOpenAiResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a number',
+            provider: 'openai',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+        $this->assertArrayHasKey('previous_response_id', $followUpBody);
+        $this->assertSame('resp_tool_123', $followUpBody['previous_response_id']);
+
+        $hasFunctionCallOutput = false;
+
+        foreach ($followUpBody['input'] as $item) {
+            if (($item['type'] ?? '') === 'function_call_output') {
+                $hasFunctionCallOutput = true;
+                $this->assertSame('call_123', $item['call_id']);
+                $this->assertNotEmpty($item['output']);
+            }
+        }
+
+        $this->assertTrue($hasFunctionCallOutput, 'Follow-up should include function_call_output');
+    }
+
+    public function test_base64_pdf_document_maps_to_input_file(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => $this->fakeOpenAiResponse('I see a PDF'),
+        ]);
+
+        $pdf = new Base64Document(base64_encode('fake-pdf-content'), 'application/pdf');
+
+        agent('You are helpful.')->prompt(
+            'What is in this PDF?',
+            attachments: [$pdf],
+            provider: 'openai',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $userMessage = collect($body['input'])->firstWhere('role', 'user');
+            $content = $userMessage['content'];
+
+            $fileBlock = collect($content)->firstWhere('type', 'input_file');
+
+            return $fileBlock !== null
+                && str_contains($fileBlock['file_data'], 'application/pdf')
+                && str_contains($fileBlock['file_data'], base64_encode('fake-pdf-content'));
+        });
+    }
+
+    public function test_uploaded_pdf_file_maps_to_input_file(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => $this->fakeOpenAiResponse('I see a PDF'),
+        ]);
+
+        $file = UploadedFile::fake()->create('report.pdf', 100, 'application/pdf');
+
+        agent('You are helpful.')->prompt(
+            'What is in this file?',
+            attachments: [$file],
+            provider: 'openai',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $userMessage = collect($body['input'])->firstWhere('role', 'user');
+            $content = $userMessage['content'];
+
+            $fileBlock = collect($content)->firstWhere('type', 'input_file');
+
+            return $fileBlock !== null
+                && str_contains($fileBlock['file_data'], 'application/pdf');
+        });
+    }
+
+    public function test_system_instructions_are_in_input_array_as_system_role(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => $this->fakeOpenAiResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'openai',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $systemMsg = collect($body['input'])->firstWhere('role', 'system');
+
+            return $systemMsg !== null
+                && str_contains($systemMsg['content'], 'helpful assistant');
+        });
+    }
+
+    protected function fakeOpenAiResponse(string $text = 'Hello'): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [[
+                    'type' => 'output_text',
+                    'text' => $text,
+                ]],
+            ]],
+            'usage' => [
+                'input_tokens' => 1,
+                'output_tokens' => 1,
+            ],
+        ]);
+    }
+
+    protected function fakeOpenAiToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_tool_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'function_call',
+                'id' => 'fc_123',
+                'call_id' => 'call_123',
+                'name' => 'FixedNumberGenerator',
+                'arguments' => '{}',
+                'status' => 'completed',
+            ]],
+            'usage' => [
+                'input_tokens' => 10,
+                'output_tokens' => 5,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenAi;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\AttributeAgent;
+use Tests\Feature\Agents\StructuredAgent;
+use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class RequestMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openai' => [
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_request_includes_model_and_input(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        agent()->prompt('Hi there', provider: 'openai', model: 'gpt-5.4');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['model'] === 'gpt-5.4'
+                && is_array($body['input'])
+                && collect($body['input'])->contains(fn ($m) => $m['role'] === 'user'
+                    && collect($m['content'])->contains(fn ($c) => ($c['text'] ?? '') === 'Hi there'));
+        });
+    }
+
+    public function test_system_instructions_are_sent_as_system_message_in_input(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        (new AssistantAgent)->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $systemMsg = collect($body['input'])->firstWhere('role', 'system');
+
+            return $systemMsg !== null
+                && str_contains($systemMsg['content'], 'helpful assistant');
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_included_when_set_via_attributes(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        (new AttributeAgent)->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'temperature') === 0.7
+                && data_get($body, 'max_output_tokens') === 4096;
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_excluded_when_not_set(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('temperature', $body)
+                && ! array_key_exists('max_output_tokens', $body);
+        });
+    }
+
+    public function test_tools_include_tool_choice_auto(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('42')]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['tool_choice'] === 'auto'
+                && is_array($body['tools'])
+                && count($body['tools']) > 0;
+        });
+    }
+
+    public function test_request_without_tools_excludes_tool_fields(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('tools', $body)
+                && ! array_key_exists('tool_choice', $body);
+        });
+    }
+
+    public function test_structured_output_includes_json_schema_text_format(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('{"symbol": "Au"}')]);
+
+        (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $format = data_get($body, 'text.format');
+
+            return $format['type'] === 'json_schema'
+                && isset($format['name'])
+                && isset($format['schema'])
+                && $format['strict'] === true;
+        });
+    }
+
+    public function test_request_without_schema_excludes_text_format(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('text', $body);
+        });
+    }
+
+    public function test_request_sends_bearer_token_authorization(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openai');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_response_text_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('Laravel is great')]);
+
+        $response = agent()->prompt('Tell me about Laravel', provider: 'openai');
+
+        $this->assertSame('Laravel is great', $response->text);
+        $this->assertSame('openai', $response->meta->provider);
+    }
+
+    public function test_response_usage_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [[
+                    'type' => 'output_text',
+                    'text' => 'Hello',
+                ]],
+            ]],
+            'usage' => [
+                'input_tokens' => 10,
+                'output_tokens' => 5,
+            ],
+        ])]);
+
+        $response = agent()->prompt('Hello', provider: 'openai');
+
+        $this->assertSame(10, $response->usage->promptTokens);
+        $this->assertSame(5, $response->usage->completionTokens);
+    }
+
+    public function test_structured_response_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeOpenAiResponse('{"symbol": "Au"}')]);
+
+        $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openai');
+
+        $this->assertSame('Au', $response->structured['symbol']);
+    }
+
+    protected function fakeOpenAiResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [[
+                    'type' => 'output_text',
+                    'text' => $text,
+                ]],
+            ]],
+            'usage' => [
+                'input_tokens' => 1,
+                'output_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenAi;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+use Tests\TestCase;
+
+class StreamingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openai' => [
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_streaming_emits_text_events(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputTextDelta('Hello'),
+                    $this->outputTextDelta(' world'),
+                    $this->outputTextDone('Hello world'),
+                    $this->responseCompleted(10, 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertInstanceOf(StreamStart::class, $events[0]);
+        $this->assertInstanceOf(TextStart::class, $events[1]);
+        $this->assertInstanceOf(TextDelta::class, $events[2]);
+        $this->assertSame('Hello', $events[2]->delta);
+        $this->assertInstanceOf(TextDelta::class, $events[3]);
+        $this->assertSame(' world', $events[3]->delta);
+        $this->assertInstanceOf(TextEnd::class, $events[4]);
+        $this->assertInstanceOf(StreamEnd::class, $events[count($events) - 1]);
+    }
+
+    public function test_streaming_handles_tool_calls(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->responseCreated(),
+                        $this->outputItemAdded('fc_1', 'call_1', 'FixedNumberGenerator'),
+                        $this->functionCallArgumentsDelta('fc_1', '{}'),
+                        $this->functionCallArgumentsDone('fc_1', '{}'),
+                        $this->responseCompleted(10, 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        [
+                            'type' => 'response.created',
+                            'response' => ['id' => 'resp_2', 'model' => 'gpt-5.4', 'status' => 'in_progress', 'output' => []],
+                        ],
+                        $this->outputTextDelta('The number is 72019'),
+                        $this->outputTextDone('The number is 72019'),
+                        $this->responseCompleted(20, 10),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+
+        $this->assertNotEmpty($toolCallEvents);
+        $this->assertSame('FixedNumberGenerator', $toolCallEvents[0]->toolCall->name);
+        $this->assertSame('call_1', $toolCallEvents[0]->toolCall->resultId);
+    }
+
+    public function test_streaming_handles_reasoning_events(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    ['type' => 'response.reasoning_summary_text.delta', 'delta' => 'Let me think...', 'item_id' => 'rs_1'],
+                    [
+                        'type' => 'response.output_item.done',
+                        'item' => ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => [['type' => 'summary_text', 'text' => 'Let me think...']]],
+                    ],
+                    $this->outputTextDelta('Answer'),
+                    $this->outputTextDone('Answer'),
+                    $this->responseCompleted(10, 15),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $types = array_map(fn ($e) => $e::class, $events);
+
+        $this->assertContains(ReasoningStart::class, $types);
+        $this->assertContains(ReasoningDelta::class, $types);
+        $this->assertContains(ReasoningEnd::class, $types);
+
+        $reasoningDelta = array_values(array_filter($events, fn ($e) => $e instanceof ReasoningDelta))[0];
+        $this->assertSame('Let me think...', $reasoningDelta->delta);
+    }
+
+    public function test_streaming_error_event_stops_stream(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    ['type' => 'error', 'error' => ['code' => 'server_error', 'message' => 'Server overloaded']],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(Error::class, $events[0]);
+        $this->assertSame('server_error', $events[0]->type);
+        $this->assertSame('Server overloaded', $events[0]->message);
+    }
+
+    public function test_streaming_captures_usage_from_response_completed(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputTextDelta('Hello'),
+                    $this->outputTextDone('Hello'),
+                    $this->responseCompleted(42, 10, cachedTokens: 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+        $this->assertSame(37, $streamEnd->usage->promptTokens);
+        $this->assertSame(10, $streamEnd->usage->completionTokens);
+        $this->assertSame(5, $streamEnd->usage->cacheReadInputTokens);
+    }
+
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream(
+            'Hello',
+            provider: 'openai',
+        );
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            $lines[] = 'data: '.json_encode($event);
+        }
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+
+    protected function responseCreated(): array
+    {
+        return [
+            'type' => 'response.created',
+            'response' => [
+                'id' => 'resp_1',
+                'model' => 'gpt-5.4',
+                'status' => 'in_progress',
+                'output' => [],
+            ],
+        ];
+    }
+
+    protected function outputTextDelta(string $text): array
+    {
+        return [
+            'type' => 'response.output_text.delta',
+            'delta' => $text,
+            'item_id' => 'msg_1',
+            'output_index' => 0,
+            'content_index' => 0,
+        ];
+    }
+
+    protected function outputTextDone(string $text): array
+    {
+        return [
+            'type' => 'response.output_text.done',
+            'text' => $text,
+            'item_id' => 'msg_1',
+            'output_index' => 0,
+            'content_index' => 0,
+        ];
+    }
+
+    protected function outputItemAdded(string $id, string $callId, string $name): array
+    {
+        return [
+            'type' => 'response.output_item.added',
+            'output_index' => 0,
+            'item' => [
+                'type' => 'function_call',
+                'id' => $id,
+                'call_id' => $callId,
+                'name' => $name,
+                'arguments' => '',
+                'status' => 'in_progress',
+            ],
+        ];
+    }
+
+    protected function functionCallArgumentsDelta(string $itemId, string $delta): array
+    {
+        return [
+            'type' => 'response.function_call_arguments.delta',
+            'item_id' => $itemId,
+            'delta' => $delta,
+            'output_index' => 0,
+        ];
+    }
+
+    protected function functionCallArgumentsDone(string $itemId, string $arguments): array
+    {
+        return [
+            'type' => 'response.function_call_arguments.done',
+            'item_id' => $itemId,
+            'arguments' => $arguments,
+            'output_index' => 0,
+        ];
+    }
+
+    protected function responseCompleted(int $inputTokens, int $outputTokens, int $cachedTokens = 0, int $reasoningTokens = 0): array
+    {
+        return [
+            'type' => 'response.completed',
+            'response' => [
+                'id' => 'resp_1',
+                'model' => 'gpt-5.4',
+                'status' => 'completed',
+                'output' => [],
+                'usage' => [
+                    'input_tokens' => $inputTokens,
+                    'output_tokens' => $outputTokens,
+                    'input_tokens_details' => [
+                        'cached_tokens' => $cachedTokens,
+                    ],
+                    'output_tokens_details' => [
+                        'reasoning_tokens' => $reasoningTokens,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Providers/OpenAi/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolCallLoopTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenAi;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ToolUsingAgent;
+use Tests\TestCase;
+
+class ToolCallLoopTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openai' => [
+            ...config('ai.providers.openai'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_tool_calls_trigger_follow_up_request(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::sequence([
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeOpenAiResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate a random number',
+            provider: 'openai',
+        );
+
+        $recorded = Http::recorded();
+
+        $this->assertCount(2, $recorded);
+
+        $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+        $this->assertArrayHasKey('previous_response_id', $followUpBody);
+
+        $hasFunctionCallOutput = false;
+
+        foreach ($followUpBody['input'] as $item) {
+            if (($item['type'] ?? '') === 'function_call_output') {
+                $hasFunctionCallOutput = true;
+            }
+        }
+
+        $this->assertTrue($hasFunctionCallOutput, 'Follow-up request should include function_call_output');
+    }
+
+    public function test_max_steps_limits_tool_call_depth(): void
+    {
+        Http::fake([
+            'api.openai.com/*' => Http::sequence([
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeUniqueToolCallResponse(),
+                $this->fakeOpenAiResponse('Done'),
+            ]),
+        ]);
+
+        $response = (new ToolUsingAgent(fixed: true))->prompt(
+            'Generate numbers',
+            provider: 'openai',
+        );
+
+        $recorded = Http::recorded();
+
+        // ToolUsingAgent has 1 tool + structured output tool = 2 tools
+        // maxSteps = round(2 * 1.5) = 3
+        // So max 3 requests before stopping (initial + 2 follow-ups)
+        $this->assertLessThanOrEqual(3, count($recorded));
+    }
+
+    protected function fakeOpenAiResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'resp_123',
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [[
+                    'type' => 'output_text',
+                    'text' => $text,
+                ]],
+            ]],
+            'usage' => [
+                'input_tokens' => 1,
+                'output_tokens' => 1,
+            ],
+        ]);
+    }
+
+    protected function fakeUniqueToolCallResponse(): PromiseInterface
+    {
+        $id = uniqid();
+
+        return Http::response([
+            'id' => 'resp_tool_'.$id,
+            'status' => 'completed',
+            'model' => 'gpt-5.4',
+            'output' => [[
+                'type' => 'function_call',
+                'id' => 'fc_'.$id,
+                'call_id' => 'call_'.$id,
+                'name' => 'FixedNumberGenerator',
+                'arguments' => '{}',
+                'status' => 'completed',
+            ]],
+            'usage' => [
+                'input_tokens' => 10,
+                'output_tokens' => 5,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenAi/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolMappingTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature\Providers\OpenAi;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Feature\Tools\FixedNumberGenerator;
 use Tests\Feature\Tools\RandomNumberGenerator;
-use GuzzleHttp\Promise\PromiseInterface;
 use Tests\TestCase;
 
 use function Laravel\Ai\agent;


### PR DESCRIPTION
Groq and OpenAI gateway implementations had incomplete test coverage compared to Anthropic and Gemini. This brings them to parity.

### Approach

- Added MessageMappingTest, ToolCallLoopTest, StreamingTest, and ErrorHandlingTest for Groq
- Added RequestMappingTest, MessageMappingTest, ToolCallLoopTest, StreamingTest, and ErrorHandlingTest for OpenAI
- Each test is tailored to the provider's actual API format — Chat Completions for Groq, Responses API for OpenAI — rather than copied from other providers
- Groq-specific: tests image attachment support and document rejection, Chat Completions SSE chunk format
- OpenAI-specific: tests `previous_response_id` follow-ups, `input_text`/`input_file` content types, `response.*` SSE events, cached token accounting, `status: failed` error handling