### PR TITLE
[0.x] Add timeout parameter to Agent contract

### DIFF
--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -23,7 +23,8 @@ interface Agent
         string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
-        ?string $model = null
+        ?string $model = null,
+        ?int $timeout = null,
     ): AgentResponse;
 
     /**
@@ -33,7 +34,8 @@ interface Agent
         string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
-        ?string $model = null
+        ?string $model = null,
+        ?int $timeout = null,
     ): StreamableAgentResponse;
 
     /**


### PR DESCRIPTION
## Add `timeout` parameter to `Agent` contract

The `Promptable` trait already accepts an optional `?int $timeout` parameter on `prompt()` and `stream()`, but the `Agent` contract does not declare it. This causes IDE and static analysis warnings (e.g. PHPStan `argument.named`) when calling `->prompt(..., timeout: 120)` on an `Agent`-typed variable, since the contract signature doesn't include the parameter.

### Changes

- Added `?int $timeout = null` to `Agent::prompt()` and `Agent::stream()` in `src/Contracts/Agent.php`.

### Why

The `Promptable` trait (used by all concrete agents) already supports `timeout` on both methods and passes it through to `AgentPrompt`. The contract simply didn't reflect this, creating a mismatch between the interface and its implementation.

### Impact

- **Non-breaking**: the parameter is optional with a `null` default.
- **Existing tests pass**: the 4 timeout-related tests in `AgentFakeTest` already exercise `timeout:` as a named argument on both `prompt()` and `stream()`.