### PR TITLE
Remove URL overrides from providers that rarely need them

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -78,13 +78,11 @@ return [
         'cohere' => [
             'driver' => 'cohere',
             'key' => env('COHERE_API_KEY'),
-            'url' => env('COHERE_URL', 'https://api.cohere.com/v2'),
         ],
 
         'deepseek' => [
             'driver' => 'deepseek',
             'key' => env('DEEPSEEK_API_KEY'),
-            'url' => env('DEEPSEEK_URL', 'https://api.deepseek.com'),
         ],
 
         'eleven' => [
@@ -95,24 +93,22 @@ return [
         'gemini' => [
             'driver' => 'gemini',
             'key' => env('GEMINI_API_KEY'),
+            'url' => env('GEMINI_URL', 'https://generativelanguage.googleapis.com/v1beta/'),
         ],
 
         'groq' => [
             'driver' => 'groq',
             'key' => env('GROQ_API_KEY'),
-            'url' => env('GROQ_URL', 'https://api.groq.com/openai/v1'),
         ],
 
         'jina' => [
             'driver' => 'jina',
             'key' => env('JINA_API_KEY'),
-            'url' => env('JINA_URL', 'https://api.jina.ai/v1'),
         ],
 
         'mistral' => [
             'driver' => 'mistral',
             'key' => env('MISTRAL_API_KEY'),
-            'url' => env('MISTRAL_URL', 'https://api.mistral.ai/v1'),
         ],
 
         'ollama' => [
@@ -130,19 +126,16 @@ return [
         'openrouter' => [
             'driver' => 'openrouter',
             'key' => env('OPENROUTER_API_KEY'),
-            'url' => env('OPENROUTER_URL', 'https://openrouter.ai/api/v1'),
         ],
 
         'voyageai' => [
             'driver' => 'voyageai',
             'key' => env('VOYAGEAI_API_KEY'),
-            'url' => env('VOYAGEAI_URL', 'https://api.voyageai.com/v1'),
         ],
 
         'xai' => [
             'driver' => 'xai',
             'key' => env('XAI_API_KEY'),
-            'url' => env('XAI_URL', 'https://api.x.ai/v1'),
         ],
     ],
 


### PR DESCRIPTION
Most AI providers don't typically require custom base URLs, so including them in the default config creates unnecessary noise for the majority of users.

### Approach

- Strip default URL overrides from providers that rarely need them
- Keep URL overrides for providers where custom endpoints are more common