### PR TITLE
Add error handling tests for OpenAI image generation

### DIFF
--- a/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
@@ -2,7 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Image;
 
 beforeEach(function () {
@@ -194,3 +197,42 @@ test('image generation request omits response_format for gpt-image models', func
         return ! array_key_exists('response_format', $body);
     });
 });
+
+test('image rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'Rate limit exceeded',
+            ],
+        ], 429),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
+})->throws(RateLimitedException::class);
+
+test('image overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => [
+                'type' => 'server_error',
+                'message' => 'The server is currently overloaded. Please try again later.',
+            ],
+        ], 503),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
+})->throws(ProviderOverloadedException::class);
+
+test('image http error response throws request exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'Invalid model',
+            ],
+        ], 400),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
+})->throws(RequestException::class);


### PR DESCRIPTION
## Summary

Adds error-handling test coverage for the OpenAI image generation endpoint, mirroring exactly the pattern recently merged in #502 for xAI image generation and #498 for OpenRouter embeddings.

The existing `ImageGenerationTest.php` covered request shape (quality, moderation, size, response_format) and usage parsing, but had no assertions for failure modes — even though `OpenAiGateway::generateImage()` is wrapped in `withErrorHandling()`.

## Coverage added

- 429 rate-limit response → `RateLimitedException`
- 503 overloaded response → `ProviderOverloadedException`
- Generic 4xx response → `RequestException`

## Testing

```
vendor/bin/pest tests/Feature/Providers/OpenAi/ImageGenerationTest.php
# 14 passed (18 assertions)
```