### PR TITLE
Add missing type hint to $quality parameter in defaultImageOptions

### DIFF
--- a/src/Contracts/Providers/ImageProvider.php
+++ b/src/Contracts/Providers/ImageProvider.php
@@ -39,6 +39,8 @@ interface ImageProvider
 
     /**
      * Get the default / normalized image options for the provider.
+     *
+     * @param  'low'|'medium'|'high'|null  $quality
      */
     public function defaultImageOptions(?string $size = null, ?string $quality = null): array;
 }

--- a/src/Contracts/Providers/ImageProvider.php
+++ b/src/Contracts/Providers/ImageProvider.php
@@ -40,5 +40,5 @@ interface ImageProvider
     /**
      * Get the default / normalized image options for the provider.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array;
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array;
 }

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -107,7 +107,7 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, ImagePr
     /**
      * Get the default / normalized image options for the provider.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
     {
         return array_filter([
             'size' => match ($size) {

--- a/src/Providers/BedrockProvider.php
+++ b/src/Providers/BedrockProvider.php
@@ -102,7 +102,7 @@ class BedrockProvider extends Provider implements EmbeddingProvider, ImageProvid
     /**
      * Get the default / normalized image options for the provider.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
     {
         return [
             'quality' => match ($quality) {

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -122,7 +122,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
     /**
      * Get the default / normalized image options for the provider.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
     {
         return array_filter([
             'image_size' => match ($quality) {

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -112,7 +112,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     /**
      * Get the default / normalized image options for the provider.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
     {
         return array_filter([
             'size' => match ($size) {

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -89,7 +89,7 @@ class OpenRouterProvider extends Provider implements EmbeddingProvider, ImagePro
      * own API convention and are honored primarily by Gemini-family image models.
      * Other image models routed via OpenRouter may ignore these fields.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
     {
         return array_filter([
             'aspect_ratio' => $size,

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -74,7 +74,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
     /**
      * Get the default / normalized image options for the provider.
      */
-    public function defaultImageOptions(?string $size = null, $quality = null): array
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
     {
         return array_filter([
             'aspect_ratio' => match ($size) {


### PR DESCRIPTION
The `$quality` parameter in `defaultImageOptions` is missing its type declaration across the `ImageProvider` contract and all 6 implementing provider classes.

The `image()` method on the same interface already types this parameter as `?string` (line 20), but `defaultImageOptions` leaves it untyped.

### Changes

| File | Before | After |
|---|---|---|
| `Contracts/Providers/ImageProvider.php` | `$quality = null` | `?string $quality = null` |
| `Providers/OpenAiProvider.php` | `$quality = null` | `?string $quality = null` |
| `Providers/AzureOpenAiProvider.php` | `$quality = null` | `?string $quality = null` |
| `Providers/BedrockProvider.php` | `$quality = null` | `?string $quality = null` |
| `Providers/GeminiProvider.php` | `$quality = null` | `?string $quality = null` |
| `Providers/OpenRouterProvider.php` | `$quality = null` | `?string $quality = null` |
| `Providers/XaiProvider.php` | `$quality = null` | `?string $quality = null` |