### PR TITLE
Add agent fake test suite for DeepSeek provider

### DIFF
--- a/tests/Feature/Providers/DeepSeek/AgentFakeTest.php
+++ b/tests/Feature/Providers/DeepSeek/AgentFakeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Tests\Fixtures\Agents\DeepSeekAgent;
+
+test('deepseek agent can be faked', function () {
+    DeepSeekAgent::fake(['Test response']);
+
+    $response = (new DeepSeekAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Test response');
+});
+
+test('deepseek agent fake with closure', function () {
+    DeepSeekAgent::fake(fn (string $prompt) => "Echo: {$prompt}");
+
+    $response = (new DeepSeekAgent)->prompt('Hello world');
+
+    expect($response->text)->toBe('Echo: Hello world');
+});
+
+test('deepseek agent fake with no predefined responses', function () {
+    DeepSeekAgent::fake();
+
+    $response = (new DeepSeekAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Fake response for prompt: Hello');
+});
+
+test('deepseek agent fake records prompts', function () {
+    DeepSeekAgent::fake();
+
+    (new DeepSeekAgent)->prompt('Hello');
+
+    DeepSeekAgent::assertPrompted('Hello');
+    DeepSeekAgent::assertNotPrompted('Goodbye');
+});
+
+test('deepseek agent stream can be faked', function () {
+    DeepSeekAgent::fake(['Streamed response']);
+
+    $response = (new DeepSeekAgent)->stream('Hello');
+    $response->each(fn () => true);
+
+    expect($response->text)->toBe('Streamed response');
+});

--- a/tests/Fixtures/Agents/DeepSeekAgent.php
+++ b/tests/Fixtures/Agents/DeepSeekAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider('deepseek')]
+class DeepSeekAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}


### PR DESCRIPTION
## What

Adds `AgentFakeTest.php` and a `DeepSeekAgent` fixture for the DeepSeek provider, covering the standard agent faking scenarios present for all other text providers (Groq, Mistral, Ollama, OpenRouter, Xai).

## Tests added

- Agent can be faked with predefined responses
- Agent fake works with a closure
- Agent fake works with no predefined responses
- Agent fake records prompted inputs
- Agent stream can be faked