### PR TITLE
Fix MistralProvider ignoring injected fake gateways

### DIFF
--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -41,7 +41,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function textGateway(): TextGateway
     {
-        return $this->mistralGateway();
+        return $this->textGateway ??= $this->mistralGateway();
     }
 
     /**
@@ -49,7 +49,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function embeddingGateway(): EmbeddingGateway
     {
-        return $this->mistralGateway();
+        return $this->embeddingGateway ??= $this->mistralGateway();
     }
 
     /**
@@ -57,7 +57,7 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
      */
     public function transcriptionGateway(): TranscriptionGateway
     {
-        return $this->mistralGateway();
+        return $this->transcriptionGateway ??= $this->mistralGateway();
     }
 
     /**

--- a/tests/Feature/Agents/MistralAgent.php
+++ b/tests/Feature/Agents/MistralAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider('mistral')]
+class MistralAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}

--- a/tests/Feature/Providers/Mistral/AgentFakeTest.php
+++ b/tests/Feature/Providers/Mistral/AgentFakeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Providers\Mistral;
+
+use Tests\Feature\Agents\MistralAgent;
+
+class AgentFakeTest extends MistralTestCase
+{
+    public function test_mistral_agent_can_be_faked(): void
+    {
+        MistralAgent::fake(['Test response']);
+
+        $response = (new MistralAgent)->prompt('Hello');
+
+        $this->assertEquals('Test response', $response->text);
+    }
+
+    public function test_mistral_agent_fake_with_closure(): void
+    {
+        MistralAgent::fake(fn (string $prompt) => "Echo: {$prompt}");
+
+        $response = (new MistralAgent)->prompt('Hello world');
+
+        $this->assertEquals('Echo: Hello world', $response->text);
+    }
+
+    public function test_mistral_agent_fake_with_no_predefined_responses(): void
+    {
+        MistralAgent::fake();
+
+        $response = (new MistralAgent)->prompt('Hello');
+
+        $this->assertEquals('Fake response for prompt: Hello', $response->text);
+    }
+
+    public function test_mistral_agent_fake_records_prompts(): void
+    {
+        MistralAgent::fake();
+
+        (new MistralAgent)->prompt('Hello');
+
+        MistralAgent::assertPrompted('Hello');
+        MistralAgent::assertNotPrompted('Goodbye');
+    }
+
+    public function test_mistral_agent_stream_can_be_faked(): void
+    {
+        MistralAgent::fake(['Streamed response']);
+
+        $response = (new MistralAgent)->stream('Hello');
+        $response->each(fn () => true);
+
+        $this->assertEquals('Streamed response', $response->text);
+    }
+}


### PR DESCRIPTION
`Agent::fake()` on Mistral-backed agents makes real HTTP requests instead of returning fake responses, because `MistralProvider` overrides its gateway accessors to always return the real gateway, ignoring any injected fake.

Fixes #373

### Approach

- Updated the three gateway accessor methods (`textGateway`, `embeddingGateway`, `transcriptionGateway`) to check for an already-injected gateway before falling back to the real one, matching the pattern used by all other providers
- Added agent fake tests specifically for the Mistral provider to prevent regression