### PR TITLE
Fix duplicate helper function causing fatal test bootstrap error

### DIFF
--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -132,35 +132,6 @@ function fakeOpenRouterResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
-function fakeDeepSeekToolCallResponse(): PromiseInterface
-{
-    return Http::response([
-        'id' => 'chatcmpl-deepseek-tool-123',
-        'object' => 'chat.completion',
-        'model' => 'deepseek-chat',
-        'choices' => [[
-            'index' => 0,
-            'message' => [
-                'role' => 'assistant',
-                'content' => null,
-                'tool_calls' => [[
-                    'id' => 'call_123',
-                    'type' => 'function',
-                    'function' => [
-                        'name' => 'FixedNumberGenerator',
-                        'arguments' => '{}',
-                    ],
-                ]],
-            ],
-            'finish_reason' => 'tool_calls',
-        ]],
-        'usage' => [
-            'prompt_tokens' => 10,
-            'completion_tokens' => 5,
-        ],
-    ]);
-}
-
 function fakeOpenRouterToolCallResponse(): PromiseInterface
 {
     return Http::response([


### PR DESCRIPTION
The test suite was failing with a PHP fatal error because `fakeDeepSeekToolCallResponse()` was declared twice in `tests/Helpers.php`, introduced by recent DeepSeek provider test additions landing in quick succession.

### Approach

- Remove the duplicate function declaration, keeping the single remaining copy