### PR TITLE
Add type declaration to StructuredAnonymousAgent $schema property

### DIFF
--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -9,7 +9,7 @@ use Laravel\SerializableClosure\SerializableClosure;
 
 class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOutput
 {
-    public $schema;
+    public SerializableClosure $schema;
 
     public function __construct(
         public string $instructions,


### PR DESCRIPTION
The `$schema` property on `StructuredAnonymousAgent` is the only untyped property in the class. The constructor always wraps the incoming `Closure` in a `SerializableClosure` and assigns it to `$this->schema`, so the property is never any other type.

This mirrors the recently merged #518 which added a `mixed` type declaration to the only untyped property on `ToolResult`.

### Before
```php
public $schema;
```

### After
```php
public SerializableClosure $schema;
```

All other properties on the class (`$instructions`, `$messages`, `$tools`) are already typed via constructor promotion.

### Verified

- `vendor/bin/pest` — 1145 passed (no regressions)
- `vendor/bin/pint` — clean