### PR TITLE
Preserve OpenAI url citation span indices and stop deduping

### DIFF
--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -336,13 +336,15 @@ trait ParsesTextResponses
                         $citations->push(new UrlCitation(
                             $annotation['url'] ?? '',
                             $annotation['title'] ?? null,
+                            isset($annotation['start_index']) ? (int) $annotation['start_index'] : null,
+                            isset($annotation['end_index']) ? (int) $annotation['end_index'] : null,
                         ));
                     }
                 }
             }
         }
 
-        return $citations->unique('url')->values();
+        return $citations->values();
     }
 
     /**

--- a/src/Responses/Data/UrlCitation.php
+++ b/src/Responses/Data/UrlCitation.php
@@ -10,6 +10,8 @@ class UrlCitation extends Citation implements Arrayable, JsonSerializable
     public function __construct(
         public string $url,
         ?string $title = null,
+        public ?int $startIndex = null,
+        public ?int $endIndex = null,
     ) {
         parent::__construct($title);
     }
@@ -22,6 +24,8 @@ class UrlCitation extends Citation implements Arrayable, JsonSerializable
         return [
             'url' => $this->url,
             'title' => $this->title,
+            'start_index' => $this->startIndex,
+            'end_index' => $this->endIndex,
         ];
     }
 

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -180,7 +180,7 @@ test('structured response is correctly parsed', function () {
     expect($response->structured['symbol'])->toBe('Au');
 });
 
-test('citations are deduplicated by url, not title', function () {
+test('citations preserve every annotation with span indices', function () {
     Http::fake(['*' => Http::response([
         'id' => 'resp_123',
         'status' => 'completed',
@@ -196,16 +196,22 @@ test('citations are deduplicated by url, not title', function () {
                         'type' => 'url_citation',
                         'url' => 'https://example.com/one',
                         'title' => 'Same Title',
+                        'start_index' => 0,
+                        'end_index' => 10,
                     ],
                     [
                         'type' => 'url_citation',
                         'url' => 'https://example.com/two',
                         'title' => 'Same Title',
+                        'start_index' => 11,
+                        'end_index' => 25,
                     ],
                     [
                         'type' => 'url_citation',
                         'url' => 'https://example.com/one',
                         'title' => 'Same Title',
+                        'start_index' => 26,
+                        'end_index' => 40,
                     ],
                 ],
             ]],
@@ -218,7 +224,45 @@ test('citations are deduplicated by url, not title', function () {
 
     $response = agent()->prompt('Give me sources', provider: 'openai');
 
-    expect($response->meta->citations)->toHaveCount(2)
+    expect($response->meta->citations)->toHaveCount(3)
         ->and($response->meta->citations[0]->url)->toBe('https://example.com/one')
-        ->and($response->meta->citations[1]->url)->toBe('https://example.com/two');
+        ->and($response->meta->citations[0]->startIndex)->toBe(0)
+        ->and($response->meta->citations[0]->endIndex)->toBe(10)
+        ->and($response->meta->citations[1]->url)->toBe('https://example.com/two')
+        ->and($response->meta->citations[1]->startIndex)->toBe(11)
+        ->and($response->meta->citations[2]->url)->toBe('https://example.com/one')
+        ->and($response->meta->citations[2]->startIndex)->toBe(26);
+});
+
+test('citations omit span indices when not provided by the api', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'resp_123',
+        'status' => 'completed',
+        'model' => 'gpt-5.4',
+        'output' => [[
+            'type' => 'message',
+            'status' => 'completed',
+            'content' => [[
+                'type' => 'output_text',
+                'text' => 'Sources',
+                'annotations' => [
+                    [
+                        'type' => 'url_citation',
+                        'url' => 'https://example.com/one',
+                        'title' => 'One',
+                    ],
+                ],
+            ]],
+        ]],
+        'usage' => [
+            'input_tokens' => 10,
+            'output_tokens' => 5,
+        ],
+    ])]);
+
+    $response = agent()->prompt('Give me sources', provider: 'openai');
+
+    expect($response->meta->citations)->toHaveCount(1)
+        ->and($response->meta->citations[0]->startIndex)->toBeNull()
+        ->and($response->meta->citations[0]->endIndex)->toBeNull();
 });

--- a/tests/Unit/Responses/Data/UrlCitationTest.php
+++ b/tests/Unit/Responses/Data/UrlCitationTest.php
@@ -6,23 +6,36 @@ test('url citation stores url and title', function () {
     $citation = new UrlCitation('https://example.com', 'Example');
 
     expect($citation->url)->toBe('https://example.com')
-        ->and($citation->title)->toBe('Example');
+        ->and($citation->title)->toBe('Example')
+        ->and($citation->startIndex)->toBeNull()
+        ->and($citation->endIndex)->toBeNull();
 });
 
-test('url citation to array returns url and title', function () {
-    $citation = new UrlCitation('https://laravel.com', 'Laravel');
+test('url citation stores span indices when provided', function () {
+    $citation = new UrlCitation('https://example.com', 'Example', startIndex: 12, endIndex: 45);
 
-    $array = $citation->toArray();
+    expect($citation->startIndex)->toBe(12)
+        ->and($citation->endIndex)->toBe(45);
+});
 
-    expect($array['url'])->toBe('https://laravel.com')
-        ->and($array['title'])->toBe('Laravel');
+test('url citation to array returns all fields', function () {
+    $citation = new UrlCitation('https://laravel.com', 'Laravel', startIndex: 0, endIndex: 7);
+
+    expect($citation->toArray())->toBe([
+        'url' => 'https://laravel.com',
+        'title' => 'Laravel',
+        'start_index' => 0,
+        'end_index' => 7,
+    ]);
 });
 
 test('url citation json serialize returns to array', function () {
     $citation = new UrlCitation('https://google.com');
 
-    $json = $citation->jsonSerialize();
-
-    expect($json['url'])->toBe('https://google.com')
-        ->and($json['title'])->toBeNull();
+    expect($citation->jsonSerialize())->toBe([
+        'url' => 'https://google.com',
+        'title' => null,
+        'start_index' => null,
+        'end_index' => null,
+    ]);
 });


### PR DESCRIPTION
#509 fixed the wrong-key dedupe (title → url), but OpenAI's `url_citation` annotations also carry `start_index` / `end_index` describing which text span each citation supports. The parser was discarding those, then deduping by URL — so when the model cited the same source for two different paragraphs, one citation silently disappeared.


### Usage

```php
$response = agent()->prompt('Compare X and Y', provider: 'openai');

foreach ($response->meta->citations as $c) {
    echo "{$c->title} ({$c->startIndex}–{$c->endIndex}): {$c->url}\n";
}
```
