### PR TITLE
Use detected MIME types for OpenAI image attachments

### DIFF
--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -47,11 +47,11 @@ trait MapsAttachments
                 ],
                 $attachment instanceof LocalImage => [
                     'type' => 'input_image',
-                    'image_url' => 'data:'.$attachment->mime.';base64,'.base64_encode(file_get_contents($attachment->path)),
+                    'image_url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(file_get_contents($attachment->path)),
                 ],
                 $attachment instanceof StoredImage => [
                     'type' => 'input_image',
-                    'image_url' => 'data:image/png;base64,'.base64_encode(
+                    'image_url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(
                         Storage::disk($attachment->disk)->get($attachment->path)
                     ),
                 ],

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Tests\Fixtures\Agents\AssistantAgent;
@@ -142,6 +143,62 @@ test('uploaded pdf file maps to input file', function () {
 
         return $fileBlock !== null
             && str_contains($fileBlock['file_data'], 'application/pdf');
+    });
+});
+
+test('local jpg image maps to a jpeg data url', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse(),
+    ]);
+
+    $path = tempnam(sys_get_temp_dir(), 'laravel-ai-').'.jpg';
+    rename(substr($path, 0, -4), $path);
+    file_put_contents($path, base64_decode('/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQEBAQEBAPEA8PEA8PDw8QDw8PEA8QFREWFhURFRUYHSggGBolGxUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGhAQGi0fHR0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAAEAAQMBIgACEQEDEQH/xAAbAAADAQEBAQEAAAAAAAAAAAAABQYDBEcCAf/EADQQAAIBAwMCBAMHAAAAAAAAAAECAwAEEQUSITEGEyJBUWFxgZGh8BRCUsHR4f/EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EACURAQEBAAICAgIDAQAAAAAAAAABAhEDIRIxBEEiUWEUMv/aAAwDAQACEQMRAD8A9WiiigAooooAKKKKACiiigAooooAKKKKACiiigD/2Q=='));
+
+    try {
+        agent('You are helpful.')->prompt(
+            'Describe this image.',
+            attachments: [Files\Image::fromPath($path)],
+            provider: 'openai',
+        );
+
+        Http::assertSent(function (Request $request) {
+            $body = json_decode($request->body(), true);
+            $userMessage = collect($body['input'])->firstWhere('role', 'user');
+            $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+            return $imageBlock !== null
+                && str_starts_with($imageBlock['image_url'], 'data:image/jpeg;base64,');
+        });
+    } finally {
+        @unlink($path);
+    }
+});
+
+test('stored jpg image maps to a jpeg data url', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse(),
+    ]);
+
+    Storage::fake('images');
+    Storage::disk('images')->put(
+        'photo.jpg',
+        base64_decode('/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQEBAQEBAPEA8PEA8PDw8QDw8PEA8QFREWFhURFRUYHSggGBolGxUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGhAQGi0fHR0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAAEAAQMBIgACEQEDEQH/xAAbAAADAQEBAQEAAAAAAAAAAAAABQYDBEcCAf/EADQQAAIBAwMCBAMHAAAAAAAAAAECAwAEEQUSITEGEyJBUWFxgZGh8BRCUsHR4f/EABkBAQEBAQEBAAAAAAAAAAAAAAABAgMEBf/EACURAQEBAAICAgIDAQAAAAAAAAABAhEDIRIxBEEiUWEUMv/aAAwDAQACEQMRAD8A9WiiigAooooAKKKKACiiigAooooAKKKKACiiigD/2Q==')
+    );
+
+    agent('You are helpful.')->prompt(
+        'Describe this image.',
+        attachments: [Files\Image::fromStorage('photo.jpg', 'images')],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+        return $imageBlock !== null
+            && str_starts_with($imageBlock['image_url'], 'data:image/jpeg;base64,');
     });
 });
 


### PR DESCRIPTION
## Summary
Fix OpenAI image attachment mapping for local and stored image files.

## Problem
`Files\Image::fromPath()` could produce an invalid OpenAI image data URL because the OpenAI attachment mapper used the raw image MIME property instead of the file's detected MIME type. When the MIME property was unset, requests could be sent as `data:;base64,...`, which OpenAI rejects with a 400 error.

Fixes #417

## Solution
Updated the OpenAI attachment mapper to use `mimeType()` for local and stored image attachments, while preserving the existing `image/png` fallback when MIME detection is unavailable.

## Tests
Added regression tests covering:
- local `.jpg` images mapped as `data:image/jpeg;base64,...`
- stored `.jpg` images mapped as `data:image/jpeg;base64,...`
