### PR TITLE
Propagate conversationId to StreamableAgentResponse after stream completes

### DIFF
--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -152,5 +152,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         foreach ($this->thenCallbacks as $callback) {
             call_user_func($callback, $this->streamedResponse);
         }
+
+        $this->conversationId = $this->streamedResponse->conversationId;
+        $this->conversationUser = $this->streamedResponse->conversationUser;
     }
 }


### PR DESCRIPTION
Fixes #336.

`RememberConversation` middleware calls `$response->withinConversation(...)` on the inner `StreamedAgentResponse` inside the `then()` callback. The outer `StreamableAgentResponse` — which the caller holds — never had its `conversationId` updated, so `$stream->conversationId` was always `null` after iterating.

The fix copies `conversationId` and `conversationUser` from the inner response to the outer response after all `thenCallbacks` have executed.