### PR TITLE
fix(anthropic): cast server_tool_use.input to object

### DIFF
--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -361,10 +361,7 @@ trait ParsesTextResponses
     }
 
     /**
-     * Ensure tool_use and server_tool_use content blocks have their input cast
-     * to object for JSON serialization. Anthropic's API rejects `input: []` on
-     * replay; PHP's json_decode('{}', true) produces [], so an explicit cast
-     * is required before the follow-up request is sent.
+     * Ensure tool_use and server_tool_use content blocks have their input cast to object for JSON serialization.
      */
     protected function ensureToolInputIsObject(array $content): array
     {

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -361,12 +361,15 @@ trait ParsesTextResponses
     }
 
     /**
-     * Ensure tool_use content blocks have their input cast to object for JSON serialization.
+     * Ensure tool_use and server_tool_use content blocks have their input cast
+     * to object for JSON serialization. Anthropic's API rejects `input: []` on
+     * replay; PHP's json_decode('{}', true) produces [], so an explicit cast
+     * is required before the follow-up request is sent.
      */
     protected function ensureToolInputIsObject(array $content): array
     {
         return array_map(function (array $block) {
-            if (($block['type'] ?? '') === 'tool_use') {
+            if (in_array($block['type'] ?? '', ['tool_use', 'server_tool_use'], true)) {
                 $block['input'] = (object) ($block['input'] ?? []);
             }
 

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -48,58 +48,31 @@ test('tool calls trigger follow up request', function () {
 });
 
 test('server_tool_use input is serialized as object on follow-up replay', function () {
-    // First response: tool_use (triggers loop) alongside a server_tool_use
-    // with empty input — simulating e.g. the advisor tool, whose input is
-    // documented as always empty. Anthropic's API requires `input` to be a
-    // JSON object ({}). PHP's json_decode('{}', true) produces [], which
-    // re-encodes as JSON array [] — causing 400 invalid_request_error on
-    // replay unless ensureToolInputIsObject() covers server_tool_use too.
-    $responseWithServerTool = Http::response([
-        'id' => 'msg_tool_123',
-        'type' => 'message',
-        'role' => 'assistant',
-        'model' => 'claude-sonnet-4-6',
-        'content' => [
-            [
-                'type' => 'server_tool_use',
-                'id' => 'srvtoolu_123',
-                'name' => 'advisor',
-                'input' => (object) [],
-            ],
-            [
-                'type' => 'tool_use',
-                'id' => 'toolu_123',
-                'name' => 'FixedNumberGenerator',
-                'input' => (object) [],
-            ],
-        ],
-        'stop_reason' => 'tool_use',
-        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
-    ]);
-
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([
-            $responseWithServerTool,
-            $this->fakeTextResponse('The number is 72019'),
+            Http::response([
+                'id' => 'msg_tool_123',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [
+                    ['type' => 'server_tool_use', 'id' => 'srvtoolu_123', 'name' => 'advisor', 'input' => (object) []],
+                    ['type' => 'tool_use', 'id' => 'toolu_123', 'name' => 'FixedNumberGenerator', 'input' => (object) []],
+                ],
+                'stop_reason' => 'tool_use',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            $this->fakeTextResponse('done'),
         ]),
     ]);
 
-    (new ToolUsingAgent(fixed: true))->prompt(
-        'Generate a random number',
-        provider: 'anthropic',
-    );
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a random number', provider: 'anthropic');
 
-    $recorded = Http::recorded();
-    expect($recorded)->toHaveCount(2);
+    $followUpBody = Http::recorded()[1][0]->body();
 
-    $payload = json_decode($recorded[1][0]->body(), false, 512, JSON_THROW_ON_ERROR);
-
-    $assistant = collect($payload->messages)->first(fn ($message) => $message->role === 'assistant');
-    $serverToolUse = collect($assistant->content)->first(fn ($block) => $block->type === 'server_tool_use');
-
-    expect($serverToolUse)->not->toBeNull()
-        ->and($serverToolUse->input)->toBeInstanceOf(stdClass::class)
-        ->and(get_object_vars($serverToolUse->input))->toBeEmpty();
+    expect($followUpBody)
+        ->toContain('"type":"server_tool_use"')
+        ->not->toContain('"input":[]');
 });
 
 test('max steps limits tool call depth', function () {

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -47,6 +47,61 @@ test('tool calls trigger follow up request', function () {
         ->and($hasToolResult)->toBeTrue('Follow-up request should include user message with tool_result block');
 });
 
+test('server_tool_use input is serialized as object on follow-up replay', function () {
+    // First response: tool_use (triggers loop) alongside a server_tool_use
+    // with empty input — simulating e.g. the advisor tool, whose input is
+    // documented as always empty. Anthropic's API requires `input` to be a
+    // JSON object ({}). PHP's json_decode('{}', true) produces [], which
+    // re-encodes as JSON array [] — causing 400 invalid_request_error on
+    // replay unless ensureToolInputIsObject() covers server_tool_use too.
+    $responseWithServerTool = Http::response([
+        'id' => 'msg_tool_123',
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-sonnet-4-6',
+        'content' => [
+            [
+                'type' => 'server_tool_use',
+                'id' => 'srvtoolu_123',
+                'name' => 'advisor',
+                'input' => (object) [],
+            ],
+            [
+                'type' => 'tool_use',
+                'id' => 'toolu_123',
+                'name' => 'FixedNumberGenerator',
+                'input' => (object) [],
+            ],
+        ],
+        'stop_reason' => 'tool_use',
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ]);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            $responseWithServerTool,
+            $this->fakeTextResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a random number',
+        provider: 'anthropic',
+    );
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $payload = json_decode($recorded[1][0]->body(), false, 512, JSON_THROW_ON_ERROR);
+
+    $assistant = collect($payload->messages)->first(fn ($message) => $message->role === 'assistant');
+    $serverToolUse = collect($assistant->content)->first(fn ($block) => $block->type === 'server_tool_use');
+
+    expect($serverToolUse)->not->toBeNull()
+        ->and($serverToolUse->input)->toBeInstanceOf(stdClass::class)
+        ->and(get_object_vars($serverToolUse->input))->toBeEmpty();
+});
+
 test('max steps limits tool call depth', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([


### PR DESCRIPTION
Ran into a `400 invalid_request_error` from Anthropic when replaying assistant history containing a `server_tool_use` block with empty input. The replayed payload sent `"input":[]` instead of `"input":{}`.

The issue is that `json_decode('{}', true)` returns `[]`, which then gets re-encoded as a JSON array. `ensureToolInputIsObject()` already handles `tool_use`; this extends the same cast to `server_tool_use`.

```diff
 protected function ensureToolInputIsObject(array $content): array
 {
     return array_map(function (array $block) {
-        if (($block['type'] ?? '') === 'tool_use') {
+        if (in_array($block['type'] ?? '', ['tool_use', 'server_tool_use'], true)) {
             $block['input'] = (object) ($block['input'] ?? []);
         }
         return $block;
     }, $content);
 }
```

The helper is called from both the streaming and non-streaming replay paths.

I hit this with the advisor beta (`advisor_20260301`), which always emits an empty `input`, but the change applies to any `server_tool_use` block. Today advisor is the only server tool where this surfaces in practice — `web_search`, `web_fetch`, `code_execution`, and `tool_search` all have required input fields — but the helper should cover server tools as a category regardless.

Added a test covering replay of a `server_tool_use` block with empty input and confirmed the request body now sends `{}`.
