### PR TITLE
Fix HasStructuredOutput agents crashing with empty schema

### DIFF
--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -56,18 +56,20 @@ trait GeneratesText
 
                 $this->listenForToolInvocations($invocationId, $agent);
 
+                $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
+
                 $response = $this->textGateway()->generateText(
                     $this,
                     $prompt->model,
                     (string) $agent->instructions(),
                     $messages,
                     $agent instanceof HasTools ? $agent->tools() : [],
-                    $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null,
+                    $schema,
                     TextGenerationOptions::forAgent($agent),
                     $prompt->timeout,
                 );
 
-                return $agent instanceof HasStructuredOutput
+                return ! empty($schema)
                     ? (new StructuredAgentResponse($invocationId, $response->structured, $response->text, $response->usage, $response->meta))
                         ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
                         ->withSteps($response->steps)

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -4,12 +4,15 @@ use Laravel\Ai\Ai;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\QueuedAgentPrompt;
+use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
 use PHPUnit\Framework\AssertionFailedError;
 use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\EmptySchemaStructuredAgent;
 use Tests\Feature\Agents\StructuredAgent;
 
 describe('prompt responses', function () {
@@ -109,6 +112,18 @@ describe('prompt responses', function () {
 
         $response = (new AssistantAgent)->prompt('Test prompt');
     })->throws(Exception::class);
+
+    test('structured agents with empty schemas fall back to a text response', function () {
+        EmptySchemaStructuredAgent::fake([
+            new TextResponse('Hello', new Usage, new Meta),
+        ]);
+
+        $response = (new EmptySchemaStructuredAgent)->prompt('Anything');
+
+        expect($response)->toBeInstanceOf(AgentResponse::class)
+            ->and($response)->not->toBeInstanceOf(StructuredAgentResponse::class)
+            ->and($response->text)->toEqual('Hello');
+    });
 });
 
 describe('stream responses', function () {

--- a/tests/Feature/Agents/EmptySchemaStructuredAgent.php
+++ b/tests/Feature/Agents/EmptySchemaStructuredAgent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+
+class EmptySchemaStructuredAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    /**
+     * Get the structured output's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
When an agent implements `HasStructuredOutput` but `schema()` returns an empty array, the SDK crashes with `Undefined property: Laravel\Ai\Responses\TextResponse::$structured`. The gateway already correctly falls back to a plain text request for empty schemas, but the response-wrapping layer still expected a structured response.

Fixes #294

### Approach

- Align the response-wrapping decision with the gateway: wrap in a structured response only when the resolved schema is non-empty
- Empty schemas now transparently fall back to a regular text response instead of crashing