### PR TITLE
Expand OpenAI-family streaming finish reason parity tests

### DIFF
--- a/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
@@ -148,4 +148,20 @@ test('streaming finish reason maps correctly', function (array $output, $expecte
         [['type' => 'message', 'status' => 'incomplete', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => '']]]],
         FinishReason::Length,
     ],
+    'completed function_call maps to ToolCalls' => [
+        [['type' => 'function_call', 'status' => 'completed', 'name' => 'FixedNumberGenerator', 'arguments' => '{}']],
+        FinishReason::ToolCalls,
+    ],
+    'failed maps to Error' => [
+        [['type' => 'message', 'status' => 'failed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => '']]]],
+        FinishReason::Error,
+    ],
+    'unknown status maps to Unknown' => [
+        [['type' => 'message', 'status' => 'mystery_status', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => '']]]],
+        FinishReason::Unknown,
+    ],
+    'completed unknown type maps to Unknown' => [
+        [['type' => 'mystery_output', 'status' => 'completed']],
+        FinishReason::Unknown,
+    ],
 ]);

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -181,6 +181,9 @@ test('streaming finish reason maps correctly', function (string $status, string 
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'completed message maps to Stop' => ['completed', 'message', FinishReason::Stop],
+    'completed function_call maps to ToolCalls' => ['completed', 'function_call', FinishReason::ToolCalls],
     'incomplete maps to Length' => ['incomplete', 'message', FinishReason::Length],
     'failed maps to Error' => ['failed', 'message', FinishReason::Error],
+    'unknown status maps to Unknown' => ['mystery_status', 'message', FinishReason::Unknown],
+    'completed unknown type maps to Unknown' => ['completed', 'mystery_output', FinishReason::Unknown],
 ]);

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -145,6 +145,9 @@ test('streaming finish reason maps correctly', function (string $status, string 
     expect($streamEnd->reason)->toBe($expected->value);
 })->with([
     'completed message maps to Stop' => ['completed', 'message', FinishReason::Stop],
+    'completed function_call maps to ToolCalls' => ['completed', 'function_call', FinishReason::ToolCalls],
     'incomplete maps to Length' => ['incomplete', 'message', FinishReason::Length],
     'failed maps to Error' => ['failed', 'message', FinishReason::Error],
+    'unknown status maps to Unknown' => ['mystery_status', 'message', FinishReason::Unknown],
+    'completed unknown type maps to Unknown' => ['completed', 'mystery_output', FinishReason::Unknown],
 ]);


### PR DESCRIPTION
## Summary

This PR expands streaming finish-reason parity coverage for OpenAI-family providers to ensure consistent `FinishReason` mappings for tool calls and unknown cases.

## Changes

Updated streaming finish-reason datasets in:

- `tests/Feature/Providers/OpenAi/StreamingTest.php`
- `tests/Feature/Providers/AzureOpenAi/StreamingTest.php`
- `tests/Feature/Providers/Xai/StreamingTest.php`

Added/expanded cases for:

- `completed function_call` -> `FinishReason::ToolCalls`
- unknown status -> `FinishReason::Unknown`
- completed unknown output type -> `FinishReason::Unknown`
- Azure OpenAI `failed` -> `FinishReason::Error`

## Why

Some providers already map these states in gateway logic, but test matrices did not consistently assert them. Adding these cases improves cross-provider parity and protects against regressions in streaming finish-reason handling.

## Testing

```bash
vendor/bin/pest \
  tests/Feature/Providers/OpenAi/StreamingTest.php \
  tests/Feature/Providers/AzureOpenAi/StreamingTest.php \
  tests/Feature/Providers/Xai/StreamingTest.php