### PR TITLE
Refine document attachment mapping and parameterize agent tests

### DIFF
--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
@@ -76,19 +77,19 @@ trait MapsAttachments
                 ],
                 $attachment instanceof Base64Document => [
                     'type' => 'document',
-                    'source' => [
-                        'type' => 'base64',
-                        'media_type' => $attachment->mime,
-                        'data' => $attachment->base64,
-                    ],
+                    'source' => $this->documentSource(
+                        $attachment->mime,
+                        fn () => base64_decode($attachment->base64),
+                        fn () => $attachment->base64,
+                    ),
                 ],
                 $attachment instanceof LocalDocument => [
                     'type' => 'document',
-                    'source' => [
-                        'type' => 'base64',
-                        'media_type' => $attachment->mimeType(),
-                        'data' => base64_encode(file_get_contents($attachment->path)),
-                    ],
+                    'source' => $this->documentSource(
+                        $attachment->mimeType(),
+                        fn () => file_get_contents($attachment->path),
+                        fn () => base64_encode(file_get_contents($attachment->path)),
+                    ),
                 ],
                 $attachment instanceof RemoteDocument => [
                     'type' => 'document',
@@ -99,13 +100,11 @@ trait MapsAttachments
                 ],
                 $attachment instanceof StoredDocument => [
                     'type' => 'document',
-                    'source' => [
-                        'type' => 'base64',
-                        'media_type' => $attachment->mimeType(),
-                        'data' => base64_encode(
-                            Storage::disk($attachment->disk)->get($attachment->path)
-                        ),
-                    ],
+                    'source' => $this->documentSource(
+                        $attachment->mimeType(),
+                        fn () => Storage::disk($attachment->disk)->get($attachment->path),
+                        fn () => base64_encode(Storage::disk($attachment->disk)->get($attachment->path)),
+                    ),
                 ],
                 $attachment instanceof UploadedFile && $this->isImage($attachment) => [
                     'type' => 'image',
@@ -117,11 +116,11 @@ trait MapsAttachments
                 ],
                 $attachment instanceof UploadedFile => [
                     'type' => 'document',
-                    'source' => [
-                        'type' => 'base64',
-                        'media_type' => $attachment->getClientMimeType(),
-                        'data' => base64_encode($attachment->get()),
-                    ],
+                    'source' => $this->documentSource(
+                        $attachment->getClientMimeType(),
+                        fn () => $attachment->get(),
+                        fn () => base64_encode($attachment->get()),
+                    ),
                 ],
                 default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
             };
@@ -132,6 +131,30 @@ trait MapsAttachments
 
             return $mapped;
         })->all();
+    }
+
+    /**
+     * Build the Anthropic document `source` block for the given mime type.
+     *
+     * @param  callable():string  $rawResolver
+     * @param  callable():string  $base64Resolver
+     * @return array<string, string>
+     */
+    protected function documentSource(?string $mimeType, callable $rawResolver, callable $base64Resolver): array
+    {
+        if ($mimeType !== null && Str::startsWith($mimeType, 'text/')) {
+            return [
+                'type' => 'text',
+                'media_type' => $mimeType,
+                'data' => $rawResolver(),
+            ];
+        }
+
+        return [
+            'type' => 'base64',
+            'media_type' => $mimeType,
+            'data' => $base64Resolver(),
+        ];
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/MapsAttachments.php
+++ b/src/Gateway/Gemini/Concerns/MapsAttachments.php
@@ -58,7 +58,7 @@ trait MapsAttachments
                 ],
                 $attachment instanceof StoredImage => [
                     'inlineData' => [
-                        'mimeType' => 'image/png',
+                        'mimeType' => $attachment->mimeType() ?? 'image/png',
                         'data' => base64_encode(
                             Storage::disk($attachment->disk)->get($attachment->path)
                         ),
@@ -77,7 +77,7 @@ trait MapsAttachments
                 ],
                 $attachment instanceof LocalDocument => [
                     'inlineData' => [
-                        'mimeType' => 'application/octet-stream',
+                        'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
                         'data' => base64_encode(file_get_contents($attachment->path)),
                     ],
                 ],
@@ -89,7 +89,7 @@ trait MapsAttachments
                 ],
                 $attachment instanceof StoredDocument => [
                     'inlineData' => [
-                        'mimeType' => 'application/octet-stream',
+                        'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
                         'data' => base64_encode(
                             Storage::disk($attachment->disk)->get($attachment->path)
                         ),

--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -59,28 +59,28 @@ trait MapsAttachments
                     'type' => 'input_file',
                     'file_id' => $attachment->id,
                 ]),
-                $attachment instanceof Base64Document => array_filter([
+                $attachment instanceof Base64Document => [
                     'type' => 'input_file',
                     'file_data' => 'data:'.$attachment->mime.';base64,'.$attachment->base64,
-                    'filename' => $attachment->name(),
-                ]),
-                $attachment instanceof LocalDocument => array_filter([
+                    'filename' => $attachment->name() ?? $this->fallbackFilename($attachment->mime),
+                ],
+                $attachment instanceof LocalDocument => [
                     'type' => 'input_file',
                     'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(file_get_contents($attachment->path)),
-                    'filename' => $attachment->name(),
-                ]),
+                    'filename' => $attachment->name() ?? $this->fallbackFilename($attachment->mimeType()),
+                ],
                 $attachment instanceof RemoteDocument => array_filter([
                     'type' => 'input_file',
                     'file_url' => $attachment->url,
                     'filename' => $attachment->name(),
                 ]),
-                $attachment instanceof StoredDocument => array_filter([
+                $attachment instanceof StoredDocument => [
                     'type' => 'input_file',
                     'file_data' => 'data:'.($attachment->mimeType() ?? 'application/octet-stream').';base64,'.base64_encode(
                         Storage::disk($attachment->disk)->get($attachment->path)
                     ),
-                    'filename' => $attachment->name(),
-                ]),
+                    'filename' => $attachment->name() ?? $this->fallbackFilename($attachment->mimeType()),
+                ],
                 $attachment instanceof UploadedFile && $this->isImage($attachment) => [
                     'type' => 'input_image',
                     'image_url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get()),
@@ -106,5 +106,18 @@ trait MapsAttachments
             'image/gif',
             'image/webp',
         ]);
+    }
+
+    protected function fallbackFilename(?string $mimeType): string
+    {
+        return 'document'.match ($mimeType) {
+            'text/plain' => '.txt',
+            'text/markdown' => '.md',
+            'text/csv' => '.csv',
+            'text/html' => '.html',
+            'application/pdf' => '.pdf',
+            'application/json' => '.json',
+            default => '',
+        };
     }
 }

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -18,3 +18,20 @@ dataset('reranking-providers', [
     'cohere' => ['cohere', 'COHERE_API_KEY'],
     'voyageai' => ['voyageai', 'VOYAGEAI_API_KEY'],
 ]);
+
+dataset('agent-providers', [
+    'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
+    'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
+    'groq' => ['groq', 'GROQ_API_KEY', 'openai/gpt-oss-20b'],
+    'deepseek' => ['deepseek', 'DEEPSEEK_API_KEY', 'deepseek-chat'],
+    'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
+    'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
+    'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'anthropic/claude-haiku-4.5'],
+]);
+
+dataset('agent-document-providers', [
+    'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
+    'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
+]);

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -101,6 +103,103 @@ test('base64 pdf document maps to document content block', function () {
             && $docBlock['source']['type'] === 'base64'
             && $docBlock['source']['media_type'] === 'application/pdf'
             && $docBlock['source']['data'] === base64_encode('fake-pdf-content');
+    });
+});
+
+test('base64 text document maps to text source block', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $document = Files\Document::fromString('hello world', 'text/plain');
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [$document],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request) {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['type'] === 'document'
+            && $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === 'hello world';
+    });
+});
+
+test('stored text document maps to text source block', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    Storage::fake('docs');
+    Storage::disk('docs')->put('notes.txt', 'stored text contents');
+
+    agent('You are helpful.')->prompt(
+        'Analyze the attached record.',
+        attachments: [Files\Document::fromStorage('notes.txt', 'docs')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request) {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['type'] === 'document'
+            && $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === 'stored text contents';
+    });
+});
+
+test('local text document maps to text source block', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $path = tempnam(sys_get_temp_dir(), 'ai-').'.txt';
+    file_put_contents($path, 'local text contents');
+
+    try {
+        agent('You are helpful.')->prompt(
+            'Read this.',
+            attachments: [Files\Document::fromPath($path)],
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $docBlock = $request->data()['messages'][0]['content'][0];
+
+            return $docBlock['type'] === 'document'
+                && $docBlock['source']['type'] === 'text'
+                && str_starts_with($docBlock['source']['media_type'], 'text/')
+                && $docBlock['source']['data'] === 'local text contents';
+        });
+    } finally {
+        @unlink($path);
+    }
+});
+
+test('uploaded text file maps to text source block', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $upload = UploadedFile::fake()->createWithContent('notes.txt', 'uploaded text contents');
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [$upload],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request) {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['type'] === 'document'
+            && $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['data'] === 'uploaded text contents';
     });
 });
 

--- a/tests/Feature/Providers/Gemini/MessageMappingTest.php
+++ b/tests/Feature/Providers/Gemini/MessageMappingTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -90,6 +92,34 @@ test('base64 pdf document maps to inline data', function () {
             if (isset($part['inlineData'])) {
                 return $part['inlineData']['mimeType'] === 'application/pdf'
                     && $part['inlineData']['data'] === base64_encode('fake-pdf-content');
+            }
+        }
+
+        return false;
+    });
+});
+
+test('stored text document sends real mime type', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    Storage::fake('docs');
+    Storage::disk('docs')->put('notes.txt', 'stored text contents');
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromStorage('notes.txt', 'docs')],
+        provider: 'gemini',
+    );
+
+    Http::assertSent(function ($request) {
+        $parts = $request->data()['contents'][0]['parts'];
+
+        foreach ($parts as $part) {
+            if (isset($part['inlineData'])) {
+                return $part['inlineData']['mimeType'] === 'text/plain'
+                    && $part['inlineData']['data'] === base64_encode('stored text contents');
             }
         }
 

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -95,6 +96,27 @@ test('base64 pdf document maps to input file', function () {
         return $fileBlock !== null
             && str_contains($fileBlock['file_data'], 'application/pdf')
             && str_contains($fileBlock['file_data'], base64_encode('fake-pdf-content'));
+    });
+});
+
+test('nameless text document falls back to derived filename', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse(),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromString('hello world', 'text/plain')],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $fileBlock = collect($userMessage['content'])->firstWhere('type', 'input_file');
+
+        return $fileBlock !== null
+            && ($fileBlock['filename'] ?? null) === 'document.txt';
     });
 });
 

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\AgentStreamed;
@@ -10,6 +11,7 @@ use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Files;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -20,56 +22,53 @@ use Tests\Fixtures\Agents\ToolUsingAgent;
 
 use function Laravel\Ai\agent;
 
-beforeEach(function () {
-    requiresApiKey('GROQ_API_KEY', 'ANTHROPIC_API_KEY');
+test('agents can get a simple text response', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
 
-    $this->provider = 'groq';
-    $this->model = 'openai/gpt-oss-20b';
-    $this->toolProvider = 'anthropic';
-    $this->toolModel = 'claude-haiku-4-5-20251001';
-});
-
-test('agents can get a simple text response', function () {
     Event::fake();
 
     $agent = new AssistantAgent;
 
     $response = $agent->prompt(
         'What is the name of the PHP framework created by Taylor Otwell?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     );
 
     expect(str_contains($response->text, 'Laravel'))->toBeTrue()
         ->and(Str::isUuid($response->invocationId, 7))->toBeTrue()
         ->and($response->messages->count())->toBeGreaterThan(0)
-        ->and($response->meta->provider)->toEqual('groq')
-        ->and($response->meta->model)->toEqual('openai/gpt-oss-20b')
+        ->and($response->meta->provider)->toEqual($provider)
+        ->and($response->meta->model)->toBeString()->not->toBeEmpty()
         ->and($response->steps->count())->toBeGreaterThan(0);
 
     Event::assertDispatched(PromptingAgent::class);
     Event::assertDispatched(AgentPrompted::class);
-});
+})->with('agent-providers');
 
-test('ad hoc agents can be prompted', function () {
+test('ad hoc agents can be prompted', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     $response = agent()->prompt(
         'What is the name of the PHP framework created by Taylor Otwell?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     );
 
     expect(str_contains($response->text, 'Laravel'))->toBeTrue();
-});
+})->with('agent-providers');
 
-test('agents can stream a response', function () {
+test('agents can stream a response', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     Event::fake();
 
     $agent = new AssistantAgent;
 
     $response = $agent->stream(
         'What is the name of the PHP framework created by Taylor Otwell?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     )->then(function (StreamedAgentResponse $response) {
         $_SERVER['__testing.response'] = $response;
     })->then(function () {
@@ -94,15 +93,17 @@ test('agents can stream a response', function () {
 
     unset($_SERVER['__testing.response']);
     unset($_SERVER['__testing.invoked']);
-});
+})->with('agent-providers');
 
-test('agents can queue a response', function () {
+test('agents can queue a response', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     $agent = new AssistantAgent;
 
     $agent->queue(
         'What is the name of the PHP framework created by Taylor Otwell?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     )->then(function (AgentResponse $response) {
         $_ENV['__testing.response'] = $response;
     });
@@ -112,13 +113,15 @@ test('agents can queue a response', function () {
     expect(str_contains($response->text, 'Laravel'))->toBeTrue();
 
     unset($_SERVER['__testing.response']);
-});
+})->with('agent-providers');
 
-test('ad hoc agents can queue a response', function () {
+test('ad hoc agents can queue a response', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     agent()->queue(
         'What is the name of the PHP framework created by Taylor Otwell?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     )->then(function (AgentResponse $response) {
         $_ENV['__testing.response'] = $response;
     });
@@ -128,17 +131,19 @@ test('ad hoc agents can queue a response', function () {
     expect(str_contains($response->text, 'Laravel'))->toBeTrue();
 
     unset($_SERVER['__testing.response']);
-});
+})->with('agent-providers');
 
-test('ad hoc structured agents can queue a response', function () {
+test('ad hoc structured agents can queue a response', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     agent(
         schema: fn ($schema) => [
             'symbol' => $schema->string()->required(),
         ]
     )->queue(
         'What is the chemical symbol for silver?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     )->then(function (AgentResponse $response) {
         $_ENV['__testing.response'] = $response;
     });
@@ -148,48 +153,56 @@ test('ad hoc structured agents can queue a response', function () {
     expect(strtolower($response['symbol']))->toEqual('ag');
 
     unset($_SERVER['__testing.response']);
-});
+})->with('agent-providers');
 
-test('agents can have conversation state', function () {
+test('agents can have conversation state', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     $agent = new ConversationalAgent;
 
     $response = $agent->prompt(
         'What did I say my name was?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     );
 
     expect(str_contains($response->text, 'Taylor'))->toBeTrue();
-});
+})->with('agent-providers');
 
-test('agents can have structured output', function () {
+test('agents can have structured output', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     $agent = new StructuredAgent;
 
     $response = $agent->prompt(
         'What is the chemical symbol for silver?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     );
 
     expect(strtolower($response['symbol']))->toEqual('ag')
         ->and($response->steps->count())->toBeGreaterThan(0);
-});
+})->with('agent-providers');
 
-test('ad hoc agents can have structured output', function () {
+test('ad hoc agents can have structured output', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     $response = agent(
         schema: fn (JsonSchema $schema) => [
             'symbol' => $schema->string()->required(),
         ],
     )->prompt(
         'What is the chemical symbol for silver?',
-        provider: $this->provider,
-        model: $this->model,
+        provider: $provider,
+        model: $model,
     );
 
     expect(strtolower($response['symbol']))->toEqual('ag');
-});
+})->with('agent-providers');
 
-test('agents can use tools', function () {
+test('agents can use tools', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     Event::fake();
 
     // Verify with a random number...
@@ -197,8 +210,8 @@ test('agents can use tools', function () {
 
     $response = $agent->prompt(
         'Can I have a random number between 1 and 1000?',
-        provider: $this->toolProvider,
-        model: $this->toolModel,
+        provider: $provider,
+        model: $model,
     );
 
     expect($response['number'])->toBeBetween(1, 1000)
@@ -216,14 +229,45 @@ test('agents can use tools', function () {
 
     $response = $agent->prompt(
         'Can I have a random number?',
-        provider: $this->toolProvider,
-        model: $this->toolModel,
+        provider: $provider,
+        model: $model,
     );
 
     expect($response['number'])->toBe(72019);
-});
+})->with('agent-providers');
 
-test('agent tool exception handling is not magical', function () {
+test('agents can analyze text document attachments', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
+    Storage::fake('docs');
+
+    Storage::disk('docs')->put('document-one.txt', 'The capital of France is Paris.');
+    Storage::disk('docs')->put('document-two.txt', 'The capital of Japan is Tokyo.');
+    Storage::disk('docs')->put('document-three.txt', 'The capital of Australia is Canberra.');
+
+    $record = ['name' => 'Taylor', 'role' => 'creator of Laravel'];
+
+    $response = agent('Answer using only the attached documents.')->prompt(
+        'List the three capital cities mentioned across the attached documents and name the person in the JSON record.',
+        [
+            Files\Document::fromStorage('document-one.txt', 'docs'),
+            Files\Document::fromStorage('document-two.txt', 'docs'),
+            Files\Document::fromStorage('document-three.txt', 'docs'),
+            Files\Document::fromString(json_encode($record), 'text/plain'),
+        ],
+        provider: $provider,
+        model: $model,
+    );
+
+    expect($response->text)->toContain('Paris')
+        ->and($response->text)->toContain('Tokyo')
+        ->and($response->text)->toContain('Canberra')
+        ->and($response->text)->toContain('Taylor');
+})->with('agent-document-providers');
+
+test('agent tool exception handling is not magical', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
     Event::fake();
 
     $agent = new ToolUsingAgent(toolThrowsException: true);
@@ -233,8 +277,8 @@ test('agent tool exception handling is not magical', function () {
     try {
         $response = $agent->prompt(
             'Can I have a random number between 1 and 1000?',
-            provider: $this->toolProvider,
-            model: $this->toolModel,
+            provider: $provider,
+            model: $model,
         );
 
         $text = $response->text;
@@ -246,4 +290,4 @@ test('agent tool exception handling is not magical', function () {
     }
 
     expect($caught)->toBeTrue();
-});
+})->with('agent-providers');


### PR DESCRIPTION
Document attachment mapping for Anthropic, Gemini, and OpenAI had gaps that caused failures with text/markdown documents and untyped attachments. Agent integration tests also hardcoded a single Groq provider, leaving the other configured providers untested.
