### PR TITLE
Add error handling tests for OpenRouter embeddings

### DIFF
--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -230,6 +230,8 @@ class OpenRouterGateway implements EmbeddingGateway, ImageGateway, TextGateway
 
         $data = $response->json();
 
+        $this->validateTextResponse($data);
+
         return new EmbeddingsResponse(
             (new Collection($data['data'] ?? []))->pluck('embedding')->all(),
             $data['usage']['prompt_tokens'] ?? 0,

--- a/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
@@ -82,21 +82,29 @@ test('embeddings rate limit response throws rate limited exception', function ()
         'openrouter.ai/*' => Http::response(['error' => ['message' => 'Rate limited']], 429),
     ]);
 
-    Ai::instance('openrouter')->embeddings(['Hello']);
-})->throws(RateLimitedException::class);
+    expect(fn () => Ai::instance('openrouter')->embeddings(['Hello']))
+        ->toThrow(RateLimitedException::class);
+});
 
 test('embeddings overloaded response throws provider overloaded exception', function () {
     Http::fake([
         'openrouter.ai/*' => Http::response(['error' => ['message' => 'Server overloaded']], 503),
     ]);
 
-    Ai::instance('openrouter')->embeddings(['Hello']);
-})->throws(ProviderOverloadedException::class);
+    expect(fn () => Ai::instance('openrouter')->embeddings(['Hello']))
+        ->toThrow(ProviderOverloadedException::class);
+});
 
-test('embeddings http error response throws request exception', function () {
+test('embeddings error in 200 response throws ai exception', function () {
     Http::fake([
-        'openrouter.ai/*' => Http::response(['error' => ['message' => 'Bad request']], 400),
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'The model does not exist.',
+            ],
+        ]),
     ]);
 
-    Ai::instance('openrouter')->embeddings(['Hello']);
-})->throws(RequestException::class);
+    expect(fn () => Ai::instance('openrouter')->embeddings(['Hello']))
+        ->toThrow(AiException::class, 'OpenRouter Error');
+});

--- a/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
     config(['ai.providers.openrouter' => [
@@ -73,3 +76,27 @@ test('embeddings request uses openrouter base url', function () {
 
     Http::assertSent(fn (Request $request) => $request->url() === 'https://openrouter.ai/api/v1/embeddings');
 });
+
+test('embeddings rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response(['error' => ['message' => 'Rate limited']], 429),
+    ]);
+
+    Ai::instance('openrouter')->embeddings(['Hello']);
+})->throws(RateLimitedException::class);
+
+test('embeddings overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response(['error' => ['message' => 'Server overloaded']], 503),
+    ]);
+
+    Ai::instance('openrouter')->embeddings(['Hello']);
+})->throws(ProviderOverloadedException::class);
+
+test('embeddings http error response throws request exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response(['error' => ['message' => 'Bad request']], 400),
+    ]);
+
+    Ai::instance('openrouter')->embeddings(['Hello']);
+})->throws(RequestException::class);


### PR DESCRIPTION
The existing `EmbeddingsTest` for OpenRouter covers the happy path but `withErrorHandling()` on the embedding gateway is never exercised. This adds the three error cases:

- 429 → `RateLimitedException`
- 503 → `ProviderOverloadedException`
- 400 → `RequestException`

Error response shapes and URL pattern match the format used in the existing OpenRouter `ErrorHandlingTest`.