### PR TITLE
fix(bedrock): bedrock converse API parameter edge cases 

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -555,7 +555,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                     'toolUse' => [
                         'toolUseId' => $toolCall->id,
                         'name' => $toolCall->name,
-                        'input' => $toolCall->arguments,
+                        'input' => (object) $toolCall->arguments,
                     ],
                 ], $toolCalls),
             ),
@@ -656,7 +656,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 'toolUse' => [
                     'toolUseId' => $toolCall->id,
                     'name' => $toolCall->name,
-                    'input' => $toolCall->arguments,
+                    'input' => (object) $toolCall->arguments,
                 ],
             ];
         }

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -555,7 +555,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                     'toolUse' => [
                         'toolUseId' => $toolCall->id,
                         'name' => $toolCall->name,
-                        'input' => (object) $toolCall->arguments,
+                        'input' => $toolCall->arguments ?: new stdClass,
                     ],
                 ], $toolCalls),
             ),
@@ -656,7 +656,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 'toolUse' => [
                     'toolUseId' => $toolCall->id,
                     'name' => $toolCall->name,
-                    'input' => (object) $toolCall->arguments,
+                    'input' => $toolCall->arguments ?: new stdClass,
                 ],
             ];
         }

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -615,7 +615,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 'tools' => $schemaTools,
                 'toolChoice' => ($isFinalStep || $toolsEmpty)
                     ? ['tool' => ['name' => self::STRUCTURED_OUTPUT_TOOL]]
-                    : ['auto' => new stdClass],
+                    : ['auto' => []],
             ];
         }
 

--- a/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
@@ -151,6 +151,18 @@ test('assistant message with tool calls is formatted with tool use blocks', func
     ]);
 });
 
+test('assistant message with empty tool input is formatted as a json object', function () {
+    $assistant = new AssistantMessage('', new Collection([
+        new ToolCall('tool-1', 'NoArgGenerator', []),
+    ]));
+
+    $formatted = textGateway()->callFormatMessages([$assistant]);
+    $input = $formatted[0]['content'][0]['toolUse']['input'];
+
+    expect($input)->toBeInstanceOf(stdClass::class)
+        ->and(json_encode($input))->toBe('{}');
+});
+
 test('tool result message is formatted with tool result blocks', function () {
     $message = new ToolResultMessage(new Collection([
         new ToolResult('tool-1', 'RandomGenerator', [], 'the result'),


### PR DESCRIPTION
Summary
---

- The message we pass to converse API is incorrect for certain edge cases, specifically related to tool calls. 

##### Issue 1: 
-  [toolConfig][toolChoice][auto] is expected to be an associative array but is a stdClass 

<img width="744" height="364" alt="Screenshot 2026-04-28 at 10 40 18 PM" src="https://github.com/user-attachments/assets/f8b0ff2b-cda2-40e8-add6-0471dc1a7ed1" />

- Fix: toolChoice.auto should be an array 

##### Issue 2: 
- for AssistantMessage when toolUse.input is an empty array ([]), it gets serialized to a JSON array ('[]') inside the aws bedrock sdk, but the API always expects it to be a JSON object. 

<img width="1159" height="428" alt="Screenshot 2026-04-28 at 10 45 53 PM" src="https://github.com/user-attachments/assets/87dffa76-c96e-45c2-ae5a-0c1255f0336e" />

- Fix: ensure toolUse.input is always such that it serialized to a JSON object on json_encode, to do that, we can cast it to an object 



