### PR TITLE
Drop redundant tool_config from Gemini text requests

### DIFF
--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -65,9 +65,6 @@ trait BuildsTextRequests
 
         if (filled($tools)) {
             $body['tools'] = $this->mapTools($tools, $provider);
-            $body['tool_config'] = [
-                'function_calling_config' => ['mode' => 'AUTO'],
-            ];
         }
 
         $generationConfig = [];

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -79,7 +79,7 @@ describe('request structure', function () {
         });
     });
 
-    test('tools include tool config', function () {
+    test('tool_config is omitted to rely on Gemini default AUTO mode', function () {
         Http::fake([
             'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('The number is 42'),
         ]);
@@ -93,8 +93,7 @@ describe('request structure', function () {
             $body = $request->data();
 
             return isset($body['tools'])
-                && isset($body['tool_config'])
-                && $body['tool_config']['function_calling_config']['mode'] === 'AUTO';
+                && ! isset($body['tool_config']);
         });
     });
 

--- a/tests/Feature/Providers/Gemini/ToolMappingTest.php
+++ b/tests/Feature/Providers/Gemini/ToolMappingTest.php
@@ -1,9 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\FileSearch;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Agents\NamedToolAgent;
 use Tests\Fixtures\Agents\NullableToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+use function Laravel\Ai\agent;
 
 test('empty schema omits parameters key', function () {
     Http::fake([
@@ -109,6 +114,49 @@ test('tool without a name() method falls back to class basename', function () {
         }
 
         return in_array('FixedNumberGenerator', $names, true);
+    });
+});
+
+test('provider tools are sent without function_calling_config', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(
+        'Answer using the uploaded knowledge base.',
+        tools: [new FileSearch(['fileSearchStores/store123'])],
+    )->prompt('Question?', provider: 'gemini');
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+        $tools = $body['tools'] ?? [];
+
+        return isset($tools[0]['fileSearch']['fileSearchStoreNames'])
+            && $tools[0]['fileSearch']['fileSearchStoreNames'] === ['fileSearchStores/store123']
+            && ! isset($body['tool_config']);
+    });
+});
+
+test('mixed function and provider tools are sent without tool_config', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(
+        'Generate a number, optionally searching the web.',
+        tools: [new FixedNumberGenerator, new WebSearch],
+    )->prompt('Generate', provider: 'gemini');
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+        $tools = $body['tools'] ?? [];
+
+        $hasFunctionDeclarations = collect($tools)->contains(fn ($tool) => isset($tool['function_declarations']));
+        $hasGoogleSearch = collect($tools)->contains(fn ($tool) => isset($tool['google_search']));
+
+        return $hasFunctionDeclarations
+            && $hasGoogleSearch
+            && ! isset($body['tool_config']);
     });
 });
 


### PR DESCRIPTION
Gemini's API rejects generateContent requests that include `tool_config.function_calling_config` without `function_declarations` (HTTP 400: *Function calling config is set without function_declarations*). The SDK was emitting it for every request that had tools, breaking agents that use only provider tools like `FileSearch`, `WebSearch`, or `WebFetch`.

Fixes #489

### Approach

- Stop sending `tool_config` from Gemini text requests entirely. `AUTO` is already Gemini's default mode, and the official REST examples for both function calling and the provider tools omit `tool_config`, so the field was redundant even on the working function-tool path.
- Adjust the existing tool-config assertion to verify the field is no longer sent, and add coverage for provider-only and mixed function-plus-provider-tool requests.