### PR TITLE
Add missing parameter name in EmbeddingsResponse PHPDoc

### DIFF
--- a/src/Responses/EmbeddingsResponse.php
+++ b/src/Responses/EmbeddingsResponse.php
@@ -14,7 +14,7 @@ class EmbeddingsResponse implements Arrayable, Countable, IteratorAggregate, Jso
     /**
      * Create a new embeddings response instance.
      *
-     * @param  array<int, array<float>>
+     * @param  array<int, array<float>>  $embeddings
      */
     public function __construct(public array $embeddings, public int $tokens, public Meta $meta) {}
 


### PR DESCRIPTION
The `@param` annotation for the `$embeddings` constructor parameter in `EmbeddingsResponse` is missing the variable name.

### Before
```php
@param  array<int, array<float>>
```

### After
```php
@param  array<int, array<float>>  $embeddings
```