### PR TITLE
Add error handling feature tests for ElevenLabs, Cohere, Jina, and VoyageAi

### DIFF
--- a/tests/Feature/Providers/Cohere/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Cohere/ErrorHandlingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Reranking;
+
+beforeEach(function () {
+    config(['ai.providers.cohere' => [
+        ...config('ai.providers.cohere'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('embeddings rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response(['message' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+})->throws(RateLimitedException::class);
+
+test('embeddings overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response(['message' => 'Service overloaded'], 503),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+})->throws(ProviderOverloadedException::class);
+
+test('embeddings http error response throws request exception', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response(['message' => 'Unauthorized'], 401),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+})->throws(RequestException::class);
+
+test('reranking rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response(['message' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'cohere', model: 'rerank-v3.5');
+})->throws(RateLimitedException::class);
+
+test('reranking overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response(['message' => 'Service overloaded'], 503),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'cohere', model: 'rerank-v3.5');
+})->throws(ProviderOverloadedException::class);
+
+test('reranking http error response throws request exception', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response(['message' => 'Unauthorized'], 401),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'cohere', model: 'rerank-v3.5');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/ElevenLabs/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/ElevenLabs/ErrorHandlingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Transcription;
+
+beforeEach(function () {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.elevenlabs.io/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Audio::of('Hello world')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+})->throws(RateLimitedException::class);
+
+test('audio overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.elevenlabs.io/*' => Http::response(['detail' => 'Service overloaded'], 503),
+    ]);
+
+    Audio::of('Hello world')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+})->throws(ProviderOverloadedException::class);
+
+test('audio http error response throws request exception', function () {
+    Http::fake([
+        'api.elevenlabs.io/*' => Http::response(['detail' => 'Unauthorized'], 401),
+    ]);
+
+    Audio::of('Hello world')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+})->throws(RequestException::class);
+
+test('transcription rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.elevenlabs.io/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'eleven');
+})->throws(RateLimitedException::class);
+
+test('transcription overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.elevenlabs.io/*' => Http::response(['detail' => 'Service overloaded'], 503),
+    ]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'eleven');
+})->throws(ProviderOverloadedException::class);
+
+test('transcription http error response throws request exception', function () {
+    Http::fake([
+        'api.elevenlabs.io/*' => Http::response(['detail' => 'Unauthorized'], 401),
+    ]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'eleven');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/Jina/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Jina/ErrorHandlingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Reranking;
+
+beforeEach(function () {
+    config(['ai.providers.jina' => [
+        ...config('ai.providers.jina'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('embeddings rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.jina.ai/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+})->throws(RateLimitedException::class);
+
+test('embeddings overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.jina.ai/*' => Http::response(['detail' => 'Service overloaded'], 503),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+})->throws(ProviderOverloadedException::class);
+
+test('embeddings http error response throws request exception', function () {
+    Http::fake([
+        'api.jina.ai/*' => Http::response(['detail' => 'Unauthorized'], 401),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+})->throws(RequestException::class);
+
+test('reranking rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.jina.ai/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'jina', model: 'jina-reranker-v3');
+})->throws(RateLimitedException::class);
+
+test('reranking overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.jina.ai/*' => Http::response(['detail' => 'Service overloaded'], 503),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'jina', model: 'jina-reranker-v3');
+})->throws(ProviderOverloadedException::class);
+
+test('reranking http error response throws request exception', function () {
+    Http::fake([
+        'api.jina.ai/*' => Http::response(['detail' => 'Unauthorized'], 401),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'jina', model: 'jina-reranker-v3');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/VoyageAi/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/VoyageAi/ErrorHandlingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Reranking;
+
+beforeEach(function () {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('embeddings rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+})->throws(RateLimitedException::class);
+
+test('embeddings overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Service overloaded'], 503),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+})->throws(ProviderOverloadedException::class);
+
+test('embeddings http error response throws request exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Unauthorized'], 401),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+})->throws(RequestException::class);
+
+test('reranking rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'voyageai', model: 'rerank-2.5-lite');
+})->throws(RateLimitedException::class);
+
+test('reranking overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Service overloaded'], 503),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'voyageai', model: 'rerank-2.5-lite');
+})->throws(ProviderOverloadedException::class);
+
+test('reranking http error response throws request exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Unauthorized'], 401),
+    ]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'voyageai', model: 'rerank-2.5-lite');
+})->throws(RequestException::class);


### PR DESCRIPTION
## Summary

ElevenLabs, Cohere, Jina, and VoyageAi all use `HandlesFailoverErrors` via `withErrorHandling()`, but none had a dedicated `ErrorHandlingTest`. Every text provider has one — this brings these providers into parity.

Each new test file covers:
- 429 → `RateLimitedException`
- 503 → `ProviderOverloadedException`
- Other HTTP errors → `RequestException`

**ElevenLabs** — covers both `generateAudio` and `generateTranscription`
**Cohere** — covers both `generateEmbeddings` and `rerank`
**Jina** — covers both `generateEmbeddings` and `rerank`
**VoyageAi** — covers both `generateEmbeddings` and `rerank`