### PR TITLE
Memoize ElevenLabs gateway instances

### DIFF
--- a/src/Providers/ElevenLabsProvider.php
+++ b/src/Providers/ElevenLabsProvider.php
@@ -25,7 +25,7 @@ class ElevenLabsProvider extends Provider implements AudioProvider, Transcriptio
      */
     public function audioGateway(): AudioGateway
     {
-        return $this->audioGateway ?? new ElevenLabsGateway;
+        return $this->audioGateway ??= new ElevenLabsGateway;
     }
 
     /**
@@ -33,7 +33,7 @@ class ElevenLabsProvider extends Provider implements AudioProvider, Transcriptio
      */
     public function transcriptionGateway(): TranscriptionGateway
     {
-        return $this->transcriptionGateway ?? new ElevenLabsGateway;
+        return $this->transcriptionGateway ??= new ElevenLabsGateway;
     }
 
     /**

--- a/tests/Feature/Providers/ElevenLabs/GatewayCachingTest.php
+++ b/tests/Feature/Providers/ElevenLabs/GatewayCachingTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Laravel\Ai\Ai;
+
+beforeEach(function () {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio gateway is memoized across calls', function () {
+    $provider = Ai::audioProvider('eleven');
+
+    expect($provider->audioGateway())->toBe($provider->audioGateway());
+});
+
+test('transcription gateway is memoized across calls', function () {
+    $provider = Ai::transcriptionProvider('eleven');
+
+    expect($provider->transcriptionGateway())->toBe($provider->transcriptionGateway());
+});


### PR DESCRIPTION
`ElevenLabsProvider::audioGateway()` and `transcriptionGateway()` use the `??` operator instead of `??=`, so the memoized property is never assigned — every call allocates a fresh `ElevenLabsGateway` instead of reusing the cached one.

This diverges from the pattern every other provider follows (`AnthropicProvider`, `OpenAiProvider`, `CohereProvider`, `JinaProvider`, `VoyageAiProvider`, etc., all use `??=`).

## Fix

```diff
- return $this->audioGateway ?? new ElevenLabsGateway;
+ return $this->audioGateway ??= new ElevenLabsGateway;
```

(and the same for `transcriptionGateway()`)

## Test plan

Includes a regression test that verifies both accessors return the same instance on repeated calls. Verified the test fails on `main` (without the fix) and passes with it.