### PR TITLE
Add test suite for ElevenLabsProvider (audio and transcription)

### DIFF
--- a/tests/Feature/Providers/ElevenLabs/AudioTest.php
+++ b/tests/Feature/Providers/ElevenLabs/AudioTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+
+beforeEach(function () {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio request includes model_id, text, and resolves default-female voice', function () {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello world')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model_id'] === 'eleven_multilingual_v2'
+            && $body['text'] === 'Hello world'
+            && $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/XrExE9yKIg1WjnnlVkGX';
+    });
+});
+
+test('audio request resolves default-male voice alias', function () {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->male()->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $request) => $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/onwK4e9ZLuTAKqWW03F9');
+});
+
+test('audio request passes custom voice id through unchanged', function () {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->voice('my-custom-voice-id')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $request) => $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/my-custom-voice-id');
+});
+
+test('audio request sends xi-api-key header', function () {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('xi-api-key', 'test-key'));
+});
+
+test('audio response is base64-encoded with audio/mpeg mime type', function () {
+    Http::fake(['*' => Http::response('raw-audio-bytes')]);
+
+    $response = Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    expect($response->audio)->toBe(base64_encode('raw-audio-bytes'))
+        ->and($response->mimeType())->toBe('audio/mpeg')
+        ->and($response->meta->provider)->toBe('eleven')
+        ->and($response->meta->model)->toBe('eleven_multilingual_v2');
+});
+
+test('audio uses default model when none specified', function () {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'eleven');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['model_id'] === 'eleven_multilingual_v2');
+});
+
+test('audio throws when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
+
+    Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+})->throws(RequestException::class);
+
+function fakeElevenAudioResponse()
+{
+    return Http::response('fake-audio-bytes');
+}

--- a/tests/Feature/Providers/ElevenLabs/TranscriptionTest.php
+++ b/tests/Feature/Providers/ElevenLabs/TranscriptionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Transcription;
+
+beforeEach(function () {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('transcription request posts to speech-to-text with model, language, and diarize flag', function () {
+    Http::fake(['*' => fakeElevenTranscriptionResponse()]);
+
+    Transcription::of(base64_encode('fake-audio'))
+        ->language('en')
+        ->generate(provider: 'eleven', model: 'scribe_v2');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'https://api.elevenlabs.io/v1/speech-to-text'
+            && $request->isMultipart()
+            && collect($request->data())->contains(fn ($part) => $part['name'] === 'model_id' && $part['contents'] === 'scribe_v2')
+            && collect($request->data())->contains(fn ($part) => $part['name'] === 'language' && $part['contents'] === 'en')
+            && collect($request->data())->contains(fn ($part) => $part['name'] === 'diarize' && $part['contents'] === 'false');
+    });
+});
+
+test('transcription request sends diarize=true when enabled', function () {
+    Http::fake(['*' => fakeElevenTranscriptionResponse(diarized: true)]);
+
+    Transcription::of(base64_encode('fake-audio'))
+        ->diarize()
+        ->generate(provider: 'eleven', model: 'scribe_v2');
+
+    Http::assertSent(
+        fn (Request $request) => collect($request->data())
+            ->contains(fn ($part) => $part['name'] === 'diarize' && $part['contents'] === 'true')
+    );
+});
+
+test('transcription request sends xi-api-key header', function () {
+    Http::fake(['*' => fakeElevenTranscriptionResponse()]);
+
+    Transcription::of(base64_encode('fake-audio'))->generate(provider: 'eleven', model: 'scribe_v2');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('xi-api-key', 'test-key'));
+});
+
+test('transcription response returns plain text with no segments when diarize is off', function () {
+    Http::fake(['*' => fakeElevenTranscriptionResponse()]);
+
+    $response = Transcription::of(base64_encode('fake-audio'))->generate(provider: 'eleven', model: 'scribe_v2');
+
+    expect($response->text)->toBe('Hello world')
+        ->and($response->segments)->toHaveCount(0)
+        ->and($response->meta->provider)->toBe('eleven')
+        ->and($response->meta->model)->toBe('scribe_v2');
+});
+
+test('transcription response builds segments from words when diarize is on', function () {
+    Http::fake(['*' => fakeElevenTranscriptionResponse(diarized: true)]);
+
+    $response = Transcription::of(base64_encode('fake-audio'))
+        ->diarize()
+        ->generate(provider: 'eleven', model: 'scribe_v2');
+
+    expect($response->segments)->toHaveCount(2)
+        ->and($response->segments[0]->text)->toBe('Hello')
+        ->and($response->segments[0]->speaker)->toBe('speaker_0')
+        ->and($response->segments[0]->startSeconds)->toBe(0.0)
+        ->and($response->segments[0]->endSeconds)->toBe(0.5)
+        ->and($response->segments[1]->text)->toBe('world')
+        ->and($response->segments[1]->speaker)->toBe('speaker_1');
+});
+
+test('transcription filters out non-word segments (e.g. spacing)', function () {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hello world',
+        'words' => [
+            ['type' => 'word', 'text' => 'Hello', 'speaker_id' => 'speaker_0', 'start' => 0.0, 'end' => 0.5],
+            ['type' => 'spacing', 'text' => ' ', 'start' => 0.5, 'end' => 0.6],
+            ['type' => 'word', 'text' => 'world', 'speaker_id' => 'speaker_0', 'start' => 0.6, 'end' => 1.0],
+        ],
+    ])]);
+
+    $response = Transcription::of(base64_encode('fake-audio'))
+        ->diarize()
+        ->generate(provider: 'eleven', model: 'scribe_v2');
+
+    expect($response->segments)->toHaveCount(2)
+        ->and($response->segments->pluck('text')->all())->toBe(['Hello', 'world']);
+});
+
+test('transcription uses default model when none specified', function () {
+    Http::fake(['*' => fakeElevenTranscriptionResponse()]);
+
+    Transcription::of(base64_encode('fake-audio'))->generate(provider: 'eleven');
+
+    Http::assertSent(
+        fn (Request $request) => collect($request->data())
+            ->contains(fn ($part) => $part['name'] === 'model_id' && $part['contents'] === 'scribe_v2')
+    );
+});
+
+test('transcription throws when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
+
+    Transcription::of(base64_encode('fake-audio'))->generate(provider: 'eleven', model: 'scribe_v2');
+})->throws(RequestException::class);
+
+function fakeElevenTranscriptionResponse(bool $diarized = false)
+{
+    $body = ['text' => 'Hello world'];
+
+    if ($diarized) {
+        $body['words'] = [
+            ['type' => 'word', 'text' => 'Hello', 'speaker_id' => 'speaker_0', 'start' => 0.0, 'end' => 0.5],
+            ['type' => 'word', 'text' => 'world', 'speaker_id' => 'speaker_1', 'start' => 0.6, 'end' => 1.0],
+        ];
+    }
+
+    return Http::response($body);
+}


### PR DESCRIPTION
Adds comprehensive test coverage for the ElevenLabs provider, mirroring the existing pattern used for other provider test suites.

## Coverage

**Audio / TTS (7 tests):**
- Request format (`model_id`, `text`, URL with resolved voice id)
- `default-female` alias resolution (`XrExE9yKIg1WjnnlVkGX`)
- `default-male` alias resolution (`onwK4e9ZLuTAKqWW03F9`)
- Custom voice id passed through unchanged
- `xi-api-key` header authentication
- Response base64-encoded with `audio/mpeg` mime type
- Default model resolution (`eleven_multilingual_v2`)
- Error propagation (`RequestException` on 4xx)

**Transcription / STT (8 tests):**
- Multipart request format (`model_id`, `language`, `diarize`)
- `diarize=true` sent when enabled
- `xi-api-key` header authentication
- Plain-text response with no segments when diarize is off
- Segments built from `words` array when diarize is on
- Non-word entries (e.g. `spacing`) filtered out
- Default model resolution (`scribe_v2`)
- Error propagation (`RequestException` on 4xx)

All 15 tests pass with 28 assertions.