### PR TITLE
Align Bedrock image and error handling with AWS API

### DIFF
--- a/src/Gateway/Bedrock/BedrockException.php
+++ b/src/Gateway/Bedrock/BedrockException.php
@@ -34,7 +34,11 @@ class BedrockException
         if ($e instanceof BedrockRuntimeException) {
             return match ($e->getAwsErrorCode()) {
                 'ThrottlingException' => RateLimitedException::forProvider($provider, $e->getStatusCode(), $e),
-                'ServiceUnavailableException', 'ModelNotReadyException' => new ProviderOverloadedException(
+                'ServiceUnavailableException',
+                'ModelNotReadyException',
+                'ModelTimeoutException',
+                'ModelStreamErrorException',
+                'InternalServerException' => new ProviderOverloadedException(
                     'AI provider ['.$provider.'] is overloaded or unavailable.',
                     code: $e->getStatusCode(),
                     previous: $e,

--- a/src/Gateway/Bedrock/BedrockImageGateway.php
+++ b/src/Gateway/Bedrock/BedrockImageGateway.php
@@ -36,6 +36,7 @@ class BedrockImageGateway implements ImageGateway
         ?int $timeout = null,
     ): ImageResponse {
         $client = $this->createBedrockClient($provider, $timeout);
+        $options = $provider->defaultImageOptions($size, $quality);
 
         try {
             $response = $this->withErrorHandling(
@@ -44,7 +45,7 @@ class BedrockImageGateway implements ImageGateway
                     'modelId' => $model,
                     'contentType' => 'application/json',
                     'accept' => 'application/json',
-                    'body' => json_encode($this->prepareImageRequestBody($model, $prompt, $size, $quality)),
+                    'body' => json_encode($this->prepareImageRequestBody($model, $prompt, $size, $options)),
                 ]),
             );
         } catch (Throwable $e) {
@@ -62,27 +63,35 @@ class BedrockImageGateway implements ImageGateway
 
     /**
      * Prepare the request body for the given model family.
+     *
+     * @param  array{quality: string, size: string}  $options
      */
-    protected function prepareImageRequestBody(string $model, string $prompt, ?string $size, ?string $quality): array
+    protected function prepareImageRequestBody(string $model, string $prompt, ?string $size, array $options): array
     {
         [$width, $height] = $this->parseSize($size);
+        $quality = $options['quality'];
 
         return match (true) {
-            str_starts_with($model, 'stability.') => [
+            $this->isLegacyStabilityModel($model) => [
                 'text_prompts' => [
                     ['text' => $prompt, 'weight' => 1.0],
                 ],
                 'cfg_scale' => 7.0,
-                'steps' => $quality === 'high' ? 50 : 30,
+                'steps' => $quality === 'premium' ? 50 : 30,
                 'width' => $width,
                 'height' => $height,
             ],
+            str_starts_with($model, 'stability.') => array_filter([
+                'prompt' => $prompt,
+                'aspect_ratio' => $this->stabilityAspectRatio($size),
+                'output_format' => 'png',
+            ]),
             str_starts_with($model, 'amazon.titan-image') => [
                 'taskType' => 'TEXT_IMAGE',
                 'textToImageParams' => ['text' => $prompt],
                 'imageGenerationConfig' => [
                     'numberOfImages' => 1,
-                    'quality' => $quality ?? 'standard',
+                    'quality' => $quality,
                     'height' => $height,
                     'width' => $width,
                     'cfgScale' => 7.0,
@@ -93,7 +102,7 @@ class BedrockImageGateway implements ImageGateway
                 'textToImageParams' => ['text' => $prompt],
                 'imageGenerationConfig' => [
                     'numberOfImages' => 1,
-                    'quality' => $quality ?? 'standard',
+                    'quality' => $quality,
                     'width' => $width,
                     'height' => $height,
                 ],
@@ -103,16 +112,37 @@ class BedrockImageGateway implements ImageGateway
     }
 
     /**
+     * Stability SDXL 1.0 uses a different request shape than the newer Stable Image / SD 3.5 models.
+     */
+    protected function isLegacyStabilityModel(string $model): bool
+    {
+        return str_starts_with($model, 'stability.stable-diffusion-xl');
+    }
+
+    /**
+     * Map our canonical aspect ratios to Stability's accepted aspect_ratio values.
+     */
+    protected function stabilityAspectRatio(?string $size): ?string
+    {
+        return match ($size) {
+            '1:1', '2:3', '3:2' => $size,
+            default => null,
+        };
+    }
+
+    /**
      * Parse the image response payload into GeneratedImage instances.
      */
     protected function parseImageResponse(string $model, array $result): Collection
     {
-        if (str_starts_with($model, 'stability.')) {
+        if ($this->isLegacyStabilityModel($model)) {
             return (new Collection($result['artifacts'] ?? []))
                 ->map(fn ($artifact) => new GeneratedImage($artifact['base64'] ?? '', 'image/png'));
         }
 
-        if (str_starts_with($model, 'amazon.titan-image') || str_starts_with($model, 'amazon.nova-canvas')) {
+        if (str_starts_with($model, 'stability.')
+            || str_starts_with($model, 'amazon.titan-image')
+            || str_starts_with($model, 'amazon.nova-canvas')) {
             return (new Collection($result['images'] ?? []))
                 ->map(fn ($image) => new GeneratedImage($image ?? '', 'image/png'));
         }

--- a/src/Gateway/Bedrock/BedrockImageGateway.php
+++ b/src/Gateway/Bedrock/BedrockImageGateway.php
@@ -72,18 +72,9 @@ class BedrockImageGateway implements ImageGateway
         $quality = $options['quality'];
 
         return match (true) {
-            $this->isLegacyStabilityModel($model) => [
-                'text_prompts' => [
-                    ['text' => $prompt, 'weight' => 1.0],
-                ],
-                'cfg_scale' => 7.0,
-                'steps' => $quality === 'premium' ? 50 : 30,
-                'width' => $width,
-                'height' => $height,
-            ],
             str_starts_with($model, 'stability.') => array_filter([
                 'prompt' => $prompt,
-                'aspect_ratio' => $this->stabilityAspectRatio($size),
+                'aspect_ratio' => in_array($size, ['1:1', '2:3', '3:2'], true) ? $size : null,
                 'output_format' => 'png',
             ]),
             str_starts_with($model, 'amazon.titan-image') => [
@@ -112,34 +103,10 @@ class BedrockImageGateway implements ImageGateway
     }
 
     /**
-     * Stability SDXL 1.0 uses a different request shape than the newer Stable Image / SD 3.5 models.
-     */
-    protected function isLegacyStabilityModel(string $model): bool
-    {
-        return str_starts_with($model, 'stability.stable-diffusion-xl');
-    }
-
-    /**
-     * Map our canonical aspect ratios to Stability's accepted aspect_ratio values.
-     */
-    protected function stabilityAspectRatio(?string $size): ?string
-    {
-        return match ($size) {
-            '1:1', '2:3', '3:2' => $size,
-            default => null,
-        };
-    }
-
-    /**
      * Parse the image response payload into GeneratedImage instances.
      */
     protected function parseImageResponse(string $model, array $result): Collection
     {
-        if ($this->isLegacyStabilityModel($model)) {
-            return (new Collection($result['artifacts'] ?? []))
-                ->map(fn ($artifact) => new GeneratedImage($artifact['base64'] ?? '', 'image/png'));
-        }
-
         if (str_starts_with($model, 'stability.')
             || str_starts_with($model, 'amazon.titan-image')
             || str_starts_with($model, 'amazon.nova-canvas')) {

--- a/src/Providers/BedrockProvider.php
+++ b/src/Providers/BedrockProvider.php
@@ -105,7 +105,11 @@ class BedrockProvider extends Provider implements EmbeddingProvider, ImageProvid
     public function defaultImageOptions(?string $size = null, $quality = null): array
     {
         return [
-            'quality' => $quality ?? 'standard',
+            'quality' => match ($quality) {
+                'high', 'premium' => 'premium',
+                'low', 'medium', 'standard', null => 'standard',
+                default => $quality,
+            },
             'size' => match ($size) {
                 '2:3' => '768x1152',
                 '3:2' => '1152x768',

--- a/tests/Unit/Gateway/Bedrock/BedrockExceptionTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockExceptionTest.php
@@ -58,6 +58,30 @@ test('model not ready maps to provider overloaded', function () {
     expect($aiException)->toBeInstanceOf(ProviderOverloadedException::class);
 });
 
+test('model timeout maps to provider overloaded', function () {
+    $bedrock = mockBedrockException('ModelTimeoutException', 408);
+
+    $aiException = BedrockException::toAiException($bedrock, 'bedrock', 'claude-sonnet');
+
+    expect($aiException)->toBeInstanceOf(ProviderOverloadedException::class);
+});
+
+test('model stream error maps to provider overloaded', function () {
+    $bedrock = mockBedrockException('ModelStreamErrorException', 424);
+
+    $aiException = BedrockException::toAiException($bedrock, 'bedrock', 'claude-sonnet');
+
+    expect($aiException)->toBeInstanceOf(ProviderOverloadedException::class);
+});
+
+test('internal server error maps to provider overloaded', function () {
+    $bedrock = mockBedrockException('InternalServerException', 500);
+
+    $aiException = BedrockException::toAiException($bedrock, 'bedrock', 'claude-sonnet');
+
+    expect($aiException)->toBeInstanceOf(ProviderOverloadedException::class);
+});
+
 test('service quota exceeded maps to insufficient credits', function () {
     $bedrock = mockBedrockException('ServiceQuotaExceededException', 402);
 

--- a/tests/Unit/Gateway/Bedrock/BedrockImageGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockImageGatewayTest.php
@@ -39,25 +39,7 @@ test('parse size defaults to square dimensions', function () {
     expect(imageGateway()->callParseSize('1:1'))->toEqual([1024, 1024]);
 });
 
-test('legacy stability sdxl body uses text prompts and steps', function () {
-    $body = imageGateway()->callPrepareBody('stability.stable-diffusion-xl-v1', 'a cat', '1:1', 'premium');
-
-    expect($body)->toEqual([
-        'text_prompts' => [['text' => 'a cat', 'weight' => 1.0]],
-        'cfg_scale' => 7.0,
-        'steps' => 50,
-        'width' => 1024,
-        'height' => 1024,
-    ]);
-});
-
-test('legacy stability sdxl body uses 30 steps for standard quality', function () {
-    $body = imageGateway()->callPrepareBody('stability.stable-diffusion-xl-v1', 'a cat', '1:1', 'standard');
-
-    expect($body['steps'])->toBe(30);
-});
-
-test('modern stability body uses prompt and aspect ratio', function () {
+test('stability body uses prompt and aspect ratio', function () {
     $body = imageGateway()->callPrepareBody('stability.sd3-5-large-v1:0', 'a cat', '2:3', 'standard');
 
     expect($body)->toEqual([
@@ -67,7 +49,7 @@ test('modern stability body uses prompt and aspect ratio', function () {
     ]);
 });
 
-test('modern stability body omits aspect ratio when size is null', function () {
+test('stability body omits aspect ratio when size is null', function () {
     $body = imageGateway()->callPrepareBody('stability.stable-image-ultra-v1:0', 'a cat', null, 'standard');
 
     expect($body)->toEqual([
@@ -119,28 +101,15 @@ test('unknown model family falls back to plain prompt body', function () {
     expect($body)->toEqual(['prompt' => 'something']);
 });
 
-test('legacy stability sdxl response is parsed from artifacts', function () {
-    $images = imageGateway()->callParseResponse('stability.stable-diffusion-xl-v1', [
-        'artifacts' => [
-            ['base64' => 'imgdata-1'],
-            ['base64' => 'imgdata-2'],
-        ],
+test('stability response is parsed from images array', function () {
+    $images = imageGateway()->callParseResponse('stability.sd3-5-large-v1:0', [
+        'images' => ['sd-image-1', 'sd-image-2'],
     ]);
 
     expect($images)->toHaveCount(2)
-        ->and($images[0]->image)->toBe('imgdata-1')
-        ->and($images[0]->mime)->toBe('image/png')
-        ->and($images[1]->image)->toBe('imgdata-2');
-});
-
-test('modern stability response is parsed from images array', function () {
-    $images = imageGateway()->callParseResponse('stability.sd3-5-large-v1:0', [
-        'images' => ['sd-image-1'],
-    ]);
-
-    expect($images)->toHaveCount(1)
         ->and($images[0]->image)->toBe('sd-image-1')
-        ->and($images[0]->mime)->toBe('image/png');
+        ->and($images[0]->mime)->toBe('image/png')
+        ->and($images[1]->image)->toBe('sd-image-2');
 });
 
 test('titan response is parsed from images array', function () {
@@ -171,8 +140,7 @@ test('unknown model family returns empty collection', function () {
     expect($images)->toHaveCount(0);
 });
 
-test('missing artifacts or images key yields empty collection', function () {
-    expect(imageGateway()->callParseResponse('stability.stable-diffusion-xl-v1', [])->count())->toBe(0);
+test('missing images key yields empty collection', function () {
     expect(imageGateway()->callParseResponse('stability.sd3-5-large-v1:0', [])->count())->toBe(0);
     expect(imageGateway()->callParseResponse('amazon.titan-image-v1', [])->count())->toBe(0);
     expect(imageGateway()->callParseResponse('amazon.nova-canvas-v1', [])->count())->toBe(0);

--- a/tests/Unit/Gateway/Bedrock/BedrockImageGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockImageGatewayTest.php
@@ -8,7 +8,10 @@ function imageGateway(): object
     {
         public function callPrepareBody(string $model, string $prompt, ?string $size, ?string $quality): array
         {
-            return $this->prepareImageRequestBody($model, $prompt, $size, $quality);
+            return $this->prepareImageRequestBody($model, $prompt, $size, [
+                'quality' => $quality ?? 'standard',
+                'size' => $size ?? '1:1',
+            ]);
         }
 
         public function callParseResponse(string $model, array $result)
@@ -36,8 +39,8 @@ test('parse size defaults to square dimensions', function () {
     expect(imageGateway()->callParseSize('1:1'))->toEqual([1024, 1024]);
 });
 
-test('stability model body uses text prompts and steps', function () {
-    $body = imageGateway()->callPrepareBody('stability.sd3-large', 'a cat', '1:1', 'high');
+test('legacy stability sdxl body uses text prompts and steps', function () {
+    $body = imageGateway()->callPrepareBody('stability.stable-diffusion-xl-v1', 'a cat', '1:1', 'premium');
 
     expect($body)->toEqual([
         'text_prompts' => [['text' => 'a cat', 'weight' => 1.0]],
@@ -48,10 +51,29 @@ test('stability model body uses text prompts and steps', function () {
     ]);
 });
 
-test('stability model body uses 30 steps for non-high quality', function () {
-    $body = imageGateway()->callPrepareBody('stability.sd3-large', 'a cat', '1:1', 'standard');
+test('legacy stability sdxl body uses 30 steps for standard quality', function () {
+    $body = imageGateway()->callPrepareBody('stability.stable-diffusion-xl-v1', 'a cat', '1:1', 'standard');
 
     expect($body['steps'])->toBe(30);
+});
+
+test('modern stability body uses prompt and aspect ratio', function () {
+    $body = imageGateway()->callPrepareBody('stability.sd3-5-large-v1:0', 'a cat', '2:3', 'standard');
+
+    expect($body)->toEqual([
+        'prompt' => 'a cat',
+        'aspect_ratio' => '2:3',
+        'output_format' => 'png',
+    ]);
+});
+
+test('modern stability body omits aspect ratio when size is null', function () {
+    $body = imageGateway()->callPrepareBody('stability.stable-image-ultra-v1:0', 'a cat', null, 'standard');
+
+    expect($body)->toEqual([
+        'prompt' => 'a cat',
+        'output_format' => 'png',
+    ]);
 });
 
 test('titan image body uses text to image params', function () {
@@ -71,7 +93,7 @@ test('titan image body uses text to image params', function () {
 });
 
 test('titan image body defaults quality to standard', function () {
-    $body = imageGateway()->callPrepareBody('amazon.titan-image-generator-v1', 'a dog', null, null);
+    $body = imageGateway()->callPrepareBody('amazon.titan-image-generator-v1', 'a dog', null, 'standard');
 
     expect($body['imageGenerationConfig']['quality'])->toBe('standard');
 });
@@ -97,8 +119,8 @@ test('unknown model family falls back to plain prompt body', function () {
     expect($body)->toEqual(['prompt' => 'something']);
 });
 
-test('stability response is parsed from artifacts', function () {
-    $images = imageGateway()->callParseResponse('stability.sd3-large', [
+test('legacy stability sdxl response is parsed from artifacts', function () {
+    $images = imageGateway()->callParseResponse('stability.stable-diffusion-xl-v1', [
         'artifacts' => [
             ['base64' => 'imgdata-1'],
             ['base64' => 'imgdata-2'],
@@ -109,6 +131,16 @@ test('stability response is parsed from artifacts', function () {
         ->and($images[0]->image)->toBe('imgdata-1')
         ->and($images[0]->mime)->toBe('image/png')
         ->and($images[1]->image)->toBe('imgdata-2');
+});
+
+test('modern stability response is parsed from images array', function () {
+    $images = imageGateway()->callParseResponse('stability.sd3-5-large-v1:0', [
+        'images' => ['sd-image-1'],
+    ]);
+
+    expect($images)->toHaveCount(1)
+        ->and($images[0]->image)->toBe('sd-image-1')
+        ->and($images[0]->mime)->toBe('image/png');
 });
 
 test('titan response is parsed from images array', function () {
@@ -140,7 +172,8 @@ test('unknown model family returns empty collection', function () {
 });
 
 test('missing artifacts or images key yields empty collection', function () {
-    expect(imageGateway()->callParseResponse('stability.sd3', [])->count())->toBe(0);
+    expect(imageGateway()->callParseResponse('stability.stable-diffusion-xl-v1', [])->count())->toBe(0);
+    expect(imageGateway()->callParseResponse('stability.sd3-5-large-v1:0', [])->count())->toBe(0);
     expect(imageGateway()->callParseResponse('amazon.titan-image-v1', [])->count())->toBe(0);
     expect(imageGateway()->callParseResponse('amazon.nova-canvas-v1', [])->count())->toBe(0);
 });

--- a/tests/Unit/Providers/BedrockProviderTest.php
+++ b/tests/Unit/Providers/BedrockProviderTest.php
@@ -227,6 +227,17 @@ class BedrockProviderTest extends TestCase
         $this->assertEquals('1152x768', $provider->defaultImageOptions('3:2')['size']);
     }
 
+    public function test_normalizes_canonical_quality_values_to_bedrock_values(): void
+    {
+        $provider = new BedrockProvider([], $this->dispatcher);
+
+        $this->assertEquals('standard', $provider->defaultImageOptions(quality: 'low')['quality']);
+        $this->assertEquals('standard', $provider->defaultImageOptions(quality: 'medium')['quality']);
+        $this->assertEquals('premium', $provider->defaultImageOptions(quality: 'high')['quality']);
+        $this->assertEquals('standard', $provider->defaultImageOptions(quality: 'standard')['quality']);
+        $this->assertEquals('premium', $provider->defaultImageOptions(quality: 'premium')['quality']);
+    }
+
     public function test_creates_text_gateway(): void
     {
         $provider = new BedrockProvider([], $this->dispatcher);


### PR DESCRIPTION
While cross-checking the newly merged Bedrock provider against the AWS Bedrock Runtime API docs, I found three real gaps. This PR fixes them so the provider stays behaviorally correct against the documented API.