### PR TITLE
Cast numeric error codes to string in streaming Error events

### DIFF
--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -52,7 +52,7 @@ trait HandlesTextStreaming
             if (isset($data['error'])) {
                 yield (new Error(
                     $this->generateEventId(),
-                    $data['error']['code'] ?? 'unknown_error',
+                    (string) ($data['error']['code'] ?? 'unknown_error'),
                     $data['error']['message'] ?? 'Unknown error',
                     false,
                     time(),

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -52,7 +52,7 @@ trait HandlesTextStreaming
             if (isset($data['error'])) {
                 yield (new Error(
                     $this->generateEventId(),
-                    $data['error']['code'] ?? 'unknown_error',
+                    (string) ($data['error']['code'] ?? 'unknown_error'),
                     $data['error']['message'] ?? 'Unknown error',
                     false,
                     time(),

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -52,7 +52,7 @@ trait HandlesTextStreaming
             if (isset($data['error'])) {
                 yield (new Error(
                     $this->generateEventId(),
-                    $data['error']['code'] ?? 'unknown_error',
+                    (string) ($data['error']['code'] ?? 'unknown_error'),
                     $data['error']['message'] ?? 'Unknown error',
                     false,
                     time(),

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -95,6 +95,24 @@ test('streaming error event stops stream', function () {
         ->and($events[0]->message)->toBe('Rate limit exceeded');
 });
 
+test('streaming error event casts numeric code to string', function () {
+    Http::fake([
+        'api.groq.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['error' => ['code' => 429, 'message' => 'Too many requests']],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(Error::class)
+        ->and($events[0]->type)->toBe('429');
+});
+
 test('streaming captures usage from final chunk', function () {
     Http::fake([
         'api.groq.com/*' => Http::response(

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -114,6 +114,24 @@ test('streaming error event stops stream', function () {
         ->and($events[0]->message)->toBe('Internal server error');
 });
 
+test('streaming error event casts numeric code to string', function () {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['error' => ['code' => 429, 'message' => 'Too many requests']],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(Error::class)
+        ->and($events[0]->type)->toBe('429');
+});
+
 test('streaming finish reason maps correctly', function (string $apiReason, $expected) {
     Http::fake([
         '*' => Http::response(

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -93,6 +93,23 @@ test('streaming error event stops stream', function () {
         ->and($errorEvents[0]->type)->toBe('server_error');
 });
 
+test('streaming error event casts numeric code to string', function () {
+    Http::fake([
+        '*' => Http::response($this->ssePayload([
+            ['error' => ['code' => 429, 'message' => 'Too many requests']],
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $errorEvents = array_values(array_filter($events, fn ($e) => $e instanceof Error));
+    expect($errorEvents)->toHaveCount(1)
+        ->and($errorEvents[0]->type)->toBe('429');
+});
+
 test('streaming error finish reason emits error event', function () {
     Http::fake([
         '*' => Http::response($this->ssePayload([


### PR DESCRIPTION
This PR casts the `code` field to string when emitting streaming `Error` events in the Groq, Mistral, and OpenRouter gateways. Previously a numeric error code from the provider (e.g. an HTTP 429) would fatal the generator with a TypeError, since the `Error` event's `type` property is declared `string`.

The cast already exists in OpenRouter's sibling error path handling `finish_reason === 'error'`; this brings the top-level error path in line with it.