### PR TITLE
Remove redundant match expressions in ElevenLabsGateway

### DIFF
--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -62,13 +62,10 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         bool $diarize = false,
         int $timeout = 30
     ): TranscriptionResponse {
-        $audioContent = $audio->content();
-        $mimeType = $audio->mimeType();
-
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
             'xi-api-key' => $provider->providerCredentials()['key'],
         ])->timeout($timeout)->attach(
-            'file', $audioContent, 'file', ['Content-Type' => $mimeType],
+            'file', $audio->content(), 'file', ['Content-Type' => $audio->mimeType()],
         )->post('https://api.elevenlabs.io/v1/speech-to-text', [
             'model_id' => $model,
             'language' => $language,

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -62,13 +62,8 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         bool $diarize = false,
         int $timeout = 30
     ): TranscriptionResponse {
-        $audioContent = match (true) {
-            $audio instanceof TranscribableAudio => $audio->content(),
-        };
-
-        $mimeType = match (true) {
-            $audio instanceof TranscribableAudio => $audio->mimeType(),
-        };
+        $audioContent = $audio->content();
+        $mimeType = $audio->mimeType();
 
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
             'xi-api-key' => $provider->providerCredentials()['key'],


### PR DESCRIPTION
## What

`generateTranscription()` used two `match (true)` expressions that each had a single arm — `$audio instanceof TranscribableAudio`. Since `$audio` is already typed as `TranscribableAudio` in the method signature, the condition is always true and the match adds no value.

## Why

Simplifies the code and removes the risk of an `UnhandledMatchError` if PHP ever evaluates the match with no matching arm (e.g. in a mocked test context). Direct method calls on the typed parameter are clearer.