### PR TITLE
Add base URL feature tests for VoyageAi provider

### DIFF
--- a/tests/Feature/Providers/VoyageAi/BaseUrlTest.php
+++ b/tests/Feature/Providers/VoyageAi/BaseUrlTest.php
@@ -54,10 +54,10 @@ test('voyageai reranking requests use the configured base url', function () {
 });
 
 test('voyageai requests fall back to the default base url', function () {
-    config(['ai.providers.voyageai' => [
-        ...config('ai.providers.voyageai'),
-        'key' => 'test-key',
-    ]]);
+    config(['ai.providers.voyageai' => array_diff_key(
+        [...config('ai.providers.voyageai'), 'key' => 'test-key'],
+        ['url' => null],
+    )]);
 
     Http::fake(['*' => fakeVoyageBaseUrlEmbeddingsResponse()]);
 

--- a/tests/Feature/Providers/VoyageAi/BaseUrlTest.php
+++ b/tests/Feature/Providers/VoyageAi/BaseUrlTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Reranking;
+
+function fakeVoyageBaseUrlEmbeddingsResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]]],
+        'model' => 'voyage-4',
+        'usage' => ['total_tokens' => 5],
+    ]);
+}
+
+function fakeVoyageBaseUrlRerankingResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'object' => 'list',
+        'data' => [['index' => 0, 'relevance_score' => 0.9]],
+        'model' => 'rerank-2.5-lite',
+        'usage' => ['total_tokens' => 5],
+    ]);
+}
+
+test('voyageai embedding requests use the configured base url', function () {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeVoyageBaseUrlEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v1/embeddings');
+});
+
+test('voyageai reranking requests use the configured base url', function () {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeVoyageBaseUrlRerankingResponse()]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'voyageai', model: 'rerank-2.5-lite');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v1/rerank');
+});
+
+test('voyageai requests fall back to the default base url', function () {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+    ]]);
+
+    Http::fake(['*' => fakeVoyageBaseUrlEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'https://api.voyageai.com/v1/embeddings');
+});


### PR DESCRIPTION
## Summary

- Adds `tests/Feature/Providers/VoyageAi/BaseUrlTest.php`
- VoyageAi supports a configurable `url` key in `config/ai.php` but had no test verifying it works
- Tests cover: custom URL for embeddings, custom URL for reranking, and fallback to default `https://api.voyageai.com/v1`
- Follows the same pattern as `Groq`, `Mistral`, `Ollama`, and other provider `BaseUrlTest` files