### PR TITLE
Add error handling tests for VoyageAI reranking

### DIFF
--- a/tests/Feature/Providers/VoyageAi/RerankingTest.php
+++ b/tests/Feature/Providers/VoyageAi/RerankingTest.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
 
@@ -61,6 +64,30 @@ test('reranking request sends bearer token', function () {
 
     Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
 });
+
+test('reranking rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Rate limit exceeded'], 429),
+    ]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'voyageai', model: 'rerank-2.5-lite');
+})->throws(RateLimitedException::class);
+
+test('reranking overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Service unavailable'], 503),
+    ]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'voyageai', model: 'rerank-2.5-lite');
+})->throws(ProviderOverloadedException::class);
+
+test('reranking http error response throws request exception', function () {
+    Http::fake([
+        'api.voyageai.com/*' => Http::response(['detail' => 'Invalid model'], 400),
+    ]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'voyageai', model: 'rerank-2.5-lite');
+})->throws(RequestException::class);
 
 function fakeVoyageRerankingResponse()
 {


### PR DESCRIPTION
## Summary

Adds error-handling test coverage for the VoyageAI reranking endpoint. Mirrors the pattern recently merged for OpenRouter embeddings (#498) and xAI image generation (#502), and complements the embeddings coverage I just opened in #526.

The existing `RerankingTest.php` covered the happy paths (request shape, top_k, response parsing, bearer auth) but had no assertions for failure modes.

## Coverage added

- 429 rate-limit response → `RateLimitedException`
- 503 overloaded response → `ProviderOverloadedException`
- Generic 4xx response → `RequestException`

These exceptions are produced by `HandlesFailoverErrors` (used by `VoyageAiGateway`); the new tests pin that contract for the reranking endpoint.

## Testing

```
vendor/bin/pest tests/Feature/Providers/VoyageAi/RerankingTest.php
# 7 passed (13 assertions)
```