### PR TITLE
Add test suite for CohereProvider (embeddings and reranking)

### DIFF
--- a/tests/Feature/Providers/Cohere/EmbeddingTest.php
+++ b/tests/Feature/Providers/Cohere/EmbeddingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+beforeEach(function () {
+    config(['ai.providers.cohere' => [
+        ...config('ai.providers.cohere'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('embeddings request includes model, texts, input_type, and embedding_types', function () {
+    Http::fake(['*' => fakeCohereEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello world'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'embed-v4.0'
+            && $body['texts'] === ['Hello world']
+            && $body['input_type'] === 'search_document'
+            && $body['embedding_types'] === ['float']
+            && $request->url() === 'https://api.cohere.com/v2/embed';
+    });
+});
+
+test('embeddings response is correctly parsed', function () {
+    Http::fake(['*' => fakeCohereEmbeddingsResponse()]);
+
+    $response = Embeddings::for(['Hello world'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect($response->embeddings)->toHaveCount(1)
+        ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
+        ->and($response->tokens)->toBe(10)
+        ->and($response->meta->provider)->toBe('cohere')
+        ->and($response->meta->model)->toBe('embed-v4.0');
+});
+
+test('embeddings request sends bearer token', function () {
+    Http::fake(['*' => fakeCohereEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('embeddings use default model when none specified', function () {
+    Http::fake(['*' => fakeCohereEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['model'] === 'embed-v4.0');
+});
+
+test('multiple inputs return multiple embeddings', function () {
+    Http::fake(['*' => Http::response([
+        'embeddings' => ['float' => [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]],
+        'meta' => ['billed_units' => ['input_tokens' => 20]],
+    ])]);
+
+    $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6]);
+});
+
+test('embeddings throw when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+})->throws(RequestException::class);
+
+function fakeCohereEmbeddingsResponse()
+{
+    return Http::response([
+        'embeddings' => ['float' => [[0.1, 0.2, 0.3]]],
+        'meta' => ['billed_units' => ['input_tokens' => 10]],
+    ]);
+}

--- a/tests/Feature/Providers/Cohere/RerankingTest.php
+++ b/tests/Feature/Providers/Cohere/RerankingTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Reranking;
+use Laravel\Ai\Responses\Data\RankedDocument;
+
+beforeEach(function () {
+    config(['ai.providers.cohere' => [
+        ...config('ai.providers.cohere'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('reranking request includes model, query, and documents', function () {
+    Http::fake(['*' => fakeCohereRerankingResponse()]);
+
+    Reranking::of(['Laravel is a PHP framework', 'React is a JS library'])
+        ->rerank('What is Laravel?', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'rerank-v3.5'
+            && $body['query'] === 'What is Laravel?'
+            && $body['documents'] === ['Laravel is a PHP framework', 'React is a JS library']
+            && ! array_key_exists('top_n', $body)
+            && $request->url() === 'https://api.cohere.com/v2/rerank';
+    });
+});
+
+test('reranking request includes top_n when limit set', function () {
+    Http::fake(['*' => fakeCohereRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B', 'Doc C'])
+        ->limit(2)
+        ->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['top_n'] === 2);
+});
+
+test('reranking response is correctly parsed into RankedDocuments', function () {
+    Http::fake(['*' => fakeCohereRerankingResponse()]);
+
+    $response = Reranking::of(['Laravel is a PHP framework', 'React is a JS library'])
+        ->rerank('What is Laravel?', provider: 'cohere', model: 'rerank-v3.5');
+
+    expect($response)->toHaveCount(2)
+        ->and($response->first())->toBeInstanceOf(RankedDocument::class)
+        ->and($response->first()->index)->toBe(0)
+        ->and($response->first()->document)->toBe('Laravel is a PHP framework')
+        ->and($response->first()->score)->toBe(0.95)
+        ->and($response->meta->provider)->toBe('cohere')
+        ->and($response->meta->model)->toBe('rerank-v3.5');
+});
+
+test('reranking request sends bearer token', function () {
+    Http::fake(['*' => fakeCohereRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('reranking uses default model when none specified', function () {
+    Http::fake(['*' => fakeCohereRerankingResponse()]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['model'] === 'rerank-v3.5');
+});
+
+test('reranking maps documents by index when results are returned out of order', function () {
+    Http::fake(['*' => Http::response([
+        'results' => [
+            ['index' => 2, 'relevance_score' => 0.91],
+            ['index' => 0, 'relevance_score' => 0.42],
+            ['index' => 1, 'relevance_score' => 0.10],
+        ],
+    ])]);
+
+    $response = Reranking::of(['Doc A', 'Doc B', 'Doc C'])
+        ->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+
+    $ranked = $response->collect();
+
+    expect($ranked[0]->index)->toBe(2)
+        ->and($ranked[0]->document)->toBe('Doc C')
+        ->and($ranked[0]->score)->toBe(0.91)
+        ->and($ranked[1]->index)->toBe(0)
+        ->and($ranked[1]->document)->toBe('Doc A');
+});
+
+test('reranking throws when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+})->throws(RequestException::class);
+
+function fakeCohereRerankingResponse()
+{
+    return Http::response([
+        'results' => [
+            ['index' => 0, 'relevance_score' => 0.95],
+            ['index' => 1, 'relevance_score' => 0.12],
+        ],
+    ]);
+}


### PR DESCRIPTION
Adds comprehensive test coverage for the Cohere provider, mirroring the existing pattern used for Jina and VoyageAi.

## Coverage

**Embeddings (6 tests):**
- Request format (model, texts, input_type, embedding_types, URL)
- Response parsing (embeddings, tokens, meta)
- Bearer token authentication
- Default model resolution (`embed-v4.0`)
- Multiple input handling
- Error propagation (`RequestException` on 4xx)

**Reranking (7 tests):**
- Request format (model, query, documents, URL, `top_n` omission)
- `top_n` inclusion when `limit()` is set
- Response parsing into `RankedDocument` objects
- Bearer token authentication
- Default model resolution (`rerank-v3.5`)
- Index-to-document mapping with out-of-order results
- Error propagation (`RequestException` on 4xx)

All 13 tests pass with 28 assertions.