### PR TITLE
Add missing timeout to VoyageAiGateway HTTP client

### DIFF
--- a/src/Gateway/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAiGateway.php
@@ -52,6 +52,7 @@ class VoyageAiGateway implements RerankingGateway
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
+            ->timeout(30)
             ->throw();
     }
 }


### PR DESCRIPTION
## What

`VoyageAiGateway::client()` was missing a `->timeout()` call, meaning HTTP requests could hang indefinitely. `CohereGateway` and `JinaGateway` both apply a 30-second timeout — this brings `VoyageAiGateway` in line with that.

## Why

Consistent timeout behaviour across all gateway HTTP clients prevents requests from hanging under slow or unresponsive upstream APIs.