### PR TITLE
Add configurable URL support and base URL tests for Cohere provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -78,6 +78,7 @@ return [
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),
+            'url' => env('COHERE_URL', 'https://api.cohere.com/v2'),
         ],
 
         'deepseek' => [

--- a/tests/Feature/Providers/Cohere/BaseUrlTest.php
+++ b/tests/Feature/Providers/Cohere/BaseUrlTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Reranking;
+
+function fakeCohereBaseUrlEmbeddingsResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'embeddings' => ['float' => [[0.1, 0.2, 0.3]]],
+        'meta' => ['billed_units' => ['input_tokens' => 5]],
+    ]);
+}
+
+function fakeCohereBaseUrlRerankingResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'results' => [['index' => 0, 'relevance_score' => 0.9]],
+        'meta' => ['billed_units' => ['search_units' => 1]],
+    ]);
+}
+
+test('cohere embedding requests use the configured base url', function () {
+    config(['ai.providers.cohere' => [
+        ...config('ai.providers.cohere'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v2',
+    ]]);
+
+    Http::fake(['*' => fakeCohereBaseUrlEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v2/embed');
+});
+
+test('cohere reranking requests use the configured base url', function () {
+    config(['ai.providers.cohere' => [
+        ...config('ai.providers.cohere'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v2',
+    ]]);
+
+    Http::fake(['*' => fakeCohereBaseUrlRerankingResponse()]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v2/rerank');
+});
+
+test('cohere requests fall back to the default base url', function () {
+    config(['ai.providers.cohere' => [
+        ...config('ai.providers.cohere'),
+        'key' => 'test-key',
+    ]]);
+
+    Http::fake(['*' => fakeCohereBaseUrlEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'https://api.cohere.com/v2/embed');
+});


### PR DESCRIPTION
## Summary

- Exposes `COHERE_URL` in `config/ai.php` — `CohereGateway` already reads `url` from `additionalConfiguration()` but it was not documented in the published config
- Adds `tests/Feature/Providers/Cohere/BaseUrlTest.php` verifying the custom URL is used for both embedding and reranking requests, and that the default falls back to `https://api.cohere.com/v2`
- Consistent with how `VoyageAi`, `xAI`, `Groq`, `Mistral`, and other providers expose their base URL