### PR TITLE
Add toArray and jsonSerialize to StructuredStep

### DIFF
--- a/src/Responses/Data/StructuredStep.php
+++ b/src/Responses/Data/StructuredStep.php
@@ -26,9 +26,7 @@ class StructuredStep extends Step
      */
     public function toArray(): array
     {
-        return array_merge(parent::toArray(), [
-            'structured' => $this->structured,
-        ]);
+        return [...parent::toArray(), 'structured' => $this->structured];
     }
 
     /**

--- a/src/Responses/Data/StructuredStep.php
+++ b/src/Responses/Data/StructuredStep.php
@@ -20,4 +20,22 @@ class StructuredStep extends Step
     ) {
         parent::__construct($text, $toolCalls, $toolResults, $finishReason, $usage, $meta);
     }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return array_merge(parent::toArray(), [
+            'structured' => $this->structured,
+        ]);
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
 }

--- a/tests/Unit/Responses/Data/FinishReasonTest.php
+++ b/tests/Unit/Responses/Data/FinishReasonTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Laravel\Ai\Responses\Data\FinishReason;
+
+test('finish reason enum has expected cases', function () {
+    expect(FinishReason::Stop->value)->toBe('stop')
+        ->and(FinishReason::ToolCalls->value)->toBe('tool_calls')
+        ->and(FinishReason::Length->value)->toBe('length')
+        ->and(FinishReason::ContentFilter->value)->toBe('content_filter')
+        ->and(FinishReason::Error->value)->toBe('error')
+        ->and(FinishReason::Unknown->value)->toBe('unknown');
+});

--- a/tests/Unit/Responses/Data/GeneratedImageTest.php
+++ b/tests/Unit/Responses/Data/GeneratedImageTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Laravel\Ai\Responses\Data\GeneratedImage;
+
+test('generated image stores base64 encoded image', function () {
+    $image = new GeneratedImage('SGVsbG8gV29ybGQ=', 'image/png');
+
+    expect($image->image)->toBe('SGVsbG8gV29ybGQ=')
+        ->and($image->mime)->toBe('image/png');
+});
+
+test('generated image accepts null mime type', function () {
+    $image = new GeneratedImage('YmFzZTY0IGRhdGE=');
+
+    expect($image->image)->toBe('YmFzZTY0IGRhdGE=')
+        ->and($image->mime)->toBeNull();
+});
+
+test('generated image content decodes base64 to string', function () {
+    $image = new GeneratedImage('SGVsbG8gV29ybGQ=');
+
+    expect($image->content())->toBe('Hello World');
+});
+
+test('generated image to array includes image and mime', function () {
+    $image = new GeneratedImage('dGVzdCBpbWFnZQ==', 'image/jpeg');
+
+    $array = $image->toArray();
+
+    expect($array['image'])->toBe('dGVzdCBpbWFnZQ==')
+        ->and($array['mime'])->toBe('image/jpeg');
+});
+
+test('generated image json serialize returns to array', function () {
+    $image = new GeneratedImage('ZGF0YQ==', 'image/webp');
+
+    $json = $image->jsonSerialize();
+
+    expect($json['image'])->toBe('ZGF0YQ==')
+        ->and($json['mime'])->toBe('image/webp');
+});
+
+test('generated image to string returns decoded content', function () {
+    $image = new GeneratedImage('VGVzdA==');
+
+    expect((string) $image)->toBe('Test');
+});

--- a/tests/Unit/Responses/Data/MetaTest.php
+++ b/tests/Unit/Responses/Data/MetaTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Laravel\Ai\Responses\Data\Meta;
+
+test('meta extracts provider and model from response', function () {
+    $meta = new Meta('openai', 'gpt-4o');
+
+    expect($meta->provider)->toBe('openai')
+        ->and($meta->model)->toBe('gpt-4o');
+});
+
+test('meta accepts null provider and model', function () {
+    $meta = new Meta(null, null);
+
+    expect($meta->provider)->toBeNull()
+        ->and($meta->model)->toBeNull();
+});
+
+test('meta returns empty citations when not provided', function () {
+    $meta = new Meta('openai', 'gpt-4o');
+
+    expect($meta->citations)->toBeEmpty();
+});
+
+test('meta to array includes provider model and citations', function () {
+    $meta = new Meta('openai', 'gpt-4o');
+
+    $array = $meta->toArray();
+
+    expect($array['provider'])->toBe('openai')
+        ->and($array['model'])->toBe('gpt-4o')
+        ->and($array['citations'])->toBe([]);
+});
+
+test('meta json serialize returns to array', function () {
+    $meta = new Meta('anthropic', 'claude-3-opus');
+
+    $json = $meta->jsonSerialize();
+
+    expect($json['provider'])->toBe('anthropic')
+        ->and($json['model'])->toBe('claude-3-opus');
+});

--- a/tests/Unit/Responses/Data/RankedDocumentTest.php
+++ b/tests/Unit/Responses/Data/RankedDocumentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Laravel\Ai\Responses\Data\RankedDocument;
+
+test('ranked document stores index document and score', function () {
+    $doc = new RankedDocument(0, 'test document content', 0.95);
+
+    expect($doc->index)->toBe(0)
+        ->and($doc->document)->toBe('test document content')
+        ->and($doc->score)->toBe(0.95);
+});
+
+test('ranked document to array returns all properties', function () {
+    $doc = new RankedDocument(2, 'relevant content', 0.85);
+
+    $array = $doc->toArray();
+
+    expect($array['index'])->toBe(2)
+        ->and($array['document'])->toBe('relevant content')
+        ->and($array['score'])->toBe(0.85);
+});
+
+test('ranked document json serialize returns to array', function () {
+    $doc = new RankedDocument(1, 'search result', 0.75);
+
+    $json = $doc->jsonSerialize();
+
+    expect($json['index'])->toBe(1)
+        ->and($json['document'])->toBe('search result')
+        ->and($json['score'])->toBe(0.75);
+});
+
+test('ranked document to string returns document content', function () {
+    $doc = new RankedDocument(0, 'document text content', 0.5);
+
+    expect((string) $doc)->toBe('document text content');
+});

--- a/tests/Unit/Responses/Data/StepTest.php
+++ b/tests/Unit/Responses/Data/StepTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\FinishReason;
-use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\Usage;
 
 test('step stores text tool calls and other properties', function () {
     $usage = new Usage(10, 5);

--- a/tests/Unit/Responses/Data/StepTest.php
+++ b/tests/Unit/Responses/Data/StepTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\Data\Meta;
+
+test('step stores text tool calls and other properties', function () {
+    $usage = new Usage(10, 5);
+    $meta = new Meta('openai', 'gpt-4o');
+    $step = new Step(
+        text: 'Hello',
+        toolCalls: [],
+        toolResults: [],
+        finishReason: FinishReason::Stop,
+        usage: $usage,
+        meta: $meta
+    );
+
+    expect($step->text)->toBe('Hello')
+        ->and($step->toolCalls)->toBeEmpty()
+        ->and($step->toolResults)->toBeEmpty()
+        ->and($step->finishReason)->toBe(FinishReason::Stop)
+        ->and($step->usage)->toBe($usage)
+        ->and($step->meta)->toBe($meta);
+});
+
+test('step to array returns all properties including serialized usage and meta', function () {
+    $usage = new Usage(10, 5);
+    $meta = new Meta('openai', 'gpt-4o');
+    $step = new Step('test', [], [], FinishReason::Stop, $usage, $meta);
+
+    $array = $step->toArray();
+
+    expect($array['text'])->toBe('test')
+        ->and($array['tool_calls'])->toBe([])
+        ->and($array['tool_results'])->toBe([])
+        ->and($array['finish_reason'])->toBe('stop')
+        ->and($array['usage'])->toBe($usage)
+        ->and($array['meta'])->toBe($meta);
+});
+
+test('step json serialize returns to array', function () {
+    $usage = new Usage(0, 0);
+    $meta = new Meta(null, null);
+    $step = new Step('', [], [], FinishReason::Unknown, $usage, $meta);
+
+    expect($step->jsonSerialize())->toBe($step->toArray());
+});

--- a/tests/Unit/Responses/Data/StoreFileCountsTest.php
+++ b/tests/Unit/Responses/Data/StoreFileCountsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Laravel\Ai\Responses\Data\StoreFileCounts;
+
+test('store file counts stores completed pending and failed counts', function () {
+    $counts = new StoreFileCounts(10, 5, 2);
+
+    expect($counts->completed)->toBe(10)
+        ->and($counts->pending)->toBe(5)
+        ->and($counts->failed)->toBe(2);
+});
+
+test('store file counts to array returns all counts', function () {
+    $counts = new StoreFileCounts(1, 0, 0);
+
+    $array = $counts->toArray();
+
+    expect($array)->toBe([
+        'completed' => 1,
+        'pending' => 0,
+        'failed' => 0,
+    ]);
+});
+
+test('store file counts json serialize returns to array', function () {
+    $counts = new StoreFileCounts(5, 5, 5);
+
+    expect($counts->jsonSerialize())->toBe($counts->toArray());
+});

--- a/tests/Unit/Responses/Data/StructuredStepTest.php
+++ b/tests/Unit/Responses/Data/StructuredStepTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\StructuredStep;
+use Laravel\Ai\Responses\Data\Usage;
+
+test('structured step stores structured data', function () {
+    $step = new StructuredStep(
+        'test response',
+        ['key' => 'value'],
+        [],
+        [],
+        FinishReason::Stop,
+        new Usage,
+        new Meta('openai', 'gpt-4o')
+    );
+
+    expect($step->text)->toBe('test response')
+        ->and($step->structured)->toBe(['key' => 'value']);
+});
+
+test('structured step to array includes structured data', function () {
+    $step = new StructuredStep(
+        'text content',
+        ['name' => 'test', 'count' => 5],
+        [],
+        [],
+        FinishReason::Stop,
+        new Usage,
+        new Meta('anthropic', 'claude-3')
+    );
+
+    $array = $step->toArray();
+
+    expect($array['text'])->toBe('text content')
+        ->and($array['structured'])->toBe(['name' => 'test', 'count' => 5]);
+});
+
+test('structured step jsonSerialize includes structured data', function () {
+    $step = new StructuredStep(
+        'response text',
+        ['result' => true],
+        [],
+        [],
+        FinishReason::Stop,
+        new Usage,
+        new Meta('openai', 'gpt-4o')
+    );
+
+    $json = json_decode(json_encode($step), true);
+
+    expect($json['structured'])->toBe(['result' => true])
+        ->and($json['text'])->toBe('response text');
+});

--- a/tests/Unit/Responses/Data/ToolCallTest.php
+++ b/tests/Unit/Responses/Data/ToolCallTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Laravel\Ai\Responses\Data\ToolCall;
+
+test('tool call stores all properties', function () {
+    $toolCall = new ToolCall(
+        id: 'call_123',
+        name: 'get_weather',
+        arguments: ['city' => 'San Francisco'],
+        resultId: 'res_456',
+        reasoningId: 'reason_789',
+        reasoningSummary: ['thought' => 'I should check the weather']
+    );
+
+    expect($toolCall->id)->toBe('call_123')
+        ->and($toolCall->name)->toBe('get_weather')
+        ->and($toolCall->arguments)->toBe(['city' => 'San Francisco'])
+        ->and($toolCall->resultId)->toBe('res_456')
+        ->and($toolCall->reasoningId)->toBe('reason_789')
+        ->and($toolCall->reasoningSummary)->toBe(['thought' => 'I should check the weather']);
+});
+
+test('tool call to array returns all properties', function () {
+    $toolCall = new ToolCall('id', 'name', ['arg' => 'val']);
+
+    $array = $toolCall->toArray();
+
+    expect($array)->toBe([
+        'id' => 'id',
+        'name' => 'name',
+        'arguments' => ['arg' => 'val'],
+        'result_id' => null,
+        'reasoning_id' => null,
+        'reasoning_summary' => null,
+    ]);
+});
+
+test('tool call json serialize returns to array', function () {
+    $toolCall = new ToolCall('id', 'name', []);
+
+    expect($toolCall->jsonSerialize())->toBe($toolCall->toArray());
+});

--- a/tests/Unit/Responses/Data/ToolResultTest.php
+++ b/tests/Unit/Responses/Data/ToolResultTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Laravel\Ai\Responses\Data\ToolResult;
+
+test('tool result stores all properties', function () {
+    $result = new ToolResult(
+        id: 'call_123',
+        name: 'get_weather',
+        arguments: ['city' => 'London'],
+        result: ['temp' => 20],
+        resultId: 'msg_789'
+    );
+
+    expect($result->id)->toBe('call_123')
+        ->and($result->name)->toBe('get_weather')
+        ->and($result->arguments)->toBe(['city' => 'London'])
+        ->and($result->result)->toBe(['temp' => 20])
+        ->and($result->resultId)->toBe('msg_789');
+});
+
+test('tool result to array returns all properties', function () {
+    $result = new ToolResult('id', 'name', [], 'raw result');
+
+    $array = $result->toArray();
+
+    expect($array)->toBe([
+        'id' => 'id',
+        'name' => 'name',
+        'arguments' => [],
+        'result' => 'raw result',
+        'result_id' => null,
+    ]);
+});
+
+test('tool result json serialize returns to array', function () {
+    $result = new ToolResult('id', 'name', [], 'val');
+
+    expect($result->jsonSerialize())->toBe($result->toArray());
+});

--- a/tests/Unit/Responses/Data/TranscriptionSegmentTest.php
+++ b/tests/Unit/Responses/Data/TranscriptionSegmentTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+
+test('transcription segment stores text speaker and timestamps', function () {
+    $segment = new TranscriptionSegment('Hello world', 'Speaker 1', 0.0, 2.5);
+
+    expect($segment->text)->toBe('Hello world')
+        ->and($segment->speaker)->toBe('Speaker 1')
+        ->and($segment->startSeconds)->toBe(0.0)
+        ->and($segment->endSeconds)->toBe(2.5);
+});
+
+test('transcription segment to array returns all properties', function () {
+    $segment = new TranscriptionSegment('Test speech', 'Speaker A', 1.0, 3.5);
+
+    $array = $segment->toArray();
+
+    expect($array['text'])->toBe('Test speech')
+        ->and($array['speaker'])->toBe('Speaker A')
+        ->and($array['start_seconds'])->toBe(1.0)
+        ->and($array['end_seconds'])->toBe(3.5);
+});
+
+test('transcription segment json serialize returns to array', function () {
+    $segment = new TranscriptionSegment('Content', 'Speaker', 5.0, 10.0);
+
+    $json = $segment->jsonSerialize();
+
+    expect($json['text'])->toBe('Content')
+        ->and($json['speaker'])->toBe('Speaker');
+});

--- a/tests/Unit/Responses/Data/UrlCitationTest.php
+++ b/tests/Unit/Responses/Data/UrlCitationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Laravel\Ai\Responses\Data\UrlCitation;
+
+test('url citation stores url and title', function () {
+    $citation = new UrlCitation('https://example.com', 'Example');
+
+    expect($citation->url)->toBe('https://example.com')
+        ->and($citation->title)->toBe('Example');
+});
+
+test('url citation to array returns url and title', function () {
+    $citation = new UrlCitation('https://laravel.com', 'Laravel');
+
+    $array = $citation->toArray();
+
+    expect($array['url'])->toBe('https://laravel.com')
+        ->and($array['title'])->toBe('Laravel');
+});
+
+test('url citation json serialize returns to array', function () {
+    $citation = new UrlCitation('https://google.com');
+
+    $json = $citation->jsonSerialize();
+
+    expect($json['url'])->toBe('https://google.com')
+        ->and($json['title'])->toBeNull();
+});

--- a/tests/Unit/Responses/Data/UsageTest.php
+++ b/tests/Unit/Responses/Data/UsageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Laravel\Ai\Responses\Data\Usage;
+
+test('usage defaults all tokens to zero', function () {
+    $usage = new Usage;
+
+    expect($usage->promptTokens)->toBe(0)
+        ->and($usage->completionTokens)->toBe(0)
+        ->and($usage->cacheWriteInputTokens)->toBe(0)
+        ->and($usage->cacheReadInputTokens)->toBe(0)
+        ->and($usage->reasoningTokens)->toBe(0);
+});
+
+test('usage accepts token values in constructor', function () {
+    $usage = new Usage(100, 50, 25, 10, 5);
+
+    expect($usage->promptTokens)->toBe(100)
+        ->and($usage->completionTokens)->toBe(50)
+        ->and($usage->cacheWriteInputTokens)->toBe(25)
+        ->and($usage->cacheReadInputTokens)->toBe(10)
+        ->and($usage->reasoningTokens)->toBe(5);
+});
+
+test('usage add returns new instance with summed tokens', function () {
+    $usage1 = new Usage(100, 50, 25, 10, 5);
+    $usage2 = new Usage(50, 25, 10, 5, 0);
+
+    $combined = $usage1->add($usage2);
+
+    expect($combined->promptTokens)->toBe(150)
+        ->and($combined->completionTokens)->toBe(75)
+        ->and($combined->cacheWriteInputTokens)->toBe(35)
+        ->and($combined->cacheReadInputTokens)->toBe(15)
+        ->and($combined->reasoningTokens)->toBe(5);
+});
+
+test('usage add does not mutate original', function () {
+    $usage1 = new Usage(100, 50, 25, 10, 5);
+    $usage2 = new Usage(50, 25, 10, 5, 0);
+
+    $usage1->add($usage2);
+
+    expect($usage1->promptTokens)->toBe(100)
+        ->and($usage1->completionTokens)->toBe(50);
+});
+
+test('usage to array includes all token fields', function () {
+    $usage = new Usage(100, 50, 25, 10, 5);
+
+    $array = $usage->toArray();
+
+    expect($array['prompt_tokens'])->toBe(100)
+        ->and($array['completion_tokens'])->toBe(50)
+        ->and($array['cache_write_input_tokens'])->toBe(25)
+        ->and($array['cache_read_input_tokens'])->toBe(10)
+        ->and($array['reasoning_tokens'])->toBe(5);
+});
+
+test('usage json serialize returns to array', function () {
+    $usage = new Usage(200, 100, 50, 20, 10);
+
+    $json = $usage->jsonSerialize();
+
+    expect($json['prompt_tokens'])->toBe(200)
+        ->and($json['completion_tokens'])->toBe(100);
+});


### PR DESCRIPTION
## Summary

- Adds `toArray()` and `jsonSerialize()` methods to `StructuredStep` class to include the `structured` property in serialization output
- Adds comprehensive unit tests for response data classes

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Pre-flight Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] I have added/changed necessary documentation (if applicable)
