### PR TITLE
Expand streaming finish-reason parity coverage across providers

### DIFF
--- a/tests/Feature/Providers/DeepSeek/StreamingTest.php
+++ b/tests/Feature/Providers/DeepSeek/StreamingTest.php
@@ -172,6 +172,8 @@ test('streaming finish reason maps correctly', function (string $apiReason, $exp
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'stop maps to Stop' => ['stop', FinishReason::Stop],
+    'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
     'length maps to Length' => ['length', FinishReason::Length],
     'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
+    'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -136,6 +136,8 @@ test('streaming finish reason maps correctly', function (string $apiReason, $exp
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'stop maps to Stop' => ['stop', FinishReason::Stop],
+    'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
     'length maps to Length' => ['length', FinishReason::Length],
     'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
+    'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -133,6 +133,8 @@ test('streaming finish reason maps correctly', function (string $apiReason, $exp
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'stop maps to Stop' => ['stop', FinishReason::Stop],
+    'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
     'length maps to Length' => ['length', FinishReason::Length],
     'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
+    'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);

--- a/tests/Feature/Providers/Ollama/StreamingTest.php
+++ b/tests/Feature/Providers/Ollama/StreamingTest.php
@@ -281,5 +281,7 @@ test('streaming finish reason maps correctly', function (string $doneReason, $ex
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'stop maps to Stop' => ['stop', FinishReason::Stop],
+    'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
     'length maps to Length' => ['length', FinishReason::Length],
+    'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -149,6 +149,8 @@ test('streaming finish reason maps correctly', function (string $apiReason, $exp
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'stop maps to Stop' => ['stop', FinishReason::Stop],
+    'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
     'length maps to Length' => ['length', FinishReason::Length],
     'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
+    'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);


### PR DESCRIPTION
## Summary

This PR expands streaming finish-reason parity coverage across providers by adding missing matrix cases for `tool_calls` and unknown finish reasons. The goal is to ensure consistent `FinishReason` mapping behavior across provider streaming implementations.

## Changes

- Updated streaming finish-reason test datasets for:
  - `OpenRouter`
  - `Groq`
  - `DeepSeek`
  - `Mistral`
  - `Ollama`
- Added explicit test coverage for:
  - `tool_calls` -> `FinishReason::ToolCalls`
  - unknown finish reason -> `FinishReason::Unknown`

## Why

Several providers already support these mappings in gateway logic, but streaming test matrices did not consistently assert them. This change improves cross-provider parity guarantees and reduces regression risk.

## Testing

```bash
vendor/bin/pest \
  tests/Feature/Providers/OpenRouter/StreamingTest.php \
  tests/Feature/Providers/Groq/StreamingTest.php \
  tests/Feature/Providers/DeepSeek/StreamingTest.php \
  tests/Feature/Providers/Mistral/StreamingTest.php \
  tests/Feature/Providers/Ollama/StreamingTest.php