### PR TITLE
Handle broadcast failures without aborting queued streams

### DIFF
--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -33,7 +33,11 @@ class BroadcastAgent implements ShouldQueue
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
             ->each(function (StreamEvent $event) {
-                $event->broadcastNow($this->channels);
+                try {
+                    $event->broadcastNow($this->channels);
+                } catch (\Throwable $e) {
+                    report($e);
+                }
             })
             ->then(function ($response) use (&$streamedResponse) {
                 $streamedResponse = $response;

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Responses\StreamedAgentResponse;
@@ -77,5 +79,36 @@ test('streamed response passed to then is fully resolved', function () {
     expect($received)->not->toBeNull('then() callback was never invoked')
         ->toBeInstanceOf(StreamedAgentResponse::class)
         ->and($received->events)->not->toBeEmpty()
+        ->and($received->text)->toBe('Hello world');
+});
+
+test('broadcast failures do not fail the queued stream job', function () {
+    Event::fake();
+    AssistantAgent::fake(['Hello world']);
+
+    $pendingBroadcast = Mockery::mock();
+    $pendingBroadcast->shouldReceive('as')->andReturnSelf();
+    $pendingBroadcast->shouldReceive('with')->andReturnSelf();
+    $pendingBroadcast->shouldReceive('sendNow')
+        ->andThrow(new BroadcastException('Payload too large'));
+
+    Broadcast::shouldReceive('on')
+        ->andReturn($pendingBroadcast);
+
+    $received = null;
+
+    $job = new BroadcastAgent(
+        agent: new AssistantAgent,
+        prompt: 'Say hello',
+        channels: new Channel('test-channel'),
+    );
+
+    $job->then(function ($response) use (&$received) {
+        $received = $response;
+    });
+
+    expect(fn () => $job->handle())->not->toThrow(BroadcastException::class);
+
+    expect($received)->toBeInstanceOf(StreamedAgentResponse::class)
         ->and($received->text)->toBe('Hello world');
 });


### PR DESCRIPTION
## Summary

`BroadcastAgent` currently broadcasts each stream event without guarding broadcast failures. If a broadcaster rejects a payload (for example, oversized tool result payloads), the queued job fails mid-stream.

This PR makes broadcasting resilient by catching per-event broadcast exceptions so streaming can continue and response callbacks still run.

Fixes #174

## Changes

- Wrap `broadcastNow()` in `BroadcastAgent::handle()` with exception handling.
- Report broadcast exceptions and continue processing subsequent events.
- Add regression test in `tests/Feature/BroadcastAgentTest.php` to verify:
  - broadcast exception does not fail the job,
  - streamed response is still resolved and delivered to `then` callbacks.

## Testing

```bash
vendor/bin/pest tests/Feature/BroadcastAgentTest.php