### PR TITLE
Add test suite for JinaProvider (embeddings and reranking)

### DIFF
--- a/tests/Feature/Providers/Jina/EmbeddingTest.php
+++ b/tests/Feature/Providers/Jina/EmbeddingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+beforeEach(function () {
+    config(['ai.providers.jina' => [
+        ...config('ai.providers.jina'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('embeddings request includes model, input, and dimensions', function () {
+    Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello world'])->dimensions(2048)->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'jina-embeddings-v4'
+            && $body['input'][0]['text'] === 'Hello world'
+            && $body['dimensions'] === 2048
+            && $body['task'] === 'retrieval.passage'
+            && $request->url() === 'https://api.jina.ai/v1/embeddings';
+    });
+});
+
+test('embeddings response is correctly parsed', function () {
+    Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
+
+    $response = Embeddings::for(['Hello world'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    expect($response->embeddings)->toHaveCount(1)
+        ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
+        ->and($response->tokens)->toBe(10)
+        ->and($response->meta->provider)->toBe('jina')
+        ->and($response->meta->model)->toBe('jina-embeddings-v4');
+});
+
+test('embeddings request sends bearer token', function () {
+    Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('Authorization', 'Bearer test-key');
+    });
+});
+
+test('multiple inputs return multiple embeddings', function () {
+    Http::fake(['*' => Http::response([
+        'model' => 'jina-embeddings-v4',
+        'object' => 'list',
+        'usage' => ['total_tokens' => 20],
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+        ],
+    ])]);
+
+    $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6]);
+});
+
+test('embeddings default to 2048 dimensions when none specified', function () {
+    Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['dimensions'] === 2048);
+});
+
+function fakeJinaEmbeddingsResponse()
+{
+    return Http::response([
+        'model' => 'jina-embeddings-v4',
+        'object' => 'list',
+        'usage' => ['total_tokens' => 10],
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+        ],
+    ]);
+}

--- a/tests/Feature/Providers/Jina/EmbeddingTest.php
+++ b/tests/Feature/Providers/Jina/EmbeddingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 
@@ -14,14 +15,14 @@ beforeEach(function () {
 test('embeddings request includes model, input, and dimensions', function () {
     Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
 
-    Embeddings::for(['Hello world'])->dimensions(2048)->generate(provider: 'jina', model: 'jina-embeddings-v4');
+    Embeddings::for(['Hello world'])->dimensions(1024)->generate(provider: 'jina', model: 'jina-embeddings-v4');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
 
         return $body['model'] === 'jina-embeddings-v4'
             && $body['input'][0]['text'] === 'Hello world'
-            && $body['dimensions'] === 2048
+            && $body['dimensions'] === 1024
             && $body['task'] === 'retrieval.passage'
             && $request->url() === 'https://api.jina.ai/v1/embeddings';
     });
@@ -44,10 +45,22 @@ test('embeddings request sends bearer token', function () {
 
     Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
 
-    Http::assertSent(function (Request $request) {
-        return $request->hasHeader('Authorization', 'Bearer test-key');
-    });
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
 });
+
+test('embeddings use default model when none specified', function () {
+    Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['model'] === 'jina-embeddings-v4');
+});
+
+test('embeddings throw when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+})->throws(RequestException::class);
 
 test('multiple inputs return multiple embeddings', function () {
     Http::fake(['*' => Http::response([

--- a/tests/Feature/Providers/Jina/RerankingTest.php
+++ b/tests/Feature/Providers/Jina/RerankingTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Reranking;
+use Laravel\Ai\Responses\Data\RankedDocument;
+
+beforeEach(function () {
+    config(['ai.providers.jina' => [
+        ...config('ai.providers.jina'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('reranking request includes model, query, and documents', function () {
+    Http::fake(['*' => fakeJinaRerankingResponse()]);
+
+    Reranking::of(['Laravel is a PHP framework', 'React is a JS library'])
+        ->rerank('What is Laravel?', provider: 'jina', model: 'jina-reranker-v3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'jina-reranker-v3'
+            && $body['query'] === 'What is Laravel?'
+            && $body['documents'] === ['Laravel is a PHP framework', 'React is a JS library']
+            && ! array_key_exists('top_n', $body)
+            && $request->url() === 'https://api.jina.ai/v1/rerank';
+    });
+});
+
+test('reranking request includes top_n when limit set', function () {
+    Http::fake(['*' => fakeJinaRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B', 'Doc C'])
+        ->limit(2)
+        ->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['top_n'] === 2);
+});
+
+test('reranking response is correctly parsed into RankedDocuments', function () {
+    Http::fake(['*' => fakeJinaRerankingResponse()]);
+
+    $response = Reranking::of(['Laravel is a PHP framework', 'React is a JS library'])
+        ->rerank('What is Laravel?', provider: 'jina', model: 'jina-reranker-v3');
+
+    expect($response)->toHaveCount(2)
+        ->and($response->first())->toBeInstanceOf(RankedDocument::class)
+        ->and($response->first()->index)->toBe(0)
+        ->and($response->first()->document)->toBe('Laravel is a PHP framework')
+        ->and($response->first()->score)->toBe(0.95)
+        ->and($response->meta->provider)->toBe('jina')
+        ->and($response->meta->model)->toBe('jina-reranker-v3');
+});
+
+test('reranking request sends bearer token', function () {
+    Http::fake(['*' => fakeJinaRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+function fakeJinaRerankingResponse()
+{
+    return Http::response([
+        'results' => [
+            ['index' => 0, 'relevance_score' => 0.95],
+            ['index' => 1, 'relevance_score' => 0.12],
+        ],
+        'model' => 'jina-reranker-v3',
+        'usage' => ['tokens' => 25],
+    ]);
+}

--- a/tests/Feature/Providers/Jina/RerankingTest.php
+++ b/tests/Feature/Providers/Jina/RerankingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
@@ -61,6 +62,43 @@ test('reranking request sends bearer token', function () {
 
     Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
 });
+
+test('reranking uses default model when none specified', function () {
+    Http::fake(['*' => fakeJinaRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['model'] === 'jina-reranker-v3');
+});
+
+test('reranking maps documents by index when results are returned out of order', function () {
+    Http::fake(['*' => Http::response([
+        'results' => [
+            ['index' => 2, 'relevance_score' => 0.91],
+            ['index' => 0, 'relevance_score' => 0.42],
+            ['index' => 1, 'relevance_score' => 0.10],
+        ],
+        'model' => 'jina-reranker-v3',
+        'usage' => ['tokens' => 25],
+    ])]);
+
+    $response = Reranking::of(['Doc A', 'Doc B', 'Doc C'])
+        ->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
+
+    $ranked = $response->collect();
+
+    expect($ranked[0]->index)->toBe(2)
+        ->and($ranked[0]->document)->toBe('Doc C')
+        ->and($ranked[0]->score)->toBe(0.91)
+        ->and($ranked[1]->index)->toBe(0)
+        ->and($ranked[1]->document)->toBe('Doc A');
+});
+
+test('reranking throws when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
+})->throws(RequestException::class);
 
 function fakeJinaRerankingResponse()
 {


### PR DESCRIPTION
Add comprehensive test coverage for JinaProvider's embeddings and reranking capabilities.

**Changes:**
- Add EmbeddingTest.php with 5 tests covering embeddings API integration
- Add RerankingTest.php with 4 tests covering reranking API integration
- Tests verify request format, response parsing, authentication, and edge cases
- All tests pass and follow established patterns in the codebase

**Test Coverage:**
- Request format validation (model, input/documents, dimensions/top_n)
- Response parsing and object conversion
- Bearer token authentication
- Multiple input handling
- Default dimension values