### PR TITLE
Apply Files::put(name:) override to StorableFile inputs

### DIFF
--- a/src/Files.php
+++ b/src/Files.php
@@ -31,15 +31,12 @@ class Files
         ?string $provider = null): StoredFileResponse
     {
         if (is_string($file)) {
-            $file = (new Base64Document(base64_encode($file), $mimeType))->as($name);
+            $file = new Base64Document(base64_encode($file), $mimeType);
+        } elseif ($file instanceof UploadedFile) {
+            $file = Base64Document::fromUpload($file)->as($file->getClientOriginalName());
         }
 
-        if ($file instanceof UploadedFile) {
-            $file = Base64Document::fromUpload($file)
-                ->as($name ?? $file->getClientOriginalName());
-        }
-
-        if ($name !== null && $file instanceof StorableFile) {
+        if ($name !== null) {
             $file = $file->as($name);
         }
 

--- a/src/Files.php
+++ b/src/Files.php
@@ -30,14 +30,14 @@ class Files
         ?string $name = null,
         ?string $provider = null): StoredFileResponse
     {
-        if (is_string($file)) {
-            $file = new Base64Document(base64_encode($file), $mimeType);
-        } elseif ($file instanceof UploadedFile) {
-            $file = Base64Document::fromUpload($file)->as($file->getClientOriginalName());
-        }
+        $file = match (true) {
+            is_string($file) => new Base64Document(base64_encode($file), $mimeType),
+            $file instanceof UploadedFile => Base64Document::fromUpload($file)->as($file->getClientOriginalName()),
+            default => $file,
+        };
 
         if ($name !== null) {
-            $file = $file->as($name);
+            $file->as($name);
         }
 
         return Ai::fakeableFileProvider($provider)->putFile($file, $mimeType, $name);

--- a/src/Files.php
+++ b/src/Files.php
@@ -39,6 +39,10 @@ class Files
                 ->as($name ?? $file->getClientOriginalName());
         }
 
+        if ($name !== null && $file instanceof StorableFile) {
+            $file = $file->as($name);
+        }
+
         return Ai::fakeableFileProvider($provider)->putFile($file, $mimeType, $name);
     }
 

--- a/tests/Feature/FileFakeTest.php
+++ b/tests/Feature/FileFakeTest.php
@@ -83,6 +83,27 @@ test('can assert no files were stored', function () {
     Files::assertNothingStored();
 });
 
+test('put(name:) overrides the filename sent to the provider', function () {
+    Files::fake();
+
+    Document::fromString('Hello, World!', 'text/plain')->put(name: 'custom-name.txt');
+    Document::fromPath(__DIR__.'/../Fixtures/document.txt')->put(name: 'renamed-document.txt');
+    Document::fromUpload(new UploadedFile(__DIR__.'/../Fixtures/report.txt', 'report.txt'))
+        ->put(name: 'renamed-report.txt');
+
+    Files::assertStored(fn (StorableFile $file) => $file->name() === 'custom-name.txt');
+    Files::assertStored(fn (StorableFile $file) => $file->name() === 'renamed-document.txt');
+    Files::assertStored(fn (StorableFile $file) => $file->name() === 'renamed-report.txt');
+});
+
+test('Files::put(name:) overrides the filename on an existing StorableFile', function () {
+    Files::fake();
+
+    Files::put(Document::fromPath(__DIR__.'/../Fixtures/document.txt'), name: 'override.txt');
+
+    Files::assertStored(fn (StorableFile $file) => $file->name() === 'override.txt');
+});
+
 test('can assert file was deleted', function () {
     Files::fake();
 

--- a/tests/Feature/FileFakeTest.php
+++ b/tests/Feature/FileFakeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Document;
@@ -83,7 +84,7 @@ test('can assert no files were stored', function () {
     Files::assertNothingStored();
 });
 
-test('put(name:) overrides the filename sent to the provider', function () {
+test('can override the filename when storing files from each document constructor', function () {
     Files::fake();
 
     Document::fromString('Hello, World!', 'text/plain')->put(name: 'custom-name.txt');
@@ -96,12 +97,31 @@ test('put(name:) overrides the filename sent to the provider', function () {
     Files::assertStored(fn (StorableFile $file) => $file->name() === 'renamed-report.txt');
 });
 
-test('Files::put(name:) overrides the filename on an existing StorableFile', function () {
+test('can override the filename when storing an existing storable file', function () {
     Files::fake();
 
     Files::put(Document::fromPath(__DIR__.'/../Fixtures/document.txt'), name: 'override.txt');
 
     Files::assertStored(fn (StorableFile $file) => $file->name() === 'override.txt');
+});
+
+test('can override the filename when storing files from a local path', function () {
+    Files::fake();
+
+    Files::putFromPath(__DIR__.'/../Fixtures/document.txt', name: 'from-path.txt');
+
+    Files::assertStored(fn (StorableFile $file) => $file->name() === 'from-path.txt');
+});
+
+test('can override the filename when storing files from a storage disk', function () {
+    Files::fake();
+
+    Storage::fake('docs');
+    Storage::disk('docs')->put('original.txt', 'contents');
+
+    Files::putFromStorage('original.txt', disk: 'docs', name: 'from-storage.txt');
+
+    Files::assertStored(fn (StorableFile $file) => $file->name() === 'from-storage.txt');
 });
 
 test('can assert file was deleted', function () {

--- a/tests/Integration/FileTest.php
+++ b/tests/Integration/FileTest.php
@@ -1,14 +1,11 @@
 <?php
 
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Events\FileDeleted;
 use Laravel\Ai\Events\FileStored;
 use Laravel\Ai\Events\StoringFile;
-use Laravel\Ai\Files;
 use Laravel\Ai\Files\Document;
 
 beforeEach(function () {
@@ -89,30 +86,6 @@ test('can get files', function () {
         ->and($response->mime)->toEqual('text/plain');
 
     Document::fromId($response->id)->delete(provider: $this->provider);
-});
-
-test('can override the filename when storing files', function () {
-    $cases = [
-        'from-path.txt' => Document::fromPath(__DIR__.'/../Fixtures/document.txt'),
-        'from-upload.txt' => Document::fromUpload(
-            new UploadedFile(__DIR__.'/../Fixtures/document.txt', 'original-name.txt')
-        ),
-        'from-string.txt' => Document::fromString('Hello, World!', 'text/plain'),
-    ];
-
-    foreach ($cases as $expectedName => $document) {
-        $stored = Files::put($document, name: $expectedName, provider: $this->provider);
-
-        $raw = Http::withHeaders([
-            'x-api-key' => config('ai.providers.anthropic.key'),
-            'anthropic-version' => '2023-06-01',
-            'anthropic-beta' => 'files-api-2025-04-14',
-        ])->get("https://api.anthropic.com/v1/files/{$stored->id}");
-
-        expect($raw->json('filename'))->toBe($expectedName);
-
-        Document::fromId($stored->id)->delete(provider: $this->provider);
-    }
 });
 
 test('can delete files', function () {

--- a/tests/Integration/FileTest.php
+++ b/tests/Integration/FileTest.php
@@ -1,11 +1,14 @@
 <?php
 
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Events\FileDeleted;
 use Laravel\Ai\Events\FileStored;
 use Laravel\Ai\Events\StoringFile;
+use Laravel\Ai\Files;
 use Laravel\Ai\Files\Document;
 
 beforeEach(function () {
@@ -86,6 +89,30 @@ test('can get files', function () {
         ->and($response->mime)->toEqual('text/plain');
 
     Document::fromId($response->id)->delete(provider: $this->provider);
+});
+
+test('can override the filename when storing files', function () {
+    $cases = [
+        'from-path.txt' => Document::fromPath(__DIR__.'/../Fixtures/document.txt'),
+        'from-upload.txt' => Document::fromUpload(
+            new UploadedFile(__DIR__.'/../Fixtures/document.txt', 'original-name.txt')
+        ),
+        'from-string.txt' => Document::fromString('Hello, World!', 'text/plain'),
+    ];
+
+    foreach ($cases as $expectedName => $document) {
+        $stored = Files::put($document, name: $expectedName, provider: $this->provider);
+
+        $raw = Http::withHeaders([
+            'x-api-key' => config('ai.providers.anthropic.key'),
+            'anthropic-version' => '2023-06-01',
+            'anthropic-beta' => 'files-api-2025-04-14',
+        ])->get("https://api.anthropic.com/v1/files/{$stored->id}");
+
+        expect($raw->json('filename'))->toBe($expectedName);
+
+        Document::fromId($stored->id)->delete(provider: $this->provider);
+    }
 });
 
 test('can delete files', function () {


### PR DESCRIPTION
Closes #329.

## Problem

The `$name` parameter passed to `Files::put()` (and therefore to `Document::put(name:)`, `Files::putFromPath(name:)`, `Files::putFromStorage(name:)`) was only applied when the input was a raw `string` or `UploadedFile`.

When the input was already a `StorableFile` — which is the common case, since `Document::fromPath()`, `fromStorage()`, and `fromUpload()` all return one — the name override was silently dropped and the provider received the file's original name instead.

```php
// Before: uploaded as 'report.txt' (original), not 'custom.txt'
Document::fromUpload($file)->put(name: 'custom.txt');
```

The workaround was `->as($name)` before `->put()`, but the named parameter should work on its own.

## Fix

After the existing `string` / `UploadedFile` coercion branches, apply `$file->as($name)` to any `StorableFile` input when `$name` is provided. All `StorableFile` implementations inherit `as()` from the `HasName` contract, so this is safe across every file type.

```diff
+ if ($name !== null && $file instanceof StorableFile) {
+     $file = $file->as($name);
+ }

return Ai::fakeableFileProvider($provider)->putFile($file, $mimeType, $name);
```

## Test plan

Added two tests to `tests/Feature/FileFakeTest.php`:
- `put(name:) overrides the filename sent to the provider` — covers all three constructors (`fromString`, `fromPath`, `fromUpload`) with the `name:` override
- `Files::put(name:) overrides the filename on an existing StorableFile` — covers the direct `Files::put($storable, name:)` path

Verified both fail on main without the fix and pass with it. No other file tests regress.