### PR TITLE
Add embedding feature tests for OpenAI provider

### DIFF
--- a/tests/Feature/Providers/OpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/OpenAi/EmbeddingTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
@@ -11,7 +12,7 @@ beforeEach(function () {
     ]]);
 });
 
-function fakeOpenAiEmbeddingResponse(): \GuzzleHttp\Promise\PromiseInterface
+function fakeOpenAiEmbeddingResponse(): PromiseInterface
 {
     return Http::response([
         'object' => 'list',

--- a/tests/Feature/Providers/OpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/OpenAi/EmbeddingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+beforeEach(function () {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'key' => 'test-key',
+    ]]);
+});
+
+function fakeOpenAiEmbeddingResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+        ],
+        'usage' => ['prompt_tokens' => 10],
+    ]);
+}
+
+test('embeddings request includes model, input, and dimensions', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    Embeddings::for(['Hello world'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'text-embedding-3-small'
+            && $body['input'] === ['Hello world']
+            && $body['dimensions'] === 1536
+            && $request->url() === 'https://api.openai.com/v1/embeddings';
+    });
+});
+
+test('embeddings response is correctly parsed', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    $response = Embeddings::for(['Hello world'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    expect($response->embeddings)->toHaveCount(1)
+        ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
+        ->and($response->tokens)->toBe(10)
+        ->and($response->meta->provider)->toBe('openai');
+});
+
+test('multiple inputs return multiple embeddings', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+        ],
+        'usage' => ['prompt_tokens' => 20],
+    ])]);
+
+    $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    expect($response->embeddings)->toHaveCount(2);
+});
+
+test('embeddings request sends bearer token', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});

--- a/tests/Feature/Providers/OpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/OpenAi/EmbeddingTest.php
@@ -2,6 +2,7 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 
@@ -26,14 +27,14 @@ function fakeOpenAiEmbeddingResponse(): PromiseInterface
 test('embeddings request includes model, input, and dimensions', function () {
     Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
 
-    Embeddings::for(['Hello world'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+    Embeddings::for(['Hello world'])->dimensions(768)->generate(provider: 'openai', model: 'text-embedding-3-small');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
 
         return $body['model'] === 'text-embedding-3-small'
             && $body['input'] === ['Hello world']
-            && $body['dimensions'] === 1536
+            && $body['dimensions'] === 768
             && $request->url() === 'https://api.openai.com/v1/embeddings';
     });
 });
@@ -46,7 +47,8 @@ test('embeddings response is correctly parsed', function () {
     expect($response->embeddings)->toHaveCount(1)
         ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
         ->and($response->tokens)->toBe(10)
-        ->and($response->meta->provider)->toBe('openai');
+        ->and($response->meta->provider)->toBe('openai')
+        ->and($response->meta->model)->toBe('text-embedding-3-small');
 });
 
 test('multiple inputs return multiple embeddings', function () {
@@ -61,7 +63,8 @@ test('multiple inputs return multiple embeddings', function () {
 
     $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'openai', model: 'text-embedding-3-small');
 
-    expect($response->embeddings)->toHaveCount(2);
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6]);
 });
 
 test('embeddings request sends bearer token', function () {
@@ -71,3 +74,25 @@ test('embeddings request sends bearer token', function () {
 
     Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
 });
+
+test('embeddings use default model when none specified', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['model'] === 'text-embedding-3-small');
+});
+
+test('embeddings default to 1536 dimensions when none specified', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['dimensions'] === 1536);
+});
+
+test('embeddings throw when the API returns an error', function () {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'unauthorized']], 401)]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+})->throws(RequestException::class);


### PR DESCRIPTION
## Summary

Adds missing embedding feature tests for the OpenAI provider. `OpenAiGateway` implements `generateEmbeddings()` but had no corresponding feature test.

Tests cover:
- Request includes model, input, dimensions, and posts to the correct endpoint
- Response is correctly parsed (embeddings, token count, provider meta)
- Multiple inputs return multiple embedding vectors
- Request sends bearer token authorization