### PR TITLE
fix(anthropic): preserve provider content blocks on assistant replay (refs #298)

### DIFF
--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -54,9 +54,6 @@ trait MapsMessages
      */
     protected function mapAssistantMessage(AssistantMessage|Message $message, array &$mapped): void
     {
-        // In-memory replay only: persisted assistant messages rehydrated by
-        // DatabaseConversationStore have no provider blocks and fall through
-        // to the rebuild path. See #380 for the persistence story.
         if ($message instanceof AssistantMessage && filled($message->providerContentBlocks)) {
             $mapped[] = [
                 'role' => 'assistant',

--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -54,10 +54,13 @@ trait MapsMessages
      */
     protected function mapAssistantMessage(AssistantMessage|Message $message, array &$mapped): void
     {
-        if ($message instanceof AssistantMessage && filled($message->contentBlocks)) {
+        // In-memory replay only: persisted assistant messages rehydrated by
+        // DatabaseConversationStore have no provider blocks and fall through
+        // to the rebuild path. See #380 for the persistence story.
+        if ($message instanceof AssistantMessage && filled($message->providerContentBlocks)) {
             $mapped[] = [
                 'role' => 'assistant',
-                'content' => $this->ensureToolInputIsObject($message->contentBlocks),
+                'content' => $this->ensureToolInputIsObject($message->providerContentBlocks),
             ];
 
             return;

--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -54,6 +54,15 @@ trait MapsMessages
      */
     protected function mapAssistantMessage(AssistantMessage|Message $message, array &$mapped): void
     {
+        if ($message instanceof AssistantMessage && filled($message->contentBlocks)) {
+            $mapped[] = [
+                'role' => 'assistant',
+                'content' => $this->ensureToolInputIsObject($message->contentBlocks),
+            ];
+
+            return;
+        }
+
         $content = [];
         $hasToolCalls = $message instanceof AssistantMessage && $message->toolCalls->isNotEmpty();
 

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -104,7 +104,7 @@ trait ParsesTextResponses
 
         $steps->push(new Step($text, $toolCalls, $toolResults, $finishReason, $usage, $meta));
 
-        $messages->push(new AssistantMessage($text, collect($toolCalls)));
+        $messages->push(new AssistantMessage($text, collect($toolCalls), $content));
 
         if ($shouldContinue) {
             $messages->push(new ToolResultMessage(collect($toolResults)));

--- a/src/Messages/AssistantMessage.php
+++ b/src/Messages/AssistantMessage.php
@@ -9,12 +9,28 @@ class AssistantMessage extends Message
     public Collection $toolCalls;
 
     /**
-     * Create a new text conversation message instance.
+     * Raw provider content blocks in original order. When populated, gateways
+     * replay these verbatim on follow-up requests instead of rebuilding
+     * assistant content from text + tool calls — preserving provider-specific
+     * blocks (server_tool_use, server_tool_result, thinking, ...) that the
+     * rebuild would drop. When populated, this array is the source of truth
+     * for outgoing assistant content; `content` and `toolCalls` are ignored
+     * by the mapper.
+     *
+     * @var array<int, array<string, mixed>>
      */
-    public function __construct(string $content, ?Collection $toolCalls = null)
+    public array $contentBlocks = [];
+
+    /**
+     * Create a new text conversation message instance.
+     *
+     * @param  array<int, array<string, mixed>>  $contentBlocks
+     */
+    public function __construct(string $content, ?Collection $toolCalls = null, array $contentBlocks = [])
     {
         parent::__construct('assistant', $content);
 
         $this->toolCalls = $toolCalls ?: new Collection;
+        $this->contentBlocks = $contentBlocks;
     }
 }

--- a/src/Messages/AssistantMessage.php
+++ b/src/Messages/AssistantMessage.php
@@ -9,13 +9,15 @@ class AssistantMessage extends Message
     public Collection $toolCalls;
 
     /**
-     * Raw provider content blocks in original order. When populated, gateways
-     * replay these verbatim on follow-up requests instead of rebuilding
-     * assistant content from text + tool calls — preserving provider-specific
-     * blocks (server_tool_use, server_tool_result, thinking, ...) that the
-     * rebuild would drop. When populated, this array is the source of truth
-     * for outgoing assistant content; `content` and `toolCalls` are ignored
-     * by the mapper.
+     * Raw provider replay state. Carries provider-native content blocks
+     * (server_tool_use, server_tool_result, thinking, ...) in original
+     * order so gateways can replay them verbatim on follow-up requests —
+     * blocks the default text + tool_calls rebuild would otherwise drop.
+     *
+     * Typically populated by the SDK's own response parser, not by user
+     * code. When populated, this array is the source of truth for outgoing
+     * assistant content; `content` and `toolCalls` are ignored by the
+     * mapper.
      *
      * @var array<int, array<string, mixed>>
      */

--- a/src/Messages/AssistantMessage.php
+++ b/src/Messages/AssistantMessage.php
@@ -9,30 +9,22 @@ class AssistantMessage extends Message
     public Collection $toolCalls;
 
     /**
-     * Raw provider replay state. Carries provider-native content blocks
-     * (server_tool_use, server_tool_result, thinking, ...) in original
-     * order so gateways can replay them verbatim on follow-up requests —
-     * blocks the default text + tool_calls rebuild would otherwise drop.
-     *
-     * Typically populated by the SDK's own response parser, not by user
-     * code. When populated, this array is the source of truth for outgoing
-     * assistant content; `content` and `toolCalls` are ignored by the
-     * mapper.
+     * Raw provider replay state populated by the SDK's response parser.
      *
      * @var array<int, array<string, mixed>>
      */
-    public array $contentBlocks = [];
+    public array $providerContentBlocks;
 
     /**
      * Create a new text conversation message instance.
      *
-     * @param  array<int, array<string, mixed>>  $contentBlocks
+     * @param  array<int, array<string, mixed>>  $providerContentBlocks
      */
-    public function __construct(string $content, ?Collection $toolCalls = null, array $contentBlocks = [])
+    public function __construct(string $content, ?Collection $toolCalls = null, array $providerContentBlocks = [])
     {
         parent::__construct('assistant', $content);
 
         $this->toolCalls = $toolCalls ?: new Collection;
-        $this->contentBlocks = $contentBlocks;
+        $this->providerContentBlocks = $providerContentBlocks;
     }
 }

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -290,6 +290,153 @@ test('non-empty tool arguments preserve shape on assistant replay', function () 
     expect($toolUse['input'])->toBe(['query' => 'test']);
 });
 
+test('assistant message with contentBlocks is replayed verbatim preserving order', function () {
+    $contentBlocks = [
+        ['type' => 'text', 'text' => 'Let me consult the advisor.'],
+        [
+            'type' => 'server_tool_use',
+            'id' => 'srvtoolu_abc',
+            'name' => 'advisor',
+            'input' => [],
+        ],
+        [
+            'type' => 'advisor_tool_result',
+            'tool_use_id' => 'srvtoolu_abc',
+            'content' => [
+                'type' => 'advisor_result',
+                'text' => 'Use a channel-based coordination pattern.',
+            ],
+        ],
+        [
+            'type' => 'tool_use',
+            'id' => 'toolu_xyz',
+            'name' => 'write_file',
+            'input' => ['path' => 'worker.go'],
+        ],
+        ['type' => 'text', 'text' => "Here's the implementation."],
+    ];
+
+    $assistant = new AssistantMessage('Here\'s the implementation.', null, $contentBlocks);
+
+    $gateway = app(AnthropicGateway::class);
+    $method = (new ReflectionClass($gateway))->getMethod('mapMessages');
+    $method->setAccessible(true);
+
+    $mapped = $method->invoke($gateway, [$assistant]);
+
+    expect($mapped)->toHaveCount(1)
+        ->and($mapped[0]['role'])->toBe('assistant')
+        ->and(array_column($mapped[0]['content'], 'type'))->toBe([
+            'text',
+            'server_tool_use',
+            'advisor_tool_result',
+            'tool_use',
+            'text',
+        ]);
+
+    $serverToolUse = collect($mapped[0]['content'])->firstWhere('type', 'server_tool_use');
+    expect($serverToolUse['input'])->toBeInstanceOf(stdClass::class);
+});
+
+test('parsed response populates contentBlocks on the assistant message', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_1',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [
+                ['type' => 'text', 'text' => 'Consulted the advisor.'],
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'advisor',
+                    'input' => (object) [],
+                ],
+                [
+                    'type' => 'advisor_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => ['type' => 'advisor_result', 'text' => 'Proceed.'],
+                ],
+                ['type' => 'text', 'text' => 'Done.'],
+            ],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = (new AssistantAgent)->prompt('hi', provider: 'anthropic');
+
+    $assistant = $response->messages->whereInstanceOf(AssistantMessage::class)->first();
+
+    expect($assistant)->not->toBeNull()
+        ->and(array_column($assistant->contentBlocks, 'type'))->toBe([
+            'text',
+            'server_tool_use',
+            'advisor_tool_result',
+            'text',
+        ]);
+});
+
+test('assistant message produced by parser round-trips through mapping with server blocks intact', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_1',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [
+                ['type' => 'text', 'text' => 'Searching.'],
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'web_search',
+                    'input' => (object) ['query' => 'laravel ai'],
+                ],
+                [
+                    'type' => 'web_search_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => [['title' => 'Laravel', 'url' => 'https://laravel.com']],
+                ],
+                ['type' => 'text', 'text' => 'Found it.'],
+            ],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = (new AssistantAgent)->prompt('search laravel', provider: 'anthropic');
+    $assistant = $response->messages->whereInstanceOf(AssistantMessage::class)->first();
+
+    $gateway = app(AnthropicGateway::class);
+    $method = (new ReflectionClass($gateway))->getMethod('mapMessages');
+    $method->setAccessible(true);
+
+    $mapped = $method->invoke($gateway, [$assistant]);
+
+    expect(array_column($mapped[0]['content'], 'type'))->toBe([
+        'text',
+        'server_tool_use',
+        'web_search_tool_result',
+        'text',
+    ]);
+});
+
+test('assistant message without contentBlocks falls back to text plus tool calls rebuild', function () {
+    $assistant = new AssistantMessage('Hello');
+
+    $gateway = app(AnthropicGateway::class);
+    $method = (new ReflectionClass($gateway))->getMethod('mapMessages');
+    $method->setAccessible(true);
+
+    $mapped = $method->invoke($gateway, [$assistant]);
+
+    expect($mapped[0]['role'])->toBe('assistant')
+        ->and($mapped[0]['content'])->toBe([
+            ['type' => 'text', 'text' => 'Hello'],
+        ]);
+});
+
 test('system instructions are not in messages array', function () {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse(),

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -290,7 +290,7 @@ test('non-empty tool arguments preserve shape on assistant replay', function () 
     expect($toolUse['input'])->toBe(['query' => 'test']);
 });
 
-test('assistant message with contentBlocks is replayed verbatim preserving order', function () {
+test('assistant message with provider content blocks is replayed verbatim preserving order', function () {
     $contentBlocks = [
         ['type' => 'text', 'text' => 'Let me consult the advisor.'],
         [
@@ -338,7 +338,7 @@ test('assistant message with contentBlocks is replayed verbatim preserving order
     expect($serverToolUse['input'])->toBeInstanceOf(stdClass::class);
 });
 
-test('parsed response populates contentBlocks on the assistant message', function () {
+test('parsed response populates provider content blocks on the assistant message', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::response([
             'id' => 'msg_1',
@@ -368,14 +368,22 @@ test('parsed response populates contentBlocks on the assistant message', functio
     $response = (new AssistantAgent)->prompt('hi', provider: 'anthropic');
 
     $assistant = $response->messages->whereInstanceOf(AssistantMessage::class)->first();
+    $blocks = $assistant->providerContentBlocks;
 
     expect($assistant)->not->toBeNull()
-        ->and(array_column($assistant->contentBlocks, 'type'))->toBe([
-            'text',
-            'server_tool_use',
-            'advisor_tool_result',
-            'text',
-        ]);
+        ->and($blocks)->toHaveCount(4)
+        ->and($blocks[0])->toBe(['type' => 'text', 'text' => 'Consulted the advisor.'])
+        ->and($blocks[1])->toMatchArray([
+            'type' => 'server_tool_use',
+            'id' => 'srvtoolu_1',
+            'name' => 'advisor',
+        ])
+        ->and($blocks[2])->toBe([
+            'type' => 'advisor_tool_result',
+            'tool_use_id' => 'srvtoolu_1',
+            'content' => ['type' => 'advisor_result', 'text' => 'Proceed.'],
+        ])
+        ->and($blocks[3])->toBe(['type' => 'text', 'text' => 'Done.']);
 });
 
 test('assistant message produced by parser round-trips through mapping with server blocks intact', function () {
@@ -413,16 +421,26 @@ test('assistant message produced by parser round-trips through mapping with serv
     $method->setAccessible(true);
 
     $mapped = $method->invoke($gateway, [$assistant]);
+    $content = $mapped[0]['content'];
 
-    expect(array_column($mapped[0]['content'], 'type'))->toBe([
-        'text',
-        'server_tool_use',
-        'web_search_tool_result',
-        'text',
-    ]);
+    expect($content)->toHaveCount(4)
+        ->and($content[0])->toBe(['type' => 'text', 'text' => 'Searching.'])
+        ->and($content[1])->toMatchArray([
+            'type' => 'server_tool_use',
+            'id' => 'srvtoolu_1',
+            'name' => 'web_search',
+        ])
+        ->and($content[1]['input'])->toBeInstanceOf(stdClass::class)
+        ->and((array) $content[1]['input'])->toBe(['query' => 'laravel ai'])
+        ->and($content[2])->toBe([
+            'type' => 'web_search_tool_result',
+            'tool_use_id' => 'srvtoolu_1',
+            'content' => [['title' => 'Laravel', 'url' => 'https://laravel.com']],
+        ])
+        ->and($content[3])->toBe(['type' => 'text', 'text' => 'Found it.']);
 });
 
-test('assistant message without contentBlocks falls back to text plus tool calls rebuild', function () {
+test('assistant message without provider content blocks falls back to text plus tool calls rebuild', function () {
     $assistant = new AssistantMessage('Hello');
 
     $gateway = app(AnthropicGateway::class);
@@ -435,6 +453,24 @@ test('assistant message without contentBlocks falls back to text plus tool calls
         ->and($mapped[0]['content'])->toBe([
             ['type' => 'text', 'text' => 'Hello'],
         ]);
+});
+
+test('thinking and redacted_thinking blocks are preserved on replay', function () {
+    $contentBlocks = [
+        ['type' => 'thinking', 'thinking' => 'Considering options.', 'signature' => 'sig_1'],
+        ['type' => 'redacted_thinking', 'data' => 'opaque'],
+        ['type' => 'text', 'text' => 'Answer.'],
+    ];
+
+    $assistant = new AssistantMessage('Answer.', null, $contentBlocks);
+
+    $gateway = app(AnthropicGateway::class);
+    $method = (new ReflectionClass($gateway))->getMethod('mapMessages');
+    $method->setAccessible(true);
+
+    $mapped = $method->invoke($gateway, [$assistant]);
+
+    expect($mapped[0]['content'])->toBe($contentBlocks);
 });
 
 test('system instructions are not in messages array', function () {


### PR DESCRIPTION
Hit this integrating advisor — every multi-turn advisor conversation 400s because the `advisor_tool_result` block drops on replay.

`MapsMessages::mapAssistantMessage()` rebuilds assistant content from `text` + `tool_calls` only. On replay that drops Anthropic provider blocks like `server_tool_use`, `server_tool_result`, `thinking`, and `redacted_thinking`. In multi-turn conversations that used server tools, the next request can fail with `400 invalid_request_error` because the assistant history no longer matches what Anthropic expects. This is the in-memory replay side of #298.

This change adds a `contentBlocks` property to `AssistantMessage` and uses it verbatim in `mapAssistantMessage()` when present, instead of rebuilding from `text` + `tool_calls`. The non-streaming parser now passes the raw ordered content array into `AssistantMessage`. If `contentBlocks` is empty, the existing path is unchanged, so current behavior and older cached/unserialized messages still fall back to the old rebuild logic.

Scope is limited to in-memory `AssistantMessage` replay. `DatabaseConversationStore` still rehydrates assistant messages from `text` + `tool_calls`, so persisted conversations are unchanged here; that needs schema work and is already tracked in #380. Streaming is also unchanged: same-request replay already uses the raw response content directly and does not go through `mapAssistantMessage()`.

Tests cover the verbatim mapping path, parser population of `contentBlocks`, round-tripping a parsed assistant message back through `mapMessages()`, and the fallback behavior when `contentBlocks` is absent. Anthropic tests are green. Related: #380 for persistence, #301 for adjacent reasoning-data loss, and #349 for the TextOrchestrator refactor this avoids touching.
