### PR TITLE
Update Anthropic smartest model default to Claude Opus 4.7

### DIFF
--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -74,7 +74,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['text']['smartest'] ?? 'claude-opus-4-6';
+        return $this->config['models']['text']['smartest'] ?? 'claude-opus-4-7';
     }
 
     /**


### PR DESCRIPTION
The latest Claude model is now Opus 4.7 — update the default smartest text model for the Anthropic provider to match.
