### PR TITLE
Update conversation updated_at when messages are stored

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -68,6 +68,10 @@ class DatabaseConversationStore implements ConversationStore
             'updated_at' => now(),
         ]);
 
+        DB::table('agent_conversations')
+            ->where('id', $conversationId)
+            ->update(['updated_at' => now()]);
+
         return $messageId;
     }
 
@@ -93,6 +97,10 @@ class DatabaseConversationStore implements ConversationStore
             'created_at' => now(),
             'updated_at' => now(),
         ]);
+
+        DB::table('agent_conversations')
+            ->where('id', $conversationId)
+            ->update(['updated_at' => now()]);
 
         return $messageId;
     }


### PR DESCRIPTION
Fixes #381.

`latestConversationId()` orders by `agent_conversations.updated_at DESC`, but that column was only written at conversation creation time. Adding new messages to an older conversation never updated the parent row, so `continueLastConversation()` could resume the wrong conversation.

This fix updates `agent_conversations.updated_at` in both `storeUserMessage()` and `storeAssistantMessage()` so the most recently active conversation always sorts to the top.