### PR TITLE
Add HandlesFailoverErrors to CohereGateway and JinaGateway

### DIFF
--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
 use Laravel\Ai\Responses\EmbeddingsResponse;
@@ -16,6 +17,8 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class CohereGateway implements EmbeddingGateway, RerankingGateway
 {
+    use HandlesFailoverErrors;
+
     /**
      * Generate embedding vectors representing the given inputs.
      *
@@ -28,12 +31,15 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         int $dimensions,
         int $timeout = 30,
     ): EmbeddingsResponse {
-        $response = $this->client($provider, $timeout)->post('/embed', [
-            'model' => $model,
-            'texts' => $inputs,
-            'input_type' => 'search_document',
-            'embedding_types' => ['float'],
-        ]);
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('/embed', [
+                'model' => $model,
+                'texts' => $inputs,
+                'input_type' => 'search_document',
+                'embedding_types' => ['float'],
+            ]),
+        );
 
         $data = $response->json();
 
@@ -56,12 +62,15 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         string $query,
         ?int $limit = null
     ): RerankingResponse {
-        $response = $this->client($provider)->post('/rerank', array_filter([
-            'model' => $model,
-            'query' => $query,
-            'documents' => $documents,
-            'top_n' => $limit,
-        ]));
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('/rerank', array_filter([
+                'model' => $model,
+                'query' => $query,
+                'documents' => $documents,
+                'top_n' => $limit,
+            ])),
+        );
 
         $data = $response->json();
 

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
 use Laravel\Ai\Responses\EmbeddingsResponse;
@@ -16,6 +17,8 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class JinaGateway implements EmbeddingGateway, RerankingGateway
 {
+    use HandlesFailoverErrors;
+
     /**
      * Generate embedding vectors representing the given inputs.
      *
@@ -28,12 +31,15 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         int $dimensions,
         int $timeout = 30,
     ): EmbeddingsResponse {
-        $response = $this->client($provider, $timeout)->post('/embeddings', [
-            'model' => $model,
-            'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
-            'dimensions' => $dimensions,
-            'task' => 'retrieval.passage',
-        ]);
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('/embeddings', [
+                'model' => $model,
+                'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
+                'dimensions' => $dimensions,
+                'task' => 'retrieval.passage',
+            ]),
+        );
 
         $data = $response->json();
 
@@ -58,12 +64,15 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         string $query,
         ?int $limit = null
     ): RerankingResponse {
-        $response = $this->client($provider)->post('/rerank', array_filter([
-            'model' => $model,
-            'query' => $query,
-            'documents' => $documents,
-            'top_n' => $limit,
-        ]));
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('/rerank', array_filter([
+                'model' => $model,
+                'query' => $query,
+                'documents' => $documents,
+                'top_n' => $limit,
+            ])),
+        );
 
         $data = $response->json();
 


### PR DESCRIPTION
## What

`CohereGateway` and `JinaGateway` were making raw HTTP calls without any error handling. Every other gateway uses the `HandlesFailoverErrors` concern to convert 429 and 503 responses into `RateLimitedException` and `ProviderOverloadedException` — enabling the failover system to kick in automatically.

This adds the trait to both gateways and wraps each HTTP call with `withErrorHandling()`.

## Why

Without this, a rate limit or overload response from Cohere or Jina would bubble up as a raw `RequestException` rather than a failoverable exception, meaning the SDK's failover mechanism would never trigger for these providers.