### PR TITLE
Support configurable base URL for Jina provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -106,6 +106,7 @@ return [
         'jina' => [
             'driver' => 'jina',
             'key' => env('JINA_API_KEY'),
+            'url' => env('JINA_URL', 'https://api.jina.ai/v1'),
         ],
 
         'mistral' => [

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -93,12 +93,20 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
      */
     protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
     {
-        return Http::baseUrl('https://api.jina.ai/v1')
+        return Http::baseUrl($this->baseUrl($provider))
             ->withHeaders([
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
             ->timeout($timeout)
             ->throw();
+    }
+
+    /**
+     * Get the base URL for the Jina API.
+     */
+    protected function baseUrl(EmbeddingProvider|RerankingProvider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.jina.ai/v1', '/');
     }
 }

--- a/tests/Feature/Providers/Jina/BaseUrlTest.php
+++ b/tests/Feature/Providers/Jina/BaseUrlTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Reranking;
+
+function fakeJinaBaseUrlEmbeddingsResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'model' => 'jina-embeddings-v4',
+        'data' => [['index' => 0, 'embedding' => [0.1, 0.2, 0.3]]],
+        'usage' => ['total_tokens' => 5],
+    ]);
+}
+
+function fakeJinaBaseUrlRerankingResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response([
+        'model' => 'jina-reranker-v3',
+        'results' => [['index' => 0, 'relevance_score' => 0.9]],
+    ]);
+}
+
+test('jina embedding requests use the configured base url', function () {
+    config(['ai.providers.jina' => [
+        ...config('ai.providers.jina'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeJinaBaseUrlEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v1/embeddings');
+});
+
+test('jina reranking requests use the configured base url', function () {
+    config(['ai.providers.jina' => [
+        ...config('ai.providers.jina'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeJinaBaseUrlRerankingResponse()]);
+
+    Reranking::of(['doc1'])->rerank('What is AI?', provider: 'jina', model: 'jina-reranker-v3');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v1/rerank');
+});
+
+test('jina requests fall back to the default base url', function () {
+    config(['ai.providers.jina' => array_diff_key(
+        [...config('ai.providers.jina'), 'key' => 'test-key'],
+        ['url' => null],
+    )]);
+
+    Http::fake(['*' => fakeJinaBaseUrlEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'https://api.jina.ai/v1/embeddings');
+});


### PR DESCRIPTION
## Summary

`JinaGateway` had a hardcoded `https://api.jina.ai/v1` base URL, unlike every other provider in the SDK (VoyageAi, Cohere, Mistral, OpenAI, etc.) which read the URL from `additionalConfiguration()`.

This makes Jina impossible to point at a proxy or self-hosted endpoint.

Changes:
- `JinaGateway::client()` now calls `baseUrl()` instead of using a string literal
- `JinaGateway::baseUrl()` reads `url` from `additionalConfiguration()`, falling back to `https://api.jina.ai/v1`
- `config/ai.php` adds `'url' => env('JINA_URL', 'https://api.jina.ai/v1')` to the jina provider block
- Adds `BaseUrlTest` covering custom URL for embeddings, custom URL for reranking, and fallback to default

No behaviour change when `JINA_URL` is not set.