### PR TITLE
Fix structured output and tool-call handling in native gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 CLAUDE.md
 .env
 .claude
+AGENTS.md

--- a/src/Gateway/Concerns/ComposesSchemaInstructions.php
+++ b/src/Gateway/Concerns/ComposesSchemaInstructions.php
@@ -6,10 +6,6 @@ use Laravel\Ai\ObjectSchema;
 
 trait ComposesSchemaInstructions
 {
-    /**
-     * Compose the system instructions, appending JSON schema guidance when a
-     * structured output schema is configured.
-     */
     protected function composeInstructions(?string $instructions, ?array $schema): ?string
     {
         if (blank($schema)) {

--- a/src/Gateway/Concerns/ComposesSchemaInstructions.php
+++ b/src/Gateway/Concerns/ComposesSchemaInstructions.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Laravel\Ai\ObjectSchema;
+
+trait ComposesSchemaInstructions
+{
+    /**
+     * Compose the system instructions, appending JSON schema guidance when a
+     * structured output schema is configured.
+     */
+    protected function composeInstructions(?string $instructions, ?array $schema): ?string
+    {
+        if (blank($schema)) {
+            return $instructions;
+        }
+
+        $schemaJson = json_encode((new ObjectSchema($schema))->toSchema(), JSON_PRETTY_PRINT);
+
+        $schemaInstruction = sprintf(
+            "You MUST respond EXCLUSIVELY with a JSON object that strictly adheres to the following schema. Do NOT explain or add other content. Validate your response against this schema:\n%s",
+            $schemaJson,
+        );
+
+        return blank($instructions)
+            ? $schemaInstruction
+            : $instructions."\n\n".$schemaInstruction;
+    }
+}

--- a/src/Gateway/DeepSeek/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/DeepSeek/Concerns/BuildsTextRequests.php
@@ -2,13 +2,14 @@
 
 namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
-use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 
 trait BuildsTextRequests
 {
+    use ComposesSchemaInstructions;
+
     /**
      * Build the request body for the Chat Completions API.
      */
@@ -23,7 +24,10 @@ trait BuildsTextRequests
     ): array {
         $body = [
             'model' => $model,
-            'messages' => $this->mapMessagesToChat($messages, $instructions),
+            'messages' => $this->mapMessagesToChat(
+                $messages,
+                $this->composeInstructions($instructions, $schema),
+            ),
         ];
 
         if (filled($tools)) {
@@ -36,7 +40,7 @@ trait BuildsTextRequests
         }
 
         if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
+            $body['response_format'] = $this->buildResponseFormat();
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -59,19 +63,8 @@ trait BuildsTextRequests
     /**
      * Build the response format options for structured output.
      */
-    protected function buildResponseFormat(array $schema): array
+    protected function buildResponseFormat(): array
     {
-        $objectSchema = new ObjectSchema($schema);
-
-        $schemaArray = $objectSchema->toSchema();
-
-        return [
-            'type' => 'json_schema',
-            'json_schema' => [
-                'name' => $schemaArray['name'] ?? 'schema_definition',
-                'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
-            ],
-        ];
+        return ['type' => 'json_object'];
     }
 }

--- a/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
@@ -258,7 +258,10 @@ trait HandlesTextStreaming
             $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
 
             $chatMessages = [
-                ...$this->mapMessagesToChat($originalMessages, $instructions),
+                ...$this->mapMessagesToChat(
+                    $originalMessages,
+                    $this->composeInstructions($instructions, $schema),
+                ),
                 ...$updatedPriorMessages,
             ];
 
@@ -279,7 +282,7 @@ trait HandlesTextStreaming
             }
 
             if (filled($schema)) {
-                $body['response_format'] = $this->buildResponseFormat($schema);
+                $body['response_format'] = $this->buildResponseFormat();
             }
 
             if (! is_null($options?->maxTokens)) {

--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -230,7 +230,10 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
+        $chatMessages = $this->mapMessagesToChat(
+            $originalMessages,
+            $this->composeInstructions($instructions, $schema),
+        );
 
         foreach ($messages as $msg) {
             if ($msg instanceof AssistantMessage) {
@@ -273,7 +276,7 @@ trait ParsesTextResponses
         }
 
         if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
+            $body['response_format'] = $this->buildResponseFormat();
         }
 
         if (! is_null($options?->maxTokens)) {

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -268,7 +268,7 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $contents[] = ['role' => 'model', 'parts' => $this->excludeThinkingParts($modelParts)];
+            $contents[] = ['role' => 'model', 'parts' => $this->sanitizeRequestParts($this->excludeThinkingParts($modelParts))];
             $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
 
             $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);

--- a/src/Gateway/Gemini/Concerns/MapsMessages.php
+++ b/src/Gateway/Gemini/Concerns/MapsMessages.php
@@ -60,12 +60,13 @@ trait MapsMessages
 
         if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
             foreach ($message->toolCalls as $toolCall) {
-                $parts[] = [
-                    'functionCall' => [
-                        'name' => $toolCall->name,
-                        'args' => $toolCall->arguments,
-                    ],
-                ];
+                $functionCall = ['name' => $toolCall->name];
+
+                if (filled($toolCall->arguments)) {
+                    $functionCall['args'] = $toolCall->arguments;
+                }
+
+                $parts[] = ['functionCall' => $functionCall];
             }
         }
 

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -116,7 +116,7 @@ trait ParsesTextResponses
         if (filled($toolResults)) {
             $messages->push(new ToolResultMessage(collect($toolResults)));
 
-            $contents[] = ['role' => 'model', 'parts' => $this->excludeThinkingParts($parts)];
+            $contents[] = ['role' => 'model', 'parts' => $this->sanitizeRequestParts($this->excludeThinkingParts($parts))];
             $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
 
             return $this->continueWithToolResults(
@@ -257,6 +257,32 @@ trait ParsesTextResponses
             $parts,
             fn (array $part) => ! $this->isThinkingPart($part),
         ));
+    }
+
+    /**
+     * Sanitize functionCall parts so they can be sent back to Gemini as
+     * conversation history. Gemini rejects request payloads containing
+     * the response-only `id` field or an empty `args` value.
+     */
+    protected function sanitizeRequestParts(array $parts): array
+    {
+        return array_map(function (array $part) {
+            if (! isset($part['functionCall'])) {
+                return $part;
+            }
+
+            $functionCall = ['name' => $part['functionCall']['name'] ?? ''];
+
+            $args = $part['functionCall']['args'] ?? null;
+
+            if (filled($args)) {
+                $functionCall['args'] = $args;
+            }
+
+            $part['functionCall'] = $functionCall;
+
+            return $part;
+        }, $parts);
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -246,23 +246,7 @@ trait ParsesTextResponses
     }
 
     /**
-     * Filter out thinking parts from the response, keeping only text and functionCall parts.
-     *
-     * Gemini may reject thought content in the conversation history, so these
-     * must be excluded from continuation requests.
-     */
-    protected function excludeThinkingParts(array $parts): array
-    {
-        return array_values(array_filter(
-            $parts,
-            fn (array $part) => ! $this->isThinkingPart($part),
-        ));
-    }
-
-    /**
-     * Sanitize functionCall parts so they can be sent back to Gemini as
-     * conversation history. Gemini rejects request payloads containing
-     * the response-only `id` field or an empty `args` value.
+     * Sanitize functionCall parts so they can be sent back to Gemini as conversation history.
      */
     protected function sanitizeRequestParts(array $parts): array
     {
@@ -283,6 +267,17 @@ trait ParsesTextResponses
 
             return $part;
         }, $parts);
+    }
+
+    /**
+     * Filter out thinking parts from the response, keeping only text and functionCall parts.
+     */
+    protected function excludeThinkingParts(array $parts): array
+    {
+        return array_values(array_filter(
+            $parts,
+            fn (array $part) => ! $this->isThinkingPart($part),
+        ));
     }
 
     /**

--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -66,11 +66,6 @@ trait BuildsTextRequests
         return $body;
     }
 
-    /**
-     * Whether the schema must be embedded in the system instructions instead
-     * of being sent as `response_format`. Groq's API rejects requests that
-     * combine `response_format` with tool use.
-     */
     protected function shouldInlineSchemaInInstructions(bool $hasTools, ?array $schema): bool
     {
         return $hasTools && filled($schema);

--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -38,7 +38,7 @@ trait BuildsTextRequests
             }
         }
 
-        $inlineSchema = $this->shouldInlineSchemaInInstructions($hasTools, $schema);
+        $inlineSchema = $hasTools && filled($schema);
 
         $body['messages'] = $this->mapMessagesToChat(
             $messages,
@@ -64,11 +64,6 @@ trait BuildsTextRequests
         }
 
         return $body;
-    }
-
-    protected function shouldInlineSchemaInInstructions(bool $hasTools, ?array $schema): bool
-    {
-        return $hasTools && filled($schema);
     }
 
     /**

--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -3,12 +3,15 @@
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 
 trait BuildsTextRequests
 {
+    use ComposesSchemaInstructions;
+
     /**
      * Build the request body for the Chat Completions API.
      */
@@ -21,10 +24,9 @@ trait BuildsTextRequests
         ?array $schema,
         ?TextGenerationOptions $options,
     ): array {
-        $body = [
-            'model' => $model,
-            'messages' => $this->mapMessagesToChat($messages, $instructions),
-        ];
+        $hasTools = false;
+
+        $body = ['model' => $model];
 
         if (filled($tools)) {
             $mappedTools = $this->mapTools($tools);
@@ -32,10 +34,18 @@ trait BuildsTextRequests
             if (filled($mappedTools)) {
                 $body['tool_choice'] = 'auto';
                 $body['tools'] = $mappedTools;
+                $hasTools = true;
             }
         }
 
-        if (filled($schema)) {
+        $inlineSchema = $this->shouldInlineSchemaInInstructions($hasTools, $schema);
+
+        $body['messages'] = $this->mapMessagesToChat(
+            $messages,
+            $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
+        );
+
+        if (filled($schema) && ! $inlineSchema) {
             $body['response_format'] = $this->buildResponseFormat($schema);
         }
 
@@ -54,6 +64,16 @@ trait BuildsTextRequests
         }
 
         return $body;
+    }
+
+    /**
+     * Whether the schema must be embedded in the system instructions instead
+     * of being sent as `response_format`. Groq's API rejects requests that
+     * combine `response_format` with tool use.
+     */
+    protected function shouldInlineSchemaInInstructions(bool $hasTools, ?array $schema): bool
+    {
+        return $hasTools && filled($schema);
     }
 
     /**

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -257,8 +257,15 @@ trait HandlesTextStreaming
 
             $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
 
+            $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
+            $hasTools = filled($mappedTools);
+            $inlineSchema = $this->shouldInlineSchemaInInstructions($hasTools, $schema);
+
             $chatMessages = [
-                ...$this->mapMessagesToChat($originalMessages, $instructions),
+                ...$this->mapMessagesToChat(
+                    $originalMessages,
+                    $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
+                ),
                 ...$updatedPriorMessages,
             ];
 
@@ -269,16 +276,12 @@ trait HandlesTextStreaming
                 'stream_options' => ['include_usage' => true],
             ];
 
-            if (filled($tools)) {
-                $mappedTools = $this->mapTools($tools);
-
-                if (filled($mappedTools)) {
-                    $body['tool_choice'] = 'auto';
-                    $body['tools'] = $mappedTools;
-                }
+            if ($hasTools) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
             }
 
-            if (filled($schema)) {
+            if (filled($schema) && ! $inlineSchema) {
                 $body['response_format'] = $this->buildResponseFormat($schema);
             }
 

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -259,7 +259,7 @@ trait HandlesTextStreaming
 
             $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
             $hasTools = filled($mappedTools);
-            $inlineSchema = $this->shouldInlineSchemaInInstructions($hasTools, $schema);
+            $inlineSchema = $hasTools && filled($schema);
 
             $chatMessages = [
                 ...$this->mapMessagesToChat(

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -226,7 +226,14 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
+        $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
+        $hasTools = filled($mappedTools);
+        $inlineSchema = $this->shouldInlineSchemaInInstructions($hasTools, $schema);
+
+        $chatMessages = $this->mapMessagesToChat(
+            $originalMessages,
+            $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
+        );
 
         foreach ($messages as $msg) {
             if ($msg instanceof AssistantMessage) {
@@ -259,16 +266,12 @@ trait ParsesTextResponses
             'messages' => $chatMessages,
         ];
 
-        if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
-
-            if (filled($mappedTools)) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
+        if ($hasTools) {
+            $body['tool_choice'] = 'auto';
+            $body['tools'] = $mappedTools;
         }
 
-        if (filled($schema)) {
+        if (filled($schema) && ! $inlineSchema) {
             $body['response_format'] = $this->buildResponseFormat($schema);
         }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -228,7 +228,7 @@ trait ParsesTextResponses
     ): TextResponse {
         $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
         $hasTools = filled($mappedTools);
-        $inlineSchema = $this->shouldInlineSchemaInInstructions($hasTools, $schema);
+        $inlineSchema = $hasTools && filled($schema);
 
         $chatMessages = $this->mapMessagesToChat(
             $originalMessages,

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -22,10 +22,10 @@ dataset('reranking-providers', [
 dataset('agent-providers', [
     'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
-    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3-flash-preview'],
     'groq' => ['groq', 'GROQ_API_KEY', 'openai/gpt-oss-20b'],
     'deepseek' => ['deepseek', 'DEEPSEEK_API_KEY', 'deepseek-chat'],
-    'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
+    'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-medium-latest'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
     'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'openai/gpt-oss-20b:nitro'],
 ]);

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -27,7 +27,7 @@ dataset('agent-providers', [
     'deepseek' => ['deepseek', 'DEEPSEEK_API_KEY', 'deepseek-chat'],
     'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
-    'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'anthropic/claude-haiku-4.5'],
+    'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'openai/gpt-oss-20b:nitro'],
 ]);
 
 dataset('agent-document-providers', [

--- a/tests/Feature/Providers/DeepSeek/RequestMappingTest.php
+++ b/tests/Feature/Providers/DeepSeek/RequestMappingTest.php
@@ -97,19 +97,30 @@ test('request without tools excludes tool fields', function () {
     });
 });
 
-test('structured output includes json schema response format', function () {
+test('structured output uses json object response format', function () {
     Http::fake(['*' => fakeDeepSeekResponse('{"symbol": "Au"}')]);
 
     (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'deepseek');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
-        $format = data_get($body, 'response_format');
 
-        return $format['type'] === 'json_schema'
-            && isset($format['json_schema']['name'])
-            && isset($format['json_schema']['schema'])
-            && $format['json_schema']['strict'] === true;
+        return data_get($body, 'response_format') === ['type' => 'json_object'];
+    });
+});
+
+test('structured output appends schema instructions to system message', function () {
+    Http::fake(['*' => fakeDeepSeekResponse('{"symbol": "Au"}')]);
+
+    (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'deepseek');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+        return $systemMsg !== null
+            && str_contains($systemMsg['content'], 'JSON object that strictly adheres')
+            && str_contains($systemMsg['content'], '"symbol"');
     });
 });
 

--- a/tests/Feature/Providers/Gemini/MessageMappingTest.php
+++ b/tests/Feature/Providers/Gemini/MessageMappingTest.php
@@ -75,9 +75,6 @@ test('tool result follow up maps model and function response', function () {
         }
     }
 
-    // Regression: laravel/ai#388 — an empty `args: []` or response-only `id`
-    // field on a request `functionCall` causes Gemini to reject the call with
-    // a 400. The continuation must omit both for argument-less tool calls.
     expect($modelFunctionCall)->not->toBeNull('Follow-up should include model message with functionCall')
         ->and($modelFunctionCall)->not->toHaveKey('args')
         ->and($modelFunctionCall)->not->toHaveKey('id')
@@ -117,8 +114,6 @@ test('prior assistant tool call with empty arguments omits args in conversation 
             ->flatMap(fn ($content) => $content['parts'] ?? [])
             ->firstWhere(fn ($part) => isset($part['functionCall']))['functionCall'] ?? null;
 
-        // Regression: laravel/ai#388 — when args is empty, the JSON must not
-        // include "args": [] (empty PHP array re-encoded as a list).
         return $modelFunctionCall !== null
             && ! array_key_exists('args', $modelFunctionCall);
     });

--- a/tests/Feature/Providers/Gemini/MessageMappingTest.php
+++ b/tests/Feature/Providers/Gemini/MessageMappingTest.php
@@ -1,9 +1,16 @@
 <?php
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Responses\Data\ToolCall;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -47,14 +54,14 @@ test('tool result follow up maps model and function response', function () {
 
     $followUpContents = $recorded[1][0]->data()['contents'];
 
-    $hasModelWithFunctionCall = false;
+    $modelFunctionCall = null;
     $hasFunctionResponse = false;
 
     foreach ($followUpContents as $content) {
         if ($content['role'] === 'model') {
             foreach ($content['parts'] ?? [] as $part) {
                 if (isset($part['functionCall'])) {
-                    $hasModelWithFunctionCall = true;
+                    $modelFunctionCall = $part['functionCall'];
                 }
             }
         }
@@ -68,8 +75,53 @@ test('tool result follow up maps model and function response', function () {
         }
     }
 
-    expect($hasModelWithFunctionCall)->toBeTrue('Follow-up should include model message with functionCall')
+    // Regression: laravel/ai#388 — an empty `args: []` or response-only `id`
+    // field on a request `functionCall` causes Gemini to reject the call with
+    // a 400. The continuation must omit both for argument-less tool calls.
+    expect($modelFunctionCall)->not->toBeNull('Follow-up should include model message with functionCall')
+        ->and($modelFunctionCall)->not->toHaveKey('args')
+        ->and($modelFunctionCall)->not->toHaveKey('id')
         ->and($hasFunctionResponse)->toBeTrue('Follow-up should include user message with functionResponse');
+});
+
+test('prior assistant tool call with empty arguments omits args in conversation history', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('OK'),
+    ]);
+
+    $agent = new class implements Agent, Conversational
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function messages(): iterable
+        {
+            return [
+                new Message(role: 'user', content: 'Generate a number'),
+                new AssistantMessage('', new Collection([
+                    new ToolCall('call_123', 'FixedNumberGenerator', [], 'call_123'),
+                ])),
+            ];
+        }
+    };
+
+    $agent->prompt('And again', provider: 'gemini');
+
+    Http::assertSent(function ($request) {
+        $modelFunctionCall = collect($request->data()['contents'])
+            ->where('role', 'model')
+            ->flatMap(fn ($content) => $content['parts'] ?? [])
+            ->firstWhere(fn ($part) => isset($part['functionCall']))['functionCall'] ?? null;
+
+        // Regression: laravel/ai#388 — when args is empty, the JSON must not
+        // include "args": [] (empty PHP array re-encoded as a list).
+        return $modelFunctionCall !== null
+            && ! array_key_exists('args', $modelFunctionCall);
+    });
 });
 
 test('base64 pdf document maps to inline data', function () {

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -125,6 +125,25 @@ test('request without schema excludes response format', function () {
     });
 });
 
+test('schema combined with tools omits response format but keeps schema instructions', function () {
+    Http::fake(['*' => fakeGroqResponse('{"number": 42}')]);
+
+    agent(
+        tools: [new RandomNumberGenerator],
+        schema: fn ($s) => ['number' => $s->integer()->required()],
+    )->prompt('Give me a number', provider: 'groq');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+        return ! array_key_exists('response_format', $body)
+            && is_array($body['tools'])
+            && $systemMsg !== null
+            && str_contains($systemMsg['content'], 'JSON object that strictly adheres');
+    });
+});
+
 test('streaming request includes stream options', function () {
     Http::fake(['*' => Http::response("data: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n")]);
 


### PR DESCRIPTION
Fixes failures across the DeepSeek, Groq, and Gemini native gateways surfaced by the agent integration suite, including the argument-less tool-call bug reported in #388 which caused Gemini to reject continuation requests with HTTP 400.

Fixes #388

### Approach

- DeepSeek: its API only supports `json_object`, so the schema is now embedded in the system instructions (matching prism's approach) and `json_object` is used as the response format.
- Groq: `response_format` and tool use cannot be combined, so when both are requested the schema is inlined into the system instructions instead. The strict `json_schema` mode is still used for structured-only requests where Groq's API supports it.
- Gemini: empty-argument tool calls produced `"args": []` (a JSON list rather than an object) and response-only `id` fields leaked back into continuation requests. Both are now stripped before replay, in the assistant history, the tool-result continuation, and the streaming continuation.
- Extracted the shared schema-as-system-message helper into a single trait to avoid duplicating the instruction wording between gateways.
