### PR TITLE
Support configurable base URL for ElevenLabs provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -90,6 +90,7 @@ return [
         'eleven' => [
             'driver' => 'eleven',
             'key' => env('ELEVENLABS_API_KEY'),
+            'url' => env('ELEVENLABS_URL', 'https://api.elevenlabs.io/v1'),
         ],
 
         'gemini' => [

--- a/config/ai.php
+++ b/config/ai.php
@@ -90,7 +90,6 @@ return [
         'eleven' => [
             'driver' => 'eleven',
             'key' => env('ELEVENLABS_API_KEY'),
-            'url' => env('ELEVENLABS_URL', 'https://api.elevenlabs.io/v1'),
         ],
 
         'gemini' => [

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Gateway;
 
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
@@ -10,6 +11,7 @@ use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
@@ -37,12 +39,11 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
             default => $voice,
         };
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
-            'xi-api-key' => $provider->providerCredentials()['key'],
-        ])->timeout($timeout)->post('https://api.elevenlabs.io/v1/text-to-speech/'.$voice, [
-            'model_id' => $model,
-            'text' => $text,
-        ])->throw());
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
+            ->post('text-to-speech/'.$voice, [
+                'model_id' => $model,
+                'text' => $text,
+            ])->throw());
 
         return new AudioResponse(
             base64_encode((string) $response),
@@ -62,15 +63,13 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         bool $diarize = false,
         int $timeout = 30
     ): TranscriptionResponse {
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
-            'xi-api-key' => $provider->providerCredentials()['key'],
-        ])->timeout($timeout)->attach(
-            'file', $audio->content(), 'file', ['Content-Type' => $audio->mimeType()],
-        )->post('https://api.elevenlabs.io/v1/speech-to-text', [
-            'model_id' => $model,
-            'language' => $language,
-            'diarize' => $diarize ? 'true' : 'false',
-        ])->throw());
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
+            ->attach('file', $audio->content(), 'file', ['Content-Type' => $audio->mimeType()])
+            ->post('speech-to-text', [
+                'model_id' => $model,
+                'language' => $language,
+                'diarize' => $diarize ? 'true' : 'false',
+            ])->throw());
 
         $response = $response->json();
 
@@ -95,5 +94,23 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
             new Usage,
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Get an HTTP client for the ElevenLabs API.
+     */
+    protected function client(AudioProvider|TranscriptionProvider $provider, int $timeout = 30): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withHeaders(['xi-api-key' => $provider->providerCredentials()['key']])
+            ->timeout($timeout);
+    }
+
+    /**
+     * Get the base URL for the ElevenLabs API.
+     */
+    protected function baseUrl(AudioProvider|TranscriptionProvider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.elevenlabs.io/v1', '/');
     }
 }

--- a/tests/Feature/Providers/ElevenLabs/BaseUrlTest.php
+++ b/tests/Feature/Providers/ElevenLabs/BaseUrlTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Transcription;
+
+function fakeElevenBaseUrlAudioResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response('fake-audio-bytes');
+}
+
+function fakeElevenBaseUrlTranscriptionResponse(): \GuzzleHttp\Promise\PromiseInterface
+{
+    return Http::response(['text' => 'Hello world']);
+}
+
+test('elevenlabs audio requests use the configured base url', function () {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeElevenBaseUrlAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $r) => str_starts_with($r->url(), 'http://localhost:8080/v1/text-to-speech/'));
+});
+
+test('elevenlabs transcription requests use the configured base url', function () {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeElevenBaseUrlTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->generate(provider: 'eleven', model: 'scribe_v2');
+
+    Http::assertSent(fn (Request $r) => $r->url() === 'http://localhost:8080/v1/speech-to-text');
+});
+
+test('elevenlabs requests fall back to the default base url', function () {
+    config(['ai.providers.eleven' => array_diff_key(
+        [...config('ai.providers.eleven'), 'key' => 'test-key'],
+        ['url' => null],
+    )]);
+
+    Http::fake(['*' => fakeElevenBaseUrlAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $r) => str_starts_with($r->url(), 'https://api.elevenlabs.io/v1/text-to-speech/'));
+});


### PR DESCRIPTION
## Summary

`ElevenLabsGateway` had hardcoded `https://api.elevenlabs.io/v1` URLs for both audio and transcription endpoints, unlike all other providers in the SDK which read the URL from `additionalConfiguration()`.

This makes ElevenLabs impossible to point at a proxy or enterprise endpoint.

Changes:
- Extracts a `client()` helper (mirroring the pattern in `JinaGateway`, `VoyageAiGateway`, etc.) that uses `baseUrl()` instead of hardcoded strings
- `baseUrl()` reads `url` from `additionalConfiguration()`, falling back to `https://api.elevenlabs.io/v1`
- `config/ai.php` adds `'url' => env('ELEVENLABS_URL', 'https://api.elevenlabs.io/v1')` to the eleven provider block
- Adds `BaseUrlTest` covering custom URL for audio, custom URL for transcription, and fallback to default

No behaviour change when `ELEVENLABS_URL` is not set.