### PR TITLE
Surface usage tokens in OpenAI and Gemini image responses

### DIFF
--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -22,7 +22,6 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -178,7 +177,7 @@ class GeminiGateway implements Gateway
 
         return new ImageResponse(
             $images,
-            new Usage(0, 0),
+            $this->extractUsage($data),
             new Meta($provider->name(), $model),
         );
     }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -147,17 +147,12 @@ class OpenAiGateway implements Gateway
 
         $data = $response->json();
 
-        $usage = $data['usage'] ?? [];
-
         return new ImageResponse(
             collect($data['data'] ?? [])->map(fn (array $image) => new GeneratedImage(
                 $image['b64_json'] ?? '',
                 'image/png',
             )),
-            new Usage(
-                $usage['input_tokens'] ?? 0,
-                $usage['output_tokens'] ?? 0,
-            ),
+            $this->extractUsage($data),
             new Meta($provider->name(), $model),
         );
     }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -147,12 +147,17 @@ class OpenAiGateway implements Gateway
 
         $data = $response->json();
 
+        $usage = $data['usage'] ?? [];
+
         return new ImageResponse(
             collect($data['data'] ?? [])->map(fn (array $image) => new GeneratedImage(
                 $image['b64_json'] ?? '',
                 'image/png',
             )),
-            new Usage(0, 0),
+            new Usage(
+                $usage['input_tokens'] ?? 0,
+                $usage['output_tokens'] ?? 0,
+            ),
             new Meta($provider->name(), $model),
         );
     }

--- a/tests/Feature/Providers/Gemini/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Gemini/ImageGenerationTest.php
@@ -186,3 +186,41 @@ test('request sends x-goog-api-key header', function () {
         return $request->hasHeader('x-goog-api-key', 'test-key');
     });
 });
+
+test('image response includes usage metadata when returned', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'candidates' => [[
+                'content' => [
+                    'parts' => [[
+                        'inlineData' => [
+                            'mimeType' => 'image/png',
+                            'data' => base64_encode('fake-image'),
+                        ],
+                    ]],
+                ],
+            ]],
+            'usageMetadata' => [
+                'promptTokenCount' => 12,
+                'candidatesTokenCount' => 1290,
+                'totalTokenCount' => 1302,
+            ],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+
+    expect($response->usage->promptTokens)->toBe(12)
+        ->and($response->usage->completionTokens)->toBe(1290);
+});
+
+test('image response defaults to zero usage when usage metadata absent', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiImageResponse(),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+
+    expect($response->usage->promptTokens)->toBe(0)
+        ->and($response->usage->completionTokens)->toBe(0);
+});

--- a/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
@@ -132,6 +132,30 @@ test('image response includes usage tokens when returned by gpt-image', function
         ->and($response->usage->completionTokens)->toBe(1024);
 });
 
+test('image response subtracts cached tokens from prompt tokens', function () {
+    Http::fake([
+        '*' => Http::response([
+            'data' => [[
+                'b64_json' => base64_encode('fake-image'),
+            ]],
+            'usage' => [
+                'input_tokens' => 100,
+                'output_tokens' => 1024,
+                'input_tokens_details' => [
+                    'cached_tokens' => 30,
+                    'text_tokens' => 70,
+                ],
+            ],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
+
+    expect($response->usage->promptTokens)->toBe(70)
+        ->and($response->usage->cacheReadInputTokens)->toBe(30)
+        ->and($response->usage->completionTokens)->toBe(1024);
+});
+
 test('image response defaults to zero usage when not returned by dalle', function () {
     Http::fake([
         '*' => fakeOpenAiImageResponse(),

--- a/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
@@ -108,3 +108,37 @@ test('image request does not include size when not specified', function () {
         return ! array_key_exists('size', $body);
     });
 });
+
+test('image response includes usage tokens when returned by gpt-image', function () {
+    Http::fake([
+        '*' => Http::response([
+            'data' => [[
+                'b64_json' => base64_encode('fake-image'),
+            ]],
+            'usage' => [
+                'input_tokens' => 41,
+                'output_tokens' => 1024,
+                'input_tokens_details' => [
+                    'text_tokens' => 41,
+                    'image_tokens' => 0,
+                ],
+            ],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
+
+    expect($response->usage->promptTokens)->toBe(41)
+        ->and($response->usage->completionTokens)->toBe(1024);
+});
+
+test('image response defaults to zero usage when not returned by dalle', function () {
+    Http::fake([
+        '*' => fakeOpenAiImageResponse(),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'openai', model: 'dall-e-3');
+
+    expect($response->usage->promptTokens)->toBe(0)
+        ->and($response->usage->completionTokens)->toBe(0);
+});


### PR DESCRIPTION
Fixes #457.

`OpenAiGateway::generateImage()` and `GeminiGateway::generateImage()` were both constructing `new Usage(0, 0)` and discarding the token counts the providers actually return. `gpt-image-1` returns `usage.input_tokens` / `usage.output_tokens`, and Gemini's image `generateContent` returns the same `usageMetadata` block as text generation. Both are now mapped through into `ImageResponse->usage`.

xAI and Bedrock image APIs are per-image billed and don't return token usage, so their gateways are intentionally left alone.