### PR TITLE
Make OpenAI strict mode opt-in via Strict attribute

### DIFF
--- a/src/Attributes/Strict.php
+++ b/src/Attributes/Strict.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+use ReflectionClass;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Strict
+{
+    public static function isAppliedTo(?object $target): bool
+    {
+        return $target !== null
+            && (new ReflectionClass($target))->getAttributes(self::class) !== [];
+    }
+}

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -32,7 +33,7 @@ trait BuildsTextRequests
         }
 
         if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema);
+            $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -58,18 +59,16 @@ trait BuildsTextRequests
     /**
      * Build the text format options for structured output.
      */
-    protected function buildSchemaFormat(array $schema): array
+    protected function buildSchemaFormat(array $schema, bool $strict): array
     {
-        $objectSchema = new ObjectSchema($schema);
-
-        $schemaArray = $objectSchema->toSchema();
+        $schemaArray = (new ObjectSchema($schema, strict: $strict))->toSchema();
 
         return [
             'format' => [
                 'type' => 'json_schema',
                 'name' => $schemaArray['name'] ?? 'schema_definition',
                 'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
+                'strict' => $strict,
             ],
         ];
     }

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 use Generator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
@@ -373,7 +374,7 @@ trait HandlesTextStreaming
             }
 
             if (filled($schema)) {
-                $body['text'] = $this->buildSchemaFormat($schema);
+                $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
             }
 
             $body = array_merge($body, Arr::whereNotNull([

--- a/src/Gateway/OpenAi/Concerns/MapsTools.php
+++ b/src/Gateway/OpenAi/Concerns/MapsTools.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
@@ -39,17 +40,19 @@ trait MapsTools
      */
     protected function mapTool(Tool $tool): array
     {
+        $strict = Strict::isAppliedTo($tool);
+
         $schema = $tool->schema(new JsonSchemaTypeFactory);
 
         $schemaArray = filled($schema)
-            ? (new ObjectSchema($schema))->toSchema()
+            ? (new ObjectSchema($schema, strict: $strict))->toSchema()
             : [];
 
         return [
             'type' => 'function',
             'name' => ToolNameResolver::resolve($tool),
             'description' => (string) $tool->description(),
-            'strict' => true,
+            'strict' => $strict,
             'parameters' => [
                 'type' => 'object',
                 'properties' => $schemaArray['properties'] ?? (object) [],

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\AiException;
@@ -243,7 +244,7 @@ trait ParsesTextResponses
         }
 
         if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema);
+            $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         $body = array_merge($body, Arr::whereNotNull([

--- a/src/ObjectSchema.php
+++ b/src/ObjectSchema.php
@@ -12,7 +12,7 @@ class ObjectSchema extends Schema
     public function __construct(
         array $schema,
         string $name = 'schema_definition',
-        bool $strict = true
+        bool $strict = false
     ) {
         parent::__construct(
             schema: (new ObjectType($schema))->withoutAdditionalProperties(),

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -13,7 +13,7 @@ class Schema implements Schemable
     public function __construct(
         public Type $schema,
         public string $name = 'schema_definition',
-        public bool $strict = true
+        public bool $strict = false
     ) {}
 
     /**

--- a/tests/Feature/Providers/OpenAi/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
+use Tests\Fixtures\Tools\NonStrictTool;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
 use function Laravel\Ai\agent;
@@ -63,6 +64,23 @@ test('tool without a name() method falls back to class basename for openai', fun
         $names = collect(data_get($body, 'tools'))->pluck('name')->all();
 
         return in_array('FixedNumberGenerator', $names, true);
+    });
+});
+
+test('tool without Strict attribute sends strict false and honors developer-declared required fields', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('ok'),
+    ]);
+
+    agent(tools: [new NonStrictTool])->prompt('Hi', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+
+        return $tool['strict'] === false
+            && $tool['parameters']['required'] === ['query']
+            && array_key_exists('limit', $tool['parameters']['properties']);
     });
 });
 

--- a/tests/Fixtures/Agents/StructuredAgent.php
+++ b/tests/Fixtures/Agents/StructuredAgent.php
@@ -3,10 +3,12 @@
 namespace Tests\Fixtures\Agents;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 
+#[Strict]
 class StructuredAgent implements Agent, HasStructuredOutput
 {
     use Promptable;

--- a/tests/Fixtures/Tools/FixedNumberGenerator.php
+++ b/tests/Fixtures/Tools/FixedNumberGenerator.php
@@ -3,9 +3,11 @@
 namespace Tests\Fixtures\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 
+#[Strict]
 class FixedNumberGenerator implements Tool
 {
     public function __construct(public bool $throwsException = false) {}

--- a/tests/Fixtures/Tools/NonStrictTool.php
+++ b/tests/Fixtures/Tools/NonStrictTool.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class NonStrictTool implements Tool
+{
+    public function description(): string
+    {
+        return 'A tool without the Strict attribute.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return 'ok';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()->required(),
+            'limit' => $schema->integer(),
+        ];
+    }
+}

--- a/tests/Fixtures/Tools/RandomNumberGenerator.php
+++ b/tests/Fixtures/Tools/RandomNumberGenerator.php
@@ -3,9 +3,11 @@
 namespace Tests\Fixtures\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 
+#[Strict]
 class RandomNumberGenerator implements Tool
 {
     public function __construct(public bool $throwsException = false) {}


### PR DESCRIPTION
The OpenAI gateway has hardcoded `strict: true` on every tool and structured-output schema. OpenAI's strict mode requires every key in `properties` to also appear in `required`, so any tool that defines a parameter without calling `->required()` is rejected at runtime with a 400 `invalid_function_parameters`. There's no way for the developer to opt out.

Fixes #506

### Usage

Tools and structured-output agents now opt into strict mode with the `#[Strict]` attribute:

```php
use Laravel\Ai\Attributes\Strict;
use Laravel\Ai\Contracts\Tool;

#[Strict]
class WeatherTool implements Tool
{
    public function schema(JsonSchema $schema): array
    {
        return ['location' => $schema->string()->required()];
    }
}
```

Without the attribute, the SDK sends `strict: false` and the schema is forwarded as the developer wrote it, so optional parameters work without producing an OpenAI 400.

### Approach

- Added a `#[Strict]` attribute that the OpenAI gateway reads via reflection from the tool or agent class.
- The reflected boolean drives the `strict` flag in both tool definitions and structured-output requests.
- Mirrors the design Vercel AI SDK 6 chose for the same problem: opt-in per tool, no hidden auto-transformations.

> [!WARNING]
> **Breaking change.** Strict mode is now opt-in. Previously every OpenAI tool and structured-output schema was sent with `strict: true`; from this PR the default is `strict: false`. Tools or agents that relied on OpenAI's strict-mode guarantees (schema-precise parameter validation) must add `#[Strict]` and ensure every property in their schema is marked `->required()`.