### PR TITLE
Add Reasoning attribute for disabling reasoning across providers

### DIFF
--- a/src/Attributes/Reasoning.php
+++ b/src/Attributes/Reasoning.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Reasoning
+{
+    public function __construct(public bool $enabled = true)
+    {
+        //
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -36,6 +36,10 @@ trait BuildsTextRequests
 
         $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
 
+        if ($options?->reasoning === false) {
+            unset($providerOptions['thinking']);
+        }
+
         if (filled($schema) && $this->supportsNativeStructuredOutput($provider)) {
             $body['output_config'] = [
                 'format' => [

--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -92,6 +92,10 @@ trait BuildsTextRequests
             $generationConfig = array_merge($generationConfig, $providerOptions);
         }
 
+        if ($options?->reasoning === false && ! array_key_exists('thinkingConfig', $generationConfig)) {
+            $generationConfig['thinkingConfig'] = ['thinkingBudget' => 0];
+        }
+
         if (filled($generationConfig)) {
             $body['generationConfig'] = $generationConfig;
         }

--- a/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
@@ -75,6 +75,10 @@ trait BuildsTextRequests
             $body['options'] = $mergedOptions;
         }
 
+        if ($options?->reasoning === false && ! array_key_exists('think', $body)) {
+            $body['think'] = false;
+        }
+
         return $body;
     }
 

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -44,6 +44,10 @@ trait BuildsTextRequests
             'top_p' => $options?->topP,
         ]));
 
+        if ($options?->reasoning === false) {
+            $body['reasoning'] = ['effort' => 'minimal'];
+        }
+
         $providerOptions = $options?->providerOptions(
             Lab::tryFrom($provider->driver()) ?? $provider->driver()
         );

--- a/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
@@ -54,6 +54,10 @@ trait BuildsTextRequests
             $body = array_merge($body, $providerOptions);
         }
 
+        if ($options?->reasoning === false && ! array_key_exists('reasoning', $body)) {
+            $body['reasoning'] = ['exclude' => true];
+        }
+
         return $body;
     }
 

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway;
 
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Reasoning;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Attributes\TopP;
 use Laravel\Ai\Contracts\Agent;
@@ -19,6 +20,7 @@ class TextGenerationOptions
         public readonly ?float $temperature = null,
         public readonly ?Agent $agent = null,
         public readonly ?float $topP = null,
+        public readonly ?bool $reasoning = null,
     ) {
         //
     }
@@ -50,6 +52,7 @@ class TextGenerationOptions
             temperature: self::resolve($agent, $reflection, 'temperature', Temperature::class),
             agent: $agent,
             topP: self::resolve($agent, $reflection, 'topP', TopP::class),
+            reasoning: self::resolveReasoning($agent, $reflection),
         );
     }
 
@@ -75,5 +78,27 @@ class TextGenerationOptions
         $attributes = $reflection->getAttributes($attribute);
 
         return ! empty($attributes) ? $attributes[0]->newInstance()->value : null;
+    }
+
+    /**
+     * Resolve the reasoning preference from a `reasoning()` method or a `#[Reasoning]` attribute.
+     */
+    private static function resolveReasoning(Agent $agent, ReflectionClass $reflection): ?bool
+    {
+        if (method_exists($agent, 'reasoning')) {
+            try {
+                $value = $agent->reasoning();
+            } catch (\ArgumentCountError|\Error) {
+                $value = null;
+            }
+
+            if (! is_null($value)) {
+                return (bool) $value;
+            }
+        }
+
+        $attributes = $reflection->getAttributes(Reasoning::class);
+
+        return ! empty($attributes) ? $attributes[0]->newInstance()->enabled : null;
     }
 }

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -9,6 +9,8 @@ use Tests\Fixtures\Agents\IncompatibleMethodsAgent;
 use Tests\Fixtures\Agents\MethodOptionsAgent;
 use Tests\Fixtures\Agents\MethodOverridesAttributeAgent;
 use Tests\Fixtures\Agents\NullableMethodOptionsAgent;
+use Tests\Fixtures\Agents\ReasoningDisabledAgent;
+use Tests\Fixtures\Agents\ReasoningMethodAgent;
 
 test('text generation options can be created from agent attributes', function () {
     $options = TextGenerationOptions::forAgent(new AttributeAgent);
@@ -58,6 +60,24 @@ test('non-public or parameterized option methods are ignored', function () {
     expect($options->maxSteps)->toBe(8)
         ->and($options->maxTokens)->toBe(1024)
         ->and($options->temperature)->toBe(0.9);
+});
+
+test('reasoning attribute is read from agent class', function () {
+    $options = TextGenerationOptions::forAgent(new ReasoningDisabledAgent);
+
+    expect($options->reasoning)->toBeFalse();
+});
+
+test('reasoning method takes priority over attribute', function () {
+    $options = TextGenerationOptions::forAgent(new ReasoningMethodAgent);
+
+    expect($options->reasoning)->toBeFalse();
+});
+
+test('reasoning is null when neither attribute nor method is provided', function () {
+    $options = TextGenerationOptions::forAgent(new AssistantAgent);
+
+    expect($options->reasoning)->toBeNull();
 });
 
 test('provider attribute is used when prompting', function () {

--- a/tests/Feature/Providers/Ollama/RequestMappingTest.php
+++ b/tests/Feature/Providers/Ollama/RequestMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\ReasoningDisabledAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
@@ -164,6 +165,30 @@ test('structured response is correctly parsed', function () {
     $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'ollama');
 
     expect($response->structured['symbol'])->toBe('Au');
+});
+
+test('reasoning-disabled agent sends think:false at the request top level', function () {
+    Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+    (new ReasoningDisabledAgent)->prompt('Hello', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return array_key_exists('think', $body) && $body['think'] === false;
+    });
+});
+
+test('agents without reasoning attribute do not send think key', function () {
+    Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('think', $body);
+    });
 });
 
 test('request is sent to the chat endpoint', function () {

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\ReasoningDisabledAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
@@ -178,4 +179,28 @@ test('structured response is correctly parsed', function () {
     $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openai');
 
     expect($response->structured['symbol'])->toBe('Au');
+});
+
+test('reasoning-disabled agent sends reasoning effort minimal', function () {
+    Http::fake(['*' => fakeOpenAiResponse('Hello')]);
+
+    (new ReasoningDisabledAgent)->prompt('Hello', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'reasoning.effort') === 'minimal';
+    });
+});
+
+test('agents without reasoning attribute do not send reasoning key', function () {
+    Http::fake(['*' => fakeOpenAiResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('reasoning', $body);
+    });
 });

--- a/tests/Fixtures/Agents/ReasoningDisabledAgent.php
+++ b/tests/Fixtures/Agents/ReasoningDisabledAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Reasoning;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Reasoning(false)]
+class ReasoningDisabledAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}

--- a/tests/Fixtures/Agents/ReasoningMethodAgent.php
+++ b/tests/Fixtures/Agents/ReasoningMethodAgent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+class ReasoningMethodAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function reasoning(): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `#[Reasoning(false)]` class attribute (and matching `reasoning()` agent method) so an agent can express "skip reasoning / thinking" once and have each gateway translate it to the right wire-format key.

## Why

Each provider exposes reasoning / thinking through a different field: Ollama uses `think`, OpenAI uses `reasoning.effort`, Anthropic uses a `thinking` block, Gemini uses `thinkingConfig.thinkingBudget`, OpenRouter uses `reasoning.exclude`. To disable reasoning today, an agent has to know each provider's wire format and hand-roll it via `providerOptions()`. Code that's portable across providers (an agent that can run against an OpenAI or an Ollama backend at runtime) ends up maintaining a translation table.

This PR puts that table inside the SDK.

## Per-provider mapping when reasoning is disabled

| Provider   | Wire format                                          |
|------------|------------------------------------------------------|
| Ollama     | top-level `think: false`                             |
| OpenAI     | `reasoning: { effort: "minimal" }`                 |
| Anthropic  | strips any `thinking` provider option                |
| Gemini     | `generationConfig.thinkingConfig.thinkingBudget = 0` |
| OpenRouter | `reasoning: { exclude: true }`                       |

Other providers (Mistral, Groq, DeepSeek, xAI, Bedrock) treat the attribute as a graceful no-op — no error, no extra key sent.

## Example

```php
use Laravel\Ai\Attributes\Reasoning;

#[Reasoning(false)]
class TriageAgent implements Agent
{
    use Promptable;

    public function instructions(): string
    {
        return 'You are a triage assistant. Answer concisely.';
    }
}
```

The same can be expressed via a method, mirroring how `temperature()` / `maxSteps()` work today:

```php
public function reasoning(): bool
{
    return false;
}
```

The method takes priority over the attribute, matching the resolution order in `TextGenerationOptions::forAgent()`.

## Backward compatibility

Fully additive. If `#[Reasoning]` is never declared and no `reasoning()` method exists, requests are built exactly as today. Existing `providerOptions()` keys (`think`, `reasoning`, `thinkingConfig`) still win — the new logic only fills in the default when the corresponding key is not already set.

## Tests

- `tests/Feature/AgentAttributeTest.php`: attribute resolution, method takes priority, null when neither is set
- `tests/Feature/Providers/Ollama/RequestMappingTest.php`: `think: false` is sent at the top level when reasoning is disabled; key is absent otherwise
- `tests/Feature/Providers/OpenAi/RequestMappingTest.php`: `reasoning.effort = minimal` is sent when reasoning is disabled; key is absent otherwise

`vendor/bin/pest --exclude-group=integration` reports 1012 passing / 1 pre-existing skipped. (3 integration tests in `AgentReasoningTest` fail on the base branch as well due to a missing `pdo_sqlite` extension in this environment — unrelated to this change.)

`vendor/bin/pint --test` is clean for every file changed by this PR.
