### PR TITLE
Add OpenRouter gateway for direct API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /vendor
 CLAUDE.md
 .env
+.claude

--- a/config/ai.php
+++ b/config/ai.php
@@ -117,6 +117,7 @@ return [
         'openrouter' => [
             'driver' => 'openrouter',
             'key' => env('OPENROUTER_API_KEY'),
+            'url' => env('OPENROUTER_URL', 'https://openrouter.ai/api/v1'),
         ],
 
         'voyageai' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -410,7 +410,6 @@ class AiManager extends MultipleInstanceManager
     public function createOpenrouterDriver(array $config): OpenRouterProvider
     {
         return new OpenRouterProvider(
-            new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
@@ -40,7 +40,7 @@ trait BuildsTextRequests
         }
 
         if (! is_null($options?->maxTokens)) {
-            $body['max_completion_tokens'] = $options->maxTokens;
+            $body['max_tokens'] = $options->maxTokens;
         }
 
         if (! is_null($options?->temperature)) {

--- a/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    /**
+     * Build the request body for the Chat Completions API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessagesToChat($messages, $instructions),
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat($schema);
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the response format options for structured output.
+     */
+    protected function buildResponseFormat(array $schema): array
+    {
+        $objectSchema = new ObjectSchema($schema);
+
+        $schemaArray = $objectSchema->toSchema();
+
+        return [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => $schemaArray['name'] ?? 'schema_definition',
+                'schema' => Arr::except($schemaArray, ['name']),
+                'strict' => true,
+            ],
+        ];
+    }
+}

--- a/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
+++ b/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
@@ -19,7 +19,7 @@ trait CreatesOpenRouterClient
             ->withToken($provider->providerCredentials()['key'])
             ->withHeaders(array_filter([
                 'HTTP-Referer' => $config['http_referer'] ?? null,
-                'X-Title' => $config['x_title'] ?? null,
+                'X-OpenRouter-Title' => $config['x_title'] ?? null,
             ]))
             ->timeout($timeout ?? 60)
             ->throw();

--- a/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
+++ b/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesOpenRouterClient
+{
+    /**
+     * Get an HTTP client for the OpenRouter API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $config = $provider->additionalConfiguration();
+
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->withHeaders(array_filter([
+                'HTTP-Referer' => $config['http_referer'] ?? null,
+                'X-Title' => $config['x_title'] ?? null,
+            ]))
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the OpenRouter API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://openrouter.ai/api/v1', '/');
+    }
+}

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -36,6 +36,7 @@ trait HandlesTextStreaming
         int $depth = 0,
         ?int $maxSteps = null,
         array $priorChatMessages = [],
+        ?int $timeout = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -191,6 +192,7 @@ trait HandlesTextStreaming
                 $depth,
                 $maxSteps,
                 $priorChatMessages,
+                $timeout,
             );
 
             return;
@@ -221,6 +223,7 @@ trait HandlesTextStreaming
         int $depth,
         ?int $maxSteps,
         array $priorChatMessages,
+        ?int $timeout = null,
     ): Generator {
         $toolResults = [];
 
@@ -300,15 +303,23 @@ trait HandlesTextStreaming
                 $body['response_format'] = $this->buildResponseFormat($schema);
             }
 
+            if (! is_null($options?->maxTokens)) {
+                $body['max_tokens'] = $options->maxTokens;
+            }
+
+            if (! is_null($options?->temperature)) {
+                $body['temperature'] = $options->temperature;
+            }
+
             $providerOptions = $options?->providerOptions($provider->driver());
 
             if (filled($providerOptions)) {
                 $body = array_merge($body, $providerOptions);
             }
 
-            $response = $this->withRateLimitHandling(
+            $response = $this->withErrorHandling(
                 $provider->name(),
-                fn () => $this->client($provider)
+                fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
                     ->post('chat/completions', $body),
             );
@@ -326,6 +337,7 @@ trait HandlesTextStreaming
                 $depth + 1,
                 $maxSteps,
                 $updatedPriorMessages,
+                $timeout,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Generator;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Process a Chat Completions streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        array $priorChatMessages = [],
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $usage = null;
+        $finishReason = null;
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            if (isset($data['error'])) {
+                yield (new Error(
+                    $this->generateEventId(),
+                    $data['error']['code'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            $choice = $data['choices'][0] ?? null;
+
+            if (! $choice) {
+                if (isset($data['usage'])) {
+                    $usage = new Usage(
+                        $data['usage']['prompt_tokens'] ?? 0,
+                        $data['usage']['completion_tokens'] ?? 0,
+                        cacheWriteInputTokens: $data['usage']['prompt_tokens_details']['cache_write_tokens'] ?? 0,
+                        cacheReadInputTokens: $data['usage']['prompt_tokens_details']['cached_tokens'] ?? 0,
+                        reasoningTokens: $data['usage']['completion_tokens_details']['reasoning_tokens'] ?? 0,
+                    );
+                }
+
+                continue;
+            }
+
+            $delta = $choice['delta'] ?? [];
+
+            // Handle error finish reason from OpenRouter
+            if (($choice['finish_reason'] ?? null) === 'error') {
+                $error = $choice['error'] ?? [];
+
+                yield (new Error(
+                    $this->generateEventId(),
+                    (string) ($error['code'] ?? 'provider_error'),
+                    $error['message'] ?? 'An upstream provider error occurred.',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            if (! $streamStartEmitted) {
+                $streamStartEmitted = true;
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    $data['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['content']) && $delta['content'] !== '') {
+                if (! $textStartEmitted) {
+                    $textStartEmitted = true;
+
+                    yield (new TextStart(
+                        $this->generateEventId(),
+                        $messageId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                $currentText .= $delta['content'];
+
+                yield (new TextDelta(
+                    $this->generateEventId(),
+                    $messageId,
+                    $delta['content'],
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['tool_calls'])) {
+                foreach ($delta['tool_calls'] as $tcDelta) {
+                    $idx = $tcDelta['index'];
+
+                    if (! isset($pendingToolCalls[$idx])) {
+                        $pendingToolCalls[$idx] = [
+                            'id' => $tcDelta['id'] ?? '',
+                            'name' => $tcDelta['function']['name'] ?? '',
+                            'arguments' => '',
+                        ];
+                    }
+
+                    if (isset($tcDelta['function']['arguments'])) {
+                        $pendingToolCalls[$idx]['arguments'] .= $tcDelta['function']['arguments'];
+                    }
+                }
+            }
+
+            if (isset($choice['finish_reason']) && $choice['finish_reason'] !== null) {
+                $finishReason = $choice['finish_reason'];
+            }
+
+            if (isset($data['usage'])) {
+                $usage = new Usage(
+                    $data['usage']['prompt_tokens'] ?? 0,
+                    $data['usage']['completion_tokens'] ?? 0,
+                    cacheWriteInputTokens: $data['usage']['prompt_tokens_details']['cache_write_tokens'] ?? 0,
+                    cacheReadInputTokens: $data['usage']['prompt_tokens_details']['cached_tokens'] ?? 0,
+                    reasoningTokens: $data['usage']['completion_tokens_details']['reasoning_tokens'] ?? 0,
+                );
+            }
+        }
+
+        if ($textStartEmitted) {
+            yield (new TextEnd(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
+            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+            foreach ($mappedToolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield from $this->handleStreamingToolCalls(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $mappedToolCalls,
+                $currentText,
+                $instructions,
+                $originalMessages,
+                $depth,
+                $maxSteps,
+                $priorChatMessages,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            'stop',
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $mappedToolCalls,
+        string $currentText,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        array $priorChatMessages,
+    ): Generator {
+        $toolResults = [];
+
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $assistantMsg = ['role' => 'assistant'];
+
+            if (filled($currentText)) {
+                $assistantMsg['content'] = $currentText;
+            }
+
+            $assistantMsg['tool_calls'] = array_map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
+            );
+
+            $toolResultMessages = [];
+
+            foreach ($toolResults as $toolResult) {
+                $toolResultMessages[] = [
+                    'role' => 'tool',
+                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                    'content' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+
+            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
+
+            $chatMessages = [
+                ...$this->mapMessagesToChat($originalMessages, $instructions),
+                ...$updatedPriorMessages,
+            ];
+
+            $body = [
+                'model' => $model,
+                'messages' => $chatMessages,
+                'stream' => true,
+                'stream_options' => ['include_usage' => true],
+            ];
+
+            if (filled($tools)) {
+                $mappedTools = $this->mapTools($tools);
+
+                if (filled($mappedTools)) {
+                    $body['tool_choice'] = 'auto';
+                    $body['tools'] = $mappedTools;
+                }
+            }
+
+            if (filled($schema)) {
+                $body['response_format'] = $this->buildResponseFormat($schema);
+            }
+
+            $providerOptions = $options?->providerOptions($provider->driver());
+
+            if (filled($providerOptions)) {
+                $body = array_merge($body, $providerOptions);
+            }
+
+            $response = $this->withRateLimitHandling(
+                $provider->name(),
+                fn () => $this->client($provider)
+                    ->withOptions(['stream' => true])
+                    ->post('chat/completions', $body),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $updatedPriorMessages,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['name'] ?? '',
+            json_decode($toolCall['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+}

--- a/src/Gateway/OpenRouter/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenRouter/Concerns/MapsAttachments.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalDocument;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredDocument;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to Chat Completions content parts.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof Base64Image => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.$attachment->base64],
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => $attachment->url],
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(file_get_contents($attachment->path))],
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    )],
+                ],
+                $attachment instanceof Base64Document => [
+                    'type' => 'file',
+                    'file' => array_filter([
+                        'filename' => $attachment->name(),
+                        'file_data' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
+                    ]),
+                ],
+                $attachment instanceof LocalDocument => [
+                    'type' => 'file',
+                    'file' => array_filter([
+                        'filename' => $attachment->name(),
+                        'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(file_get_contents($attachment->path)),
+                    ]),
+                ],
+                $attachment instanceof RemoteDocument => [
+                    'type' => 'file',
+                    'file' => array_filter([
+                        'filename' => $attachment->name(),
+                        'file_data' => $attachment->url,
+                    ]),
+                ],
+                $attachment instanceof StoredDocument => [
+                    'type' => 'file',
+                    'file' => array_filter([
+                        'filename' => $attachment->name(),
+                        'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(
+                            Storage::disk($attachment->disk)->get($attachment->path)
+                        ),
+                    ]),
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
+                ],
+                $attachment instanceof UploadedFile => [
+                    'type' => 'file',
+                    'file' => [
+                        'filename' => $attachment->getClientOriginalName(),
+                        'file_data' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
+                    ],
+                ],
+                default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/OpenRouter/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenRouter/Concerns/MapsMessages.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to Chat Completions messages format.
+     */
+    protected function mapMessagesToChat(array $messages, ?string $instructions = null): array
+    {
+        $chatMessages = [];
+
+        if (filled($instructions)) {
+            $chatMessages[] = [
+                'role' => 'system',
+                'content' => $instructions,
+            ];
+        }
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $chatMessages),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $chatMessages),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $chatMessages),
+            };
+        }
+
+        return $chatMessages;
+    }
+
+    /**
+     * Map a user message to Chat Completions format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof UserMessage || $message->attachments->isEmpty()) {
+            $chatMessages[] = [
+                'role' => 'user',
+                'content' => $message->content,
+            ];
+
+            return;
+        }
+
+        $chatMessages[] = [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => $message->content],
+                ...$this->mapAttachments($message->attachments),
+            ],
+        ];
+    }
+
+    /**
+     * Map an assistant message to Chat Completions format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$chatMessages): void
+    {
+        $msg = ['role' => 'assistant'];
+
+        if (filled($message->content)) {
+            $msg['content'] = $message->content;
+        }
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            $msg['tool_calls'] = $message->toolCalls->map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+            )->all();
+        }
+
+        $chatMessages[] = $msg;
+    }
+
+    /**
+     * Map a tool result message to Chat Completions format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        foreach ($message->toolResults as $toolResult) {
+            $chatMessages[] = [
+                'role' => 'tool',
+                'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                'content' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+    }
+
+    /**
+     * Serialize a tool call DTO to Chat Completions array format.
+     */
+    protected function serializeToolCallToChat(ToolCall $toolCall): array
+    {
+        return [
+            'id' => $toolCall->resultId ?? $toolCall->id,
+            'type' => 'function',
+            'function' => [
+                'name' => $toolCall->name,
+                'arguments' => json_encode($toolCall->arguments ?: (object) []),
+            ],
+        ];
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+}

--- a/src/Gateway/OpenRouter/Concerns/MapsTools.php
+++ b/src/Gateway/OpenRouter/Concerns/MapsTools.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use RuntimeException;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to Chat Completions function definitions.
+     */
+    protected function mapTools(array $tools): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                throw new RuntimeException('OpenRouter does not support ['.class_basename($tool).'] provider tools.');
+            }
+
+            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to a Chat Completions function definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $schemaArray = filled($schema)
+            ? (new ObjectSchema($schema))->toSchema()
+            : [];
+
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => class_basename($tool),
+                'description' => (string) $tool->description(),
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $schemaArray['properties'] ?? (object) [],
+                    'required' => $schemaArray['required'] ?? [],
+                    'additionalProperties' => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -48,6 +48,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?string $instructions = null,
         array $originalMessages = [],
+        ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -61,6 +62,7 @@ trait ParsesTextResponses
             originalMessages: $originalMessages,
             maxSteps: $options?->maxSteps,
             options: $options,
+            timeout: $timeout,
         );
     }
 
@@ -80,6 +82,7 @@ trait ParsesTextResponses
         int $depth = 0,
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -145,6 +148,7 @@ trait ParsesTextResponses
                 $depth + 1,
                 $maxSteps,
                 $options,
+                $timeout,
             );
         }
 
@@ -220,6 +224,7 @@ trait ParsesTextResponses
         int $depth,
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
     ): TextResponse {
         $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
 
@@ -267,15 +272,23 @@ trait ParsesTextResponses
             $body['response_format'] = $this->buildResponseFormat($schema);
         }
 
+        if (! is_null($options?->maxTokens)) {
+            $body['max_tokens'] = $options->maxTokens;
+        }
+
+        if (! is_null($options?->temperature)) {
+            $body['temperature'] = $options->temperature;
+        }
+
         $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {
             $body = array_merge($body, $providerOptions);
         }
 
-        $response = $this->withRateLimitHandling(
+        $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('chat/completions', $body),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
         );
 
         $data = $response->json();
@@ -295,6 +308,7 @@ trait ParsesTextResponses
             $depth,
             $maxSteps,
             $options,
+            $timeout,
         );
     }
 
@@ -324,7 +338,6 @@ trait ParsesTextResponses
             'tool_calls' => FinishReason::ToolCalls,
             'length' => FinishReason::Length,
             'content_filter' => FinishReason::ContentFilter,
-            'error' => FinishReason::Unknown,
             default => FinishReason::Unknown,
         };
     }

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Validate the OpenRouter response data.
+     *
+     * @throws AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || isset($data['error'])) {
+            throw new AiException(sprintf(
+                'OpenRouter Error: [%s] %s',
+                $data['error']['type'] ?? $data['error']['code'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown OpenRouter error.',
+            ));
+        }
+    }
+
+    /**
+     * Parse the OpenRouter response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?string $instructions = null,
+        array $originalMessages = [],
+    ): TextResponse {
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            instructions: $instructions,
+            originalMessages: $originalMessages,
+            maxSteps: $options?->maxSteps,
+            options: $options,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        ?TextGenerationOptions $options = null,
+    ): TextResponse {
+        $choice = $data['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+        $model = $data['model'] ?? '';
+
+        $text = $message['content'] ?? '';
+        $rawToolCalls = $message['tool_calls'] ?? [];
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->extractFinishReason($choice);
+
+        $mappedToolCalls = array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['function']['name'] ?? '',
+            json_decode($toolCall['function']['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), $rawToolCalls);
+
+        $step = new Step(
+            $text,
+            $mappedToolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model),
+        );
+
+        $steps->push($step);
+
+        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+
+        $messages->push($assistantMessage);
+
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($mappedToolCalls) &&
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+
+            $steps->pop();
+
+            $steps->push(new Step(
+                $text,
+                $mappedToolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $options,
+            );
+        }
+
+        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
+        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
+
+        if ($structured) {
+            $structuredData = json_decode($text, true) ?? [];
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                $text,
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model),
+            ))->withToolCallsAndResults(
+                toolCalls: $allToolCalls,
+                toolResults: $allToolResults,
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        string $model,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        ?TextGenerationOptions $options = null,
+    ): TextResponse {
+        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
+
+        foreach ($messages as $msg) {
+            if ($msg instanceof AssistantMessage) {
+                $mapped = ['role' => 'assistant'];
+
+                if (filled($msg->content)) {
+                    $mapped['content'] = $msg->content;
+                }
+
+                if ($msg->toolCalls->isNotEmpty()) {
+                    $mapped['tool_calls'] = $msg->toolCalls->map(
+                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+                    )->all();
+                }
+
+                $chatMessages[] = $mapped;
+            } elseif ($msg instanceof ToolResultMessage) {
+                foreach ($msg->toolResults as $toolResult) {
+                    $chatMessages[] = [
+                        'role' => 'tool',
+                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                        'content' => $this->serializeToolResultOutput($toolResult->result),
+                    ];
+                }
+            }
+        }
+
+        $body = [
+            'model' => $model,
+            'messages' => $chatMessages,
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat($schema);
+        }
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $instructions,
+            $originalMessages,
+            $depth,
+            $maxSteps,
+            $options,
+        );
+    }
+
+    /**
+     * Extract usage data from the response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+
+        return new Usage(
+            $usage['prompt_tokens'] ?? 0,
+            $usage['completion_tokens'] ?? 0,
+            cacheWriteInputTokens: $usage['prompt_tokens_details']['cache_write_tokens'] ?? 0,
+            cacheReadInputTokens: $usage['prompt_tokens_details']['cached_tokens'] ?? 0,
+            reasoningTokens: $usage['completion_tokens_details']['reasoning_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract and map the finish reason from the response.
+     */
+    protected function extractFinishReason(array $choice): FinishReason
+    {
+        return match ($choice['finish_reason'] ?? '') {
+            'stop' => FinishReason::Stop,
+            'tool_calls' => FinishReason::ToolCalls,
+            'length' => FinishReason::Length,
+            'content_filter' => FinishReason::ContentFilter,
+            'error' => FinishReason::Unknown,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+}

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -9,7 +9,7 @@ use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
-use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -26,7 +26,7 @@ class OpenRouterGateway implements EmbeddingGateway, TextGateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
-    use HandlesRateLimiting;
+    use HandlesFailoverErrors;
     use InvokesTools;
     use ParsesServerSentEvents;
 
@@ -58,7 +58,7 @@ class OpenRouterGateway implements EmbeddingGateway, TextGateway
             $options,
         );
 
-        $response = $this->withRateLimitHandling(
+        $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
         );
@@ -76,6 +76,7 @@ class OpenRouterGateway implements EmbeddingGateway, TextGateway
             $options,
             $instructions,
             $messages,
+            $timeout,
         );
     }
 
@@ -106,7 +107,7 @@ class OpenRouterGateway implements EmbeddingGateway, TextGateway
         $body['stream'] = true;
         $body['stream_options'] = ['include_usage' => true];
 
-        $response = $this->withRateLimitHandling(
+        $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)
                 ->withOptions(['stream' => true])
@@ -123,6 +124,10 @@ class OpenRouterGateway implements EmbeddingGateway, TextGateway
             $response->getBody(),
             $instructions,
             $messages,
+            0,
+            null,
+            [],
+            $timeout,
         );
     }
 
@@ -142,7 +147,7 @@ class OpenRouterGateway implements EmbeddingGateway, TextGateway
             'dimensions' => $dimensions,
         ];
 
-        $response = $this->withRateLimitHandling(
+        $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('embeddings', $body),
         );

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenRouter;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesRateLimiting;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+class OpenRouterGateway implements EmbeddingGateway, TextGateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\CreatesOpenRouterClient;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesRateLimiting;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $instructions,
+            $messages,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $body['stream'] = true;
+        $body['stream_options'] = ['include_usage' => true];
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('chat/completions', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $instructions,
+            $messages,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
+        $body = [
+            'model' => $model,
+            'input' => $inputs,
+            'dimensions' => $dimensions,
+        ];
+
+        $response = $this->withRateLimitHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('embeddings', $body),
+        );
+
+        $data = $response->json();
+
+        return new EmbeddingsResponse(
+            (new Collection($data['data'] ?? []))->pluck('embedding')->all(),
+            $data['usage']['prompt_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
+    }
+}

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -2,8 +2,12 @@
 
 namespace Laravel\Ai\Providers;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
 
 class OpenRouterProvider extends Provider implements EmbeddingProvider, TextProvider
 {
@@ -12,6 +16,27 @@ class OpenRouterProvider extends Provider implements EmbeddingProvider, TextProv
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
+
+    public function __construct(protected array $config, protected Dispatcher $events)
+    {
+        //
+    }
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new OpenRouterGateway($this->events);
+    }
+
+    /**
+     * Get the provider's embedding gateway.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ??= new OpenRouterGateway($this->events);
+    }
 
     /**
      * Get the name of the default text model.

--- a/tests/Feature/Providers/OpenRouter/AgentFakeTest.php
+++ b/tests/Feature/Providers/OpenRouter/AgentFakeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Tests\Fixtures\Agents\OpenRouterAgent;
+
+test('openrouter agent can be faked', function () {
+    OpenRouterAgent::fake(['Test response']);
+
+    $response = (new OpenRouterAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Test response');
+});
+
+test('openrouter agent fake with closure', function () {
+    OpenRouterAgent::fake(fn (string $prompt) => "Echo: {$prompt}");
+
+    $response = (new OpenRouterAgent)->prompt('Hello world');
+
+    expect($response->text)->toBe('Echo: Hello world');
+});
+
+test('openrouter agent fake with no predefined responses', function () {
+    OpenRouterAgent::fake();
+
+    $response = (new OpenRouterAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Fake response for prompt: Hello');
+});
+
+test('openrouter agent fake records prompts', function () {
+    OpenRouterAgent::fake();
+
+    (new OpenRouterAgent)->prompt('Hello');
+
+    OpenRouterAgent::assertPrompted('Hello');
+    OpenRouterAgent::assertNotPrompted('Goodbye');
+});
+
+test('openrouter agent stream can be faked', function () {
+    OpenRouterAgent::fake(['Streamed response']);
+
+    $response = (new OpenRouterAgent)->stream('Hello');
+    $response->each(fn () => true);
+
+    expect($response->text)->toBe('Streamed response');
+});

--- a/tests/Feature/Providers/OpenRouter/BaseUrlTest.php
+++ b/tests/Feature/Providers/OpenRouter/BaseUrlTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class BaseUrlTest extends TestCase
+{
+    protected string $customUrl = 'http://localhost:1234/v1';
+
+    public function test_openrouter_text_requests_use_the_configured_base_url(): void
+    {
+        $this->configureOpenRouterProvider($this->customUrl);
+
+        Http::fake([
+            '*' => Http::response([
+                'id' => 'chatcmpl-123',
+                'object' => 'chat.completion',
+                'model' => 'anthropic/claude-sonnet-4.6',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello from local model',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 1,
+                    'completion_tokens' => 1,
+                ],
+            ]),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'openrouter');
+
+        $this->assertSame('Hello from local model', $response->text);
+
+        Http::assertSentCount(1);
+        $this->assertRequestSent('POST', "{$this->customUrl}/chat/completions");
+    }
+
+    public function test_openrouter_requests_fall_back_to_the_default_base_url(): void
+    {
+        $this->configureOpenRouterProvider();
+
+        Http::fake([
+            '*' => Http::response([
+                'id' => 'chatcmpl-456',
+                'object' => 'chat.completion',
+                'model' => 'anthropic/claude-sonnet-4.6',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => 'Hello from OpenRouter',
+                    ],
+                    'finish_reason' => 'stop',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 1,
+                    'completion_tokens' => 1,
+                ],
+            ]),
+        ]);
+
+        $response = agent()->prompt('Hello', provider: 'openrouter');
+
+        $this->assertSame('Hello from OpenRouter', $response->text);
+
+        Http::assertSentCount(1);
+        $this->assertRequestSent('POST', 'https://openrouter.ai/api/v1/chat/completions');
+    }
+
+    protected function configureOpenRouterProvider(?string $url = null): void
+    {
+        config(['ai.providers.openrouter' => array_filter([
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+            'url' => $url,
+        ])]);
+    }
+
+    protected function assertRequestSent(string $method, string $url): void
+    {
+        Http::assertSent(fn (Request $request) => $request->method() === $method
+            && $request->url() === $url);
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/BaseUrlTest.php
+++ b/tests/Feature/Providers/OpenRouter/BaseUrlTest.php
@@ -5,10 +5,12 @@ use Illuminate\Support\Facades\Http;
 
 use function Laravel\Ai\agent;
 
-test('openrouter text requests use the configured base url', function () {
-    $customUrl = 'http://localhost:1234/v1';
+beforeEach(function () {
+    $this->customUrl = 'http://localhost:1234/v1';
+});
 
-    configureOpenRouterProvider($customUrl);
+test('openrouter text requests use the configured base url', function () {
+    configureOpenRouterProvider($this->customUrl);
 
     Http::fake(['*' => fakeOpenRouterResponse('Hello from local model')]);
 
@@ -17,7 +19,7 @@ test('openrouter text requests use the configured base url', function () {
     expect($response->text)->toBe('Hello from local model');
 
     Http::assertSentCount(1);
-    openRouterAssertRequestSent('POST', "{$customUrl}/chat/completions");
+    openRouterAssertRequestSent('POST', "{$this->customUrl}/chat/completions");
 });
 
 test('openrouter requests fall back to the default base url', function () {

--- a/tests/Feature/Providers/OpenRouter/BaseUrlTest.php
+++ b/tests/Feature/Providers/OpenRouter/BaseUrlTest.php
@@ -1,93 +1,49 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class BaseUrlTest extends TestCase
+test('openrouter text requests use the configured base url', function () {
+    $customUrl = 'http://localhost:1234/v1';
+
+    configureOpenRouterProvider($customUrl);
+
+    Http::fake(['*' => fakeOpenRouterResponse('Hello from local model')]);
+
+    $response = agent()->prompt('Hello', provider: 'openrouter');
+
+    expect($response->text)->toBe('Hello from local model');
+
+    Http::assertSentCount(1);
+    openRouterAssertRequestSent('POST', "{$customUrl}/chat/completions");
+});
+
+test('openrouter requests fall back to the default base url', function () {
+    configureOpenRouterProvider();
+
+    Http::fake(['*' => fakeOpenRouterResponse('Hello from OpenRouter')]);
+
+    $response = agent()->prompt('Hello', provider: 'openrouter');
+
+    expect($response->text)->toBe('Hello from OpenRouter');
+
+    Http::assertSentCount(1);
+    openRouterAssertRequestSent('POST', 'https://openrouter.ai/api/v1/chat/completions');
+});
+
+function configureOpenRouterProvider(?string $url = null): void
 {
-    protected string $customUrl = 'http://localhost:1234/v1';
+    config(['ai.providers.openrouter' => array_filter([
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+        'url' => $url,
+    ])]);
+}
 
-    public function test_openrouter_text_requests_use_the_configured_base_url(): void
-    {
-        $this->configureOpenRouterProvider($this->customUrl);
-
-        Http::fake([
-            '*' => Http::response([
-                'id' => 'chatcmpl-123',
-                'object' => 'chat.completion',
-                'model' => 'anthropic/claude-sonnet-4.6',
-                'choices' => [[
-                    'index' => 0,
-                    'message' => [
-                        'role' => 'assistant',
-                        'content' => 'Hello from local model',
-                    ],
-                    'finish_reason' => 'stop',
-                ]],
-                'usage' => [
-                    'prompt_tokens' => 1,
-                    'completion_tokens' => 1,
-                ],
-            ]),
-        ]);
-
-        $response = agent()->prompt('Hello', provider: 'openrouter');
-
-        $this->assertSame('Hello from local model', $response->text);
-
-        Http::assertSentCount(1);
-        $this->assertRequestSent('POST', "{$this->customUrl}/chat/completions");
-    }
-
-    public function test_openrouter_requests_fall_back_to_the_default_base_url(): void
-    {
-        $this->configureOpenRouterProvider();
-
-        Http::fake([
-            '*' => Http::response([
-                'id' => 'chatcmpl-456',
-                'object' => 'chat.completion',
-                'model' => 'anthropic/claude-sonnet-4.6',
-                'choices' => [[
-                    'index' => 0,
-                    'message' => [
-                        'role' => 'assistant',
-                        'content' => 'Hello from OpenRouter',
-                    ],
-                    'finish_reason' => 'stop',
-                ]],
-                'usage' => [
-                    'prompt_tokens' => 1,
-                    'completion_tokens' => 1,
-                ],
-            ]),
-        ]);
-
-        $response = agent()->prompt('Hello', provider: 'openrouter');
-
-        $this->assertSame('Hello from OpenRouter', $response->text);
-
-        Http::assertSentCount(1);
-        $this->assertRequestSent('POST', 'https://openrouter.ai/api/v1/chat/completions');
-    }
-
-    protected function configureOpenRouterProvider(?string $url = null): void
-    {
-        config(['ai.providers.openrouter' => array_filter([
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-            'url' => $url,
-        ])]);
-    }
-
-    protected function assertRequestSent(string $method, string $url): void
-    {
-        Http::assertSent(fn (Request $request) => $request->method() === $method
-            && $request->url() === $url);
-    }
+function openRouterAssertRequestSent(string $method, string $url): void
+{
+    Http::assertSent(fn (Request $request) => $request->method() === $method
+        && $request->url() === $url);
 }

--- a/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Tests\TestCase;
+
+class EmbeddingsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_embeddings_request_is_correctly_formatted(): void
+    {
+        Http::fake(['*' => Http::response([
+            'object' => 'list',
+            'data' => [
+                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ],
+            'usage' => [
+                'prompt_tokens' => 5,
+            ],
+        ])]);
+
+        Ai::instance('openrouter')->embeddings(['Hello world']);
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['model'] === 'google/gemini-embedding-001'
+                && $body['input'] === ['Hello world']
+                && $body['dimensions'] === 1536
+                && str_contains($request->url(), 'embeddings');
+        });
+    }
+
+    public function test_embeddings_response_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => Http::response([
+            'object' => 'list',
+            'data' => [
+                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+                ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+            ],
+            'usage' => [
+                'prompt_tokens' => 10,
+            ],
+        ])]);
+
+        $response = Ai::instance('openrouter')->embeddings(['Hello', 'World']);
+
+        $this->assertCount(2, $response->embeddings);
+        $this->assertSame([0.1, 0.2, 0.3], $response->embeddings[0]);
+        $this->assertSame([0.4, 0.5, 0.6], $response->embeddings[1]);
+        $this->assertSame(10, $response->tokens);
+    }
+
+    public function test_embeddings_request_sends_bearer_token(): void
+    {
+        Http::fake(['*' => Http::response([
+            'object' => 'list',
+            'data' => [
+                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]],
+            ],
+            'usage' => ['prompt_tokens' => 1],
+        ])]);
+
+        Ai::instance('openrouter')->embeddings(['test']);
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_embeddings_request_uses_openrouter_base_url(): void
+    {
+        Http::fake(['*' => Http::response([
+            'object' => 'list',
+            'data' => [
+                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]],
+            ],
+            'usage' => ['prompt_tokens' => 1],
+        ])]);
+
+        Ai::instance('openrouter')->embeddings(['test']);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://openrouter.ai/api/v1/embeddings';
+        });
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
@@ -1,100 +1,75 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Ai;
-use Tests\TestCase;
 
-class EmbeddingsTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
-    }
+test('embeddings request is correctly formatted', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+        ],
+        'usage' => ['prompt_tokens' => 5],
+    ])]);
 
-    public function test_embeddings_request_is_correctly_formatted(): void
-    {
-        Http::fake(['*' => Http::response([
-            'object' => 'list',
-            'data' => [
-                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
-            ],
-            'usage' => [
-                'prompt_tokens' => 5,
-            ],
-        ])]);
+    Ai::instance('openrouter')->embeddings(['Hello world']);
 
-        Ai::instance('openrouter')->embeddings(['Hello world']);
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
+        return $body['model'] === 'google/gemini-embedding-001'
+            && $body['input'] === ['Hello world']
+            && $body['dimensions'] === 1536
+            && str_contains($request->url(), 'embeddings');
+    });
+});
 
-            return $body['model'] === 'google/gemini-embedding-001'
-                && $body['input'] === ['Hello world']
-                && $body['dimensions'] === 1536
-                && str_contains($request->url(), 'embeddings');
-        });
-    }
+test('embeddings response is correctly parsed', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+        ],
+        'usage' => ['prompt_tokens' => 10],
+    ])]);
 
-    public function test_embeddings_response_is_correctly_parsed(): void
-    {
-        Http::fake(['*' => Http::response([
-            'object' => 'list',
-            'data' => [
-                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
-                ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
-            ],
-            'usage' => [
-                'prompt_tokens' => 10,
-            ],
-        ])]);
+    $response = Ai::instance('openrouter')->embeddings(['Hello', 'World']);
 
-        $response = Ai::instance('openrouter')->embeddings(['Hello', 'World']);
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
+        ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6])
+        ->and($response->tokens)->toBe(10);
+});
 
-        $this->assertCount(2, $response->embeddings);
-        $this->assertSame([0.1, 0.2, 0.3], $response->embeddings[0]);
-        $this->assertSame([0.4, 0.5, 0.6], $response->embeddings[1]);
-        $this->assertSame(10, $response->tokens);
-    }
+test('embeddings request sends bearer token', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
 
-    public function test_embeddings_request_sends_bearer_token(): void
-    {
-        Http::fake(['*' => Http::response([
-            'object' => 'list',
-            'data' => [
-                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]],
-            ],
-            'usage' => ['prompt_tokens' => 1],
-        ])]);
+    Ai::instance('openrouter')->embeddings(['test']);
 
-        Ai::instance('openrouter')->embeddings(['test']);
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
 
-        Http::assertSent(function (Request $request) {
-            return $request->hasHeader('Authorization', 'Bearer test-key');
-        });
-    }
+test('embeddings request uses openrouter base url', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
 
-    public function test_embeddings_request_uses_openrouter_base_url(): void
-    {
-        Http::fake(['*' => Http::response([
-            'object' => 'list',
-            'data' => [
-                ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]],
-            ],
-            'usage' => ['prompt_tokens' => 1],
-        ])]);
+    Ai::instance('openrouter')->embeddings(['test']);
 
-        Ai::instance('openrouter')->embeddings(['test']);
-
-        Http::assertSent(function (Request $request) {
-            return $request->url() === 'https://openrouter.ai/api/v1/embeddings';
-        });
-    }
-}
+    Http::assertSent(fn (Request $request) => $request->url() === 'https://openrouter.ai/api/v1/embeddings');
+});

--- a/tests/Feature/Providers/OpenRouter/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ErrorHandlingTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ErrorHandlingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_http_error_response_throws_request_exception(): void
+    {
+        Http::fake(['*' => Http::response(['error' => ['message' => 'Bad request']], 400)]);
+
+        $this->expectException(RequestException::class);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+    }
+
+    public function test_rate_limit_response_throws_rate_limited_exception(): void
+    {
+        Http::fake(['*' => Http::response(['error' => ['message' => 'Rate limited']], 429)]);
+
+        $this->expectException(RateLimitedException::class);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+    }
+
+    public function test_error_in_200_response_throws_ai_exception(): void
+    {
+        Http::fake(['*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'The model does not exist.',
+            ],
+        ])]);
+
+        $this->expectException(AiException::class);
+        $this->expectExceptionMessage('OpenRouter Error');
+
+        agent()->prompt('Hello', provider: 'openrouter');
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ErrorHandlingTest.php
@@ -1,57 +1,41 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\RateLimitedException;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class ErrorHandlingTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
-    }
+test('http error response throws request exception', function () {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Bad request']], 400)]);
 
-    public function test_http_error_response_throws_request_exception(): void
-    {
-        Http::fake(['*' => Http::response(['error' => ['message' => 'Bad request']], 400)]);
+    expect(fn () => agent()->prompt('Hello', provider: 'openrouter'))
+        ->toThrow(RequestException::class);
+});
 
-        $this->expectException(RequestException::class);
+test('rate limit response throws rate limited exception', function () {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Rate limited']], 429)]);
 
-        agent()->prompt('Hello', provider: 'openrouter');
-    }
+    expect(fn () => agent()->prompt('Hello', provider: 'openrouter'))
+        ->toThrow(RateLimitedException::class);
+});
 
-    public function test_rate_limit_response_throws_rate_limited_exception(): void
-    {
-        Http::fake(['*' => Http::response(['error' => ['message' => 'Rate limited']], 429)]);
+test('error in 200 response throws ai exception', function () {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'The model does not exist.',
+        ],
+    ])]);
 
-        $this->expectException(RateLimitedException::class);
-
-        agent()->prompt('Hello', provider: 'openrouter');
-    }
-
-    public function test_error_in_200_response_throws_ai_exception(): void
-    {
-        Http::fake(['*' => Http::response([
-            'error' => [
-                'type' => 'invalid_request_error',
-                'message' => 'The model does not exist.',
-            ],
-        ])]);
-
-        $this->expectException(AiException::class);
-        $this->expectExceptionMessage('OpenRouter Error');
-
-        agent()->prompt('Hello', provider: 'openrouter');
-    }
-}
+    expect(fn () => agent()->prompt('Hello', provider: 'openrouter'))
+        ->toThrow(AiException::class, 'OpenRouter Error');
+});

--- a/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
@@ -45,7 +44,7 @@ test('system instructions are sent as system role message', function () {
 test('tool result follow up maps assistant and tool result messages', function () {
     Http::fake([
         '*' => Http::sequence([
-            fakeOpenRouterMessageToolCallResponse(),
+            fakeOpenRouterToolCallResponse(),
             fakeOpenRouterResponse('The number is 72019'),
         ]),
     ]);
@@ -65,32 +64,3 @@ test('tool result follow up maps assistant and tool result messages', function (
     expect($toolMsg)->not->toBeNull()
         ->and($toolMsg['tool_call_id'])->toBe('call_123');
 });
-
-function fakeOpenRouterMessageToolCallResponse(): PromiseInterface
-{
-    return Http::response([
-        'id' => 'chatcmpl-tool-123',
-        'object' => 'chat.completion',
-        'model' => 'anthropic/claude-sonnet-4.6',
-        'choices' => [[
-            'index' => 0,
-            'message' => [
-                'role' => 'assistant',
-                'content' => null,
-                'tool_calls' => [[
-                    'id' => 'call_123',
-                    'type' => 'function',
-                    'function' => [
-                        'name' => 'FixedNumberGenerator',
-                        'arguments' => '{}',
-                    ],
-                ]],
-            ],
-            'finish_reason' => 'tool_calls',
-        ]],
-        'usage' => [
-            'prompt_tokens' => 10,
-            'completion_tokens' => 5,
-        ],
-    ]);
-}

--- a/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
@@ -1,133 +1,96 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Tools\FixedNumberGenerator;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class MessageMappingTest extends TestCase
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('user message maps to chat completions format', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    agent()->prompt('Hello there', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMsg = collect($body['messages'])->firstWhere('role', 'user');
+
+        return $userMsg !== null
+            && $userMsg['content'] === 'Hello there';
+    });
+});
+
+test('system instructions are sent as system role message', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['messages'][0]['role'] === 'system'
+            && str_contains($body['messages'][0]['content'], 'helpful assistant');
+    });
+});
+
+test('tool result follow up maps assistant and tool result messages', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenRouterMessageToolCallResponse(),
+            fakeOpenRouterResponse('The number is 72019'),
+        ]),
+    ]);
+
+    agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
+
+    $requests = Http::recorded(fn (Request $r) => true);
+    $followUpBody = json_decode($requests[1][0]->body(), true);
+    $messages = $followUpBody['messages'];
+
+    $assistantMsg = collect($messages)->firstWhere('role', 'assistant');
+    expect($assistantMsg)->not->toBeNull()
+        ->and($assistantMsg)->toHaveKey('tool_calls')
+        ->and($assistantMsg['tool_calls'][0]['function']['name'])->toBe('FixedNumberGenerator');
+
+    $toolMsg = collect($messages)->firstWhere('role', 'tool');
+    expect($toolMsg)->not->toBeNull()
+        ->and($toolMsg['tool_call_id'])->toBe('call_123');
+});
+
+function fakeOpenRouterMessageToolCallResponse(): PromiseInterface
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
-    }
-
-    public function test_user_message_maps_to_chat_completions_format(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
-
-        agent()->prompt('Hello there', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $userMsg = collect($body['messages'])->firstWhere('role', 'user');
-
-            return $userMsg !== null
-                && $userMsg['content'] === 'Hello there';
-        });
-    }
-
-    public function test_system_instructions_are_sent_as_system_role_message(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
-
-        (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $messages = $body['messages'];
-
-            // System message should be the first message
-            return $messages[0]['role'] === 'system'
-                && str_contains($messages[0]['content'], 'helpful assistant');
-        });
-    }
-
-    public function test_tool_result_follow_up_maps_assistant_and_tool_result_messages(): void
-    {
-        Http::fake([
-            '*' => Http::sequence([
-                $this->fakeToolCallResponse(),
-                $this->fakeOpenRouterResponse('The number is 72019'),
-            ]),
-        ]);
-
-        agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
-
-        $requests = Http::recorded(fn (Request $r) => true);
-        $followUpBody = json_decode($requests[1][0]->body(), true);
-        $messages = $followUpBody['messages'];
-
-        // Should have assistant message with tool_calls
-        $assistantMsg = collect($messages)->firstWhere('role', 'assistant');
-        $this->assertNotNull($assistantMsg);
-        $this->assertArrayHasKey('tool_calls', $assistantMsg);
-        $this->assertSame('FixedNumberGenerator', $assistantMsg['tool_calls'][0]['function']['name']);
-
-        // Should have tool result message
-        $toolMsg = collect($messages)->firstWhere('role', 'tool');
-        $this->assertNotNull($toolMsg);
-        $this->assertSame('call_123', $toolMsg['tool_call_id']);
-    }
-
-    protected function fakeToolCallResponse(): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-tool-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => null,
-                    'tool_calls' => [[
-                        'id' => 'call_123',
-                        'type' => 'function',
-                        'function' => [
-                            'name' => 'FixedNumberGenerator',
-                            'arguments' => '{}',
-                        ],
-                    ]],
-                ],
-                'finish_reason' => 'tool_calls',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 10,
-                'completion_tokens' => 5,
+    return Http::response([
+        'id' => 'chatcmpl-tool-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_123',
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
             ],
-        ]);
-    }
-
-    protected function fakeOpenRouterResponse(string $text): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => $text,
-                ],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 1,
-                'completion_tokens' => 1,
-            ],
-        ]);
-    }
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ]);
 }

--- a/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class MessageMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_user_message_maps_to_chat_completions_format(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hello there', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $userMsg = collect($body['messages'])->firstWhere('role', 'user');
+
+            return $userMsg !== null
+                && $userMsg['content'] === 'Hello there';
+        });
+    }
+
+    public function test_system_instructions_are_sent_as_system_role_message(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $messages = $body['messages'];
+
+            // System message should be the first message
+            return $messages[0]['role'] === 'system'
+                && str_contains($messages[0]['content'], 'helpful assistant');
+        });
+    }
+
+    public function test_tool_result_follow_up_maps_assistant_and_tool_result_messages(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeOpenRouterResponse('The number is 72019'),
+            ]),
+        ]);
+
+        agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
+
+        $requests = Http::recorded(fn (Request $r) => true);
+        $followUpBody = json_decode($requests[1][0]->body(), true);
+        $messages = $followUpBody['messages'];
+
+        // Should have assistant message with tool_calls
+        $assistantMsg = collect($messages)->firstWhere('role', 'assistant');
+        $this->assertNotNull($assistantMsg);
+        $this->assertArrayHasKey('tool_calls', $assistantMsg);
+        $this->assertSame('FixedNumberGenerator', $assistantMsg['tool_calls'][0]['function']['name']);
+
+        // Should have tool result message
+        $toolMsg = collect($messages)->firstWhere('role', 'tool');
+        $this->assertNotNull($toolMsg);
+        $this->assertSame('call_123', $toolMsg['tool_call_id']);
+    }
+
+    protected function fakeToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+
+    protected function fakeOpenRouterResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/MessageMappingTest.php
@@ -3,8 +3,8 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\Feature\Agents\AssistantAgent;
-use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
 use function Laravel\Ai\agent;
 

--- a/tests/Feature/Providers/OpenRouter/OpenRouterHelpers.php
+++ b/tests/Feature/Providers/OpenRouter/OpenRouterHelpers.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use Tests\Fixtures\Agents\AssistantAgent;
+
+trait OpenRouterHelpers
+{
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream(
+            'Hello',
+            provider: 'openrouter',
+        );
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            $lines[] = 'data: '.json_encode($event);
+        }
+
+        $lines[] = 'data: [DONE]';
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+
+    protected function chatChunk(array $delta, ?string $finishReason = null): array
+    {
+        return [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'delta' => $delta,
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+    }
+
+    protected function chatChunkFinish(string $finishReason, ?array $usage = null): array
+    {
+        $chunk = [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'delta' => (object) [],
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+
+        if ($usage) {
+            $chunk['usage'] = $usage;
+        }
+
+        return $chunk;
+    }
+
+    protected function chatChunkToolCallStart(int $index, string $id, string $name): array
+    {
+        return [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'id' => $id,
+                        'type' => 'function',
+                        'function' => ['name' => $name, 'arguments' => ''],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+
+    protected function chatChunkToolCallDelta(int $index, string $arguments): array
+    {
+        return [
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'function' => ['arguments' => $arguments],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
@@ -1,127 +1,60 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Feature\Agents\ProviderOptionsAgent;
 use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class ProviderOptionsTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
-    }
+test('provider options are included in openrouter request body', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
 
-    public function test_provider_options_are_included_in_openrouter_request_body(): void
-    {
-        Http::fake([
-            '*' => $this->fakeOpenRouterResponse('Hello'),
-        ]);
+    (new ProviderOptionsAgent)->prompt('Hello', provider: 'openrouter');
 
-        (new ProviderOptionsAgent)->prompt('Hello', provider: 'openrouter');
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
+        return data_get($body, 'frequency_penalty') === 0.5
+            && data_get($body, 'presence_penalty') === 0.3;
+    });
+});
 
-            return data_get($body, 'frequency_penalty') === 0.5
-                && data_get($body, 'presence_penalty') === 0.3;
-        });
-    }
+test('request body does not contain provider options when agent does not implement interface', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
 
-    public function test_request_body_does_not_contain_provider_options_when_agent_does_not_implement_interface(): void
-    {
-        Http::fake([
-            '*' => $this->fakeOpenRouterResponse('Hello'),
-        ]);
+    agent()->prompt('Hello', provider: 'openrouter');
 
-        agent()->prompt('Hello', provider: 'openrouter');
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
+        return ! array_key_exists('frequency_penalty', $body)
+            && ! array_key_exists('presence_penalty', $body);
+    });
+});
 
-            return ! array_key_exists('frequency_penalty', $body)
-                && ! array_key_exists('presence_penalty', $body);
-        });
-    }
+test('provider options are persisted in tool call follow up requests', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenRouterToolCallResponse(),
+            fakeOpenRouterResponse('The number is 72019'),
+        ]),
+    ]);
 
-    public function test_provider_options_are_persisted_in_tool_call_follow_up_requests(): void
-    {
-        Http::fake([
-            '*' => Http::sequence([
-                $this->fakeOpenRouterToolCallResponse(),
-                $this->fakeOpenRouterResponse('The number is 72019'),
-            ]),
-        ]);
+    (new ProviderOptionsWithToolsAgent)->prompt('Give me a number', provider: 'openrouter');
 
-        (new ProviderOptionsWithToolsAgent)->prompt('Give me a number', provider: 'openrouter');
+    $requests = Http::recorded(fn (Request $r) => true);
 
-        $requests = Http::recorded(fn (Request $r) => true);
+    expect(count($requests))->toBeGreaterThanOrEqual(2);
 
-        $this->assertGreaterThanOrEqual(2, count($requests));
+    $followUpBody = json_decode($requests[1][0]->body(), true);
 
-        $followUpBody = json_decode($requests[1][0]->body(), true);
-
-        $this->assertSame(0.5, data_get($followUpBody, 'frequency_penalty'));
-    }
-
-    protected function fakeOpenRouterToolCallResponse(): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-tool-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => null,
-                    'tool_calls' => [[
-                        'id' => 'call_123',
-                        'type' => 'function',
-                        'function' => [
-                            'name' => 'FixedNumberGenerator',
-                            'arguments' => '{}',
-                        ],
-                    ]],
-                ],
-                'finish_reason' => 'tool_calls',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 10,
-                'completion_tokens' => 5,
-            ],
-        ]);
-    }
-
-    protected function fakeOpenRouterResponse(string $text): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => $text,
-                ],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 1,
-                'completion_tokens' => 1,
-            ],
-        ]);
-    }
-}
+    expect(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5);
+});

--- a/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\Feature\Agents\ProviderOptionsAgent;
-use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Agents\ProviderOptionsAgent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 
 use function Laravel\Ai\agent;
 

--- a/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\ProviderOptionsAgent;
+use Tests\Feature\Agents\ProviderOptionsWithToolsAgent;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ProviderOptionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_provider_options_are_included_in_openrouter_request_body(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenRouterResponse('Hello'),
+        ]);
+
+        (new ProviderOptionsAgent)->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'frequency_penalty') === 0.5
+                && data_get($body, 'presence_penalty') === 0.3;
+        });
+    }
+
+    public function test_request_body_does_not_contain_provider_options_when_agent_does_not_implement_interface(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenRouterResponse('Hello'),
+        ]);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('frequency_penalty', $body)
+                && ! array_key_exists('presence_penalty', $body);
+        });
+    }
+
+    public function test_provider_options_are_persisted_in_tool_call_follow_up_requests(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeOpenRouterToolCallResponse(),
+                $this->fakeOpenRouterResponse('The number is 72019'),
+            ]),
+        ]);
+
+        (new ProviderOptionsWithToolsAgent)->prompt('Give me a number', provider: 'openrouter');
+
+        $requests = Http::recorded(fn (Request $r) => true);
+
+        $this->assertGreaterThanOrEqual(2, count($requests));
+
+        $followUpBody = json_decode($requests[1][0]->body(), true);
+
+        $this->assertSame(0.5, data_get($followUpBody, 'frequency_penalty'));
+    }
+
+    protected function fakeOpenRouterToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+
+    protected function fakeOpenRouterResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -2,10 +2,10 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Tests\Feature\Agents\AssistantAgent;
-use Tests\Feature\Agents\AttributeAgent;
-use Tests\Feature\Agents\StructuredAgent;
-use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\StructuredAgent;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
 
 use function Laravel\Ai\agent;
 

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Feature\Agents\AssistantAgent;
+use Tests\Feature\Agents\AttributeAgent;
+use Tests\Feature\Agents\StructuredAgent;
+use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class RequestMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_request_includes_model_and_messages(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hi there', provider: 'openrouter', model: 'anthropic/claude-sonnet-4.6');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['model'] === 'anthropic/claude-sonnet-4.6'
+                && count($body['messages']) >= 1
+                && collect($body['messages'])->contains(fn ($m) => $m['role'] === 'user' && $m['content'] === 'Hi there');
+        });
+    }
+
+    public function test_system_instructions_are_sent_as_system_message(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+            return $systemMsg !== null
+                && str_contains($systemMsg['content'], 'helpful assistant');
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_included_when_set_via_attributes(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        (new AttributeAgent)->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'temperature') === 0.7
+                && data_get($body, 'max_completion_tokens') === 4096;
+        });
+    }
+
+    public function test_temperature_and_max_tokens_are_excluded_when_not_set(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('temperature', $body)
+                && ! array_key_exists('max_completion_tokens', $body);
+        });
+    }
+
+    public function test_tools_include_tool_choice_auto(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('42')]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['tool_choice'] === 'auto'
+                && is_array($body['tools'])
+                && count($body['tools']) > 0;
+        });
+    }
+
+    public function test_request_without_tools_excludes_tool_fields(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('tools', $body)
+                && ! array_key_exists('tool_choice', $body);
+        });
+    }
+
+    public function test_structured_output_includes_json_schema_response_format(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('{"symbol": "Au"}')]);
+
+        (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $format = data_get($body, 'response_format');
+
+            return $format['type'] === 'json_schema'
+                && isset($format['json_schema']['name'])
+                && isset($format['json_schema']['schema'])
+                && $format['json_schema']['strict'] === true;
+        });
+    }
+
+    public function test_request_without_schema_excludes_response_format(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return ! array_key_exists('response_format', $body);
+        });
+    }
+
+    public function test_streaming_request_includes_stream_options(): void
+    {
+        Http::fake(['*' => Http::response("data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n")]);
+
+        $stream = agent()->stream('Hello', provider: 'openrouter');
+
+        // Consume the stream
+        foreach ($stream as $event) {
+            //
+        }
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return $body['stream'] === true
+                && data_get($body, 'stream_options.include_usage') === true;
+        });
+    }
+
+    public function test_request_sends_bearer_token_authorization(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+
+    public function test_request_sends_http_referer_and_x_title_headers_when_configured(): void
+    {
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+            'http_referer' => 'https://example.com',
+            'x_title' => 'My App',
+        ]]);
+
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+
+        agent()->prompt('Hello', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            return $request->hasHeader('HTTP-Referer', 'https://example.com')
+                && $request->hasHeader('X-Title', 'My App');
+        });
+    }
+
+    public function test_response_text_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('Laravel is great')]);
+
+        $response = agent()->prompt('Tell me about Laravel', provider: 'openrouter');
+
+        $this->assertSame('Laravel is great', $response->text);
+        $this->assertSame('openrouter', $response->meta->provider);
+    }
+
+    public function test_response_usage_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello'],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ])]);
+
+        $response = agent()->prompt('Hello', provider: 'openrouter');
+
+        $this->assertSame(10, $response->usage->promptTokens);
+        $this->assertSame(5, $response->usage->completionTokens);
+    }
+
+    public function test_response_usage_includes_cache_and_reasoning_tokens(): void
+    {
+        Http::fake(['*' => Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello'],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 100,
+                'completion_tokens' => 50,
+                'prompt_tokens_details' => [
+                    'cached_tokens' => 20,
+                    'cache_write_tokens' => 80,
+                ],
+                'completion_tokens_details' => [
+                    'reasoning_tokens' => 10,
+                ],
+            ],
+        ])]);
+
+        $response = agent()->prompt('Hello', provider: 'openrouter');
+
+        $this->assertSame(100, $response->usage->promptTokens);
+        $this->assertSame(50, $response->usage->completionTokens);
+        $this->assertSame(20, $response->usage->cacheReadInputTokens);
+        $this->assertSame(80, $response->usage->cacheWriteInputTokens);
+        $this->assertSame(10, $response->usage->reasoningTokens);
+    }
+
+    public function test_structured_response_is_correctly_parsed(): void
+    {
+        Http::fake(['*' => $this->fakeOpenRouterResponse('{"symbol": "Au"}')]);
+
+        $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openrouter');
+
+        $this->assertSame('Au', $response->structured['symbol']);
+    }
+
+    protected function fakeOpenRouterResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -65,7 +65,7 @@ class RequestMappingTest extends TestCase
             $body = json_decode($request->body(), true);
 
             return data_get($body, 'temperature') === 0.7
-                && data_get($body, 'max_completion_tokens') === 4096;
+                && data_get($body, 'max_tokens') === 4096;
         });
     }
 
@@ -79,7 +79,7 @@ class RequestMappingTest extends TestCase
             $body = json_decode($request->body(), true);
 
             return ! array_key_exists('temperature', $body)
-                && ! array_key_exists('max_completion_tokens', $body);
+                && ! array_key_exists('max_tokens', $body);
         });
     }
 
@@ -172,7 +172,7 @@ class RequestMappingTest extends TestCase
         });
     }
 
-    public function test_request_sends_http_referer_and_x_title_headers_when_configured(): void
+    public function test_request_sends_http_referer_and_x_openrouter_title_headers_when_configured(): void
     {
         config(['ai.providers.openrouter' => [
             ...config('ai.providers.openrouter'),
@@ -187,7 +187,7 @@ class RequestMappingTest extends TestCase
 
         Http::assertSent(function (Request $request) {
             return $request->hasHeader('HTTP-Referer', 'https://example.com')
-                && $request->hasHeader('X-Title', 'My App');
+                && $request->hasHeader('X-OpenRouter-Title', 'My App');
         });
     }
 

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -1,289 +1,238 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Feature\Agents\AssistantAgent;
 use Tests\Feature\Agents\AttributeAgent;
 use Tests\Feature\Agents\StructuredAgent;
 use Tests\Feature\Tools\RandomNumberGenerator;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class RequestMappingTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
+test('request includes model and messages', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    agent()->prompt('Hi there', provider: 'openrouter', model: 'anthropic/claude-sonnet-4.6');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'anthropic/claude-sonnet-4.6'
+            && count($body['messages']) >= 1
+            && collect($body['messages'])->contains(fn ($m) => $m['role'] === 'user' && $m['content'] === 'Hi there');
+    });
+});
+
+test('system instructions are sent as system message', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+        return $systemMsg !== null
+            && str_contains($systemMsg['content'], 'helpful assistant');
+    });
+});
+
+test('temperature and max tokens are included when set via attributes', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    (new AttributeAgent)->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'temperature') === 0.7
+            && data_get($body, 'max_tokens') === 4096;
+    });
+});
+
+test('temperature and max tokens are excluded when not set', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('temperature', $body)
+            && ! array_key_exists('max_tokens', $body);
+    });
+});
+
+test('tools include tool choice auto', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('42')]);
+
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['tool_choice'] === 'auto'
+            && is_array($body['tools'])
+            && count($body['tools']) > 0;
+    });
+});
+
+test('request without tools excludes tool fields', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('tools', $body)
+            && ! array_key_exists('tool_choice', $body);
+    });
+});
+
+test('structured output includes json schema response format', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('{"symbol": "Au"}')]);
+
+    (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $format = data_get($body, 'response_format');
+
+        return $format['type'] === 'json_schema'
+            && isset($format['json_schema']['name'])
+            && isset($format['json_schema']['schema'])
+            && $format['json_schema']['strict'] === true;
+    });
+});
+
+test('request without schema excludes response format', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('response_format', $body);
+    });
+});
+
+test('streaming request includes stream options', function () {
+    Http::fake(['*' => Http::response("data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n")]);
+
+    $stream = agent()->stream('Hello', provider: 'openrouter');
+
+    foreach ($stream as $event) {
+        //
     }
 
-    public function test_request_includes_model_and_messages(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
 
-        agent()->prompt('Hi there', provider: 'openrouter', model: 'anthropic/claude-sonnet-4.6');
+        return $body['stream'] === true
+            && data_get($body, 'stream_options.include_usage') === true;
+    });
+});
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
+test('request sends bearer token authorization', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
 
-            return $body['model'] === 'anthropic/claude-sonnet-4.6'
-                && count($body['messages']) >= 1
-                && collect($body['messages'])->contains(fn ($m) => $m['role'] === 'user' && $m['content'] === 'Hi there');
-        });
-    }
+    agent()->prompt('Hello', provider: 'openrouter');
 
-    public function test_system_instructions_are_sent_as_system_message(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
 
-        (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
+test('request sends http referer and x openrouter title headers when configured', function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+        'http_referer' => 'https://example.com',
+        'x_title' => 'My App',
+    ]]);
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
 
-            return $systemMsg !== null
-                && str_contains($systemMsg['content'], 'helpful assistant');
-        });
-    }
+    agent()->prompt('Hello', provider: 'openrouter');
 
-    public function test_temperature_and_max_tokens_are_included_when_set_via_attributes(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+    Http::assertSent(fn (Request $request) => $request->hasHeader('HTTP-Referer', 'https://example.com')
+        && $request->hasHeader('X-OpenRouter-Title', 'My App'));
+});
 
-        (new AttributeAgent)->prompt('Hello', provider: 'openrouter');
+test('response text is correctly parsed', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Laravel is great')]);
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
+    $response = agent()->prompt('Tell me about Laravel', provider: 'openrouter');
 
-            return data_get($body, 'temperature') === 0.7
-                && data_get($body, 'max_tokens') === 4096;
-        });
-    }
+    expect($response->text)->toBe('Laravel is great')
+        ->and($response->meta->provider)->toBe('openrouter');
+});
 
-    public function test_temperature_and_max_tokens_are_excluded_when_not_set(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
+test('response usage is correctly parsed', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => ['role' => 'assistant', 'content' => 'Hello'],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ])]);
 
-        agent()->prompt('Hello', provider: 'openrouter');
+    $response = agent()->prompt('Hello', provider: 'openrouter');
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
+    expect($response->usage->promptTokens)->toBe(10)
+        ->and($response->usage->completionTokens)->toBe(5);
+});
 
-            return ! array_key_exists('temperature', $body)
-                && ! array_key_exists('max_tokens', $body);
-        });
-    }
-
-    public function test_tools_include_tool_choice_auto(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('42')]);
-
-        agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-
-            return $body['tool_choice'] === 'auto'
-                && is_array($body['tools'])
-                && count($body['tools']) > 0;
-        });
-    }
-
-    public function test_request_without_tools_excludes_tool_fields(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
-
-        agent()->prompt('Hello', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-
-            return ! array_key_exists('tools', $body)
-                && ! array_key_exists('tool_choice', $body);
-        });
-    }
-
-    public function test_structured_output_includes_json_schema_response_format(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('{"symbol": "Au"}')]);
-
-        (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $format = data_get($body, 'response_format');
-
-            return $format['type'] === 'json_schema'
-                && isset($format['json_schema']['name'])
-                && isset($format['json_schema']['schema'])
-                && $format['json_schema']['strict'] === true;
-        });
-    }
-
-    public function test_request_without_schema_excludes_response_format(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
-
-        agent()->prompt('Hello', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-
-            return ! array_key_exists('response_format', $body);
-        });
-    }
-
-    public function test_streaming_request_includes_stream_options(): void
-    {
-        Http::fake(['*' => Http::response("data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n")]);
-
-        $stream = agent()->stream('Hello', provider: 'openrouter');
-
-        // Consume the stream
-        foreach ($stream as $event) {
-            //
-        }
-
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-
-            return $body['stream'] === true
-                && data_get($body, 'stream_options.include_usage') === true;
-        });
-    }
-
-    public function test_request_sends_bearer_token_authorization(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
-
-        agent()->prompt('Hello', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            return $request->hasHeader('Authorization', 'Bearer test-key');
-        });
-    }
-
-    public function test_request_sends_http_referer_and_x_openrouter_title_headers_when_configured(): void
-    {
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-            'http_referer' => 'https://example.com',
-            'x_title' => 'My App',
-        ]]);
-
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Hello')]);
-
-        agent()->prompt('Hello', provider: 'openrouter');
-
-        Http::assertSent(function (Request $request) {
-            return $request->hasHeader('HTTP-Referer', 'https://example.com')
-                && $request->hasHeader('X-OpenRouter-Title', 'My App');
-        });
-    }
-
-    public function test_response_text_is_correctly_parsed(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('Laravel is great')]);
-
-        $response = agent()->prompt('Tell me about Laravel', provider: 'openrouter');
-
-        $this->assertSame('Laravel is great', $response->text);
-        $this->assertSame('openrouter', $response->meta->provider);
-    }
-
-    public function test_response_usage_is_correctly_parsed(): void
-    {
-        Http::fake(['*' => Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => ['role' => 'assistant', 'content' => 'Hello'],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 10,
-                'completion_tokens' => 5,
+test('response usage includes cache and reasoning tokens', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => ['role' => 'assistant', 'content' => 'Hello'],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 20,
+                'cache_write_tokens' => 80,
             ],
-        ])]);
-
-        $response = agent()->prompt('Hello', provider: 'openrouter');
-
-        $this->assertSame(10, $response->usage->promptTokens);
-        $this->assertSame(5, $response->usage->completionTokens);
-    }
-
-    public function test_response_usage_includes_cache_and_reasoning_tokens(): void
-    {
-        Http::fake(['*' => Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => ['role' => 'assistant', 'content' => 'Hello'],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 100,
-                'completion_tokens' => 50,
-                'prompt_tokens_details' => [
-                    'cached_tokens' => 20,
-                    'cache_write_tokens' => 80,
-                ],
-                'completion_tokens_details' => [
-                    'reasoning_tokens' => 10,
-                ],
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 10,
             ],
-        ])]);
+        ],
+    ])]);
 
-        $response = agent()->prompt('Hello', provider: 'openrouter');
+    $response = agent()->prompt('Hello', provider: 'openrouter');
 
-        $this->assertSame(100, $response->usage->promptTokens);
-        $this->assertSame(50, $response->usage->completionTokens);
-        $this->assertSame(20, $response->usage->cacheReadInputTokens);
-        $this->assertSame(80, $response->usage->cacheWriteInputTokens);
-        $this->assertSame(10, $response->usage->reasoningTokens);
-    }
+    expect($response->usage->promptTokens)->toBe(100)
+        ->and($response->usage->completionTokens)->toBe(50)
+        ->and($response->usage->cacheReadInputTokens)->toBe(20)
+        ->and($response->usage->cacheWriteInputTokens)->toBe(80)
+        ->and($response->usage->reasoningTokens)->toBe(10);
+});
 
-    public function test_structured_response_is_correctly_parsed(): void
-    {
-        Http::fake(['*' => $this->fakeOpenRouterResponse('{"symbol": "Au"}')]);
+test('structured response is correctly parsed', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('{"symbol": "Au"}')]);
 
-        $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openrouter');
+    $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openrouter');
 
-        $this->assertSame('Au', $response->structured['symbol']);
-    }
-
-    protected function fakeOpenRouterResponse(string $text): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => $text,
-                ],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 1,
-                'completion_tokens' => 1,
-            ],
-        ]);
-    }
-}
+    expect($response->structured['symbol'])->toBe('Au');
+});

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -9,7 +9,7 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
-use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
 use function Laravel\Ai\agent;
 
@@ -22,7 +22,7 @@ beforeEach(function () {
 
 test('streaming emits text events', function () {
     Http::fake([
-        '*' => Http::response(openRouterSsePayload([
+        '*' => Http::response($this->ssePayload([
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hello'], 'finish_reason' => null]]],
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['content' => ' world'], 'finish_reason' => null]]],
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 2]],
@@ -50,12 +50,12 @@ test('streaming emits text events', function () {
 test('streaming handles tool calls', function () {
     Http::fake([
         '*' => Http::sequence([
-            Http::response(openRouterSsePayload([
+            Http::response($this->ssePayload([
                 ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_123', 'type' => 'function', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
                 ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
                 ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 10]],
             ])),
-            Http::response(openRouterSsePayload([
+            Http::response($this->ssePayload([
                 ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
                 ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 5]],
             ])),
@@ -77,7 +77,7 @@ test('streaming handles tool calls', function () {
 
 test('streaming error event stops stream', function () {
     Http::fake([
-        '*' => Http::response(openRouterSsePayload([
+        '*' => Http::response($this->ssePayload([
             ['error' => ['code' => 'server_error', 'message' => 'Internal error']],
         ])),
     ]);
@@ -94,7 +94,7 @@ test('streaming error event stops stream', function () {
 
 test('streaming error finish reason emits error event', function () {
     Http::fake([
-        '*' => Http::response(openRouterSsePayload([
+        '*' => Http::response($this->ssePayload([
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Partial'], 'finish_reason' => null]]],
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'error', 'error' => ['code' => 502, 'message' => 'Provider returned error']]]],
         ])),
@@ -112,7 +112,7 @@ test('streaming error finish reason emits error event', function () {
 
 test('streaming captures usage from final chunk', function () {
     Http::fake([
-        '*' => Http::response(openRouterSsePayload([
+        '*' => Http::response($this->ssePayload([
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 15, 'completion_tokens' => 3]],
@@ -129,16 +129,3 @@ test('streaming captures usage from final chunk', function () {
         ->and($streamEnd[0]->usage->promptTokens)->toBe(15)
         ->and($streamEnd[0]->usage->completionTokens)->toBe(3);
 });
-
-function openRouterSsePayload(array $events): string
-{
-    $lines = [];
-
-    foreach ($events as $event) {
-        $lines[] = 'data: '.json_encode($event);
-    }
-
-    $lines[] = 'data: [DONE]';
-
-    return implode("\n\n", $lines)."\n\n";
-}

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -12,147 +10,135 @@ use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 use Tests\Feature\Tools\FixedNumberGenerator;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class StreamingTest extends TestCase
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('streaming emits text events', function () {
+    Http::fake([
+        '*' => Http::response(openRouterSsePayload([
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hello'], 'finish_reason' => null]]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['content' => ' world'], 'finish_reason' => null]]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 2]],
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $types = array_map(fn ($e) => $e::class, $events);
+
+    expect($types)->toContain(StreamStart::class)
+        ->toContain(TextStart::class)
+        ->toContain(TextDelta::class)
+        ->toContain(TextEnd::class)
+        ->toContain(StreamEnd::class);
+
+    $textDeltas = array_values(array_filter($events, fn ($e) => $e instanceof TextDelta));
+    expect($textDeltas[0]->delta)->toBe('Hello')
+        ->and($textDeltas[1]->delta)->toBe(' world');
+});
+
+test('streaming handles tool calls', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            Http::response(openRouterSsePayload([
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_123', 'type' => 'function', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 10]],
+            ])),
+            Http::response(openRouterSsePayload([
+                ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 5]],
+            ])),
+        ]),
+    ]);
+
+    $events = [];
+    foreach (agent(tools: [new FixedNumberGenerator])->stream('Give me a number', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+    $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
+
+    expect($toolCallEvents)->toHaveCount(1)
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolResultEvents)->toHaveCount(1);
+});
+
+test('streaming error event stops stream', function () {
+    Http::fake([
+        '*' => Http::response(openRouterSsePayload([
+            ['error' => ['code' => 'server_error', 'message' => 'Internal error']],
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
+    expect($errorEvents)->toHaveCount(1)
+        ->and($errorEvents[0]->type)->toBe('server_error');
+});
+
+test('streaming error finish reason emits error event', function () {
+    Http::fake([
+        '*' => Http::response(openRouterSsePayload([
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Partial'], 'finish_reason' => null]]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'error', 'error' => ['code' => 502, 'message' => 'Provider returned error']]]],
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
+    expect($errorEvents)->toHaveCount(1)
+        ->and($errorEvents[0]->type)->toBe('502');
+});
+
+test('streaming captures usage from final chunk', function () {
+    Http::fake([
+        '*' => Http::response(openRouterSsePayload([
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 15, 'completion_tokens' => 3]],
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd));
+    expect($streamEnd)->toHaveCount(1)
+        ->and($streamEnd[0]->usage->promptTokens)->toBe(15)
+        ->and($streamEnd[0]->usage->completionTokens)->toBe(3);
+});
+
+function openRouterSsePayload(array $events): string
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
+    $lines = [];
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
+    foreach ($events as $event) {
+        $lines[] = 'data: '.json_encode($event);
     }
 
-    public function test_streaming_emits_text_events(): void
-    {
-        Http::fake([
-            '*' => Http::response($this->ssePayload([
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hello'], 'finish_reason' => null]]],
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['content' => ' world'], 'finish_reason' => null]]],
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 2]],
-            ])),
-        ]);
+    $lines[] = 'data: [DONE]';
 
-        $events = [];
-        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
-            $events[] = $event;
-        }
-
-        $types = array_map(fn ($e) => $e::class, $events);
-
-        $this->assertContains(StreamStart::class, $types);
-        $this->assertContains(TextStart::class, $types);
-        $this->assertContains(TextDelta::class, $types);
-        $this->assertContains(TextEnd::class, $types);
-        $this->assertContains(StreamEnd::class, $types);
-
-        $textDeltas = array_values(array_filter($events, fn ($e) => $e instanceof TextDelta));
-        $this->assertSame('Hello', $textDeltas[0]->delta);
-        $this->assertSame(' world', $textDeltas[1]->delta);
-    }
-
-    public function test_streaming_handles_tool_calls(): void
-    {
-        Http::fake([
-            '*' => Http::sequence([
-                Http::response($this->ssePayload([
-                    ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_123', 'type' => 'function', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
-                    ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
-                    ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 10]],
-                ])),
-                Http::response($this->ssePayload([
-                    ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
-                    ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 5]],
-                ])),
-            ]),
-        ]);
-
-        $events = [];
-        foreach (agent(tools: [new FixedNumberGenerator])->stream('Give me a number', provider: 'openrouter') as $event) {
-            $events[] = $event;
-        }
-
-        $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
-        $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
-
-        $this->assertCount(1, $toolCallEvents);
-        $this->assertSame('FixedNumberGenerator', $toolCallEvents[0]->toolCall->name);
-        $this->assertCount(1, $toolResultEvents);
-    }
-
-    public function test_streaming_error_event_stops_stream(): void
-    {
-        Http::fake([
-            '*' => Http::response($this->ssePayload([
-                ['error' => ['code' => 'server_error', 'message' => 'Internal error']],
-            ])),
-        ]);
-
-        $events = [];
-        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
-            $events[] = $event;
-        }
-
-        $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
-        $this->assertCount(1, $errorEvents);
-        $this->assertSame('server_error', $errorEvents[0]->type);
-    }
-
-    public function test_streaming_error_finish_reason_emits_error_event(): void
-    {
-        Http::fake([
-            '*' => Http::response($this->ssePayload([
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Partial'], 'finish_reason' => null]]],
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'error', 'error' => ['code' => 502, 'message' => 'Provider returned error']]]],
-            ])),
-        ]);
-
-        $events = [];
-        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
-            $events[] = $event;
-        }
-
-        $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
-        $this->assertCount(1, $errorEvents);
-        $this->assertSame('502', $errorEvents[0]->type);
-    }
-
-    public function test_streaming_captures_usage_from_final_chunk(): void
-    {
-        Http::fake([
-            '*' => Http::response($this->ssePayload([
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 15, 'completion_tokens' => 3]],
-            ])),
-        ]);
-
-        $events = [];
-        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
-            $events[] = $event;
-        }
-
-        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd));
-        $this->assertCount(1, $streamEnd);
-        $this->assertSame(15, $streamEnd[0]->usage->promptTokens);
-        $this->assertSame(3, $streamEnd[0]->usage->completionTokens);
-    }
-
-    protected function ssePayload(array $events): string
-    {
-        $lines = [];
-
-        foreach ($events as $event) {
-            $lines[] = 'data: '.json_encode($event);
-        }
-
-        $lines[] = 'data: [DONE]';
-
-        return implode("\n\n", $lines)."\n\n";
-    }
+    return implode("\n\n", $lines)."\n\n";
 }

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class StreamingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_streaming_emits_text_events(): void
+    {
+        Http::fake([
+            '*' => Http::response($this->ssePayload([
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hello'], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['content' => ' world'], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 2]],
+            ])),
+        ]);
+
+        $events = [];
+        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+
+        $types = array_map(fn ($e) => $e::class, $events);
+
+        $this->assertContains(StreamStart::class, $types);
+        $this->assertContains(TextStart::class, $types);
+        $this->assertContains(TextDelta::class, $types);
+        $this->assertContains(TextEnd::class, $types);
+        $this->assertContains(StreamEnd::class, $types);
+
+        $textDeltas = array_values(array_filter($events, fn ($e) => $e instanceof TextDelta));
+        $this->assertSame('Hello', $textDeltas[0]->delta);
+        $this->assertSame(' world', $textDeltas[1]->delta);
+    }
+
+    public function test_streaming_handles_tool_calls(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                Http::response($this->ssePayload([
+                    ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_123', 'type' => 'function', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 10]],
+                ])),
+                Http::response($this->ssePayload([
+                    ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 5]],
+                ])),
+            ]),
+        ]);
+
+        $events = [];
+        foreach (agent(tools: [new FixedNumberGenerator])->stream('Give me a number', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+
+        $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+        $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
+
+        $this->assertCount(1, $toolCallEvents);
+        $this->assertSame('FixedNumberGenerator', $toolCallEvents[0]->toolCall->name);
+        $this->assertCount(1, $toolResultEvents);
+    }
+
+    public function test_streaming_error_event_stops_stream(): void
+    {
+        Http::fake([
+            '*' => Http::response($this->ssePayload([
+                ['error' => ['code' => 'server_error', 'message' => 'Internal error']],
+            ])),
+        ]);
+
+        $events = [];
+        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+
+        $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
+        $this->assertCount(1, $errorEvents);
+        $this->assertSame('server_error', $errorEvents[0]->type);
+    }
+
+    public function test_streaming_error_finish_reason_emits_error_event(): void
+    {
+        Http::fake([
+            '*' => Http::response($this->ssePayload([
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Partial'], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'error', 'error' => ['code' => 502, 'message' => 'Provider returned error']]]],
+            ])),
+        ]);
+
+        $events = [];
+        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+
+        $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
+        $this->assertCount(1, $errorEvents);
+        $this->assertSame('502', $errorEvents[0]->type);
+    }
+
+    public function test_streaming_captures_usage_from_final_chunk(): void
+    {
+        Http::fake([
+            '*' => Http::response($this->ssePayload([
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 15, 'completion_tokens' => 3]],
+            ])),
+        ]);
+
+        $events = [];
+        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+
+        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd));
+        $this->assertCount(1, $streamEnd);
+        $this->assertSame(15, $streamEnd[0]->usage->promptTokens);
+        $this->assertSame(3, $streamEnd[0]->usage->completionTokens);
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            $lines[] = 'data: '.json_encode($event);
+        }
+
+        $lines[] = 'data: [DONE]';
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ToolCallLoopTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_tool_calls_trigger_follow_up_request(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('The number is 72019'),
+            ]),
+        ]);
+
+        $response = agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
+
+        $this->assertSame('The number is 72019', $response->text);
+
+        $requests = Http::recorded(fn (Request $r) => true);
+        $this->assertGreaterThanOrEqual(2, count($requests));
+
+        $followUpBody = json_decode($requests[1][0]->body(), true);
+        $messages = $followUpBody['messages'];
+
+        // Verify the follow-up includes assistant message with tool_calls and tool result message
+        $assistantMsg = collect($messages)->firstWhere('role', 'assistant');
+        $this->assertNotNull($assistantMsg);
+        $this->assertArrayHasKey('tool_calls', $assistantMsg);
+
+        $toolMsg = collect($messages)->firstWhere('role', 'tool');
+        $this->assertNotNull($toolMsg);
+        $this->assertSame('call_123', $toolMsg['tool_call_id']);
+    }
+
+    public function test_max_steps_limits_tool_call_depth(): void
+    {
+        Http::fake([
+            '*' => Http::sequence([
+                $this->fakeToolCallResponse(),
+                $this->fakeToolCallResponse(),
+                $this->fakeToolCallResponse(),
+                $this->fakeTextResponse('Done'),
+            ]),
+        ]);
+
+        $agent = new #[MaxSteps(3)] class implements Agent, HasTools
+        {
+            use Promptable;
+
+            public function instructions(): string
+            {
+                return 'You are a helpful assistant.';
+            }
+
+            public function tools(): iterable
+            {
+                return [new FixedNumberGenerator];
+            }
+        };
+
+        $response = $agent->prompt('Keep calling tools', provider: 'openrouter');
+
+        $requests = Http::recorded(fn (Request $r) => true);
+
+        // Should have been limited to 3 total requests
+        $this->assertLessThanOrEqual(3, count($requests));
+    }
+
+    protected function fakeToolCallResponse(): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-tool-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_123',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'FixedNumberGenerator',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+
+    protected function fakeTextResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
@@ -1,13 +1,12 @@
 <?php
 
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Promptable;
-use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
 use function Laravel\Ai\agent;
 

--- a/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
@@ -10,132 +8,71 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Promptable;
 use Tests\Feature\Tools\FixedNumberGenerator;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class ToolCallLoopTest extends TestCase
-{
-    protected function setUp(): void
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('tool calls trigger follow up request', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenRouterToolCallResponse(),
+            fakeOpenRouterResponse('The number is 72019'),
+        ]),
+    ]);
+
+    $response = agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
+
+    expect($response->text)->toBe('The number is 72019');
+
+    $requests = Http::recorded(fn (Request $r) => true);
+    expect(count($requests))->toBeGreaterThanOrEqual(2);
+
+    $followUpBody = json_decode($requests[1][0]->body(), true);
+    $messages = $followUpBody['messages'];
+
+    $assistantMsg = collect($messages)->firstWhere('role', 'assistant');
+    expect($assistantMsg)->not->toBeNull()
+        ->and($assistantMsg)->toHaveKey('tool_calls');
+
+    $toolMsg = collect($messages)->firstWhere('role', 'tool');
+    expect($toolMsg)->not->toBeNull()
+        ->and($toolMsg['tool_call_id'])->toBe('call_123');
+});
+
+test('max steps limits tool call depth', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenRouterToolCallResponse(),
+            fakeOpenRouterToolCallResponse(),
+            fakeOpenRouterToolCallResponse(),
+            fakeOpenRouterResponse('Done'),
+        ]),
+    ]);
+
+    $agent = new #[MaxSteps(3)] class implements Agent, HasTools
     {
-        parent::setUp();
+        use Promptable;
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
-    }
-
-    public function test_tool_calls_trigger_follow_up_request(): void
-    {
-        Http::fake([
-            '*' => Http::sequence([
-                $this->fakeToolCallResponse(),
-                $this->fakeTextResponse('The number is 72019'),
-            ]),
-        ]);
-
-        $response = agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'openrouter');
-
-        $this->assertSame('The number is 72019', $response->text);
-
-        $requests = Http::recorded(fn (Request $r) => true);
-        $this->assertGreaterThanOrEqual(2, count($requests));
-
-        $followUpBody = json_decode($requests[1][0]->body(), true);
-        $messages = $followUpBody['messages'];
-
-        // Verify the follow-up includes assistant message with tool_calls and tool result message
-        $assistantMsg = collect($messages)->firstWhere('role', 'assistant');
-        $this->assertNotNull($assistantMsg);
-        $this->assertArrayHasKey('tool_calls', $assistantMsg);
-
-        $toolMsg = collect($messages)->firstWhere('role', 'tool');
-        $this->assertNotNull($toolMsg);
-        $this->assertSame('call_123', $toolMsg['tool_call_id']);
-    }
-
-    public function test_max_steps_limits_tool_call_depth(): void
-    {
-        Http::fake([
-            '*' => Http::sequence([
-                $this->fakeToolCallResponse(),
-                $this->fakeToolCallResponse(),
-                $this->fakeToolCallResponse(),
-                $this->fakeTextResponse('Done'),
-            ]),
-        ]);
-
-        $agent = new #[MaxSteps(3)] class implements Agent, HasTools
+        public function instructions(): string
         {
-            use Promptable;
+            return 'You are a helpful assistant.';
+        }
 
-            public function instructions(): string
-            {
-                return 'You are a helpful assistant.';
-            }
+        public function tools(): iterable
+        {
+            return [new FixedNumberGenerator];
+        }
+    };
 
-            public function tools(): iterable
-            {
-                return [new FixedNumberGenerator];
-            }
-        };
+    $agent->prompt('Keep calling tools', provider: 'openrouter');
 
-        $response = $agent->prompt('Keep calling tools', provider: 'openrouter');
+    $requests = Http::recorded(fn (Request $r) => true);
 
-        $requests = Http::recorded(fn (Request $r) => true);
-
-        // Should have been limited to 3 total requests
-        $this->assertLessThanOrEqual(3, count($requests));
-    }
-
-    protected function fakeToolCallResponse(): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-tool-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => null,
-                    'tool_calls' => [[
-                        'id' => 'call_123',
-                        'type' => 'function',
-                        'function' => [
-                            'name' => 'FixedNumberGenerator',
-                            'arguments' => '{}',
-                        ],
-                    ]],
-                ],
-                'finish_reason' => 'tool_calls',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 10,
-                'completion_tokens' => 5,
-            ],
-        ]);
-    }
-
-    protected function fakeTextResponse(string $text): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => $text,
-                ],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 1,
-                'completion_tokens' => 1,
-            ],
-        ]);
-    }
-}
+    expect(count($requests))->toBeLessThanOrEqual(3);
+});

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -1,118 +1,75 @@
 <?php
 
-namespace Tests\Feature\Providers\OpenRouter;
-
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Feature\Tools\FixedNumberGenerator;
 use Tests\Feature\Tools\RandomNumberGenerator;
-use Tests\TestCase;
 
 use function Laravel\Ai\agent;
 
-class ToolMappingTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
 
-        config(['ai.providers.openrouter' => [
-            ...config('ai.providers.openrouter'),
-            'key' => 'test-key',
-        ]]);
-    }
+test('tool with parameters includes correct schema', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('42')]);
 
-    public function test_tool_with_parameters_includes_correct_schema(): void
-    {
-        Http::fake([
-            '*' => $this->fakeOpenRouterResponse('42'),
-        ]);
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
 
-        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
-            $function = $tool['function'] ?? [];
+        return $function['parameters']['type'] === 'object'
+            && array_key_exists('min', $function['parameters']['properties'])
+            && array_key_exists('max', $function['parameters']['properties'])
+            && in_array('min', $function['parameters']['required'])
+            && in_array('max', $function['parameters']['required'])
+            && $function['parameters']['additionalProperties'] === false;
+    });
+});
 
-            return $function['parameters']['type'] === 'object'
-                && array_key_exists('min', $function['parameters']['properties'])
-                && array_key_exists('max', $function['parameters']['properties'])
-                && in_array('min', $function['parameters']['required'])
-                && in_array('max', $function['parameters']['required'])
-                && $function['parameters']['additionalProperties'] === false;
-        });
-    }
+test('tool with empty schema includes parameters', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('72019')]);
 
-    public function test_tool_with_empty_schema_includes_parameters(): void
-    {
-        Http::fake([
-            '*' => $this->fakeOpenRouterResponse('72019'),
-        ]);
+    agent(tools: [new FixedNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
 
-        agent(tools: [new FixedNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
-            $function = $tool['function'] ?? [];
+        return array_key_exists('parameters', $function)
+            && $function['parameters']['type'] === 'object'
+            && $function['parameters']['properties'] === []
+            && $function['parameters']['required'] === []
+            && $function['parameters']['additionalProperties'] === false;
+    });
+});
 
-            return array_key_exists('parameters', $function)
-                && $function['parameters']['type'] === 'object'
-                && $function['parameters']['properties'] === []
-                && $function['parameters']['required'] === []
-                && $function['parameters']['additionalProperties'] === false;
-        });
-    }
+test('tool parameters are not wrapped in schema definition', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
-    public function test_tool_parameters_are_not_wrapped_in_schema_definition(): void
-    {
-        Http::fake([
-            '*' => $this->fakeOpenRouterResponse('done'),
-        ]);
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
 
-        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
 
-        Http::assertSent(function (Request $request) {
-            $body = json_decode($request->body(), true);
-            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
-            $function = $tool['function'] ?? [];
+        return ! array_key_exists('schema_definition', $function['parameters']['properties'] ?? [])
+            && ! in_array('schema_definition', $function['parameters']['required'] ?? []);
+    });
+});
 
-            return ! array_key_exists('schema_definition', $function['parameters']['properties'] ?? [])
-                && ! in_array('schema_definition', $function['parameters']['required'] ?? []);
-        });
-    }
+test('provider tools throw runtime exception', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
-    public function test_provider_tools_throw_runtime_exception(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('OpenRouter does not support');
-
-        Http::fake(['*' => $this->fakeOpenRouterResponse('done')]);
-
-        agent(tools: [new WebSearch])->prompt('Search', provider: 'openrouter');
-    }
-
-    protected function fakeOpenRouterResponse(string $text): PromiseInterface
-    {
-        return Http::response([
-            'id' => 'chatcmpl-123',
-            'object' => 'chat.completion',
-            'model' => 'anthropic/claude-sonnet-4.6',
-            'choices' => [[
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => $text,
-                ],
-                'finish_reason' => 'stop',
-            ]],
-            'usage' => [
-                'prompt_tokens' => 1,
-                'completion_tokens' => 1,
-            ],
-        ]);
-    }
-}
+    expect(fn () => agent(tools: [new WebSearch])->prompt('Search', provider: 'openrouter'))
+        ->toThrow(\RuntimeException::class, 'OpenRouter does not support');
+});

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -3,8 +3,8 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Providers\Tools\WebSearch;
-use Tests\Feature\Tools\FixedNumberGenerator;
-use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
 
 use function Laravel\Ai\agent;
 
@@ -71,5 +71,5 @@ test('provider tools throw runtime exception', function () {
     Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
     expect(fn () => agent(tools: [new WebSearch])->prompt('Search', provider: 'openrouter'))
-        ->toThrow(\RuntimeException::class, 'OpenRouter does not support');
+        ->toThrow(RuntimeException::class, 'OpenRouter does not support');
 });

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Providers\OpenRouter;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\WebSearch;
+use Tests\Feature\Tools\FixedNumberGenerator;
+use Tests\Feature\Tools\RandomNumberGenerator;
+use Tests\TestCase;
+
+use function Laravel\Ai\agent;
+
+class ToolMappingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['ai.providers.openrouter' => [
+            ...config('ai.providers.openrouter'),
+            'key' => 'test-key',
+        ]]);
+    }
+
+    public function test_tool_with_parameters_includes_correct_schema(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenRouterResponse('42'),
+        ]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return $function['parameters']['type'] === 'object'
+                && array_key_exists('min', $function['parameters']['properties'])
+                && array_key_exists('max', $function['parameters']['properties'])
+                && in_array('min', $function['parameters']['required'])
+                && in_array('max', $function['parameters']['required'])
+                && $function['parameters']['additionalProperties'] === false;
+        });
+    }
+
+    public function test_tool_with_empty_schema_includes_parameters(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenRouterResponse('72019'),
+        ]);
+
+        agent(tools: [new FixedNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return array_key_exists('parameters', $function)
+                && $function['parameters']['type'] === 'object'
+                && $function['parameters']['properties'] === []
+                && $function['parameters']['required'] === []
+                && $function['parameters']['additionalProperties'] === false;
+        });
+    }
+
+    public function test_tool_parameters_are_not_wrapped_in_schema_definition(): void
+    {
+        Http::fake([
+            '*' => $this->fakeOpenRouterResponse('done'),
+        ]);
+
+        agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'openrouter');
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+            $function = $tool['function'] ?? [];
+
+            return ! array_key_exists('schema_definition', $function['parameters']['properties'] ?? [])
+                && ! in_array('schema_definition', $function['parameters']['required'] ?? []);
+        });
+    }
+
+    public function test_provider_tools_throw_runtime_exception(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('OpenRouter does not support');
+
+        Http::fake(['*' => $this->fakeOpenRouterResponse('done')]);
+
+        agent(tools: [new WebSearch])->prompt('Search', provider: 'openrouter');
+    }
+
+    protected function fakeOpenRouterResponse(string $text): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'anthropic/claude-sonnet-4.6',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $text,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 1,
+                'completion_tokens' => 1,
+            ],
+        ]);
+    }
+}

--- a/tests/Fixtures/Agents/OpenRouterAgent.php
+++ b/tests/Fixtures/Agents/OpenRouterAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider('openrouter')]
+class OpenRouterAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}

--- a/tests/Fixtures/Agents/ProviderOptionsAgent.php
+++ b/tests/Fixtures/Agents/ProviderOptionsAgent.php
@@ -46,6 +46,10 @@ class ProviderOptionsAgent implements Agent, HasProviderOptions
                 'frequency_penalty' => 0.5,
                 'presence_penalty' => 0.3,
             ],
+            Lab::OpenRouter => [
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
+            ],
             Lab::Gemini => [
                 'thinkingConfig' => [
                     'thinkingBudget' => 10000,

--- a/tests/Fixtures/Agents/ProviderOptionsWithToolsAgent.php
+++ b/tests/Fixtures/Agents/ProviderOptionsWithToolsAgent.php
@@ -51,6 +51,9 @@ class ProviderOptionsWithToolsAgent implements Agent, HasProviderOptions, HasToo
             Lab::Mistral => [
                 'frequency_penalty' => 0.5,
             ],
+            Lab::OpenRouter => [
+                'frequency_penalty' => 0.5,
+            ],
             Lab::Gemini => [
                 'thinkingConfig' => [
                     'thinkingBudget' => 10000,

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -53,3 +53,53 @@ function fakeOpenAiResponse(string $text = 'Hello'): PromiseInterface
         ],
     ]);
 }
+
+function fakeOpenRouterResponse(string $text = 'Hello'): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => $text,
+            ],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 1,
+            'completion_tokens' => 1,
+        ],
+    ]);
+}
+
+function fakeOpenRouterToolCallResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-tool-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_123',
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ]);
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,7 +9,7 @@ use Tests\Feature\Providers\Xai\XaiHelpers;
 use Tests\TestCase;
 
 require __DIR__.'/Expectations.php';
-require __DIR__.'/Helpers.php';
+require_once __DIR__.'/Helpers.php';
 
 Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env', '.env.testing'])->safeLoad();
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -5,6 +5,7 @@ use Tests\Feature\Providers\Gemini\GeminiHelpers;
 use Tests\Feature\Providers\Groq\GroqHelpers;
 use Tests\Feature\Providers\Mistral\MistralHelpers;
 use Tests\Feature\Providers\OpenAi\OpenAiHelpers;
+use Tests\Feature\Providers\OpenRouter\OpenRouterHelpers;
 use Tests\Feature\Providers\Xai\XaiHelpers;
 use Tests\TestCase;
 
@@ -21,7 +22,7 @@ pest()->use(MistralHelpers::class)->group('provider-mistral')->in('Feature/Provi
 pest()->use(OpenAiHelpers::class)->group('provider-openai')->in('Feature/Providers/OpenAi');
 pest()->use(XaiHelpers::class)->group('provider-xai')->in('Feature/Providers/Xai');
 
+pest()->use(OpenRouterHelpers::class)->group('provider-openrouter')->in('Feature/Providers/OpenRouter');
 uses()->group('providers')->in('Feature/Providers');
-uses()->group('provider-openrouter')->in('Feature/Providers/OpenRouter');
 
 uses()->group('integration')->in('Integration');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,6 +9,7 @@ use Tests\Feature\Providers\Xai\XaiHelpers;
 use Tests\TestCase;
 
 require __DIR__.'/Expectations.php';
+require __DIR__.'/Helpers.php';
 
 Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env', '.env.testing'])->safeLoad();
 
@@ -21,5 +22,6 @@ pest()->use(OpenAiHelpers::class)->group('provider-openai')->in('Feature/Provide
 pest()->use(XaiHelpers::class)->group('provider-xai')->in('Feature/Providers/Xai');
 
 uses()->group('providers')->in('Feature/Providers');
+uses()->group('provider-openrouter')->in('Feature/Providers/OpenRouter');
 
 uses()->group('integration')->in('Integration');


### PR DESCRIPTION
Migrates the OpenRouter provider from the Prism abstraction layer to a direct gateway implementation, consistent with how Anthropic, Gemini, Groq, and OpenAI providers are implemented.

### Approach

- Implements a direct HTTP gateway using the OpenRouter Chat Completions API, bypassing Prism
- Supports text generation, streaming, tool calling with recursive loops, structured output, and embeddings
- Adds OpenRouter-specific headers (`HTTP-Referer`, `X-Title`) and extended usage tracking (cached tokens, reasoning tokens)
- Handles OpenRouter's `finish_reason: "error"` for mid-stream upstream provider failures
- Full test coverage with 41 tests across 8 test files covering request mapping, message mapping, tool mapping, streaming, error handling, tool call loops, provider options, base URL, and embeddings