### PR TITLE
Handle Anthropic pause_turn server-tool continuations

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -6,7 +6,6 @@ use Generator;
 use Illuminate\Support\Str;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
-use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
@@ -58,6 +57,7 @@ trait HandlesTextStreaming
         $currentThinkingText = '';
         $currentSignature = '';
         $currentToolIndex = -1;
+        $currentServerToolInput = '';
         $pendingToolCalls = [];
         $responseContent = [];
 
@@ -156,6 +156,8 @@ trait HandlesTextStreaming
                         'arguments' => '',
                     ];
                 } elseif ($blockType === 'server_tool_use') {
+                    $currentServerToolInput = '';
+
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
                         $data['content_block']['id'] ?? '',
@@ -240,6 +242,8 @@ trait HandlesTextStreaming
                     if ($currentToolIndex >= 0 && isset($pendingToolCalls[$currentToolIndex])) {
                         $pendingToolCalls[$currentToolIndex]['arguments'] .= $partial;
                     }
+                } elseif ($deltaType === 'input_json_delta' && $currentBlockType === 'server_tool_use') {
+                    $currentServerToolInput .= (string) ($data['delta']['partial_json'] ?? '');
                 }
 
                 continue;
@@ -297,6 +301,10 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
                 } elseif ($currentBlockType === 'server_tool_use') {
                     $index = $data['index'] ?? count($responseContent) - 1;
+
+                    if ($currentServerToolInput !== '' && isset($responseContent[$index])) {
+                        $responseContent[$index]['input'] = json_decode($currentServerToolInput, true) ?? [];
+                    }
 
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
@@ -424,7 +432,7 @@ trait HandlesTextStreaming
         if ($depth + 1 >= ($maxSteps ?? round(count($tools) * 1.5))) {
             yield (new StreamEnd(
                 $this->generateEventId(),
-                FinishReason::ToolCalls->value,
+                'stop',
                 new Usage(0, 0),
                 time(),
             ))->withInvocationId($invocationId);

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -344,6 +344,29 @@ trait HandlesTextStreaming
             return;
         }
 
+        $lastBlock = $responseContent !== [] ? end($responseContent) : [];
+        $lastBlockType = $lastBlock['type'] ?? '';
+
+        if ($stopReason === 'pause_turn'
+            && $lastBlockType === 'server_tool_use'
+            && $depth + 1 < ($maxSteps ?? max(3, round(count($tools) * 1.5)))) {
+            yield from $this->resumeFromPauseTurn(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $responseContent,
+                $requestBody,
+                $depth,
+                $maxSteps,
+                $timeout,
+            );
+
+            return;
+        }
+
         yield (new StreamEnd(
             $this->generateEventId(),
             $this->extractFinishReason(['stop_reason' => $stopReason])->value,
@@ -424,6 +447,52 @@ trait HandlesTextStreaming
                 'tool_use_id' => $result->id,
                 'content' => $this->serializeToolResultOutput($result->result),
             ], $toolResults),
+        ];
+
+        $requestBody['stream'] = true;
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('messages', $requestBody),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $requestBody,
+            $depth + 1,
+            $maxSteps,
+            $timeout,
+        );
+    }
+
+    /**
+     * Resume a paused server-side loop by replaying the assistant response
+     * as-is and continuing to stream the follow-up response.
+     */
+    protected function resumeFromPauseTurn(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $responseContent,
+        array $requestBody,
+        int $depth,
+        ?int $maxSteps,
+        ?int $timeout = null,
+    ): Generator {
+        $requestBody['messages'][] = [
+            'role' => 'assistant',
+            'content' => $this->ensureToolInputIsObject(array_values($responseContent)),
         ];
 
         $requestBody['stream'] = true;

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -6,6 +6,7 @@ use Generator;
 use Illuminate\Support\Str;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
@@ -344,12 +345,8 @@ trait HandlesTextStreaming
             return;
         }
 
-        $lastBlock = $responseContent !== [] ? end($responseContent) : [];
-        $lastBlockType = $lastBlock['type'] ?? '';
-
         if ($stopReason === 'pause_turn'
-            && $lastBlockType === 'server_tool_use'
-            && $depth + 1 < ($maxSteps ?? max(3, round(count($tools) * 1.5)))) {
+            && $depth + 1 < ($maxSteps ?? 5)) {
             yield from $this->resumeFromPauseTurn(
                 $invocationId,
                 $provider,
@@ -427,7 +424,7 @@ trait HandlesTextStreaming
         if ($depth + 1 >= ($maxSteps ?? round(count($tools) * 1.5))) {
             yield (new StreamEnd(
                 $this->generateEventId(),
-                'stop',
+                FinishReason::ToolCalls->value,
                 new Usage(0, 0),
                 time(),
             ))->withInvocationId($invocationId);

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -236,14 +236,14 @@ trait HandlesTextStreaming
                             time(),
                         ))->withInvocationId($invocationId);
                     }
-                } elseif ($deltaType === 'input_json_delta' && $currentBlockType === 'tool_use') {
-                    $partial = $data['delta']['partial_json'] ?? '';
+                } elseif ($deltaType === 'input_json_delta') {
+                    $partial = (string) ($data['delta']['partial_json'] ?? '');
 
-                    if ($currentToolIndex >= 0 && isset($pendingToolCalls[$currentToolIndex])) {
+                    if ($currentBlockType === 'tool_use' && $currentToolIndex >= 0 && isset($pendingToolCalls[$currentToolIndex])) {
                         $pendingToolCalls[$currentToolIndex]['arguments'] .= $partial;
+                    } elseif ($currentBlockType === 'server_tool_use') {
+                        $currentServerToolInput .= $partial;
                     }
-                } elseif ($deltaType === 'input_json_delta' && $currentBlockType === 'server_tool_use') {
-                    $currentServerToolInput .= (string) ($data['delta']['partial_json'] ?? '');
                 }
 
                 continue;
@@ -353,8 +353,7 @@ trait HandlesTextStreaming
             return;
         }
 
-        if ($stopReason === 'pause_turn'
-            && $depth + 1 < ($maxSteps ?? 5)) {
+        if ($stopReason === 'pause_turn' && $depth + 1 < ($maxSteps ?? 5)) {
             yield from $this->resumeFromPauseTurn(
                 $invocationId,
                 $provider,

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -94,9 +94,21 @@ trait ParsesTextResponses
         $hasStructuredToolCall = count($realToolCalls) < count($toolCalls);
         $toolResults = [];
 
+        $stopReason = $data['stop_reason'] ?? '';
+
         $shouldContinue = $finishReason === FinishReason::ToolCalls
             && filled($realToolCalls)
             && $depth + 1 < ($maxSteps ?? round(count($tools) * 1.5));
+
+        // pause_turn is a server-side loop signal: the last content block is
+        // a dangling server_tool_use that the server needs echoed back. Can
+        // happen with no client tools registered, so its cap can't be tied
+        // to the tool count the way tool_use is. Fall back to a small
+        // default when not set.
+        $lastBlockType = $content !== [] ? ($content[array_key_last($content)]['type'] ?? '') : '';
+        $shouldResumePauseTurn = $stopReason === 'pause_turn'
+            && $lastBlockType === 'server_tool_use'
+            && $depth + 1 < ($maxSteps ?? max(3, round(count($tools) * 1.5)));
 
         if ($shouldContinue) {
             $toolResults = $this->executeToolCalls($realToolCalls, $tools);
@@ -105,6 +117,22 @@ trait ParsesTextResponses
         $steps->push(new Step($text, $toolCalls, $toolResults, $finishReason, $usage, $meta));
 
         $messages->push(new AssistantMessage($text, collect($toolCalls), $content));
+
+        if ($shouldResumePauseTurn) {
+            return $this->continueFromPauseTurn(
+                $data,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $requestBody,
+                $depth + 1,
+                $maxSteps,
+                $timeout,
+            );
+        }
 
         if ($shouldContinue) {
             $messages->push(new ToolResultMessage(collect($toolResults)));
@@ -217,6 +245,55 @@ trait ParsesTextResponses
         $requestBody['messages'][] = [
             'role' => 'user',
             'content' => $toolResultContent,
+        ];
+
+        unset($requestBody['stream']);
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('messages', $requestBody),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $requestBody,
+            $depth,
+            $maxSteps,
+            $timeout,
+        );
+    }
+
+    /**
+     * Continue the conversation after a pause_turn stop reason by replaying
+     * the assistant response as-is. No tool results are sent — the
+     * server-side loop resumes from the dangling server_tool_use block.
+     */
+    protected function continueFromPauseTurn(
+        array $previousData,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        array $requestBody,
+        int $depth,
+        ?int $maxSteps,
+        ?int $timeout = null,
+    ): TextResponse {
+        $requestBody['messages'][] = [
+            'role' => 'assistant',
+            'content' => $this->ensureToolInputIsObject($previousData['content'] ?? []),
         ];
 
         unset($requestBody['stream']);

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -100,15 +100,8 @@ trait ParsesTextResponses
             && filled($realToolCalls)
             && $depth + 1 < ($maxSteps ?? round(count($tools) * 1.5));
 
-        // pause_turn is a server-side loop signal: the last content block is
-        // a dangling server_tool_use that the server needs echoed back. Can
-        // happen with no client tools registered, so its cap can't be tied
-        // to the tool count the way tool_use is. Fall back to a small
-        // default when not set.
-        $lastBlockType = $content !== [] ? ($content[array_key_last($content)]['type'] ?? '') : '';
         $shouldResumePauseTurn = $stopReason === 'pause_turn'
-            && $lastBlockType === 'server_tool_use'
-            && $depth + 1 < ($maxSteps ?? max(3, round(count($tools) * 1.5)));
+            && $depth + 1 < ($maxSteps ?? 5);
 
         if ($shouldContinue) {
             $toolResults = $this->executeToolCalls($realToolCalls, $tools);
@@ -275,8 +268,7 @@ trait ParsesTextResponses
 
     /**
      * Continue the conversation after a pause_turn stop reason by replaying
-     * the assistant response as-is. No tool results are sent — the
-     * server-side loop resumes from the dangling server_tool_use block.
+     * the assistant response as-is so the server can resume its turn.
      */
     protected function continueFromPauseTurn(
         array $previousData,

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -164,16 +164,13 @@ describe('thinking blocks', function () {
 
 describe('pause_turn', function () {
     test('streaming pause_turn triggers follow-up stream with assistant replayed', function () {
-        // A paused server-side loop (e.g. a dangling server_tool_use for
-        // advisor) ends the first stream with stop_reason: pause_turn.
-        // The client must reopen the stream replaying the assistant content
-        // verbatim so the server can resume.
         Http::fake([
             'api.anthropic.com/*' => Http::sequence([
                 Http::response(
                     body: $this->ssePayload([
                         $this->messageStart(),
-                        $this->contentBlockStart(0, ['type' => 'server_tool_use', 'id' => 'srvtoolu_pause', 'name' => 'advisor']),
+                        $this->contentBlockStart(0, ['type' => 'server_tool_use', 'id' => 'srvtoolu_pause', 'name' => 'web_search']),
+                        $this->contentBlockDelta(0, ['type' => 'input_json_delta', 'partial_json' => '{"query":"laravel ai"}']),
                         $this->contentBlockStop(0),
                         $this->messageDelta('pause_turn', 5),
                     ]),
@@ -204,7 +201,8 @@ describe('pause_turn', function () {
 
         expect($lastMessage['role'])->toBe('assistant')
             ->and($lastMessage['content'][0]['type'])->toBe('server_tool_use')
-            ->and($lastMessage['content'][0]['input'])->toBeInstanceOf(stdClass::class);
+            ->and($lastMessage['content'][0]['input'])->toBeInstanceOf(stdClass::class)
+            ->and($lastMessage['content'][0]['input']->query)->toBe('laravel ai');
 
         $textDeltas = array_values(array_filter($events, fn ($e) => $e instanceof TextDelta));
         expect($textDeltas)->not->toBeEmpty()

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -162,6 +162,56 @@ describe('thinking blocks', function () {
     });
 });
 
+describe('pause_turn', function () {
+    test('streaming pause_turn triggers follow-up stream with assistant replayed', function () {
+        // A paused server-side loop (e.g. a dangling server_tool_use for
+        // advisor) ends the first stream with stop_reason: pause_turn.
+        // The client must reopen the stream replaying the assistant content
+        // verbatim so the server can resume.
+        Http::fake([
+            'api.anthropic.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->messageStart(),
+                        $this->contentBlockStart(0, ['type' => 'server_tool_use', 'id' => 'srvtoolu_pause', 'name' => 'advisor']),
+                        $this->contentBlockStop(0),
+                        $this->messageDelta('pause_turn', 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->messageStart(),
+                        $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+                        $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'Resumed']),
+                        $this->contentBlockStop(0),
+                        $this->messageDelta('end_turn', 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $recorded = Http::recorded();
+        expect($recorded)->toHaveCount(2);
+
+        $followUpBody = $recorded[1][0]->data();
+        $lastMessage = end($followUpBody['messages']);
+
+        expect($lastMessage['role'])->toBe('assistant')
+            ->and($lastMessage['content'][0]['type'])->toBe('server_tool_use')
+            ->and($lastMessage['content'][0]['input'])->toBeInstanceOf(stdClass::class);
+
+        $textDeltas = array_values(array_filter($events, fn ($e) => $e instanceof TextDelta));
+        expect($textDeltas)->not->toBeEmpty()
+            ->and($textDeltas[0]->delta)->toBe('Resumed');
+    });
+});
+
 describe('error handling', function () {
     test('streaming error event stops stream', function () {
         Http::fake([

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -75,56 +75,6 @@ test('server_tool_use input is serialized as object on follow-up replay', functi
         ->not->toContain('"input":[]');
 });
 
-test('pause_turn stop reason triggers follow-up request replaying assistant content', function () {
-    // A dangling server_tool_use (e.g. advisor) can produce stop_reason:
-    // pause_turn, which means the server-side loop needs the client to send
-    // the assistant response back verbatim so the server can continue.
-    // Without handling, the conversation terminates prematurely.
-    $pauseTurnResponse = Http::response([
-        'id' => 'msg_pause',
-        'type' => 'message',
-        'role' => 'assistant',
-        'model' => 'claude-sonnet-4-6',
-        'content' => [
-            ['type' => 'text', 'text' => 'Consulting advisor.'],
-            [
-                'type' => 'server_tool_use',
-                'id' => 'srvtoolu_pause',
-                'name' => 'advisor',
-                'input' => (object) [],
-            ],
-        ],
-        'stop_reason' => 'pause_turn',
-        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
-    ]);
-
-    Http::fake([
-        'api.anthropic.com/*' => Http::sequence([
-            $pauseTurnResponse,
-            $this->fakeTextResponse('Done'),
-        ]),
-    ]);
-
-    (new ToolUsingAgent(fixed: true))->prompt(
-        'Help me plan something',
-        provider: 'anthropic',
-    );
-
-    $recorded = Http::recorded();
-    expect($recorded)->toHaveCount(2);
-
-    $payload = json_decode($recorded[1][0]->body(), false, 512, JSON_THROW_ON_ERROR);
-
-    $messages = $payload->messages;
-    $lastMessage = end($messages);
-
-    expect($lastMessage->role)->toBe('assistant')
-        ->and(array_column((array) $lastMessage->content, 'type'))->toBe(['text', 'server_tool_use']);
-
-    $serverToolUse = collect($lastMessage->content)->firstWhere('type', 'server_tool_use');
-    expect($serverToolUse->input)->toBeInstanceOf(stdClass::class);
-});
-
 test('pause_turn resumes when last block is text following a web_search_tool_result', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -75,6 +75,56 @@ test('server_tool_use input is serialized as object on follow-up replay', functi
         ->not->toContain('"input":[]');
 });
 
+test('pause_turn stop reason triggers follow-up request replaying assistant content', function () {
+    // A dangling server_tool_use (e.g. advisor) can produce stop_reason:
+    // pause_turn, which means the server-side loop needs the client to send
+    // the assistant response back verbatim so the server can continue.
+    // Without handling, the conversation terminates prematurely.
+    $pauseTurnResponse = Http::response([
+        'id' => 'msg_pause',
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-sonnet-4-6',
+        'content' => [
+            ['type' => 'text', 'text' => 'Consulting advisor.'],
+            [
+                'type' => 'server_tool_use',
+                'id' => 'srvtoolu_pause',
+                'name' => 'advisor',
+                'input' => (object) [],
+            ],
+        ],
+        'stop_reason' => 'pause_turn',
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ]);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            $pauseTurnResponse,
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Help me plan something',
+        provider: 'anthropic',
+    );
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $payload = json_decode($recorded[1][0]->body(), false, 512, JSON_THROW_ON_ERROR);
+
+    $messages = $payload->messages;
+    $lastMessage = end($messages);
+
+    expect($lastMessage->role)->toBe('assistant')
+        ->and(array_column((array) $lastMessage->content, 'type'))->toBe(['text', 'server_tool_use']);
+
+    $serverToolUse = collect($lastMessage->content)->firstWhere('type', 'server_tool_use');
+    expect($serverToolUse->input)->toBeInstanceOf(stdClass::class);
+});
+
 test('max steps limits tool call depth', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -125,6 +125,107 @@ test('pause_turn stop reason triggers follow-up request replaying assistant cont
     expect($serverToolUse->input)->toBeInstanceOf(stdClass::class);
 });
 
+test('pause_turn is ignored when last block is not server_tool_use', function () {
+    // Guard: pause_turn should only resume when the last content block is a
+    // dangling server_tool_use (matches Anthropic's documented contract).
+    // If it fires on any pause_turn we risk spurious continuations and
+    // possibly reflecting wrong content back to the server.
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'msg_pause',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [
+                    [
+                        'type' => 'server_tool_use',
+                        'id' => 'srvtoolu_1',
+                        'name' => 'advisor',
+                        'input' => (object) [],
+                    ],
+                    ['type' => 'text', 'text' => 'Paused here.'],
+                ],
+                'stop_reason' => 'pause_turn',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            $this->fakeTextResponse('should not be called'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Ask',
+        provider: 'anthropic',
+    );
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
+test('full compose: pause_turn + server_tool_use replay with input cast and block order preserved', function () {
+    // End-to-end unit test exercising PR 1 + PR 2 + PR 3 together.
+    // First response: server_tool_use + advisor_tool_result + text with
+    // stop_reason pause_turn AND a dangling server_tool_use as the final
+    // block. The SDK must replay all blocks in original order, cast the
+    // empty server_tool_use.input to {}, and recurse without user
+    // intervention.
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'msg_compose',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [
+                    [
+                        'type' => 'server_tool_use',
+                        'id' => 'srvtoolu_1',
+                        'name' => 'advisor',
+                        'input' => (object) [],
+                    ],
+                    [
+                        'type' => 'advisor_tool_result',
+                        'tool_use_id' => 'srvtoolu_1',
+                        'content' => ['type' => 'advisor_result', 'text' => 'Plan.'],
+                    ],
+                    ['type' => 'text', 'text' => 'Consulting again.'],
+                    [
+                        'type' => 'server_tool_use',
+                        'id' => 'srvtoolu_2',
+                        'name' => 'advisor',
+                        'input' => (object) [],
+                    ],
+                ],
+                'stop_reason' => 'pause_turn',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Compose test',
+        provider: 'anthropic',
+    );
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $payload = json_decode($recorded[1][0]->body(), false, 512, JSON_THROW_ON_ERROR);
+    $assistant = collect($payload->messages)->first(fn ($m) => $m->role === 'assistant');
+
+    expect(array_column((array) $assistant->content, 'type'))->toBe([
+        'server_tool_use',
+        'advisor_tool_result',
+        'text',
+        'server_tool_use',
+    ]);
+
+    $serverBlocks = collect($assistant->content)->where('type', 'server_tool_use')->values();
+    expect($serverBlocks)->toHaveCount(2)
+        ->and($serverBlocks[0]->input)->toBeInstanceOf(stdClass::class)
+        ->and($serverBlocks[1]->input)->toBeInstanceOf(stdClass::class);
+});
+
 test('max steps limits tool call depth', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -125,11 +125,7 @@ test('pause_turn stop reason triggers follow-up request replaying assistant cont
     expect($serverToolUse->input)->toBeInstanceOf(stdClass::class);
 });
 
-test('pause_turn is ignored when last block is not server_tool_use', function () {
-    // Guard: pause_turn should only resume when the last content block is a
-    // dangling server_tool_use (matches Anthropic's documented contract).
-    // If it fires on any pause_turn we risk spurious continuations and
-    // possibly reflecting wrong content back to the server.
+test('pause_turn resumes when last block is text following a web_search_tool_result', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([
             Http::response([
@@ -141,15 +137,20 @@ test('pause_turn is ignored when last block is not server_tool_use', function ()
                     [
                         'type' => 'server_tool_use',
                         'id' => 'srvtoolu_1',
-                        'name' => 'advisor',
-                        'input' => (object) [],
+                        'name' => 'web_search',
+                        'input' => (object) ['query' => 'q'],
                     ],
-                    ['type' => 'text', 'text' => 'Paused here.'],
+                    [
+                        'type' => 'web_search_tool_result',
+                        'tool_use_id' => 'srvtoolu_1',
+                        'content' => [],
+                    ],
+                    ['type' => 'text', 'text' => 'Paused mid-summary.'],
                 ],
                 'stop_reason' => 'pause_turn',
                 'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
             ]),
-            $this->fakeTextResponse('should not be called'),
+            $this->fakeTextResponse('Done'),
         ]),
     ]);
 
@@ -158,7 +159,7 @@ test('pause_turn is ignored when last block is not server_tool_use', function ()
         provider: 'anthropic',
     );
 
-    expect(Http::recorded())->toHaveCount(1);
+    expect(Http::recorded())->toHaveCount(2);
 });
 
 test('full compose: pause_turn + server_tool_use replay with input cast and block order preserved', function () {

--- a/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolCallLoopTest.php
@@ -163,12 +163,6 @@ test('pause_turn resumes when last block is text following a web_search_tool_res
 });
 
 test('full compose: pause_turn + server_tool_use replay with input cast and block order preserved', function () {
-    // End-to-end unit test exercising PR 1 + PR 2 + PR 3 together.
-    // First response: server_tool_use + advisor_tool_result + text with
-    // stop_reason pause_turn AND a dangling server_tool_use as the final
-    // block. The SDK must replay all blocks in original order, cast the
-    // empty server_tool_use.input to {}, and recurse without user
-    // intervention.
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([
             Http::response([


### PR DESCRIPTION
Anthropic can return `stop_reason: "pause_turn"` when a server-side tool loop needs the client to send the assistant response back as-is so the server can continue. We currently treat that as terminal: streaming yields `StreamEnd`, non-streaming returns `FinishReason::Unknown`, and the conversation ends early.

This adds a dedicated resume path for both streaming and non-streaming. On `pause_turn`, the SDK replays the assistant content blocks and asks Anthropic to continue the same turn. This handles cases where the paused response ends with a dangling `server_tool_use`, and cases where server-tool results/text have already been emitted before Anthropic asks the client to continue.

The resume loop respects explicit `maxSteps`; when it is not set, it uses a small fixed cap because `pause_turn` can happen with zero client tools. Streaming replay also preserves server-tool `input_json_delta` payloads so the assistant content is replayed with the original server-tool input instead of `{}`.

Tests cover non-streaming resume, streaming resume with server-tool input preservation, continuation when the last block is text after a server-tool result, and a compose case that exercises input casting and content-block round-tripping together with resume.