### PR TITLE
fix(bedrock): correct default model IDs

### DIFF
--- a/src/Providers/BedrockProvider.php
+++ b/src/Providers/BedrockProvider.php
@@ -64,7 +64,7 @@ class BedrockProvider extends Provider implements EmbeddingProvider, ImageProvid
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['text']['cheapest'] ?? 'us.anthropic.claude-haiku-4-5-20250929-v1:0';
+        return $this->config['models']['text']['cheapest'] ?? 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
     }
 
     /**
@@ -72,7 +72,7 @@ class BedrockProvider extends Provider implements EmbeddingProvider, ImageProvid
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['text']['smartest'] ?? 'us.anthropic.claude-opus-4-6-20250929-v1:0';
+        return $this->config['models']['text']['smartest'] ?? 'us.anthropic.claude-opus-4-6-v1';
     }
 
     /**

--- a/tests/Unit/Providers/BedrockProviderTest.php
+++ b/tests/Unit/Providers/BedrockProviderTest.php
@@ -140,14 +140,14 @@ class BedrockProviderTest extends TestCase
     {
         $provider = new BedrockProvider([], $this->dispatcher);
 
-        $this->assertEquals('us.anthropic.claude-haiku-4-5-20250929-v1:0', $provider->cheapestTextModel());
+        $this->assertEquals('us.anthropic.claude-haiku-4-5-20251001-v1:0', $provider->cheapestTextModel());
     }
 
     public function test_returns_smartest_text_model(): void
     {
         $provider = new BedrockProvider([], $this->dispatcher);
 
-        $this->assertEquals('us.anthropic.claude-opus-4-6-20250929-v1:0', $provider->smartestTextModel());
+        $this->assertEquals('us.anthropic.claude-opus-4-6-v1', $provider->smartestTextModel());
     }
 
     public function test_allows_custom_text_models_in_config(): void


### PR DESCRIPTION
## Summary
- update the Bedrock cheapest text default to the valid Claude Haiku profile ID
- update the Bedrock smartest text default to the valid Claude Opus profile ID
- adjust the BedrockProvider unit test expectations

## Context
This is a small follow-up Bedrock fix related to the Bedrock provider work in #39, #270, #442, and #458.

In a native Laravel app using the package defaults against Bedrock in `us-east-1`, both fallback IDs currently reproduce as `ValidationException: The provided model identifier is invalid.`

The default Sonnet model remains unchanged because it is still valid.