### PR TITLE
Support system prompt caching via system_prompt_cache_type provider option

### DIFF
--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Files\LocalImage;
@@ -36,6 +37,7 @@ use Prism\Prism\Exceptions\PrismException as PrismVendorException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\ValueObjects\Media\Audio;
 use Prism\Prism\ValueObjects\Media\Image as PrismImage;
+use Prism\Prism\ValueObjects\Messages\SystemMessage;
 
 class PrismGateway implements Gateway
 {
@@ -71,7 +73,9 @@ class PrismGateway implements Gateway
         ];
 
         if (! empty($instructions)) {
-            $request->withSystemPrompt($instructions);
+            $request->withSystemPrompt(
+                $this->toSystemPrompt($instructions, $provider, $options)
+            );
         }
 
         if (count($tools) > 0) {
@@ -132,7 +136,9 @@ class PrismGateway implements Gateway
         ];
 
         if (! empty($instructions)) {
-            $request->withSystemPrompt($instructions);
+            $request->withSystemPrompt(
+                $this->toSystemPrompt($instructions, $provider, $options)
+            );
         }
 
         if (count($tools) > 0) {
@@ -155,6 +161,24 @@ class PrismGateway implements Gateway
         } catch (PrismVendorException $e) {
             throw PrismException::toAiException($e, $provider, $model);
         }
+    }
+
+    /**
+     * Convert the instructions string into a system prompt, applying cache control if configured.
+     */
+    protected function toSystemPrompt(string $instructions, TextProvider $provider, ?TextGenerationOptions $options): string|SystemMessage
+    {
+        $cacheType = $options?->providerOptions(
+            Lab::tryFrom($provider->driver()) ?? $provider->driver()
+        )['system_prompt_cache_type'] ?? null;
+
+        if (is_null($cacheType)) {
+            return $instructions;
+        }
+
+        return (new SystemMessage($instructions))->withProviderOptions([
+            'cacheType' => $cacheType,
+        ]);
     }
 
     /**


### PR DESCRIPTION
Fixes #119

### Problem

Anthropic's prompt caching can dramatically reduce input token costs for agents with large system prompts. However, `GeneratesText` casts `instructions()` to `(string)` before passing to the gateway, so there's no way to attach `cache_control` metadata through the agent interface — even though Prism fully supports it via `SystemMessage::withProviderOptions()`.

### Solution

Add a `system_prompt_cache_type` provider option that mirrors the existing `tool_result_cache_type` pattern. When set, the gateway wraps the instructions string in a `SystemMessage` with the appropriate cache control before passing to Prism.

This is a single new method on `PrismGateway` — `toSystemPrompt()` — called from both `generateText()` and `streamText()`. When no `system_prompt_cache_type` is configured, the plain string is passed through unchanged (zero breaking changes).

### Usage

Agents opt in by implementing `HasProviderOptions`:

```php
use Laravel\Ai\Contracts\HasProviderOptions;
use Laravel\Ai\Enums\Lab;

class MyAgent implements Agent, HasProviderOptions, HasTools
{
    public function providerOptions(Lab|string $provider): array
    {
        return match ($provider) {
            Lab::Anthropic, 'anthropic' => [
                'system_prompt_cache_type' => 'ephemeral',
                'tool_result_cache_type' => 'ephemeral', // existing, unchanged
            ],
            default => [],
        };
    }
}
```

### Why not strip `cache_control` from provider options?

PR #365 took that approach and was closed. Stripping `cache_control` from provider options would break the existing `tool_result_cache_type` mechanism — Prism's `MessageMap::map()` reads that from provider options to apply cache breakpoints on tool results between agent steps. This is critical for multi-step agents where large tool outputs (SQL results, API responses) need caching between iterations.

This PR keeps both mechanisms independent:
- **System prompt caching** — new `system_prompt_cache_type` key, applied in the gateway
- **Tool result caching** — existing `tool_result_cache_type` key, flows through Prism's `MessageMap` untouched

### Results

On a multi-step analytics agent with a ~15k token system prompt:

| | Prompt tokens (full price) | Cache read | Cache write |
|---|---|---|---|
| Before | 37,685 | 0 | 0 |
| After (warm cache) | 334 | 35,316 | 496 |

~90% reduction in effective input token cost.

### Changes

- `PrismGateway.php` — added `toSystemPrompt()` method, updated `generateText()` and `streamText()` to use it
- 2 new imports (`Lab`, `SystemMessage`)
- No interface changes, no new files, no breaking changes