### PR TITLE
Add AWS Bedrock provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@
 
 The Laravel AI SDK provides a unified, expressive API for interacting with AI providers such as OpenAI, Anthropic, Gemini, and more. With the AI SDK, you can build intelligent agents with tools and structured output, generate images, synthesize and transcribe audio, create vector embeddings, and much more — all using a consistent, Laravel-friendly interface.
 
+## AWS Bedrock
+
+The SDK includes first-class `bedrock` provider support for text generation (including streaming), embeddings, and image generation.
+
+Configure the provider in `config/ai.php` using the built-in `bedrock` block:
+
+- `region` sets your Bedrock runtime region.
+- `key` / `secret` / `session_token` enable explicit AWS credentials.
+- `use_default_credential_provider` allows IAM role / profile / environment based auth.
+
+Authentication precedence is:
+
+1. explicit credentials (`key` + `secret`, with optional `session_token`)
+2. AWS default credential chain when explicit credentials are not provided
+
 ## Documentation
 
 Documentation for the Laravel AI SDK can be found on the [Laravel website](https://laravel.com/docs/ai-sdk).

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     },
     "require": {
         "php": "^8.3",
+        "aws/aws-sdk-php": "^3.379",
         "illuminate/console": "^12.0|^13.0",
         "illuminate/container": "^12.0|^13.0",
         "illuminate/contracts": "^12.0|^13.0",

--- a/config/ai.php
+++ b/config/ai.php
@@ -65,6 +65,16 @@ return [
             'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
         ],
 
+        'bedrock' => [
+            'driver' => 'bedrock',
+            'region' => env('AWS_REGION', 'us-east-1'),
+            'url' => env('AWS_BEDROCK_URL'),
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'session_token' => env('AWS_SESSION_TOKEN'),
+            'use_default_credential_provider' => env('AWS_USE_DEFAULT_CREDENTIAL_PROVIDER', true),
+        ],
+
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -15,10 +15,12 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
+use Laravel\Ai\Gateway\Bedrock\BedrockGateway;
 use Laravel\Ai\Gateway\Gemini\GeminiGateway;
 use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Gateway\Prism\PrismGateway;
 use Laravel\Ai\Providers\AnthropicProvider;
+use Laravel\Ai\Providers\BedrockProvider;
 use Laravel\Ai\Providers\AzureOpenAiProvider;
 use Laravel\Ai\Providers\CohereProvider;
 use Laravel\Ai\Providers\DeepSeekProvider;
@@ -295,6 +297,18 @@ class AiManager extends MultipleInstanceManager
     public function createAzureDriver(array $config): AzureOpenAiProvider
     {
         return new AzureOpenAiProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create an AWS Bedrock powered instance.
+     */
+    public function createBedrockDriver(array $config): BedrockProvider
+    {
+        return new BedrockProvider(
+            new BedrockGateway($this->app['events']),
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Enums;
 enum Lab: string
 {
     case Anthropic = 'anthropic';
+    case Bedrock = 'bedrock';
     case Azure = 'azure';
     case Cohere = 'cohere';
     case DeepSeek = 'deepseek';

--- a/src/Gateway/Bedrock/BedrockGateway.php
+++ b/src/Gateway/Bedrock/BedrockGateway.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Bedrock;
+
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Files\Image as ImageFile;
+use Laravel\Ai\Gateway\Bedrock\Concerns\CreatesBedrockClient;
+use Laravel\Ai\Gateway\Prism\PrismException;
+use Laravel\Ai\Gateway\Prism\PrismGateway;
+use Laravel\Ai\Gateway\Prism\PrismUsage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\GeneratedImage;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\ImageResponse;
+use Prism\Prism\Enums\Provider as PrismProvider;
+use Prism\Prism\Exceptions\PrismException as PrismVendorException;
+use Prism\Prism\Facades\Prism;
+
+class BedrockGateway extends PrismGateway
+{
+    use CreatesBedrockClient;
+
+    /**
+     * Configure the given pending Prism request for Bedrock.
+     */
+    protected function configure($prism, Provider $provider, string $model): mixed
+    {
+        return $prism->using(
+            static::toPrismProvider($provider),
+            $model,
+            $this->bedrockProviderConfig($provider),
+        );
+    }
+
+    /**
+     * Generate an image.
+     *
+     * @param  array<ImageFile>  $attachments
+     * @param  '3:2'|'2:3'|'1:1'  $size
+     * @param  'low'|'medium'|'high'  $quality
+     */
+    public function generateImage(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments = [],
+        ?string $size = null,
+        ?string $quality = null,
+        ?int $timeout = null,
+    ): ImageResponse {
+        if (! $provider instanceof Provider) {
+            throw new InvalidArgumentException('Bedrock image provider must be an instance of ['.Provider::class.'].');
+        }
+
+        try {
+            $response = Prism::image()
+                ->using(
+                    static::toPrismProvider($provider),
+                    $model,
+                    $this->bedrockProviderConfig($provider),
+                )
+                ->withPrompt($prompt, $this->toPrismImageAttachments($attachments))
+                ->withProviderOptions($provider->defaultImageOptions($size, $quality))
+                ->withClientOptions([
+                    'timeout' => $timeout ?? 120,
+                ])
+                ->generate();
+        } catch (PrismVendorException $e) {
+            throw PrismException::toAiException($e, $provider, $model);
+        }
+
+        return new ImageResponse(
+            (new Collection($response->images))->map(function ($image) {
+                return new GeneratedImage($image->base64, $image->mimeType);
+            }),
+            PrismUsage::toLaravelUsage($response->usage),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Map the given Laravel AI provider to a Prism provider.
+     */
+    protected static function toPrismProvider(Provider $provider): PrismProvider
+    {
+        if ($provider->driver() !== 'bedrock') {
+            return parent::toPrismProvider($provider);
+        }
+
+        if (! defined(PrismProvider::class.'::Bedrock')) {
+            throw new InvalidArgumentException(
+                'Prism provider [Bedrock] is not available. Install prism-php/bedrock and ensure Prism supports Bedrock.'
+            );
+        }
+
+        /** @var PrismProvider */
+        return constant(PrismProvider::class.'::Bedrock');
+    }
+
+}

--- a/src/Gateway/Bedrock/Concerns/CreatesBedrockClient.php
+++ b/src/Gateway/Bedrock/Concerns/CreatesBedrockClient.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Bedrock\Concerns;
+
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesBedrockClient
+{
+    /**
+     * Resolve normalized Bedrock provider config for Prism.
+     */
+    protected function bedrockProviderConfig(Provider $provider): array
+    {
+        $credentials = $provider->providerCredentials();
+        $configuration = $provider->additionalConfiguration();
+
+        $hasStaticCredentials = filled($credentials['key'] ?? null)
+            && filled($credentials['secret'] ?? null);
+
+        return array_filter([
+            ...$configuration,
+            'api_key' => $credentials['key'] ?? null,
+            'api_secret' => $credentials['secret'] ?? null,
+            'session_token' => $credentials['session_token'] ?? null,
+            'use_default_credential_provider' => $hasStaticCredentials
+                ? false
+                : ($configuration['use_default_credential_provider'] ?? true),
+        ], fn (mixed $value) => ! is_null($value));
+    }
+}

--- a/src/Providers/BedrockProvider.php
+++ b/src/Providers/BedrockProvider.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+
+class BedrockProvider extends Provider implements EmbeddingProvider, ImageProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesImages;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasImageGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    /**
+     * Get the credentials for the Bedrock provider.
+     */
+    public function providerCredentials(): array
+    {
+        return array_filter([
+            'key' => $this->config['key'] ?? null,
+            'secret' => $this->config['secret'] ?? null,
+            'session_token' => $this->config['session_token'] ?? null,
+        ]);
+    }
+
+    /**
+     * Get the provider connection configuration other than credentials.
+     */
+    public function additionalConfiguration(): array
+    {
+        return array_filter([
+            'region' => $this->config['region'] ?? 'us-east-1',
+            'url' => $this->config['url'] ?? null,
+            'use_default_credential_provider' => $this->config['use_default_credential_provider'] ?? true,
+        ], fn (mixed $value) => ! is_null($value));
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['text']['default'] ?? 'anthropic.claude-3-5-sonnet-20241022-v2:0';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['text']['cheapest'] ?? 'amazon.nova-lite-v1:0';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['text']['smartest'] ?? 'anthropic.claude-opus-4-1-20250805-v1:0';
+    }
+
+    /**
+     * Get the name of the default image model.
+     */
+    public function defaultImageModel(): string
+    {
+        return $this->config['models']['image']['default'] ?? 'amazon.nova-canvas-v1:0';
+    }
+
+    /**
+     * Get the default / normalized image options for the provider.
+     */
+    public function defaultImageOptions(?string $size = null, $quality = null): array
+    {
+        return array_filter([
+            'aspect_ratio' => match ($size) {
+                '1:1' => '1:1',
+                '2:3' => '2:3',
+                '3:2' => '3:2',
+                default => null,
+            },
+            'quality' => match ($quality) {
+                'high' => 'premium',
+                'medium' => 'standard',
+                'low' => 'draft',
+                default => null,
+            },
+        ]);
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['models']['embeddings']['default'] ?? 'amazon.titan-embed-text-v2:0';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return $this->config['models']['embeddings']['dimensions'] ?? 1024;
+    }
+}

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -21,6 +21,7 @@ dataset('reranking-providers', [
 
 dataset('agent-providers', [
     'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
+    'bedrock' => ['bedrock', 'AWS_ACCESS_KEY_ID', 'anthropic.claude-3-5-sonnet-20241022-v2:0'],
     'azure' => ['azure', 'AZURE_OPENAI_API_KEY', 'gpt-5.4-mini'],
     'deepseek' => ['deepseek', 'DEEPSEEK_API_KEY', 'deepseek-chat'],
     'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -1,12 +1,21 @@
 <?php
 
 use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\BedrockProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 
 test('can get an openai provider instance', function () {
     expect(Ai::textProvider('openai'))->toBeInstanceOf(OpenAiProvider::class);
 });
 
+test('can get a bedrock provider instance', function () {
+    expect(Ai::textProvider('bedrock'))->toBeInstanceOf(BedrockProvider::class);
+});
+
 test('provider type is ensured', function () {
     Ai::audioProvider('anthropic');
+})->throws(LogicException::class);
+
+test('bedrock provider type is ensured', function () {
+    Ai::audioProvider('bedrock');
 })->throws(LogicException::class);

--- a/tests/Feature/Providers/Bedrock/BedrockProviderTest.php
+++ b/tests/Feature/Providers/Bedrock/BedrockProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\BedrockProvider;
+
+beforeEach(function () {
+    config(['ai.providers.bedrock' => [
+        ...config('ai.providers.bedrock'),
+        'name' => 'bedrock',
+        'key' => 'AKIA_TEST_KEY',
+        'secret' => 'super-secret',
+        'session_token' => 'session-token',
+        'region' => 'us-west-2',
+        'url' => 'https://bedrock-runtime.us-west-2.amazonaws.com',
+        'use_default_credential_provider' => false,
+    ]]);
+});
+
+test('bedrock provider is resolved for text embeddings and images', function () {
+    expect(Ai::textProvider('bedrock'))->toBeInstanceOf(BedrockProvider::class)
+        ->and(Ai::embeddingProvider('bedrock'))->toBeInstanceOf(BedrockProvider::class)
+        ->and(Ai::imageProvider('bedrock'))->toBeInstanceOf(BedrockProvider::class);
+});
+
+test('bedrock provider credentials include aws keys when provided', function () {
+    $provider = Ai::textProvider('bedrock');
+
+    expect($provider->providerCredentials())->toBe([
+        'key' => 'AKIA_TEST_KEY',
+        'secret' => 'super-secret',
+        'session_token' => 'session-token',
+    ]);
+});
+
+test('bedrock provider additional config includes region endpoint and credential strategy', function () {
+    $provider = Ai::textProvider('bedrock');
+
+    expect($provider->additionalConfiguration())->toBe([
+        'region' => 'us-west-2',
+        'url' => 'https://bedrock-runtime.us-west-2.amazonaws.com',
+        'use_default_credential_provider' => false,
+    ]);
+});
+
+test('bedrock provider supports default credential chain without static keys', function () {
+    config(['ai.providers.bedrock' => [
+        ...config('ai.providers.bedrock'),
+        'key' => null,
+        'secret' => null,
+        'session_token' => null,
+        'use_default_credential_provider' => true,
+    ]]);
+
+    $provider = Ai::textProvider('bedrock');
+
+    expect($provider->providerCredentials())->toBe([])
+        ->and($provider->additionalConfiguration()['use_default_credential_provider'])->toBeTrue();
+});
+
+test('bedrock provider model defaults can be overridden by config', function () {
+    config(['ai.providers.bedrock.models' => [
+        'text' => [
+            'default' => 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+            'cheapest' => 'amazon.nova-lite-v1:0',
+            'smartest' => 'anthropic.claude-opus-4-1-20250805-v1:0',
+        ],
+        'image' => [
+            'default' => 'amazon.nova-canvas-v1:0',
+        ],
+        'embeddings' => [
+            'default' => 'amazon.titan-embed-text-v2:0',
+            'dimensions' => 512,
+        ],
+    ]]);
+
+    $provider = Ai::textProvider('bedrock');
+
+    expect($provider->defaultTextModel())->toBe('anthropic.claude-3-5-sonnet-20241022-v2:0')
+        ->and($provider->cheapestTextModel())->toBe('amazon.nova-lite-v1:0')
+        ->and($provider->smartestTextModel())->toBe('anthropic.claude-opus-4-1-20250805-v1:0')
+        ->and($provider->defaultImageModel())->toBe('amazon.nova-canvas-v1:0')
+        ->and($provider->defaultEmbeddingsModel())->toBe('amazon.titan-embed-text-v2:0')
+        ->and($provider->defaultEmbeddingsDimensions())->toBe(512);
+});


### PR DESCRIPTION
Introduce a first-class bedrock driver with provider and gateway wiring for text, streaming, embeddings, and images, including AWS auth configuration for explicit keys or default credential chain. Add Bedrock config/docs updates and targeted tests to validate manager resolution and provider behavior.

Made-with: Cursor