### PR TITLE
Test Anthropic streaming tool_use finish reason without tool blocks

### DIFF
--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -223,10 +223,6 @@ describe('usage tracking', function () {
     });
 
     test('streaming finish reason maps correctly', function (string $apiReason, $expected) {
-        if ($expected === FinishReason::ToolCalls) {
-            $this->markTestSkipped('Tool use finish reason triggers tool call handling, not StreamEnd');
-        }
-
         Http::fake([
             'api.anthropic.com/*' => Http::response(
                 body: $this->ssePayload([
@@ -250,6 +246,6 @@ describe('usage tracking', function () {
         'end_turn maps to Stop' => ['end_turn', FinishReason::Stop],
         'stop_sequence maps to Stop' => ['stop_sequence', FinishReason::Stop],
         'max_tokens maps to Length' => ['max_tokens', FinishReason::Length],
-        'tool_use maps to ToolCalls' => ['tool_use', FinishReason::ToolCalls],
+        'tool_use maps to ToolCalls without tool blocks (StreamEnd still emitted)' => ['tool_use', FinishReason::ToolCalls],
     ]);
 });


### PR DESCRIPTION
## Summary

The `tool_use` finish-reason dataset case was skipped under the assumption that tool use never yields `StreamEnd`. That is only true when the stream contains `tool_use` blocks and the runtime executes the streaming tool-call path.

## Change

- Remove the obsolete skip for the text-only fixture with `stop_reason: tool_use`.
- Clarify the dataset label so the scenario is obvious to future readers.

## Testing

`vendor/bin/pest tests/Feature/Providers/Anthropic/StreamingTest.php`