### PR TITLE
use getter functions in toArray method of file classes

### DIFF
--- a/src/Files/Base64Audio.php
+++ b/src/Files/Base64Audio.php
@@ -76,7 +76,7 @@ class Base64Audio extends Audio implements Arrayable, JsonSerializable, Storable
             'type' => 'base64-audio',
             'name' => $this->name(),
             'base64' => $this->base64,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/Base64Audio.php
+++ b/src/Files/Base64Audio.php
@@ -74,9 +74,9 @@ class Base64Audio extends Audio implements Arrayable, JsonSerializable, Storable
     {
         return [
             'type' => 'base64-audio',
-            'name' => $this->name,
+            'name' => $this->name(),
             'base64' => $this->base64,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/Base64Document.php
+++ b/src/Files/Base64Document.php
@@ -63,9 +63,9 @@ class Base64Document extends Document implements Arrayable, JsonSerializable, St
     {
         return [
             'type' => 'base64-document',
-            'name' => $this->name,
+            'name' => $this->name(),
             'base64' => $this->base64,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/Base64Document.php
+++ b/src/Files/Base64Document.php
@@ -65,7 +65,7 @@ class Base64Document extends Document implements Arrayable, JsonSerializable, St
             'type' => 'base64-document',
             'name' => $this->name(),
             'base64' => $this->base64,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/Base64Image.php
+++ b/src/Files/Base64Image.php
@@ -53,7 +53,7 @@ class Base64Image extends Image implements Arrayable, JsonSerializable, Storable
             'type' => 'base64-image',
             'name' => $this->name(),
             'base64' => $this->base64,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/Base64Image.php
+++ b/src/Files/Base64Image.php
@@ -51,9 +51,9 @@ class Base64Image extends Image implements Arrayable, JsonSerializable, Storable
     {
         return [
             'type' => 'base64-image',
-            'name' => $this->name,
+            'name' => $this->name(),
             'base64' => $this->base64,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -23,7 +23,9 @@ trait HasRemoteContent
      */
     public function name(): ?string
     {
-        return $this->name ?? basename(parse_url($this->url, PHP_URL_PATH));
+        $path = parse_url($this->url, PHP_URL_PATH);
+
+        return $this->name ?? basename(is_string($path) ? $path : '');
     }
 
     /**

--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -23,7 +23,7 @@ trait HasRemoteContent
      */
     public function name(): ?string
     {
-        return $this->name ?? basename(parse_url($this->url, PHP_URL_PATH) ?? '');
+        return $this->name ?? basename(parse_url($this->url, PHP_URL_PATH));
     }
 
     /**

--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -23,7 +23,7 @@ trait HasRemoteContent
      */
     public function name(): ?string
     {
-        return $this->name ?? basename(parse_url($this->url, PHP_URL_PATH));
+        return $this->name ?? basename(parse_url($this->url, PHP_URL_PATH) ?? '');
     }
 
     /**

--- a/src/Files/LocalAudio.php
+++ b/src/Files/LocalAudio.php
@@ -78,9 +78,9 @@ class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableF
     {
         return [
             'type' => 'local-audio',
-            'name' => $this->name,
+            'name' => $this->name(),
             'path' => $this->path,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/LocalAudio.php
+++ b/src/Files/LocalAudio.php
@@ -80,7 +80,7 @@ class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableF
             'type' => 'local-audio',
             'name' => $this->name(),
             'path' => $this->path,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/LocalDocument.php
+++ b/src/Files/LocalDocument.php
@@ -67,9 +67,9 @@ class LocalDocument extends Document implements Arrayable, JsonSerializable, Sto
     {
         return [
             'type' => 'local-document',
-            'name' => $this->name,
+            'name' => $this->name(),
             'path' => $this->path,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/LocalDocument.php
+++ b/src/Files/LocalDocument.php
@@ -69,7 +69,7 @@ class LocalDocument extends Document implements Arrayable, JsonSerializable, Sto
             'type' => 'local-document',
             'name' => $this->name(),
             'path' => $this->path,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/LocalImage.php
+++ b/src/Files/LocalImage.php
@@ -69,9 +69,9 @@ class LocalImage extends Image implements Arrayable, JsonSerializable, StorableF
     {
         return [
             'type' => 'local-image',
-            'name' => $this->name,
+            'name' => $this->name(),
             'path' => $this->path,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/LocalImage.php
+++ b/src/Files/LocalImage.php
@@ -71,7 +71,7 @@ class LocalImage extends Image implements Arrayable, JsonSerializable, StorableF
             'type' => 'local-image',
             'name' => $this->name(),
             'path' => $this->path,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/ProviderDocument.php
+++ b/src/Files/ProviderDocument.php
@@ -29,7 +29,7 @@ class ProviderDocument extends Document implements Arrayable, HasProviderId, Jso
         return [
             'type' => 'provider-document',
             'id' => $this->id,
-            'name' => $this->name,
+            'name' => $this->name(),
         ];
     }
 

--- a/src/Files/ProviderImage.php
+++ b/src/Files/ProviderImage.php
@@ -29,7 +29,7 @@ class ProviderImage extends Image implements Arrayable, HasProviderId, JsonSeria
         return [
             'type' => 'provider-image',
             'id' => $this->id,
-            'name' => $this->name,
+            'name' => $this->name(),
         ];
     }
 

--- a/src/Files/RemoteAudio.php
+++ b/src/Files/RemoteAudio.php
@@ -39,7 +39,7 @@ class RemoteAudio extends Audio implements Arrayable, JsonSerializable, Storable
             'type' => 'remote-audio',
             'name' => $this->name(),
             'url' => $this->url,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/RemoteAudio.php
+++ b/src/Files/RemoteAudio.php
@@ -37,9 +37,9 @@ class RemoteAudio extends Audio implements Arrayable, JsonSerializable, Storable
     {
         return [
             'type' => 'remote-audio',
-            'name' => $this->name,
+            'name' => $this->name(),
             'url' => $this->url,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/RemoteDocument.php
+++ b/src/Files/RemoteDocument.php
@@ -28,7 +28,7 @@ class RemoteDocument extends Document implements Arrayable, JsonSerializable, St
             'type' => 'remote-document',
             'name' => $this->name(),
             'url' => $this->url,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/RemoteDocument.php
+++ b/src/Files/RemoteDocument.php
@@ -26,9 +26,9 @@ class RemoteDocument extends Document implements Arrayable, JsonSerializable, St
     {
         return [
             'type' => 'remote-document',
-            'name' => $this->name,
+            'name' => $this->name(),
             'url' => $this->url,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/RemoteImage.php
+++ b/src/Files/RemoteImage.php
@@ -26,9 +26,9 @@ class RemoteImage extends Image implements Arrayable, JsonSerializable, Storable
     {
         return [
             'type' => 'remote-image',
-            'name' => $this->name,
+            'name' => $this->name(),
             'url' => $this->url,
-            'mime' => $this->mime,
+            'mime' => $this->mimeType(),
         ];
     }
 

--- a/src/Files/RemoteImage.php
+++ b/src/Files/RemoteImage.php
@@ -28,7 +28,7 @@ class RemoteImage extends Image implements Arrayable, JsonSerializable, Storable
             'type' => 'remote-image',
             'name' => $this->name(),
             'url' => $this->url,
-            'mime' => $this->mimeType(),
+            'mime' => $this->mime,
         ];
     }
 

--- a/src/Files/StoredAudio.php
+++ b/src/Files/StoredAudio.php
@@ -58,7 +58,7 @@ class StoredAudio extends Audio implements Arrayable, JsonSerializable, Storable
     {
         return [
             'type' => 'stored-audio',
-            'name' => $this->name,
+            'name' => $this->name(),
             'path' => $this->path,
             'disk' => $this->disk ?? config('filesystems.default'),
         ];

--- a/src/Files/StoredDocument.php
+++ b/src/Files/StoredDocument.php
@@ -47,7 +47,7 @@ class StoredDocument extends Document implements Arrayable, JsonSerializable, St
     {
         return [
             'type' => 'stored-document',
-            'name' => $this->name,
+            'name' => $this->name(),
             'path' => $this->path,
             'disk' => $this->disk ?? config('filesystems.default'),
         ];

--- a/src/Files/StoredImage.php
+++ b/src/Files/StoredImage.php
@@ -47,7 +47,7 @@ class StoredImage extends Image implements Arrayable, JsonSerializable, Storable
     {
         return [
             'type' => 'stored-image',
-            'name' => $this->name,
+            'name' => $this->name(),
             'path' => $this->path,
             'disk' => $this->disk ?? config('filesystems.default'),
         ];

--- a/tests/Feature/FileToArrayTest.php
+++ b/tests/Feature/FileToArrayTest.php
@@ -40,7 +40,7 @@ test('stored image toArray falls back to basename', function () {
 });
 
 test('local image toArray uses basename and the raw mime property', function () {
-    $path = tempnam(sys_get_temp_dir(), 'local-image').'.png';
+    $path = tempnam(sys_get_temp_dir(), 'local-image');
     file_put_contents($path, 'data');
 
     try {
@@ -56,7 +56,7 @@ test('local image toArray uses basename and the raw mime property', function () 
 });
 
 test('local image toArray returns the explicitly set mime type', function () {
-    $path = tempnam(sys_get_temp_dir(), 'local-image').'.png';
+    $path = tempnam(sys_get_temp_dir(), 'local-image');
     file_put_contents($path, 'data');
 
     try {
@@ -110,7 +110,15 @@ test('remote document toArray handles urls without a path component', function (
     Http::preventStrayRequests();
     Http::fake();
 
-    $array = Document::fromUrl('https://example.com')->toArray();
+    set_error_handler(static function (int $severity, string $message, string $file, int $line): never {
+        throw new \ErrorException($message, 0, $severity, $file, $line);
+    });
+
+    try {
+        $array = Document::fromUrl('https://example.com')->toArray();
+    } finally {
+        restore_error_handler();
+    }
 
     expect($array['name'])->toBe('');
     expect($array['mime'])->toBeNull();

--- a/tests/Feature/FileToArrayTest.php
+++ b/tests/Feature/FileToArrayTest.php
@@ -105,3 +105,28 @@ test('remote image toArray returns the explicitly set mime type without HTTP cal
 
     Http::assertNothingSent();
 });
+
+test('remote document toArray handles urls without a path component', function () {
+    Http::preventStrayRequests();
+    Http::fake();
+
+    $array = Document::fromUrl('https://example.com')->toArray();
+
+    expect($array['name'])->toBe('');
+    expect($array['mime'])->toBeNull();
+
+    Http::assertNothingSent();
+});
+
+test('local image toArray does not touch the filesystem', function () {
+    $path = '/tmp/this-file-definitely-does-not-exist-'.uniqid().'.png';
+
+    $array = Image::fromPath($path)->toArray();
+
+    expect($array)->toBe([
+        'type' => 'local-image',
+        'name' => basename($path),
+        'path' => $path,
+        'mime' => null,
+    ]);
+});

--- a/tests/Feature/FileToArrayTest.php
+++ b/tests/Feature/FileToArrayTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+
+test('stored document toArray falls back to basename without touching the disk', function () {
+    Storage::fake('docs');
+
+    $array = Document::fromStorage('invoices/invoice-2026-04.pdf', 'docs')->toArray();
+
+    expect($array)->toBe([
+        'type' => 'stored-document',
+        'name' => 'invoice-2026-04.pdf',
+        'path' => 'invoices/invoice-2026-04.pdf',
+        'disk' => 'docs',
+    ]);
+});
+
+test('stored audio toArray falls back to basename', function () {
+    Storage::fake('docs');
+
+    $array = Audio::fromStorage('clips/hello.mp3', 'docs')->toArray();
+
+    expect($array['type'])->toBe('stored-audio');
+    expect($array['name'])->toBe('hello.mp3');
+    expect($array)->not->toHaveKey('mime');
+});
+
+test('stored image toArray falls back to basename', function () {
+    Storage::fake('docs');
+
+    $array = Image::fromStorage('photos/avatar.png', 'docs')->toArray();
+
+    expect($array['type'])->toBe('stored-image');
+    expect($array['name'])->toBe('avatar.png');
+    expect($array)->not->toHaveKey('mime');
+});
+
+test('local image toArray uses basename and the raw mime property', function () {
+    $path = tempnam(sys_get_temp_dir(), 'local-image').'.png';
+    file_put_contents($path, 'data');
+
+    try {
+        $array = Image::fromPath($path)->toArray();
+
+        expect($array['type'])->toBe('local-image');
+        expect($array['name'])->toBe(basename($path));
+        expect($array['path'])->toBe($path);
+        expect($array['mime'])->toBeNull();
+    } finally {
+        @unlink($path);
+    }
+});
+
+test('local image toArray returns the explicitly set mime type', function () {
+    $path = tempnam(sys_get_temp_dir(), 'local-image').'.png';
+    file_put_contents($path, 'data');
+
+    try {
+        $array = Image::fromPath($path)->withMimeType('image/custom')->toArray();
+
+        expect($array['mime'])->toBe('image/custom');
+    } finally {
+        @unlink($path);
+    }
+});
+
+test('base64 document toArray reflects name and mime', function () {
+    $doc = Document::fromString('hello world', 'text/plain')->as('greeting.txt');
+
+    expect($doc->toArray())->toMatchArray([
+        'type' => 'base64-document',
+        'name' => 'greeting.txt',
+        'mime' => 'text/plain',
+    ]);
+});
+
+test('remote document toArray never issues an HTTP request', function () {
+    Http::preventStrayRequests();
+    Http::fake();
+
+    $array = Document::fromUrl('https://example.com/signed/private.pdf')->toArray();
+
+    expect($array)->toBe([
+        'type' => 'remote-document',
+        'name' => 'private.pdf',
+        'url' => 'https://example.com/signed/private.pdf',
+        'mime' => null,
+    ]);
+
+    Http::assertNothingSent();
+});
+
+test('remote image toArray returns the explicitly set mime type without HTTP calls', function () {
+    Http::preventStrayRequests();
+    Http::fake();
+
+    $array = Image::fromUrl('https://example.com/avatar.png')->withMimeType('image/png')->toArray();
+
+    expect($array['mime'])->toBe('image/png');
+    expect($array['name'])->toBe('avatar.png');
+
+    Http::assertNothingSent();
+});


### PR DESCRIPTION
Hello,
i noticed that data that returned in `toArray` was not matching actual data used in `StoredDocument` class, class would use basename of the file in case name was not set which was not reflected in `toArray` function, same goes for `mimeTypes`. I had issue only with `StoredDocument` class but i thought each class's `toArray` using same style would be better