### PR TITLE
Bind AiManager as singleton to preserve driver extensions across jobs

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -21,7 +21,7 @@ class AiServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->scoped(AiManager::class, fn ($app): AiManager => new AiManager($app));
+        $this->app->singleton(AiManager::class, fn ($app): AiManager => new AiManager($app));
         $this->app->singleton(ConversationStore::class, DatabaseConversationStore::class);
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -3,7 +3,6 @@
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Facade;
 use Laravel\Ai\Ai;
-use Laravel\Ai\AiManager;
 use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Providers\OpenAiProvider;
 
@@ -24,11 +23,13 @@ test('driver extensions survive between queue jobs', function () {
         $app->make(Dispatcher::class),
     ));
 
-    // Mirror Illuminate\Queue\Worker::resetScope() (reset path between jobs
-    // in a long-running worker).
-    app()->forgetScopedInstances();
-    Facade::clearResolvedInstances();
+    $runJobOnFreshScope = function () {
+        app()->forgetScopedInstances();
+        Facade::clearResolvedInstances();
 
-    expect(app(AiManager::class)->textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
-    expect(Ai::textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
+        return Ai::textProvider('custom');
+    };
+
+    expect($runJobOnFreshScope())->toBeInstanceOf(OpenAiProvider::class);
+    expect($runJobOnFreshScope())->toBeInstanceOf(OpenAiProvider::class);
 });

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Support\Facades\Facade;
 use Laravel\Ai\Ai;
+use Laravel\Ai\AiManager;
 use Laravel\Ai\Providers\OpenAiProvider;
 
 test('can get an openai provider instance', function () {
@@ -10,3 +12,23 @@ test('can get an openai provider instance', function () {
 test('provider type is ensured', function () {
     Ai::audioProvider('anthropic');
 })->throws(LogicException::class);
+
+test('driver extensions survive scoped instance clears', function () {
+    config()->set('ai.providers.custom', ['driver' => 'custom']);
+
+    Ai::extend('custom', fn ($app, array $config) => new OpenAiProvider(
+        $app->make(\Laravel\Ai\Gateway\OpenAi\OpenAiGateway::class),
+        $config,
+        $app->make(\Illuminate\Contracts\Events\Dispatcher::class),
+    ));
+
+    expect(Ai::textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
+
+    // Mirror Illuminate\Queue\Worker::resetScope() (reset path between jobs
+    // in a long-running worker).
+    app()->forgetScopedInstances();
+    Facade::clearResolvedInstances();
+
+    expect(app(AiManager::class)->textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
+    expect(Ai::textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
+});

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Facade;
 use Laravel\Ai\Ai;
 use Laravel\Ai\AiManager;
+use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Providers\OpenAiProvider;
 
 test('can get an openai provider instance', function () {
@@ -13,16 +15,14 @@ test('provider type is ensured', function () {
     Ai::audioProvider('anthropic');
 })->throws(LogicException::class);
 
-test('driver extensions survive scoped instance clears', function () {
+test('driver extensions survive between queue jobs', function () {
     config()->set('ai.providers.custom', ['driver' => 'custom']);
 
     Ai::extend('custom', fn ($app, array $config) => new OpenAiProvider(
-        $app->make(\Laravel\Ai\Gateway\OpenAi\OpenAiGateway::class),
+        $app->make(OpenAiGateway::class),
         $config,
-        $app->make(\Illuminate\Contracts\Events\Dispatcher::class),
+        $app->make(Dispatcher::class),
     ));
-
-    expect(Ai::textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
 
     // Mirror Illuminate\Queue\Worker::resetScope() (reset path between jobs
     // in a long-running worker).


### PR DESCRIPTION
## Problem

`AiServiceProvider::register()` binds `AiManager` as `scoped`. In long-running queue workers (Horizon, `queue:work` daemon), Laravel calls `forgetScopedInstances()` between jobs, which drops the `AiManager` instance that driver packages extended at service-provider boot. On the next job, the scoped binding produces a fresh `AiManager` with empty `customCreators`, and `MultipleInstanceManager::resolve()` throws:

> `Instance driver [<driver-name>] is not supported.`

Packages that register drivers via `Ai::extend()` at boot can hit this, for example [`revolution/laravel-amazon-bedrock`](https://github.com/invokable/laravel-amazon-bedrock). HTTP requests, unit tests, and `queue:work --once` don't trigger it, since those paths only ever resolve one `AiManager`.

## Fix

```diff
- $this->app->scoped(AiManager::class, fn ($app): AiManager => new AiManager($app));
+ $this->app->singleton(AiManager::class, fn ($app): AiManager => new AiManager($app));
```

Matches how `CacheManager`, `HashManager`, `SessionManager`, `FilesystemManager`, and `QueueManager` are bound in the framework, so the documented `Ai::extend()` registration pattern works reliably in worker processes.

## Regression test

```php
test('driver extensions survive scoped instance clears', function () {
    config()->set('ai.providers.custom', ['driver' => 'custom']);

    Ai::extend('custom', fn ($app, array $config) => new OpenAiProvider(
        $app->make(\Laravel\Ai\Gateway\OpenAi\OpenAiGateway::class),
        $config,
        $app->make(\Illuminate\Contracts\Events\Dispatcher::class),
    ));

    expect(Ai::textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);

    // Mirror Illuminate\Queue\Worker::resetScope() (reset path between jobs in
    // a long-running worker).
    app()->forgetScopedInstances();
    Facade::clearResolvedInstances();

    expect(app(AiManager::class)->textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
    expect(Ai::textProvider('custom'))->toBeInstanceOf(OpenAiProvider::class);
});
```

Fails on `0.x` with the exact production error; passes with this change. Full suite still green (660 passed, 129 skipped for missing external API keys).

## Note on test fakes

The scoped binding cleared the fake-gateway and recorded-prompt arrays on `AiManager` (from the `InteractsWithFakeAgents` trait) between worker jobs. Those arrays are only populated by test helpers like `Ai::fakeAgent()`, and `TestCase` already rebuilds the container between cases, so the reset wasn't doing load-bearing work. If there's a concrete reason to keep `scoped`, happy to rework as `scoped` with a persistent `customCreators` store instead.
