### PR TITLE
fix(openai, anthropic): cast empty tool args to object

### DIFF
--- a/src/Gateway/Anthropic/Concerns/MapsMessages.php
+++ b/src/Gateway/Anthropic/Concerns/MapsMessages.php
@@ -86,7 +86,7 @@ trait MapsMessages
                     'type' => 'tool_use',
                     'id' => $toolCall->id,
                     'name' => $toolCall->name,
-                    'input' => $toolCall->arguments,
+                    'input' => $toolCall->arguments ?: (object) [],
                 ];
             }
         }

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -93,7 +93,7 @@ trait MapsMessages
                     'call_id' => $toolCall->resultId,
                     'type' => 'function_call',
                     'name' => $toolCall->name,
-                    'arguments' => json_encode($toolCall->arguments),
+                    'arguments' => json_encode($toolCall->arguments ?: (object) []),
                 ];
             }
         }

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -246,6 +249,45 @@ test('uploaded pdf file maps to document content block', function () {
             && $docBlock['source']['type'] === 'base64'
             && $docBlock['source']['media_type'] === 'application/pdf';
     });
+});
+
+test('empty tool arguments serialize as object on assistant replay', function () {
+    $assistant = new AssistantMessage('Listing.', collect([
+        new ToolCall(
+            id: 'toolu_empty',
+            name: 'ListTool',
+            arguments: [],
+        ),
+    ]));
+
+    $gateway = app(AnthropicGateway::class);
+    $method = (new ReflectionClass($gateway))->getMethod('mapMessages');
+    $method->setAccessible(true);
+
+    $mapped = $method->invoke($gateway, [$assistant]);
+    $toolUse = collect($mapped[0]['content'])->firstWhere('type', 'tool_use');
+
+    expect($toolUse['input'])->toBeInstanceOf(stdClass::class)
+        ->and(get_object_vars($toolUse['input']))->toBeEmpty();
+});
+
+test('non-empty tool arguments preserve shape on assistant replay', function () {
+    $assistant = new AssistantMessage('Searching.', collect([
+        new ToolCall(
+            id: 'toolu_args',
+            name: 'SearchTool',
+            arguments: ['query' => 'test'],
+        ),
+    ]));
+
+    $gateway = app(AnthropicGateway::class);
+    $method = (new ReflectionClass($gateway))->getMethod('mapMessages');
+    $method->setAccessible(true);
+
+    $mapped = $method->invoke($gateway, [$assistant]);
+    $toolUse = collect($mapped[0]['content'])->firstWhere('type', 'tool_use');
+
+    expect($toolUse['input'])->toBe(['query' => 'test']);
 });
 
 test('system instructions are not in messages array', function () {

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -165,6 +170,86 @@ test('local image attachment without explicit mime type detects mime from file',
         return $imageBlock !== null
             && str_starts_with($imageBlock['image_url'], 'data:image/png;base64,')
             && ! str_contains($imageBlock['image_url'], 'data:;base64,');
+    });
+});
+
+test('empty tool arguments serialize as object string on assistant replay', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('hi'),
+    ]);
+
+    agent(
+        instructions: 'Hi.',
+        tools: [(new ToolUsingAgent(fixed: true))->tools()[0]],
+        messages: [
+            new UserMessage('list'),
+            new AssistantMessage('Listing.', collect([
+                new ToolCall(
+                    id: 'call_empty',
+                    name: 'FixedNumberGenerator',
+                    arguments: [],
+                    resultId: 'call_empty',
+                ),
+            ])),
+            new ToolResultMessage(collect([
+                new ToolResult(
+                    id: 'call_empty',
+                    name: 'FixedNumberGenerator',
+                    arguments: [],
+                    result: '42',
+                    resultId: 'call_empty',
+                ),
+            ])),
+            new UserMessage('thanks'),
+        ],
+    )->prompt('', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $fnCall = collect($body['input'] ?? [])
+            ->firstWhere('type', 'function_call');
+
+        return $fnCall && $fnCall['arguments'] === '{}';
+    });
+});
+
+test('non-empty tool arguments preserve shape on assistant replay', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('hi'),
+    ]);
+
+    agent(
+        instructions: 'Hi.',
+        tools: [(new ToolUsingAgent(fixed: true))->tools()[0]],
+        messages: [
+            new UserMessage('search'),
+            new AssistantMessage('Searching.', collect([
+                new ToolCall(
+                    id: 'call_args',
+                    name: 'FixedNumberGenerator',
+                    arguments: ['query' => 'test'],
+                    resultId: 'call_args',
+                ),
+            ])),
+            new ToolResultMessage(collect([
+                new ToolResult(
+                    id: 'call_args',
+                    name: 'FixedNumberGenerator',
+                    arguments: ['query' => 'test'],
+                    result: '42',
+                    resultId: 'call_args',
+                ),
+            ])),
+            new UserMessage('thanks'),
+        ],
+    )->prompt('', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $fnCall = collect($body['input'] ?? [])
+            ->firstWhere('type', 'function_call');
+
+        return $fnCall && json_decode($fnCall['arguments'], true) === ['query' => 'test'];
     });
 });
 

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -5,6 +5,11 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\InvokingTool;
@@ -13,6 +18,8 @@ use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -20,6 +27,7 @@ use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ConversationalAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
 use function Laravel\Ai\agent;
 
@@ -235,6 +243,70 @@ test('agents can use tools', function (string $provider, string $apiKey, string 
     );
 
     expect($response['number'])->toBe(72019);
+})->with('agent-providers');
+
+test('agents can replay empty tool arguments', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
+    $tool = new FixedNumberGenerator;
+    $instructions = 'For every request, call the FixedNumberGenerator tool before answering. Answer with one short sentence.';
+    $firstPrompt = 'What fixed number is available?';
+    $makeAgent = fn (iterable $messages = []) => new class($instructions, $messages, [$tool]) implements Agent, Conversational, HasProviderOptions, HasTools
+    {
+        use Promptable;
+
+        public function __construct(
+            public string $instructions,
+            public iterable $messages,
+            public iterable $tools,
+        ) {}
+
+        public function instructions(): string
+        {
+            return $this->instructions;
+        }
+
+        public function messages(): iterable
+        {
+            return $this->messages;
+        }
+
+        public function tools(): iterable
+        {
+            return $this->tools;
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+            return $provider === Lab::DeepSeek
+                ? ['thinking' => ['type' => 'disabled']]
+                : [];
+        }
+    };
+
+    $firstResponse = $makeAgent()->prompt(
+        $firstPrompt,
+        provider: $provider,
+        model: $model,
+    );
+
+    expect($firstResponse->toolCalls)->toHaveCount(1)
+        ->and($firstResponse->toolCalls->first()->arguments)->toBe([]);
+
+    $secondResponse = $makeAgent([
+        new UserMessage($firstPrompt),
+        ...$firstResponse->messages->all(),
+    ])->prompt(
+        'Thanks. Confirm the fixed number again.',
+        provider: $provider,
+        model: $model,
+    );
+
+    expect($secondResponse->text)->not->toBeEmpty()
+        ->and($secondResponse->toolCalls)->toHaveCount(1)
+        ->and($secondResponse->toolCalls->first()->arguments)->toBe([]);
 })->with('agent-providers');
 
 test('agents can analyze text document attachments', function (string $provider, string $apiKey, string $model) {


### PR DESCRIPTION
This fixes replaying assistant tool calls for Anthropic and OpenAI when a stored `ToolCall` has no arguments. `mapAssistantMessage()` rebuilds the tool blocks from the stored calls, and the empty case was being serialized as `[]` instead of `{}`. Both APIs reject that shape on replay, so conversations that included argument-less tool calls would 400.

The change is just to cast the empty case to `(object) []` via `$toolCall->arguments ?: (object) []`, which matches what Groq, Mistral, and Xai already do. Non-empty arguments are unchanged.

Gemini already got its version of this in #409 by skipping empty args entirely, but Anthropic and OpenAI were missed there. This came up off the back of #388 for Gemini, and we linked that thread to #389.

I validated this against both live APIs. Anthropic was returning a 400 on the tool input shape, and OpenAI was returning a 400 on the arguments shape. This adds four tests covering empty and non-empty arguments for both gateways. Existing Groq/Mistral/Xai coverage stays green.
