### PR TITLE
fix(bedrock): silent tool call failures

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -800,11 +800,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 continue;
             }
 
-            try {
-                $result = $this->executeTool($tool, $toolCall->arguments);
-            } catch (Throwable $e) {
-                $result = 'Error executing tool: '.$e->getMessage();
-            }
+            $result = $this->executeTool($tool, $toolCall->arguments);
 
             $results[] = new ToolResult(
                 $toolCall->id,


### PR DESCRIPTION
Summary
---
- Current behaviour for bedrock provider is inconsistent with the rest of the providers, bedrock provider silently catches any exception instead of bubbling it up like rest of the providers.
- This can be checked with the following failing test.

<img width="1159" height="296" alt="Screenshot 2026-04-29 at 12 49 56 AM" src="https://github.com/user-attachments/assets/31ed9a40-60a9-420f-b7d7-e06a2ce25404" />

- To fix this we need to let exceptions bubble up
