### PR TITLE
fix(bedrock): bedrock text gateway response messages and steps

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -23,9 +23,11 @@ use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -74,6 +76,9 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         $totalInputTokens = 0;
         $totalOutputTokens = 0;
         $step = 0;
+        $responseMessages = new Collection;
+        $steps = new Collection;
+        $meta = new Meta($provider->name(), $model);
 
         while ($step < $maxSteps) {
             $parameters = $this->buildConverseParameters(
@@ -98,8 +103,10 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 throw BedrockException::toAiException($e, $provider->name(), $model);
             }
 
-            $totalInputTokens += $result['usage']['inputTokens'] ?? 0;
-            $totalOutputTokens += $result['usage']['outputTokens'] ?? 0;
+            $stepInputTokens = $result['usage']['inputTokens'] ?? 0;
+            $stepOutputTokens = $result['usage']['outputTokens'] ?? 0;
+            $totalInputTokens += $stepInputTokens;
+            $totalOutputTokens += $stepOutputTokens;
 
             $output = '';
             $toolCalls = [];
@@ -133,8 +140,14 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             }
 
             $step++;
+            $stepUsage = new Usage($stepInputTokens, $stepOutputTokens);
+            $finishReason = $this->extractFinishReason($result);
+
+            $responseMessages->push(new AssistantMessage($output, new Collection($toolCalls)));
 
             if (empty($toolCalls)) {
+                $steps->push(new Step($output, $toolCalls, [], $finishReason, $stepUsage, $meta));
+
                 break;
             }
 
@@ -144,13 +157,15 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             $toolResults = $this->executeToolCalls($tools, $toolCalls);
             $allToolResults = array_merge($allToolResults, $toolResults);
 
+            $steps->push(new Step($output, $toolCalls, $toolResults, $finishReason, $stepUsage, $meta));
+
             if (! empty($toolResults)) {
                 $conversationMessages[] = $this->buildToolResultConversationMessage($toolResults);
+                $responseMessages->push(new ToolResultMessage(new Collection($toolResults)));
             }
         }
 
         $usage = new Usage($totalInputTokens, $totalOutputTokens);
-        $meta = new Meta($provider->name(), $model);
 
         if ($schema) {
             $structured = json_decode($finalOutput, true);
@@ -160,11 +175,13 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             }
 
             return (new StructuredTextResponse($structured, $finalOutput, $usage, $meta))
-                ->withToolCallsAndResults(new Collection($allToolCalls), new Collection($allToolResults));
+                ->withToolCallsAndResults(new Collection($allToolCalls), new Collection($allToolResults))
+                ->withSteps($steps);
         }
 
         return (new TextResponse($finalOutput, $usage, $meta))
-            ->withToolCallsAndResults(new Collection($allToolCalls), new Collection($allToolResults));
+            ->withMessages($responseMessages)
+            ->withSteps($steps);
     }
 
     /**
@@ -440,6 +457,20 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         }
 
         return (int) ($options?->maxSteps ?? round(count($tools) * 1.5));
+    }
+
+    /**
+     * Extract and map the finish reason from the Bedrock Converse response.
+     */
+    protected function extractFinishReason(array $data): FinishReason
+    {
+        return match ($data['stopReason'] ?? '') {
+            'end_turn', 'stop_sequence' => FinishReason::Stop,
+            'tool_use' => FinishReason::ToolCalls,
+            'max_tokens' => FinishReason::Length,
+            'content_filtered', 'guardrail_intervened' => FinishReason::ContentFilter,
+            default => FinishReason::Unknown,
+        };
     }
 
     /**

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -22,12 +22,12 @@ use Laravel\Ai\Messages\MessageRole;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -146,6 +146,10 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             $responseMessages->push(new AssistantMessage($output, new Collection($toolCalls)));
 
             if (empty($toolCalls)) {
+                if ($schemaTools && $finishReason === FinishReason::ToolCalls) {
+                    $finishReason = FinishReason::Stop;
+                }
+
                 $steps->push(new Step($output, $toolCalls, [], $finishReason, $stepUsage, $meta));
 
                 break;


### PR DESCRIPTION
Summary
---

- Currently bedrock text gateway doesn't return messages and step counts in response, this causes certain tests to fail. 
- Notice the following test:

<img width="614" height="282" alt="Screenshot 2026-04-27 at 10 26 43 AM" src="https://github.com/user-attachments/assets/a2a12b3b-4c2d-48be-aa3e-caf127e23fec" />

- This change makes sure the gateway returns messages and steps
