### PR TITLE
fix(bedrock): incorrect name format in user attachments for bedrock provider

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -697,7 +697,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 $content[] = [
                     'document' => [
                         'format' => $this->getDocumentFormat($attachment),
-                        'name' => $attachment->name ?? 'document',
+                        'name' => $this->getDocumentName($attachment),
                         'source' => [
                             'bytes' => $attachment->content(),
                         ],
@@ -751,6 +751,21 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             'text/markdown', 'text/x-markdown' => 'md',
             default => 'txt',
         };
+    }
+
+    /**
+     * Build a unique, Bedrock-compliant document name.
+     *
+     * Bedrock requires document names to be unique within a message and limits
+     * them to alphanumerics, whitespace, hyphens, parentheses, and square brackets.
+     */
+    protected function getDocumentName(Document $document): string
+    {
+        $name = $document->name() ?? 'document';
+        $name = pathinfo($name, PATHINFO_FILENAME) ?: $name;
+        $name = preg_replace('/[^A-Za-z0-9\-\(\)\[\] ]+/', '-', $name);
+
+        return trim(preg_replace('/\s+/', ' ', $name)) ?: 'document';
     }
 
     /**


### PR DESCRIPTION
Summary
---
- Document name is being passed incorrectly to the bedrock provider. According to [the docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html), the document name should be alphanumeric with other kinds of characters but shouldn't have a dot (.), currently if we pass the file name with extension,  it contains a dot (.) 
- This merge request fixes 2 issues

##### Issue 1 
- Incorrect property is being accessed to get document name (->name instead of ->name()), which causes below error 

<img width="1177" height="286" alt="Screenshot 2026-04-29 at 1 17 25 AM" src="https://github.com/user-attachments/assets/d7cb1822-7e0b-4ae3-ba6c-e2e3645a9b97" />

##### Issue 2
- Even if we pass the document name correctly, it causes the below error as file name contains a dot (.) 

<img width="1177" height="412" alt="Screenshot 2026-04-29 at 1 19 12 AM" src="https://github.com/user-attachments/assets/5df133ff-e83e-4387-b119-a97a54a984ba" />

