### PR TITLE
Fix Gemini tool call id mismatch causing HTTP 400 on continuation

### DIFF
--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -123,38 +123,30 @@ trait BuildsTextRequests
     }
 
     /**
-     * Inject the mapped ToolCall id onto each functionCall part in the model
-     * response, so the continuation request carries the same id on both
-     * functionCall and functionResponse. Gemini matches the two by id, and
-     * rejects the request with HTTP 400 when they do not correspond.
+     * Pair each functionCall part with its mapped ToolCall id so
+     * functionCall.id and functionResponse.id stay in sync.
      *
-     * The pairing is positional: the i-th functionCall part corresponds to the
-     * i-th mapped ToolCall, mirroring how extractRawToolCalls walks the parts.
-     *
-     * @param  array<int, array<string, mixed>>  $parts
+     * @param  array<int, array<string, mixed>>  $modelParts
      * @param  array<int, ToolCall>  $mappedToolCalls
      * @return array<int, array<string, mixed>>
      */
-    protected function withToolCallIds(array $parts, array $mappedToolCalls): array
+    protected function withToolCallIds(array $modelParts, array $mappedToolCalls): array
     {
-        $index = 0;
+        $functionCallIndex = 0;
 
-        return array_map(function (array $part) use ($mappedToolCalls, &$index) {
+        return array_map(function (array $part) use ($mappedToolCalls, &$functionCallIndex) {
             if (! isset($part['functionCall'])) {
                 return $part;
             }
 
-            $toolCall = $mappedToolCalls[$index] ?? null;
-            $index++;
+            $toolCall = $mappedToolCalls[$functionCallIndex++] ?? null;
 
-            if ($toolCall === null || ! filled($toolCall->id)) {
-                return $part;
+            if ($toolCall !== null && filled($toolCall->id)) {
+                $part['functionCall']['id'] = $toolCall->id;
             }
 
-            $part['functionCall']['id'] = $toolCall->id;
-
             return $part;
-        }, $parts);
+        }, $modelParts);
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 
 trait BuildsTextRequests
@@ -113,12 +114,47 @@ trait BuildsTextRequests
                 ],
             ];
 
-            if ($result->id !== null) {
+            if (filled($result->id)) {
                 $functionResponse['id'] = $result->id;
             }
 
             return ['functionResponse' => $functionResponse];
         }, $toolResults);
+    }
+
+    /**
+     * Inject the mapped ToolCall id onto each functionCall part in the model
+     * response, so the continuation request carries the same id on both
+     * functionCall and functionResponse. Gemini matches the two by id, and
+     * rejects the request with HTTP 400 when they do not correspond.
+     *
+     * The pairing is positional: the i-th functionCall part corresponds to the
+     * i-th mapped ToolCall, mirroring how extractRawToolCalls walks the parts.
+     *
+     * @param  array<int, array<string, mixed>>  $parts
+     * @param  array<int, ToolCall>  $mappedToolCalls
+     * @return array<int, array<string, mixed>>
+     */
+    protected function withToolCallIds(array $parts, array $mappedToolCalls): array
+    {
+        $index = 0;
+
+        return array_map(function (array $part) use ($mappedToolCalls, &$index) {
+            if (! isset($part['functionCall'])) {
+                return $part;
+            }
+
+            $toolCall = $mappedToolCalls[$index] ?? null;
+            $index++;
+
+            if ($toolCall === null || ! filled($toolCall->id)) {
+                return $part;
+            }
+
+            $part['functionCall']['id'] = $toolCall->id;
+
+            return $part;
+        }, $parts);
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -267,7 +267,12 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $contents[] = ['role' => 'model', 'parts' => $this->excludeThinkingParts($modelParts)];
+            $modelPartsWithIds = $this->withToolCallIds(
+                $this->excludeThinkingParts($modelParts),
+                $mappedToolCalls,
+            );
+
+            $contents[] = ['role' => 'model', 'parts' => $modelPartsWithIds];
             $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
 
             $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);

--- a/src/Gateway/Gemini/Concerns/MapsMessages.php
+++ b/src/Gateway/Gemini/Concerns/MapsMessages.php
@@ -60,12 +60,19 @@ trait MapsMessages
 
         if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
             foreach ($message->toolCalls as $toolCall) {
-                $parts[] = [
-                    'functionCall' => [
-                        'name' => $toolCall->name,
-                        'args' => $toolCall->arguments,
-                    ],
+                $functionCall = [
+                    'name' => $toolCall->name,
+                    'args' => $toolCall->arguments,
                 ];
+
+                // Echo the id on functionCall so it matches the functionResponse
+                // emitted by buildFunctionResponseParts. Gemini rejects continuation
+                // requests where the ids on the two sides do not correspond.
+                if (filled($toolCall->id)) {
+                    $functionCall['id'] = $toolCall->id;
+                }
+
+                $parts[] = ['functionCall' => $functionCall];
             }
         }
 

--- a/src/Gateway/Gemini/Concerns/MapsMessages.php
+++ b/src/Gateway/Gemini/Concerns/MapsMessages.php
@@ -65,9 +65,6 @@ trait MapsMessages
                     'args' => $toolCall->arguments,
                 ];
 
-                // Echo the id on functionCall so it matches the functionResponse
-                // emitted by buildFunctionResponseParts. Gemini rejects continuation
-                // requests where the ids on the two sides do not correspond.
                 if (filled($toolCall->id)) {
                     $functionCall['id'] = $toolCall->id;
                 }

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -116,7 +116,12 @@ trait ParsesTextResponses
         if (filled($toolResults)) {
             $messages->push(new ToolResultMessage(collect($toolResults)));
 
-            $contents[] = ['role' => 'model', 'parts' => $this->excludeThinkingParts($parts)];
+            $modelPartsWithIds = $this->withToolCallIds(
+                $this->excludeThinkingParts($parts),
+                $mappedToolCalls,
+            );
+
+            $contents[] = ['role' => 'model', 'parts' => $modelPartsWithIds];
             $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
 
             return $this->continueWithToolResults(

--- a/tests/Feature/Providers/Gemini/GeminiHelpers.php
+++ b/tests/Feature/Providers/Gemini/GeminiHelpers.php
@@ -138,6 +138,28 @@ trait GeminiHelpers
         ];
     }
 
+    /**
+     * @return array{0: array<int, string|null>, 1: array<int, string|null>}
+     */
+    protected function extractToolCallIds(array $contents): array
+    {
+        $functionCallIds = [];
+        $functionResponseIds = [];
+
+        foreach ($contents as $content) {
+            foreach ($content['parts'] ?? [] as $part) {
+                if (isset($part['functionCall'])) {
+                    $functionCallIds[] = $part['functionCall']['id'] ?? null;
+                }
+                if (isset($part['functionResponse'])) {
+                    $functionResponseIds[] = $part['functionResponse']['id'] ?? null;
+                }
+            }
+        }
+
+        return [$functionCallIds, $functionResponseIds];
+    }
+
     protected function geminiChunkWithUsage(array $parts, int $promptTokens, int $candidatesTokens, int $cachedTokens = 0, ?string $modelVersion = null): array
     {
         $chunk = $this->geminiChunk($parts, $modelVersion);

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -119,26 +119,14 @@ describe('tool calls', function () {
 
         $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
 
-        $followUpContents = Http::recorded()[1][0]->data()['contents'];
+        [$functionCallIds, $functionResponseIds] = $this->extractToolCallIds(
+            Http::recorded()[1][0]->data()['contents'],
+        );
 
-        $functionCallId = null;
-        $functionResponseId = null;
-
-        foreach ($followUpContents as $content) {
-            foreach ($content['parts'] ?? [] as $part) {
-                if (isset($part['functionCall']['id'])) {
-                    $functionCallId = $part['functionCall']['id'];
-                }
-                if (isset($part['functionResponse']['id'])) {
-                    $functionResponseId = $part['functionResponse']['id'];
-                }
-            }
-        }
-
-        expect($functionCallId)
-            ->toBe('gemini_call_xyz', 'functionCall id must be preserved verbatim per Gemini docs')
-            ->and($functionResponseId)
-            ->toBe('gemini_call_xyz', 'functionResponse id must echo the functionCall id exactly');
+        expect($functionCallIds)
+            ->toBe(['gemini_call_xyz'], 'functionCall id must be preserved verbatim per Gemini docs')
+            ->and($functionResponseIds)
+            ->toBe(['gemini_call_xyz'], 'functionResponse id must echo the functionCall id exactly');
     });
 
     test('streaming continuation produces matching ids when gemini omits id', function () {
@@ -171,21 +159,9 @@ describe('tool calls', function () {
 
         $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
 
-        $followUpContents = Http::recorded()[1][0]->data()['contents'];
-
-        $functionCallIds = [];
-        $functionResponseIds = [];
-
-        foreach ($followUpContents as $content) {
-            foreach ($content['parts'] ?? [] as $part) {
-                if (isset($part['functionCall'])) {
-                    $functionCallIds[] = $part['functionCall']['id'] ?? null;
-                }
-                if (isset($part['functionResponse'])) {
-                    $functionResponseIds[] = $part['functionResponse']['id'] ?? null;
-                }
-            }
-        }
+        [$functionCallIds, $functionResponseIds] = $this->extractToolCallIds(
+            Http::recorded()[1][0]->data()['contents'],
+        );
 
         expect($functionCallIds)
             ->toHaveCount(1)

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -91,6 +91,113 @@ describe('tool calls', function () {
             ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator');
     });
 
+    test('streaming continuation echoes id symmetrically when gemini supplies one', function () {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([[
+                            'functionCall' => [
+                                'id' => 'gemini_call_xyz',
+                                'name' => 'FixedNumberGenerator',
+                                'args' => (object) [],
+                            ],
+                        ]], 10, 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([['text' => 'Done']], 20, 10),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $followUpContents = Http::recorded()[1][0]->data()['contents'];
+
+        $functionCallId = null;
+        $functionResponseId = null;
+
+        foreach ($followUpContents as $content) {
+            foreach ($content['parts'] ?? [] as $part) {
+                if (isset($part['functionCall']['id'])) {
+                    $functionCallId = $part['functionCall']['id'];
+                }
+                if (isset($part['functionResponse']['id'])) {
+                    $functionResponseId = $part['functionResponse']['id'];
+                }
+            }
+        }
+
+        expect($functionCallId)
+            ->toBe('gemini_call_xyz', 'functionCall id must be preserved verbatim per Gemini docs')
+            ->and($functionResponseId)
+            ->toBe('gemini_call_xyz', 'functionResponse id must echo the functionCall id exactly');
+    });
+
+    test('streaming continuation produces matching ids when gemini omits id', function () {
+        // Reproduces laravel/ai#388: when Gemini omits an id on functionCall,
+        // the continuation must NOT send an unmatched fabricated id on
+        // functionResponse — Gemini rejects the request with HTTP 400.
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([[
+                            'functionCall' => [
+                                'name' => 'FixedNumberGenerator',
+                                'args' => (object) [],
+                            ],
+                        ]], 10, 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([['text' => 'Done']], 20, 10),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $followUpContents = Http::recorded()[1][0]->data()['contents'];
+
+        $functionCallIds = [];
+        $functionResponseIds = [];
+
+        foreach ($followUpContents as $content) {
+            foreach ($content['parts'] ?? [] as $part) {
+                if (isset($part['functionCall'])) {
+                    $functionCallIds[] = $part['functionCall']['id'] ?? null;
+                }
+                if (isset($part['functionResponse'])) {
+                    $functionResponseIds[] = $part['functionResponse']['id'] ?? null;
+                }
+            }
+        }
+
+        expect($functionCallIds)
+            ->toHaveCount(1)
+            ->and($functionResponseIds)
+            ->toHaveCount(1)
+            ->and($functionCallIds[0])
+            ->toBe(
+                $functionResponseIds[0],
+                'functionCall.id and functionResponse.id must match — mismatch causes Gemini 400',
+            );
+    });
+
     test('streaming thinking parts are excluded from tool call continuation', function () {
         Http::fake([
             'generativelanguage.googleapis.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
@@ -146,6 +146,89 @@ test('parallel function calls preserve unique ids', function () {
         ->toContain('call_2');
 });
 
+test('non-streaming continuation produces matching ids when gemini omits id', function () {
+    // Reproduces laravel/ai#388 on the non-streaming path: when Gemini omits
+    // an id on functionCall, the continuation request must not send an
+    // unmatched fabricated id on functionResponse.
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            Http::response([
+                'candidates' => [[
+                    'content' => [
+                        'parts' => [[
+                            'functionCall' => [
+                                'name' => 'FixedNumberGenerator',
+                                'args' => (object) [],
+                            ],
+                        ]],
+                        'role' => 'model',
+                    ],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5, 'totalTokenCount' => 15],
+            ]),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini');
+
+    $followUpContents = Http::recorded()[1][0]->data()['contents'];
+
+    $functionCallIds = [];
+    $functionResponseIds = [];
+
+    foreach ($followUpContents as $content) {
+        foreach ($content['parts'] ?? [] as $part) {
+            if (isset($part['functionCall'])) {
+                $functionCallIds[] = $part['functionCall']['id'] ?? null;
+            }
+            if (isset($part['functionResponse'])) {
+                $functionResponseIds[] = $part['functionResponse']['id'] ?? null;
+            }
+        }
+    }
+
+    expect($functionCallIds)->toHaveCount(1)
+        ->and($functionResponseIds)->toHaveCount(1)
+        ->and($functionCallIds[0])->toBe(
+            $functionResponseIds[0],
+            'functionCall.id and functionResponse.id must match — mismatch causes Gemini 400',
+        );
+});
+
+test('non-streaming continuation preserves gemini supplied id verbatim', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            $this->fakeToolCallResponse('FixedNumberGenerator', 'gemini_call_zzz'),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini');
+
+    $followUpContents = Http::recorded()[1][0]->data()['contents'];
+
+    $functionCallId = null;
+    $functionResponseId = null;
+
+    foreach ($followUpContents as $content) {
+        foreach ($content['parts'] ?? [] as $part) {
+            if (isset($part['functionCall']['id'])) {
+                $functionCallId = $part['functionCall']['id'];
+            }
+            if (isset($part['functionResponse']['id'])) {
+                $functionResponseId = $part['functionResponse']['id'];
+            }
+        }
+    }
+
+    expect($functionCallId)
+        ->toBe('gemini_call_zzz', 'functionCall id must be preserved verbatim per Gemini docs')
+        ->and($functionResponseId)
+        ->toBe('gemini_call_zzz', 'functionResponse id must echo the functionCall id exactly');
+});
+
 test('thinking parts are excluded from tool call continuation', function () {
     Http::fake([
         'generativelanguage.googleapis.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
@@ -173,21 +173,9 @@ test('non-streaming continuation produces matching ids when gemini omits id', fu
 
     (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini');
 
-    $followUpContents = Http::recorded()[1][0]->data()['contents'];
-
-    $functionCallIds = [];
-    $functionResponseIds = [];
-
-    foreach ($followUpContents as $content) {
-        foreach ($content['parts'] ?? [] as $part) {
-            if (isset($part['functionCall'])) {
-                $functionCallIds[] = $part['functionCall']['id'] ?? null;
-            }
-            if (isset($part['functionResponse'])) {
-                $functionResponseIds[] = $part['functionResponse']['id'] ?? null;
-            }
-        }
-    }
+    [$functionCallIds, $functionResponseIds] = $this->extractToolCallIds(
+        Http::recorded()[1][0]->data()['contents'],
+    );
 
     expect($functionCallIds)->toHaveCount(1)
         ->and($functionResponseIds)->toHaveCount(1)
@@ -207,26 +195,14 @@ test('non-streaming continuation preserves gemini supplied id verbatim', functio
 
     (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini');
 
-    $followUpContents = Http::recorded()[1][0]->data()['contents'];
+    [$functionCallIds, $functionResponseIds] = $this->extractToolCallIds(
+        Http::recorded()[1][0]->data()['contents'],
+    );
 
-    $functionCallId = null;
-    $functionResponseId = null;
-
-    foreach ($followUpContents as $content) {
-        foreach ($content['parts'] ?? [] as $part) {
-            if (isset($part['functionCall']['id'])) {
-                $functionCallId = $part['functionCall']['id'];
-            }
-            if (isset($part['functionResponse']['id'])) {
-                $functionResponseId = $part['functionResponse']['id'];
-            }
-        }
-    }
-
-    expect($functionCallId)
-        ->toBe('gemini_call_zzz', 'functionCall id must be preserved verbatim per Gemini docs')
-        ->and($functionResponseId)
-        ->toBe('gemini_call_zzz', 'functionResponse id must echo the functionCall id exactly');
+    expect($functionCallIds)
+        ->toBe(['gemini_call_zzz'], 'functionCall id must be preserved verbatim per Gemini docs')
+        ->and($functionResponseIds)
+        ->toBe(['gemini_call_zzz'], 'functionResponse id must echo the functionCall id exactly');
 });
 
 test('thinking parts are excluded from tool call continuation', function () {

--- a/tests/Unit/Gateway/Gemini/MapsMessagesTest.php
+++ b/tests/Unit/Gateway/Gemini/MapsMessagesTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Gateway\Gemini\Concerns\BuildsTextRequests;
+use Laravel\Ai\Gateway\Gemini\Concerns\MapsMessages;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+
+function geminiMapper(): object
+{
+    return new class
+    {
+        use BuildsTextRequests;
+        use MapsMessages;
+
+        public function map(array $messages): array
+        {
+            return $this->mapMessagesToContents($messages);
+        }
+
+        protected function mapAttachments(Collection $attachments): array
+        {
+            return [];
+        }
+    };
+}
+
+test('persisted assistant tool call replays its id onto functionCall', function () {
+    // This is the laravel/ai#388 "I saved it in the DB" scenario: the prior
+    // turn has a synthesized id stored on the ToolCall + ToolResult. On
+    // replay, mapAssistantMessage must echo the same id onto functionCall so
+    // the matching functionResponse id is not orphaned.
+    $persistedId = 'persisted-uuid-from-db';
+
+    $contents = geminiMapper()->map([
+        new UserMessage('Generate'),
+        new AssistantMessage('', collect([
+            new ToolCall($persistedId, 'FixedNumberGenerator', []),
+        ])),
+        new ToolResultMessage(collect([
+            new ToolResult($persistedId, 'FixedNumberGenerator', [], 72019),
+        ])),
+    ]);
+
+    $functionCall = null;
+    $functionResponse = null;
+
+    foreach ($contents as $content) {
+        foreach ($content['parts'] ?? [] as $part) {
+            if (isset($part['functionCall'])) {
+                $functionCall = $part['functionCall'];
+            }
+            if (isset($part['functionResponse'])) {
+                $functionResponse = $part['functionResponse'];
+            }
+        }
+    }
+
+    expect($functionCall)->not->toBeNull()
+        ->and($functionResponse)->not->toBeNull()
+        ->and($functionCall['id'] ?? null)->toBe($persistedId)
+        ->and($functionResponse['id'] ?? null)->toBe($persistedId);
+});
+
+test('replay omits id on both sides when persisted tool call had no id', function () {
+    // Pre-id-aware data — both sides should be id-less so they still match.
+    $contents = geminiMapper()->map([
+        new UserMessage('Generate'),
+        new AssistantMessage('', collect([
+            new ToolCall('', 'FixedNumberGenerator', []),
+        ])),
+        new ToolResultMessage(collect([
+            new ToolResult('', 'FixedNumberGenerator', [], 72019),
+        ])),
+    ]);
+
+    $functionCall = null;
+    $functionResponse = null;
+
+    foreach ($contents as $content) {
+        foreach ($content['parts'] ?? [] as $part) {
+            if (isset($part['functionCall'])) {
+                $functionCall = $part['functionCall'];
+            }
+            if (isset($part['functionResponse'])) {
+                $functionResponse = $part['functionResponse'];
+            }
+        }
+    }
+
+    expect($functionCall)->not->toBeNull()
+        ->and($functionResponse)->not->toBeNull()
+        ->and($functionCall)->not->toHaveKey('id')
+        ->and($functionResponse)->not->toHaveKey('id');
+});

--- a/tests/Unit/Gateway/Gemini/MapsMessagesTest.php
+++ b/tests/Unit/Gateway/Gemini/MapsMessagesTest.php
@@ -9,9 +9,8 @@ use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 
-function geminiMapper(): object
-{
-    return new class
+beforeEach(function () {
+    $this->mapper = new class
     {
         use BuildsTextRequests;
         use MapsMessages;
@@ -26,16 +25,12 @@ function geminiMapper(): object
             return [];
         }
     };
-}
+});
 
 test('persisted assistant tool call replays its id onto functionCall', function () {
-    // This is the laravel/ai#388 "I saved it in the DB" scenario: the prior
-    // turn has a synthesized id stored on the ToolCall + ToolResult. On
-    // replay, mapAssistantMessage must echo the same id onto functionCall so
-    // the matching functionResponse id is not orphaned.
     $persistedId = 'persisted-uuid-from-db';
 
-    $contents = geminiMapper()->map([
+    $contents = $this->mapper->map([
         new UserMessage('Generate'),
         new AssistantMessage('', collect([
             new ToolCall($persistedId, 'FixedNumberGenerator', []),
@@ -66,8 +61,7 @@ test('persisted assistant tool call replays its id onto functionCall', function 
 });
 
 test('replay omits id on both sides when persisted tool call had no id', function () {
-    // Pre-id-aware data — both sides should be id-less so they still match.
-    $contents = geminiMapper()->map([
+    $contents = $this->mapper->map([
         new UserMessage('Generate'),
         new AssistantMessage('', collect([
             new ToolCall('', 'FixedNumberGenerator', []),


### PR DESCRIPTION
Per Gemini's function-calling docs, every `functionResponse.id` sent back must echo the corresponding `functionCall.id` exactly. The Gemini gateway was synthesizing UUIDs for `functionResponse` while leaving `functionCall` parts without ids, so Gemini rejected every continuation request with HTTP 400 once a tool was called. The replay path also dropped the id from `functionCall` entirely, so persisted conversations from 0.4.5 keep failing on every follow-up turn.

Fixes laravel/ai#388

### Approach

- Echo the tool call id symmetrically on both `functionCall` and `functionResponse` in all three serialization paths: streaming continuation, non-streaming continuation, and replay of persisted history.
- Preserve Gemini-supplied ids verbatim when present; when Gemini omits an id, the synthesized one round-trips on both sides so they still match.
- This also heals already-persisted v0.4.5 data without a migration — the stored UUID now appears on both sides of the wire and Gemini accepts it.
