### PR TITLE
[0.x] Add image generation support to AzureOpenAiProvider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -63,6 +63,7 @@ return [
             'api_version' => env('AZURE_OPENAI_API_VERSION', '2025-04-01-preview'),
             'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
             'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+            'image_deployment' => env('AZURE_OPENAI_IMAGE_DEPLOYMENT', 'dall-e-3'),
         ],
 
         'bedrock' => [

--- a/config/ai.php
+++ b/config/ai.php
@@ -63,7 +63,7 @@ return [
             'api_version' => env('AZURE_OPENAI_API_VERSION', '2025-04-01-preview'),
             'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
             'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
-            'image_deployment' => env('AZURE_OPENAI_IMAGE_DEPLOYMENT', 'dall-e-3'),
+            'image_deployment' => env('AZURE_OPENAI_IMAGE_DEPLOYMENT', 'gpt-image-1'),
         ],
 
         'bedrock' => [

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -4,10 +4,7 @@ namespace Laravel\Ai\Gateway\AzureOpenAi;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Http\UploadedFile;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
-use Illuminate\Support\Facades\Storage;
-use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
@@ -15,10 +12,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
-use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image as ImageFile;
-use Laravel\Ai\Files\LocalImage;
-use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\AzureOpenAi\Concerns\CreatesAzureOpenAiClient;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
@@ -33,10 +27,12 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Tools\ToolNameResolver;
+use LogicException;
 
 class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
 {
@@ -182,13 +178,18 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         ?string $quality = null,
         ?int $timeout = null,
     ): ImageResponse {
-        $hasAttachments = filled($attachments);
+        if (filled($attachments)) {
+            throw new LogicException('The Azure OpenAI provider does not support image edits.');
+        }
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $hasAttachments
-                ? $this->sendImageEditRequest($provider, $model, $prompt, $attachments, $size, $quality, $timeout)
-                : $this->sendImageGenerationRequest($provider, $model, $prompt, $size, $quality, $timeout),
+            fn () => $this->client($provider, $timeout ?? 120)->post('images/generations', [
+                'model' => $model,
+                'prompt' => $prompt,
+                'moderation' => 'low',
+                ...$provider->defaultImageOptions($size, $quality),
+            ]),
         );
 
         $data = $response->json();
@@ -198,73 +199,25 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
                 $image['b64_json'] ?? '',
                 'image/png',
             )),
-            $this->extractUsage($data),
+            $this->extractImageUsage($data),
             new Meta($provider->name(), $model),
         );
     }
 
     /**
-     * Send an image generation request.
+     * Extract usage from an Azure OpenAI image response.
      */
-    protected function sendImageGenerationRequest(
-        ImageProvider $provider,
-        string $model,
-        string $prompt,
-        ?string $size,
-        ?string $quality,
-        ?int $timeout,
-    ) {
-        return $this->client($provider, $timeout ?? 120)->post('images/generations', [
-            'model' => $model,
-            'prompt' => $prompt,
-            'moderation' => 'low',
-            ...$provider->defaultImageOptions($size, $quality),
-        ]);
-    }
+    protected function extractImageUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+        $inputTokens = $usage['input_tokens'] ?? 0;
+        $cachedTokens = $usage['input_tokens_details']['cached_tokens'] ?? 0;
 
-    /**
-     * Send an image edit request with attachments.
-     *
-     * Azure documents image edits at the deployment-scoped path
-     * `/openai/deployments/{deployment}/images/edits?api-version=…`,
-     * not the v1-compatible base used for generations.
-     *
-     * @see https://learn.microsoft.com/en-us/azure/ai-services/openai/dall-e-quickstart
-     */
-    protected function sendImageEditRequest(
-        ImageProvider $provider,
-        string $model,
-        string $prompt,
-        array $attachments,
-        ?string $size,
-        ?string $quality,
-        ?int $timeout,
-    ) {
-        $request = $this->deploymentClient($provider, $model, $timeout ?? 120);
-
-        foreach ($attachments as $attachment) {
-            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
-                throw new InvalidArgumentException(
-                    'Unsupported attachment type ['.get_class($attachment).']'
-                );
-            }
-
-            $content = match (true) {
-                $attachment instanceof LocalImage => file_get_contents($attachment->path),
-                $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
-                $attachment instanceof UploadedFile => $attachment->get(),
-                default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
-            };
-
-            $request = $request->attach('image[]', $content, 'image.png');
-        }
-
-        return $request->post('images/edits', array_filter([
-            'model' => $model,
-            'prompt' => $prompt,
-            'moderation' => 'low',
-            ...$provider->defaultImageOptions($size, $quality),
-        ]));
+        return new Usage(
+            promptTokens: $inputTokens - $cachedTokens,
+            completionTokens: $usage['output_tokens'] ?? 0,
+            cacheReadInputTokens: $cachedTokens,
+        );
     }
 
     /**

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -8,7 +8,6 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
-use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
@@ -199,7 +198,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
                 $image['b64_json'] ?? '',
                 'image/png',
             )),
-            new \Laravel\Ai\Responses\Data\Usage(
+            new Usage(
                 $data['usage']['input_tokens'] ?? 0,
                 $data['usage']['total_tokens'] ?? 0,
             ),

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -32,7 +32,6 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -198,10 +197,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
                 $image['b64_json'] ?? '',
                 'image/png',
             )),
-            new Usage(
-                $data['usage']['input_tokens'] ?? 0,
-                $data['usage']['total_tokens'] ?? 0,
-            ),
+            $this->extractUsage($data),
             new Meta($provider->name(), $model),
         );
     }
@@ -221,12 +217,20 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),
-            ...(str_starts_with($model, 'gpt-image') ? ['moderation' => 'low'] : []),
+            ...(str_starts_with($model, 'gpt-image')
+                ? ['moderation' => 'low']
+                : ['response_format' => 'b64_json']),
         ]);
     }
 
     /**
      * Send an image edit request with attachments.
+     *
+     * Azure documents image edits at the deployment-scoped path
+     * `/openai/deployments/{deployment}/images/edits?api-version=…`,
+     * not the v1-compatible base used for generations.
+     *
+     * @see https://learn.microsoft.com/en-us/azure/ai-services/openai/dall-e-quickstart
      */
     protected function sendImageEditRequest(
         ImageProvider $provider,
@@ -238,6 +242,9 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         ?int $timeout,
     ) {
         $request = $this->client($provider, $timeout ?? 120);
+
+        $isGptImage = str_starts_with($model, 'gpt-image');
+        $field = $isGptImage ? 'image[]' : 'image';
 
         foreach ($attachments as $attachment) {
             if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
@@ -253,14 +260,21 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
                 default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
             };
 
-            $request = $request->attach('image[]', $content, 'image.png');
+            $request = $request->attach($field, $content, 'image.png');
         }
 
-        return $request->post('images/edits', array_filter([
+        $config = $provider->additionalConfiguration();
+        $base = rtrim($config['url'] ?? '', '/');
+        $apiVersion = $config['api_version'] ?? '2025-04-01-preview';
+        $url = "{$base}/openai/deployments/{$model}/images/edits?api-version={$apiVersion}";
+
+        return $request->post($url, array_filter([
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),
-            ...(str_starts_with($model, 'gpt-image') ? ['moderation' => 'low'] : []),
+            ...($isGptImage
+                ? ['moderation' => 'low']
+                : ['response_format' => 'b64_json']),
         ]));
     }
 

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -4,12 +4,21 @@ namespace Laravel\Ai\Gateway\AzureOpenAi;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\UploadedFile;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\AzureOpenAi\Concerns\CreatesAzureOpenAiClient;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
@@ -22,12 +31,15 @@ use Laravel\Ai\Gateway\OpenAi\Concerns\MapsTools;
 use Laravel\Ai\Gateway\OpenAi\Concerns\ParsesTextResponses;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Tools\ToolNameResolver;
 
-class AzureOpenAiGateway implements EmbeddingGateway, TextGateway
+class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
 {
     use BuildsTextRequests;
     use CreatesAzureOpenAiClient;
@@ -153,6 +165,104 @@ class AzureOpenAiGateway implements EmbeddingGateway, TextGateway
             $data['usage']['prompt_tokens'] ?? 0,
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Generate an image.
+     *
+     * @param  array<ImageFile>  $attachments
+     * @param  '3:2'|'2:3'|'1:1'  $size
+     * @param  'low'|'medium'|'high'  $quality
+     */
+    public function generateImage(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments = [],
+        ?string $size = null,
+        ?string $quality = null,
+        ?int $timeout = null,
+    ): ImageResponse {
+        $hasAttachments = filled($attachments);
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $hasAttachments
+                ? $this->sendImageEditRequest($provider, $model, $prompt, $attachments, $size, $quality, $timeout)
+                : $this->sendImageGenerationRequest($provider, $model, $prompt, $size, $quality, $timeout),
+        );
+
+        $data = $response->json();
+
+        return new ImageResponse(
+            collect($data['data'] ?? [])->map(fn (array $image) => new GeneratedImage(
+                $image['b64_json'] ?? '',
+                'image/png',
+            )),
+            new \Laravel\Ai\Responses\Data\Usage(
+                $data['usage']['input_tokens'] ?? 0,
+                $data['usage']['total_tokens'] ?? 0,
+            ),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Send an image generation request.
+     */
+    protected function sendImageGenerationRequest(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        ?string $size,
+        ?string $quality,
+        ?int $timeout,
+    ) {
+        return $this->client($provider, $timeout ?? 120)->post('images/generations', [
+            'model' => $model,
+            'prompt' => $prompt,
+            ...$provider->defaultImageOptions($size, $quality),
+            ...(str_starts_with($model, 'gpt-image') ? ['moderation' => 'low'] : []),
+        ]);
+    }
+
+    /**
+     * Send an image edit request with attachments.
+     */
+    protected function sendImageEditRequest(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments,
+        ?string $size,
+        ?string $quality,
+        ?int $timeout,
+    ) {
+        $request = $this->client($provider, $timeout ?? 120);
+
+        foreach ($attachments as $attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            $content = match (true) {
+                $attachment instanceof LocalImage => file_get_contents($attachment->path),
+                $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
+                $attachment instanceof UploadedFile => $attachment->get(),
+                default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
+            };
+
+            $request = $request->attach('image[]', $content, 'image.png');
+        }
+
+        return $request->post('images/edits', array_filter([
+            'model' => $model,
+            'prompt' => $prompt,
+            ...$provider->defaultImageOptions($size, $quality),
+            ...(str_starts_with($model, 'gpt-image') ? ['moderation' => 'low'] : []),
+        ]));
     }
 
     /**

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -16,6 +16,7 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\AzureOpenAi\Concerns\CreatesAzureOpenAiClient;
@@ -216,10 +217,8 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         return $this->client($provider, $timeout ?? 120)->post('images/generations', [
             'model' => $model,
             'prompt' => $prompt,
+            'moderation' => 'low',
             ...$provider->defaultImageOptions($size, $quality),
-            ...(str_starts_with($model, 'gpt-image')
-                ? ['moderation' => 'low']
-                : ['response_format' => 'b64_json']),
         ]);
     }
 
@@ -241,10 +240,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         ?string $quality,
         ?int $timeout,
     ) {
-        $request = $this->client($provider, $timeout ?? 120);
-
-        $isGptImage = str_starts_with($model, 'gpt-image');
-        $field = $isGptImage ? 'image[]' : 'image';
+        $request = $this->deploymentClient($provider, $model, $timeout ?? 120);
 
         foreach ($attachments as $attachment) {
             if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
@@ -260,21 +256,14 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
                 default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
             };
 
-            $request = $request->attach($field, $content, 'image.png');
+            $request = $request->attach('image[]', $content, 'image.png');
         }
 
-        $config = $provider->additionalConfiguration();
-        $base = rtrim($config['url'] ?? '', '/');
-        $apiVersion = $config['api_version'] ?? '2025-04-01-preview';
-        $url = "{$base}/openai/deployments/{$model}/images/edits?api-version={$apiVersion}";
-
-        return $request->post($url, array_filter([
+        return $request->post('images/edits', array_filter([
             'model' => $model,
             'prompt' => $prompt,
+            'moderation' => 'low',
             ...$provider->defaultImageOptions($size, $quality),
-            ...($isGptImage
-                ? ['moderation' => 'low']
-                : ['response_format' => 'b64_json']),
         ]));
     }
 

--- a/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
+++ b/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
@@ -22,25 +22,4 @@ trait CreatesAzureOpenAiClient
             ->timeout($timeout ?? 60)
             ->throw();
     }
-
-    /**
-     * Get an HTTP client scoped to a deployment-specific Azure path.
-     *
-     * Some Azure endpoints (image edits, fine-tuning, etc.) are only available
-     * at `/openai/deployments/{deployment}/...?api-version=…`, not on the
-     * v1-compatible base used by `client()`.
-     */
-    protected function deploymentClient(Provider $provider, string $deployment, ?int $timeout = null): PendingRequest
-    {
-        $config = $provider->additionalConfiguration();
-
-        $base = rtrim($config['url'] ?? '', '/');
-        $apiVersion = $config['api_version'] ?? '2025-04-01-preview';
-
-        return Http::baseUrl("{$base}/openai/deployments/{$deployment}")
-            ->withHeaders(['api-key' => $provider->providerCredentials()['key']])
-            ->withQueryParameters(['api-version' => $apiVersion])
-            ->timeout($timeout ?? 60)
-            ->throw();
-    }
 }

--- a/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
+++ b/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
@@ -22,4 +22,25 @@ trait CreatesAzureOpenAiClient
             ->timeout($timeout ?? 60)
             ->throw();
     }
+
+    /**
+     * Get an HTTP client scoped to a deployment-specific Azure path.
+     *
+     * Some Azure endpoints (image edits, fine-tuning, etc.) are only available
+     * at `/openai/deployments/{deployment}/...?api-version=…`, not on the
+     * v1-compatible base used by `client()`.
+     */
+    protected function deploymentClient(Provider $provider, string $deployment, ?int $timeout = null): PendingRequest
+    {
+        $config = $provider->additionalConfiguration();
+
+        $base = rtrim($config['url'] ?? '', '/');
+        $apiVersion = $config['api_version'] ?? '2025-04-01-preview';
+
+        return Http::baseUrl("{$base}/openai/deployments/{$deployment}")
+            ->withHeaders(['api-key' => $provider->providerCredentials()['key']])
+            ->withQueryParameters(['api-version' => $apiVersion])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
 }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -172,7 +172,9 @@ class OpenAiGateway implements Gateway
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),
-            ...(str_starts_with($model, 'gpt-image') ? ['moderation' => 'low'] : []),
+            ...(str_starts_with($model, 'gpt-image')
+                ? ['moderation' => 'low']
+                : ['response_format' => 'b64_json']),
         ]);
     }
 
@@ -190,6 +192,9 @@ class OpenAiGateway implements Gateway
     ) {
         $request = $this->client($provider, $timeout ?? 120);
 
+        $isGptImage = str_starts_with($model, 'gpt-image');
+        $field = $isGptImage ? 'image[]' : 'image';
+
         foreach ($attachments as $attachment) {
             if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
                 throw new InvalidArgumentException(
@@ -204,14 +209,16 @@ class OpenAiGateway implements Gateway
                 default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_class($attachment).']'),
             };
 
-            $request = $request->attach('image[]', $content, 'image.png');
+            $request = $request->attach($field, $content, 'image.png');
         }
 
         return $request->post('images/edits', array_filter([
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),
-            ...(str_starts_with($model, 'gpt-image') ? ['moderation' => 'low'] : []),
+            ...($isGptImage
+                ? ['moderation' => 'low']
+                : ['response_format' => 'b64_json']),
         ]));
     }
 

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -16,6 +16,7 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -4,16 +4,20 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiGateway;
 
-class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextProvider
+class AzureOpenAiProvider extends Provider implements EmbeddingProvider, ImageProvider, TextProvider
 {
     use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
     use Concerns\HasEmbeddingGateway;
+    use Concerns\HasImageGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
 
@@ -82,6 +86,38 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, TextPro
     public function smartestTextModel(): string
     {
         return $this->config['deployment'] ?? 'gpt-4o';
+    }
+
+    /**
+     * Get the provider's image gateway.
+     */
+    public function imageGateway(): ImageGateway
+    {
+        return $this->imageGateway ??= $this->azureGateway();
+    }
+
+    /**
+     * Get the name of the default image model.
+     */
+    public function defaultImageModel(): string
+    {
+        return $this->config['image_deployment'] ?? 'dall-e-3';
+    }
+
+    /**
+     * Get the default / normalized image options for the provider.
+     */
+    public function defaultImageOptions(?string $size = null, $quality = null): array
+    {
+        return array_filter([
+            'size' => match ($size) {
+                '1:1' => '1024x1024',
+                '2:3' => '1024x1536',
+                '3:2' => '1536x1024',
+                default => $size,
+            },
+            'quality' => $quality,
+        ]);
     }
 
     /**

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -97,11 +97,11 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, ImagePr
     }
 
     /**
-     * Get the name of the default image model.
+     * Get the name of the default image deployment.
      */
     public function defaultImageModel(): string
     {
-        return $this->config['image_deployment'] ?? 'dall-e-3';
+        return $this->config['image_deployment'] ?? 'gpt-image-1';
     }
 
     /**

--- a/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Image;
+
+beforeEach(function () {
+    config(['ai.providers.azure' => [
+        ...config('ai.providers.azure'),
+        'key' => 'test-key',
+        'url' => 'https://test-resource.openai.azure.com',
+    ]]);
+});
+
+function fakeAzureImageResponse(): PromiseInterface
+{
+    return Http::response([
+        'data' => [[
+            'b64_json' => base64_encode('fake-image'),
+        ]],
+    ]);
+}
+
+test('image request uses correct deployment', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-2');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'dall-e-2';
+    });
+});
+
+test('image request does not include quality when not specified', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-2');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('quality', $body);
+    });
+});
+
+test('image request includes quality when explicitly specified', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->quality('high')->generate(provider: 'azure', model: 'dall-e-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['quality'] === 'high';
+    });
+});
+
+test('image request includes size when specified', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->square()->generate(provider: 'azure', model: 'dall-e-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['size'] === '1024x1024';
+    });
+});
+
+test('image request does not include size when not specified', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('size', $body);
+    });
+});
+
+test('image request includes moderation for gpt-image models', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['moderation'] ?? null) === 'low';
+    });
+});
+
+test('image request does not include moderation for non gpt-image models', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('moderation', $body);
+    });
+});

--- a/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
@@ -3,9 +3,7 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files\LocalImage;
-use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Image;
 
 beforeEach(function () {
@@ -110,7 +108,7 @@ test('image request always includes moderation low', function () {
     });
 });
 
-test('image edit request hits deployment-scoped endpoint with multipart attachment', function () {
+test('image generation throws when attachments are passed', function () {
     Http::fake([
         '*' => fakeAzureImageResponse(),
     ]);
@@ -118,34 +116,7 @@ test('image edit request hits deployment-scoped endpoint with multipart attachme
     Image::of('Add a leaf to the apple')
         ->attachments([new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')])
         ->generate(provider: 'azure', model: 'gpt-image-1');
-
-    Http::assertSent(function (Request $request) {
-        $body = $request->body();
-
-        return $request->url() === 'https://test-resource.openai.azure.com/openai/deployments/gpt-image-1/images/edits?api-version=2025-04-01-preview'
-            && str_contains($request->header('Content-Type')[0] ?? '', 'multipart/form-data')
-            && str_contains($body, 'name="image[]"')
-            && str_contains($body, 'name="model"')
-            && str_contains($body, 'gpt-image-1')
-            && str_contains($body, 'Add a leaf to the apple')
-            && str_contains($body, 'name="moderation"')
-            && str_contains($body, "\r\nlow\r\n");
-    });
-});
-
-test('image edit request honors configured api version', function () {
-    config(['ai.providers.azure.api_version' => '2025-09-01-preview']);
-
-    Http::fake([
-        '*' => fakeAzureImageResponse(),
-    ]);
-
-    Image::of('Add a leaf to the apple')
-        ->attachments([new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')])
-        ->generate(provider: 'azure', model: 'gpt-image-1');
-
-    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'api-version=2025-09-01-preview'));
-});
+})->throws(LogicException::class, 'The Azure OpenAI provider does not support image edits.');
 
 test('image generation request omits response_format', function () {
     Http::fake([
@@ -217,28 +188,6 @@ test('image response defaults to zero usage when not returned', function () {
 
     expect($response->usage->promptTokens)->toBe(0)
         ->and($response->usage->completionTokens)->toBe(0);
-});
-
-test('image edit reads bytes from configured storage disk for StoredImage attachments', function () {
-    Storage::fake('images');
-    Storage::disk('images')->put('apple.png', 'fake-stored-bytes');
-
-    Http::fake([
-        '*' => fakeAzureImageResponse(),
-    ]);
-
-    Image::of('Add a leaf to the apple')
-        ->attachments([new StoredImage('apple.png', 'images')])
-        ->generate(provider: 'azure', model: 'gpt-image-1');
-
-    Http::assertSent(function (Request $request) {
-        $body = $request->body();
-
-        return str_contains($request->url(), '/openai/deployments/gpt-image-1/images/edits')
-            && str_contains($request->url(), 'api-version=2025-04-01-preview')
-            && str_contains($body, 'name="image[]"')
-            && str_contains($body, 'fake-stored-bytes');
-    });
 });
 
 test('default image model falls back to gpt-image-1', function () {

--- a/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Image;
 
 beforeEach(function () {
@@ -22,7 +23,7 @@ function fakeAzureImageResponse(): PromiseInterface
     ]);
 }
 
-test('image request uses correct deployment', function () {
+test('image request uses correct deployment and url', function () {
     Http::fake([
         '*' => fakeAzureImageResponse(),
     ]);
@@ -32,7 +33,8 @@ test('image request uses correct deployment', function () {
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
 
-        return $body['model'] === 'dall-e-2';
+        return $request->url() === 'https://test-resource.openai.azure.com/openai/v1/images/generations'
+            && $body['model'] === 'dall-e-2';
     });
 });
 
@@ -118,4 +120,147 @@ test('image request does not include moderation for non gpt-image models', funct
 
         return ! array_key_exists('moderation', $body);
     });
+});
+
+test('image edit request hits deployment-scoped endpoint with multipart attachment', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('Add a leaf to the apple')
+        ->attachments([new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')])
+        ->generate(provider: 'azure', model: 'gpt-image-1');
+
+    Http::assertSent(function (Request $request) {
+        $body = $request->body();
+
+        return $request->url() === 'https://test-resource.openai.azure.com/openai/deployments/gpt-image-1/images/edits?api-version=2025-04-01-preview'
+            && str_contains($request->header('Content-Type')[0] ?? '', 'multipart/form-data')
+            && str_contains($body, 'name="image[]"')
+            && str_contains($body, 'name="model"')
+            && str_contains($body, 'gpt-image-1')
+            && str_contains($body, 'Add a leaf to the apple')
+            && str_contains($body, 'name="moderation"')
+            && str_contains($body, "\r\nlow\r\n");
+    });
+});
+
+test('image edit request honors configured api version', function () {
+    config(['ai.providers.azure.api_version' => '2025-09-01-preview']);
+
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('Add a leaf to the apple')
+        ->attachments([new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')])
+        ->generate(provider: 'azure', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'api-version=2025-09-01-preview'));
+});
+
+test('image edit request uses image field for dall-e-2', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('Add a leaf to the apple')
+        ->attachments([new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')])
+        ->generate(provider: 'azure', model: 'dall-e-2');
+
+    Http::assertSent(function (Request $request) {
+        $body = $request->body();
+
+        return $request->url() === 'https://test-resource.openai.azure.com/openai/deployments/dall-e-2/images/edits?api-version=2025-04-01-preview'
+            && str_contains($body, 'name="image"')
+            && ! str_contains($body, 'name="image[]"')
+            && str_contains($body, 'name="response_format"')
+            && str_contains($body, "\r\nb64_json\r\n");
+    });
+});
+
+test('image generation request adds response_format b64_json for dall-e models', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['response_format'] === 'b64_json';
+    });
+});
+
+test('image generation request omits response_format for gpt-image models', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('response_format', $body);
+    });
+});
+
+test('image response includes usage tokens when returned by gpt-image', function () {
+    Http::fake([
+        '*' => Http::response([
+            'data' => [[
+                'b64_json' => base64_encode('fake-image'),
+            ]],
+            'usage' => [
+                'input_tokens' => 41,
+                'output_tokens' => 1024,
+                'input_tokens_details' => [
+                    'text_tokens' => 41,
+                    'image_tokens' => 0,
+                ],
+            ],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+
+    expect($response->usage->promptTokens)->toBe(41)
+        ->and($response->usage->completionTokens)->toBe(1024);
+});
+
+test('image response subtracts cached tokens from prompt tokens', function () {
+    Http::fake([
+        '*' => Http::response([
+            'data' => [[
+                'b64_json' => base64_encode('fake-image'),
+            ]],
+            'usage' => [
+                'input_tokens' => 100,
+                'output_tokens' => 1024,
+                'input_tokens_details' => [
+                    'cached_tokens' => 30,
+                    'text_tokens' => 70,
+                ],
+            ],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+
+    expect($response->usage->promptTokens)->toBe(70)
+        ->and($response->usage->cacheReadInputTokens)->toBe(30)
+        ->and($response->usage->completionTokens)->toBe(1024);
+});
+
+test('image response defaults to zero usage when not returned by dalle', function () {
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
+
+    expect($response->usage->promptTokens)->toBe(0)
+        ->and($response->usage->completionTokens)->toBe(0);
 });

--- a/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
@@ -3,7 +3,9 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Image;
 
 beforeEach(function () {
@@ -28,13 +30,13 @@ test('image request uses correct deployment and url', function () {
         '*' => fakeAzureImageResponse(),
     ]);
 
-    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-2');
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
 
         return $request->url() === 'https://test-resource.openai.azure.com/openai/v1/images/generations'
-            && $body['model'] === 'dall-e-2';
+            && $body['model'] === 'gpt-image-1';
     });
 });
 
@@ -43,7 +45,7 @@ test('image request does not include quality when not specified', function () {
         '*' => fakeAzureImageResponse(),
     ]);
 
-    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-2');
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
@@ -57,7 +59,7 @@ test('image request includes quality when explicitly specified', function () {
         '*' => fakeAzureImageResponse(),
     ]);
 
-    Image::of('A red apple')->quality('high')->generate(provider: 'azure', model: 'dall-e-3');
+    Image::of('A red apple')->quality('high')->generate(provider: 'azure', model: 'gpt-image-1');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
@@ -71,7 +73,7 @@ test('image request includes size when specified', function () {
         '*' => fakeAzureImageResponse(),
     ]);
 
-    Image::of('A red apple')->square()->generate(provider: 'azure', model: 'dall-e-3');
+    Image::of('A red apple')->square()->generate(provider: 'azure', model: 'gpt-image-1');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
@@ -85,7 +87,7 @@ test('image request does not include size when not specified', function () {
         '*' => fakeAzureImageResponse(),
     ]);
 
-    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
@@ -94,7 +96,7 @@ test('image request does not include size when not specified', function () {
     });
 });
 
-test('image request includes moderation for gpt-image models', function () {
+test('image request always includes moderation low', function () {
     Http::fake([
         '*' => fakeAzureImageResponse(),
     ]);
@@ -105,20 +107,6 @@ test('image request includes moderation for gpt-image models', function () {
         $body = json_decode($request->body(), true);
 
         return ($body['moderation'] ?? null) === 'low';
-    });
-});
-
-test('image request does not include moderation for non gpt-image models', function () {
-    Http::fake([
-        '*' => fakeAzureImageResponse(),
-    ]);
-
-    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
-
-    Http::assertSent(function (Request $request) {
-        $body = json_decode($request->body(), true);
-
-        return ! array_key_exists('moderation', $body);
     });
 });
 
@@ -159,41 +147,7 @@ test('image edit request honors configured api version', function () {
     Http::assertSent(fn (Request $request) => str_contains($request->url(), 'api-version=2025-09-01-preview'));
 });
 
-test('image edit request uses image field for dall-e-2', function () {
-    Http::fake([
-        '*' => fakeAzureImageResponse(),
-    ]);
-
-    Image::of('Add a leaf to the apple')
-        ->attachments([new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')])
-        ->generate(provider: 'azure', model: 'dall-e-2');
-
-    Http::assertSent(function (Request $request) {
-        $body = $request->body();
-
-        return $request->url() === 'https://test-resource.openai.azure.com/openai/deployments/dall-e-2/images/edits?api-version=2025-04-01-preview'
-            && str_contains($body, 'name="image"')
-            && ! str_contains($body, 'name="image[]"')
-            && str_contains($body, 'name="response_format"')
-            && str_contains($body, "\r\nb64_json\r\n");
-    });
-});
-
-test('image generation request adds response_format b64_json for dall-e models', function () {
-    Http::fake([
-        '*' => fakeAzureImageResponse(),
-    ]);
-
-    Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
-
-    Http::assertSent(function (Request $request) {
-        $body = json_decode($request->body(), true);
-
-        return $body['response_format'] === 'b64_json';
-    });
-});
-
-test('image generation request omits response_format for gpt-image models', function () {
+test('image generation request omits response_format', function () {
     Http::fake([
         '*' => fakeAzureImageResponse(),
     ]);
@@ -207,7 +161,7 @@ test('image generation request omits response_format for gpt-image models', func
     });
 });
 
-test('image response includes usage tokens when returned by gpt-image', function () {
+test('image response includes usage tokens', function () {
     Http::fake([
         '*' => Http::response([
             'data' => [[
@@ -254,13 +208,51 @@ test('image response subtracts cached tokens from prompt tokens', function () {
         ->and($response->usage->completionTokens)->toBe(1024);
 });
 
-test('image response defaults to zero usage when not returned by dalle', function () {
+test('image response defaults to zero usage when not returned', function () {
     Http::fake([
         '*' => fakeAzureImageResponse(),
     ]);
 
-    $response = Image::of('A red apple')->generate(provider: 'azure', model: 'dall-e-3');
+    $response = Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
 
     expect($response->usage->promptTokens)->toBe(0)
         ->and($response->usage->completionTokens)->toBe(0);
+});
+
+test('image edit reads bytes from configured storage disk for StoredImage attachments', function () {
+    Storage::fake('images');
+    Storage::disk('images')->put('apple.png', 'fake-stored-bytes');
+
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('Add a leaf to the apple')
+        ->attachments([new StoredImage('apple.png', 'images')])
+        ->generate(provider: 'azure', model: 'gpt-image-1');
+
+    Http::assertSent(function (Request $request) {
+        $body = $request->body();
+
+        return str_contains($request->url(), '/openai/deployments/gpt-image-1/images/edits')
+            && str_contains($request->url(), 'api-version=2025-04-01-preview')
+            && str_contains($body, 'name="image[]"')
+            && str_contains($body, 'fake-stored-bytes');
+    });
+});
+
+test('default image model falls back to gpt-image-1', function () {
+    config(['ai.providers.azure.image_deployment' => null]);
+
+    Http::fake([
+        '*' => fakeAzureImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'gpt-image-1';
+    });
 });

--- a/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
@@ -166,3 +166,31 @@ test('image response defaults to zero usage when not returned by dalle', functio
     expect($response->usage->promptTokens)->toBe(0)
         ->and($response->usage->completionTokens)->toBe(0);
 });
+
+test('image generation request adds response_format b64_json for dall-e models', function () {
+    Http::fake([
+        '*' => fakeOpenAiImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'openai', model: 'dall-e-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['response_format'] ?? null) === 'b64_json';
+    });
+});
+
+test('image generation request omits response_format for gpt-image models', function () {
+    Http::fake([
+        '*' => fakeOpenAiImageResponse(),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('response_format', $body);
+    });
+});


### PR DESCRIPTION
AzureOpenAiProvider doesn't implement ImageProvider even though Azure OpenAI supports DALL-E models via deployments. Users currently can't generate images through the Azure provider. Closes #238.

Azure OpenAI DALL-E documentation: https://learn.microsoft.com/en-us/azure/ai-services/openai/dall-e-quickstart
