### PR TITLE
Migrate VoyageAi off Prism to native HTTP gateway

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -122,6 +122,7 @@ return [
         'voyageai' => [
             'driver' => 'voyageai',
             'key' => env('VOYAGEAI_API_KEY'),
+            'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),
         ],
 
         'xai' => [

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -422,7 +422,6 @@ class AiManager extends MultipleInstanceManager
     public function createVoyageaiDriver(array $config): VoyageAiProvider
     {
         return new VoyageAiProvider(
-            new PrismGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Gateway/Prism/PrismGateway.php
+++ b/src/Gateway/Prism/PrismGateway.php
@@ -357,7 +357,6 @@ class PrismGateway implements Gateway
             'ollama' => ['dimensions' => $dimensions],
             'openai' => ['dimensions' => $dimensions],
             'openrouter' => ['dimensions' => $dimensions],
-            'voyageai' => ['outputDimension' => $dimensions],
             default => [],
         });
 
@@ -389,7 +388,6 @@ class PrismGateway implements Gateway
             'ollama' => PrismProvider::Ollama,
             'openai' => PrismProvider::OpenAI,
             'openrouter' => PrismProvider::OpenRouter,
-            'voyageai' => PrismProvider::VoyageAI,
             default => throw new InvalidArgumentException('Gateway does not support provider ['.$provider.'].'),
         };
     }

--- a/src/Gateway/VoyageAi/Concerns/CreatesVoyageAiClient.php
+++ b/src/Gateway/VoyageAi/Concerns/CreatesVoyageAiClient.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Gateway\VoyageAi\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesVoyageAiClient
+{
+    /**
+     * Get an HTTP client for the Voyage AI API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 30)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the Voyage AI API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.voyageai.com/v1', '/');
+    }
+}

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace Laravel\Ai\Gateway;
+namespace Laravel\Ai\Gateway\VoyageAi;
 
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
@@ -16,6 +14,8 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
 {
+    use Concerns\CreatesVoyageAiClient;
+
     /**
      * Generate embedding vectors representing the given inputs.
      *
@@ -68,19 +68,5 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
             ))->all(),
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Get an HTTP client for the Voyage API.
-     */
-    protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
-    {
-        return Http::baseUrl('https://api.voyageai.com/v1')
-            ->withHeaders([
-                'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
-                'Content-Type' => 'application/json',
-            ])
-            ->timeout($timeout)
-            ->throw();
     }
 }

--- a/src/Gateway/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAiGateway.php
@@ -3,16 +3,44 @@
 namespace Laravel\Ai\Gateway;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
+use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\RerankingResponse;
 
-class VoyageAiGateway implements RerankingGateway
+class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
 {
+    /**
+     * Generate embedding vectors representing the given inputs.
+     *
+     * @param  string[]  $inputs
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
+        $data = $this->client($provider, $timeout)->post('/embeddings', [
+            'model' => $model,
+            'input' => $inputs,
+            'output_dimension' => $dimensions,
+        ])->json();
+
+        return new EmbeddingsResponse(
+            (new Collection($data['data']))->pluck('embedding')->all(),
+            $data['usage']['total_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
+    }
+
     /**
      * Rerank the given documents based on their relevance to the query.
      *
@@ -45,13 +73,14 @@ class VoyageAiGateway implements RerankingGateway
     /**
      * Get an HTTP client for the Voyage API.
      */
-    protected function client(EmbeddingProvider|RerankingProvider $provider): PendingRequest
+    protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
     {
         return Http::baseUrl('https://api.voyageai.com/v1')
             ->withHeaders([
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
+            ->timeout($timeout)
             ->throw();
     }
 }

--- a/src/Providers/VoyageAiProvider.php
+++ b/src/Providers/VoyageAiProvider.php
@@ -7,7 +7,7 @@ use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
-use Laravel\Ai\Gateway\VoyageAiGateway;
+use Laravel\Ai\Gateway\VoyageAi\VoyageAiGateway;
 
 class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingProvider
 {

--- a/src/Providers/VoyageAiProvider.php
+++ b/src/Providers/VoyageAiProvider.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Ai\Providers;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
@@ -13,6 +15,11 @@ class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingP
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasRerankingGateway;
     use Concerns\Reranks;
+
+    public function __construct(
+        protected array $config,
+        protected Dispatcher $events,
+    ) {}
 
     /**
      * Get the name of the default embeddings model.
@@ -28,6 +35,14 @@ class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingP
     public function defaultEmbeddingsDimensions(): int
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 1024;
+    }
+
+    /**
+     * Get the provider's embedding gateway.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ??= new VoyageAiGateway;
     }
 
     /**

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -8,3 +8,13 @@ dataset('providers-with-urls', [
     'groq' => ['groq', 'api.groq.com'],
     'openai' => ['openai', 'api.openai.com'],
 ]);
+
+dataset('embedding-providers', [
+    'openai' => ['openai', 'OPENAI_API_KEY', 1536],
+    'voyageai' => ['voyageai', 'VOYAGEAI_API_KEY', 1024],
+]);
+
+dataset('reranking-providers', [
+    'cohere' => ['cohere', 'COHERE_API_KEY'],
+    'voyageai' => ['voyageai', 'VOYAGEAI_API_KEY'],
+]);

--- a/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+beforeEach(function () {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('embeddings request includes model, input, and output_dimension', function () {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello world'])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'voyage-4'
+            && $body['input'] === ['Hello world']
+            && $body['output_dimension'] === 1024
+            && $request->url() === 'https://api.voyageai.com/v1/embeddings';
+    });
+});
+
+test('embeddings response is correctly parsed', function () {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    $response = Embeddings::for(['Hello world'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    expect($response->embeddings)->toHaveCount(1)
+        ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
+        ->and($response->tokens)->toBe(10)
+        ->and($response->meta->provider)->toBe('voyageai')
+        ->and($response->meta->model)->toBe('voyage-4');
+});
+
+test('embeddings request sends bearer token', function () {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('Authorization', 'Bearer test-key');
+    });
+});
+
+test('multiple inputs return multiple embeddings', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+        ],
+        'model' => 'voyage-4',
+        'usage' => ['total_tokens' => 20],
+    ])]);
+
+    $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6]);
+});
+
+test('embeddings default to 1024 dimensions when none specified', function () {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['output_dimension'] === 1024);
+});
+
+function fakeVoyageEmbeddingsResponse()
+{
+    return Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+        ],
+        'model' => 'voyage-4',
+        'usage' => ['total_tokens' => 10],
+    ]);
+}

--- a/tests/Feature/Providers/VoyageAi/RerankingTest.php
+++ b/tests/Feature/Providers/VoyageAi/RerankingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Reranking;
+use Laravel\Ai\Responses\Data\RankedDocument;
+
+beforeEach(function () {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('reranking request includes model, query, and documents', function () {
+    Http::fake(['*' => fakeVoyageRerankingResponse()]);
+
+    Reranking::of(['Laravel is a PHP framework', 'React is a JS library'])
+        ->rerank('What is Laravel?', provider: 'voyageai', model: 'rerank-2.5-lite');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'rerank-2.5-lite'
+            && $body['query'] === 'What is Laravel?'
+            && $body['documents'] === ['Laravel is a PHP framework', 'React is a JS library']
+            && ! array_key_exists('top_k', $body)
+            && $request->url() === 'https://api.voyageai.com/v1/rerank';
+    });
+});
+
+test('reranking request includes top_k when limit set', function () {
+    Http::fake(['*' => fakeVoyageRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B', 'Doc C'])
+        ->limit(2)
+        ->rerank('query', provider: 'voyageai', model: 'rerank-2.5-lite');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['top_k'] === 2);
+});
+
+test('reranking response is correctly parsed into RankedDocuments', function () {
+    Http::fake(['*' => fakeVoyageRerankingResponse()]);
+
+    $response = Reranking::of(['Laravel is a PHP framework', 'React is a JS library'])
+        ->rerank('What is Laravel?', provider: 'voyageai', model: 'rerank-2.5-lite');
+
+    expect($response)->toHaveCount(2)
+        ->and($response->first())->toBeInstanceOf(RankedDocument::class)
+        ->and($response->first()->index)->toBe(0)
+        ->and($response->first()->document)->toBe('Laravel is a PHP framework')
+        ->and($response->first()->score)->toBe(0.95)
+        ->and($response->meta->provider)->toBe('voyageai')
+        ->and($response->meta->model)->toBe('rerank-2.5-lite');
+});
+
+test('reranking request sends bearer token', function () {
+    Http::fake(['*' => fakeVoyageRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'voyageai', model: 'rerank-2.5-lite');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+function fakeVoyageRerankingResponse()
+{
+    return Http::response([
+        'object' => 'list',
+        'data' => [
+            ['index' => 0, 'relevance_score' => 0.95],
+            ['index' => 1, 'relevance_score' => 0.12],
+        ],
+        'model' => 'rerank-2.5-lite',
+        'usage' => ['total_tokens' => 25],
+    ]);
+}

--- a/tests/Integration/EmbeddingsTest.php
+++ b/tests/Integration/EmbeddingsTest.php
@@ -6,26 +6,28 @@ use Laravel\Ai\Events\EmbeddingsGenerated;
 use Laravel\Ai\Events\GeneratingEmbeddings;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 
-beforeEach(fn () => requiresApiKey('OPENAI_API_KEY'));
+test('embeddings can be generated', function (string $provider, string $apiKey, int $dimensions) {
+    requiresApiKey($apiKey);
 
-test('embeddings can be generated', function () {
     Event::fake();
 
-    $response = Embeddings::for(['I love to watch Star Trek.'])->generate();
+    $response = Embeddings::for(['I love to watch Star Trek.'])->generate(provider: $provider);
 
     expect($response)->toBeInstanceOf(EmbeddingsResponse::class)
-        ->and($response->embeddings[0])->toHaveCount(1536)
-        ->and($response->meta->provider)->toEqual('openai');
+        ->and($response->embeddings[0])->toHaveCount($dimensions)
+        ->and($response->meta->provider)->toEqual($provider);
 
     Event::assertDispatched(GeneratingEmbeddings::class, fn (GeneratingEmbeddings $event) => $event->prompt->timeout === 30);
     Event::assertDispatched(EmbeddingsGenerated::class, fn (EmbeddingsGenerated $event) => $event->prompt->timeout === 30);
-});
+})->with('embedding-providers');
 
-test('embeddings can be generated with custom dimensions', function () {
+test('embeddings can be generated with custom dimensions', function (string $provider, string $apiKey) {
+    requiresApiKey($apiKey);
+
     $response = Embeddings::for(['test text'])
         ->dimensions(256)
-        ->generate();
+        ->generate(provider: $provider);
 
     expect($response)->toBeInstanceOf(EmbeddingsResponse::class)
         ->and($response->embeddings[0])->toHaveCount(256);
-});
+})->with('embedding-providers');

--- a/tests/Integration/RerankingTest.php
+++ b/tests/Integration/RerankingTest.php
@@ -7,67 +7,75 @@ use Laravel\Ai\Events\Reranking;
 use Laravel\Ai\Reranking as RerankingFacade;
 use Laravel\Ai\Responses\RerankingResponse;
 
-beforeEach(fn () => requiresApiKey('COHERE_API_KEY'));
+test('documents can be reranked', function (string $provider, string $apiKey) {
+    requiresApiKey($apiKey);
 
-test('documents can be reranked', function () {
     Event::fake();
 
     $response = RerankingFacade::of([
         'Python is a high-level, general-purpose programming language.',
         'Laravel is a PHP web application framework with expressive, elegant syntax.',
         'React is a JavaScript library for building user interfaces.',
-    ])->rerank('What is Laravel?');
+    ])->rerank('What is Laravel?', provider: $provider);
 
     expect($response)->toBeInstanceOf(RerankingResponse::class)
         ->toHaveCount(3)
-        ->and($response->meta->provider)->toEqual('cohere')
+        ->and($response->meta->provider)->toEqual($provider)
         ->and($response->first()->document)->toContain('Laravel');
 
     Event::assertDispatched(Reranking::class);
     Event::assertDispatched(Reranked::class);
-});
+})->with('reranking-providers');
 
-test('documents can be reranked with limit', function () {
+test('documents can be reranked with limit', function (string $provider, string $apiKey) {
+    requiresApiKey($apiKey);
+
     $response = RerankingFacade::of([
         'Django is a Python web framework.',
         'Rails is a Ruby web framework.',
         'Laravel is a PHP web application framework.',
         'Express is a Node.js web framework.',
         'Spring is a Java web framework.',
-    ])->limit(2)->rerank('PHP frameworks');
+    ])->limit(2)->rerank('PHP frameworks', provider: $provider);
 
     expect($response)->toHaveCount(2)
         ->and($response->first()->score)->toBeGreaterThan($response->results[1]->score)
         ->and($response->first()->document)->toContain('Laravel');
-});
+})->with('reranking-providers');
 
-test('collections can be reranked using string field', function () {
+test('collections can be reranked using string field', function (string $provider, string $apiKey) {
+    requiresApiKey($apiKey);
+
     $items = new Collection([
         ['id' => 1, 'content' => 'Django is a Python web framework.'],
         ['id' => 2, 'content' => 'Laravel is a PHP web application framework.'],
         ['id' => 3, 'content' => 'React is a JavaScript library.'],
     ]);
 
-    $reranked = $items->rerank(by: 'content', query: 'PHP frameworks', limit: 2);
+    $reranked = $items->rerank(by: 'content', query: 'PHP frameworks', limit: 2, provider: $provider);
 
     expect($reranked)->toHaveCount(2)
         ->and($reranked->first()['id'])->toEqual(2);
-});
+})->with('reranking-providers');
 
-test('collections can be reranked using array fields', function () {
+test('collections can be reranked using array fields', function (string $provider, string $apiKey) {
+    requiresApiKey($apiKey);
+
     $items = new Collection([
         ['id' => 1, 'title' => 'Django Guide', 'body' => 'Learn Python web development.'],
         ['id' => 2, 'title' => 'Laravel Guide', 'body' => 'Learn PHP web development.'],
         ['id' => 3, 'title' => 'React Guide', 'body' => 'Learn JavaScript UI development.'],
     ]);
 
-    $reranked = $items->rerank(by: ['title', 'body'], query: 'PHP frameworks', limit: 2);
+    $reranked = $items->rerank(by: ['title', 'body'], query: 'PHP frameworks', limit: 2, provider: $provider);
 
     expect($reranked)->toHaveCount(2)
         ->and($reranked->first()['id'])->toEqual(2);
-});
+})->with('reranking-providers');
 
-test('collections can be reranked using closure', function () {
+test('collections can be reranked using closure', function (string $provider, string $apiKey) {
+    requiresApiKey($apiKey);
+
     $items = new Collection([
         ['id' => 1, 'title' => 'Django', 'body' => 'Python web framework.'],
         ['id' => 2, 'title' => 'Laravel', 'body' => 'PHP web framework.'],
@@ -77,9 +85,10 @@ test('collections can be reranked using closure', function () {
     $reranked = $items->rerank(
         fn ($item) => $item['title'].': '.$item['body'],
         'PHP frameworks',
-        limit: 2
+        limit: 2,
+        provider: $provider
     );
 
     expect($reranked)->toHaveCount(2)
         ->and($reranked->first()['id'])->toEqual(2);
-});
+})->with('reranking-providers');


### PR DESCRIPTION
VoyageAI embeddings were the last piece of the provider still routed through Prism. This aligns VoyageAI with Cohere, Jina, and Groq — each of those talks to its vendor directly, and Voyage now does the same.

### Approach

- VoyageAI's gateway now handles both embeddings and reranking natively over HTTP, against the endpoint and payload shape documented at https://docs.voyageai.com/reference/embeddings-api.
- The Voyage provider owns its own gateway instance instead of receiving one at construction time, matching how Cohere and Jina are wired.
- Prism no longer knows about Voyage, so there's only one way to call the Voyage API.