### PR TITLE
Add error handling tests for Azure OpenAI embeddings

### DIFF
--- a/tests/Feature/Providers/AzureOpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/EmbeddingTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
     config(['ai.providers.azure' => [
@@ -85,6 +88,45 @@ test('multiple inputs return multiple embeddings', function () {
 
     expect($response->embeddings)->toHaveCount(2);
 });
+
+test('embeddings rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => Http::response([
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'Rate limit exceeded',
+            ],
+        ], 429),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'azure', model: 'text-embedding-3-small');
+})->throws(RateLimitedException::class);
+
+test('embeddings overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => Http::response([
+            'error' => [
+                'type' => 'server_error',
+                'message' => 'The server is currently overloaded. Please try again later.',
+            ],
+        ], 503),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'azure', model: 'text-embedding-3-small');
+})->throws(ProviderOverloadedException::class);
+
+test('embeddings http error response throws request exception', function () {
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'Invalid input',
+            ],
+        ], 400),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'azure', model: 'text-embedding-3-small');
+})->throws(RequestException::class);
 
 function fakeAzureEmbeddingsResponse()
 {


### PR DESCRIPTION
The existing `EmbeddingTest` for Azure OpenAI covers the happy path but `withErrorHandling()` on the embedding gateway is never exercised. This adds the three error cases:

- 429 → `RateLimitedException`
- 503 → `ProviderOverloadedException`
- 400 → `RequestException`

Error response shapes and URL pattern match the format used in the existing Azure `ErrorHandlingTest`.