### PR TITLE
Restore reasoningId and reasoningSummary when rehydrating ToolCall from database

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -129,6 +129,8 @@ class DatabaseConversationStore implements ConversationStore
                             name: $toolCall['name'],
                             arguments: $toolCall['arguments'],
                             resultId: $toolCall['result_id'] ?? null,
+                            reasoningId: $toolCall['reasoning_id'] ?? null,
+                            reasoningSummary: $toolCall['reasoning_summary'] ?? null,
                         ))
                     );
 


### PR DESCRIPTION
Fixes #361.

`DatabaseConversationStore::getLatestConversationMessages()` was not restoring `reasoningId` and `reasoningSummary` when reconstructing `ToolCall` objects from the database, even though both fields are correctly serialized via `ToolCall::toArray()`.

This caused reasoning models to fail with HTTP 400 on follow-up turns because the rehydrated `ToolCall` had `reasoningId = null`, so no reasoning items were emitted — but the API expected them to be present.