### PR TITLE
Add missing type declaration to ToolResult $result property

### DIFF
--- a/src/Responses/Data/ToolResult.php
+++ b/src/Responses/Data/ToolResult.php
@@ -11,7 +11,7 @@ class ToolResult implements Arrayable, JsonSerializable
         public string $id,
         public string $name,
         public array $arguments,
-        public $result,
+        public mixed $result,
         public ?string $resultId = null,
     ) {}
 


### PR DESCRIPTION
The `$result` property in `ToolResult` is the only constructor-promoted property without a type declaration. Since tool results can be of any type, `mixed` is the appropriate type hint.

### Before
```php
public $result,
```

### After
```php
public mixed $result,
```

All other properties in the class (`$id`, `$name`, `$arguments`, `$resultId`) are already typed.