### PR TITLE
Add config option to disable LLM-generated conversation titles

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -22,6 +22,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Conversation Store
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the behaviour of the conversation store used to
+    | persist agent conversations. Set "title" to false to skip LLM-generated
+    | titles and use a truncated version of the first prompt instead.
+    |
+    */
+
+    'conversations' => [
+        'title' => env('AI_CONVERSATION_TITLE', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Caching
     |--------------------------------------------------------------------------
     |

--- a/config/ai.php
+++ b/config/ai.php
@@ -22,19 +22,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Conversation Title
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure how conversation titles are generated. By default,
-    | an LLM request generates the title. Setting this option to false will
-    | use a truncated version of the first prompt as the title instead.
-    |
-    */
-
-    'generate_conversation_title' => env('AI_GENERATE_CONVERSATION_TITLE', true),
-
-    /*
-    |--------------------------------------------------------------------------
     | Caching
     |--------------------------------------------------------------------------
     |

--- a/config/ai.php
+++ b/config/ai.php
@@ -22,18 +22,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Conversation Store
+    | Conversation Title
     |--------------------------------------------------------------------------
     |
-    | Here you may configure the behaviour of the conversation store used to
-    | persist agent conversations. Set "title" to false to skip LLM-generated
-    | titles and use a truncated version of the first prompt instead.
+    | Here you may configure how conversation titles are generated. By default,
+    | an LLM request generates the title. Setting this option to false will
+    | use a truncated version of the first prompt as the title instead.
     |
     */
 
-    'conversations' => [
-        'title' => env('AI_CONVERSATION_TITLE', true),
-    ],
+    'generate_conversation_title' => env('AI_GENERATE_CONVERSATION_TITLE', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -68,6 +68,10 @@ class RememberConversation
      */
     protected function generateTitle(string $prompt): string
     {
+        if (config('ai.conversations.title', true) === false) {
+            return Str::limit($prompt, 100, preserveWords: true);
+        }
+
         try {
             $response = $this->provider->textGateway()->generateText(
                 $this->provider,

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -68,7 +68,7 @@ class RememberConversation
      */
     protected function generateTitle(string $prompt): string
     {
-        if (! (bool) config('ai.generate_conversation_title', true)) {
+        if (! (bool) config('ai.conversations.generate_title', true)) {
             return Str::limit($prompt, 100, preserveWords: true);
         }
 

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -69,7 +69,7 @@ class RememberConversation
     protected function generateTitle(string $prompt): string
     {
         if (! (bool) config('ai.conversations.generate_title', true)) {
-            return Str::limit($prompt, 100, preserveWords: true);
+            return Str::limit($prompt, 50, preserveWords: true);
         }
 
         try {

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -68,7 +68,7 @@ class RememberConversation
      */
     protected function generateTitle(string $prompt): string
     {
-        if (config('ai.conversations.title', true) === false) {
+        if (! (bool) config('ai.generate_conversation_title', true)) {
             return Str::limit($prompt, 100, preserveWords: true);
         }
 


### PR DESCRIPTION
## Summary

Fixes #369.

Every new conversation currently fires a hidden LLM request to generate a 3-5 word title, which surprises users when they see unexpected API calls (e.g. to Claude Haiku).

This adds an `ai.conversations.title` config key (driven by `AI_CONVERSATION_TITLE`, defaulting to `true`) that, when set to `false`, skips the LLM call entirely and uses a truncated version of the first prompt as the title instead — matching the existing fallback behaviour.

No behaviour change when `AI_CONVERSATION_TITLE` is not set.