### PR TITLE
Add tool mapping test suite for DeepSeek provider

### DIFF
--- a/tests/Feature/Providers/DeepSeek/ToolMappingTest.php
+++ b/tests/Feature/Providers/DeepSeek/ToolMappingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.deepseek' => [
+        ...config('ai.providers.deepseek'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('tool with parameters includes correct schema', function () {
+    Http::fake([
+        '*' => fakeDeepSeekResponse('42'),
+    ]);
+
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'deepseek');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
+
+        return $function['parameters']['type'] === 'object'
+            && array_key_exists('min', $function['parameters']['properties'])
+            && array_key_exists('max', $function['parameters']['properties'])
+            && in_array('min', $function['parameters']['required'])
+            && in_array('max', $function['parameters']['required'])
+            && $function['parameters']['additionalProperties'] === false;
+    });
+});
+
+test('tool with empty schema includes parameters', function () {
+    Http::fake([
+        '*' => fakeDeepSeekResponse('72019'),
+    ]);
+
+    agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'deepseek');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
+
+        return array_key_exists('parameters', $function)
+            && $function['parameters']['type'] === 'object'
+            && $function['parameters']['properties'] === []
+            && $function['parameters']['required'] === []
+            && $function['parameters']['additionalProperties'] === false;
+    });
+});
+
+test('tool parameters are not wrapped in schema definition', function () {
+    Http::fake([
+        '*' => fakeDeepSeekResponse('done'),
+    ]);
+
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'deepseek');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
+
+        return ! array_key_exists('schema_definition', $function['parameters']['properties'] ?? [])
+            && ! in_array('schema_definition', $function['parameters']['required'] ?? []);
+    });
+});


### PR DESCRIPTION
## What

Adds `ToolMappingTest.php` for the DeepSeek provider, covering the standard tool schema mapping scenarios present for all other text providers (Groq, Mistral, Ollama, OpenRouter, Xai).

## Tests added

- Tool with parameters includes the correct JSON schema
- Tool with empty schema includes required parameters structure
- Tool parameters are not wrapped in a schema definition