### PR TITLE
Add NVIDIA NIM text provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -112,6 +112,12 @@ return [
             'key' => env('MISTRAL_API_KEY'),
         ],
 
+        'nvidia' => [
+            'driver' => 'nvidia',
+            'key' => env('NVIDIA_API_KEY'),
+            'url' => env('NVIDIA_NIM_URL', 'https://integrate.api.nvidia.com/v1'),
+        ],
+
         'ollama' => [
             'driver' => 'ollama',
             'key' => env('OLLAMA_API_KEY', ''),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -28,6 +28,7 @@ use Laravel\Ai\Providers\GeminiProvider;
 use Laravel\Ai\Providers\GroqProvider;
 use Laravel\Ai\Providers\JinaProvider;
 use Laravel\Ai\Providers\MistralProvider;
+use Laravel\Ai\Providers\NvidiaProvider;
 use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\OpenRouterProvider;
@@ -385,6 +386,17 @@ class AiManager extends MultipleInstanceManager
     public function createMistralDriver(array $config): MistralProvider
     {
         return new MistralProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create an NVIDIA NIM powered instance.
+     */
+    public function createNvidiaDriver(array $config): NvidiaProvider
+    {
+        return new NvidiaProvider(
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -14,6 +14,7 @@ enum Lab: string
     case Groq = 'groq';
     case Jina = 'jina';
     case Mistral = 'mistral';
+    case Nvidia = 'nvidia';
     case Ollama = 'ollama';
     case OpenAI = 'openai';
     case OpenRouter = 'openrouter';

--- a/src/Gateway/Nvidia/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Nvidia/Concerns/BuildsTextRequests.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    use ComposesSchemaInstructions;
+
+    /**
+     * Build the request body for the Chat Completions API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessagesToChat(
+                $messages,
+                $this->composeInstructions($instructions, $schema),
+            ),
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat();
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        $body = array_merge($body, Arr::whereNotNull([
+            'temperature' => $options?->temperature,
+            'top_p' => $options?->topP,
+        ]));
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the response format options for structured output.
+     */
+    protected function buildResponseFormat(): array
+    {
+        return ['type' => 'json_object'];
+    }
+}

--- a/src/Gateway/Nvidia/Concerns/CreatesNvidiaClient.php
+++ b/src/Gateway/Nvidia/Concerns/CreatesNvidiaClient.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesNvidiaClient
+{
+    /**
+     * Get an HTTP client for the NVIDIA NIM API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the NVIDIA NIM API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://integrate.api.nvidia.com/v1', '/');
+    }
+}

--- a/src/Gateway/Nvidia/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Nvidia/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Generator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Process a Chat Completions streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        array $priorChatMessages = [],
+        ?int $timeout = null,
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $usage = null;
+        $finishReason = null;
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            if (isset($data['error'])) {
+                yield (new Error(
+                    $this->generateEventId(),
+                    $data['error']['code'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            $choice = $data['choices'][0] ?? null;
+
+            if (! $choice) {
+                if (isset($data['usage'])) {
+                    $usage = $this->extractUsage($data);
+                }
+
+                continue;
+            }
+
+            $delta = $choice['delta'] ?? [];
+
+            if (! $streamStartEmitted) {
+                $streamStartEmitted = true;
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    $data['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['content']) && $delta['content'] !== '') {
+                if (! $textStartEmitted) {
+                    $textStartEmitted = true;
+
+                    yield (new TextStart(
+                        $this->generateEventId(),
+                        $messageId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                $currentText .= $delta['content'];
+
+                yield (new TextDelta(
+                    $this->generateEventId(),
+                    $messageId,
+                    $delta['content'],
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['tool_calls'])) {
+                foreach ($delta['tool_calls'] as $tcDelta) {
+                    $idx = $tcDelta['index'];
+
+                    if (! isset($pendingToolCalls[$idx])) {
+                        $pendingToolCalls[$idx] = [
+                            'id' => $tcDelta['id'] ?? '',
+                            'name' => $tcDelta['function']['name'] ?? '',
+                            'arguments' => '',
+                        ];
+                    }
+
+                    if (isset($tcDelta['function']['arguments'])) {
+                        $pendingToolCalls[$idx]['arguments'] .= $tcDelta['function']['arguments'];
+                    }
+                }
+            }
+
+            if (isset($choice['finish_reason']) && $choice['finish_reason'] !== null) {
+                $finishReason = $choice['finish_reason'];
+            }
+
+            if (isset($data['usage'])) {
+                $usage = $this->extractUsage($data);
+            }
+        }
+
+        if ($textStartEmitted) {
+            yield (new TextEnd(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
+            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+            foreach ($mappedToolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield from $this->handleStreamingToolCalls(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $mappedToolCalls,
+                $currentText,
+                $instructions,
+                $originalMessages,
+                $depth,
+                $maxSteps,
+                $priorChatMessages,
+                $timeout,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            $this->extractFinishReason(['finish_reason' => $finishReason ?? ''])->value,
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $mappedToolCalls,
+        string $currentText,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        array $priorChatMessages,
+        ?int $timeout = null,
+    ): Generator {
+        $toolResults = [];
+
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $assistantMsg = ['role' => 'assistant'];
+
+            if (filled($currentText)) {
+                $assistantMsg['content'] = $currentText;
+            }
+
+            $assistantMsg['tool_calls'] = array_map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
+            );
+
+            $toolResultMessages = [];
+
+            foreach ($toolResults as $toolResult) {
+                $toolResultMessages[] = [
+                    'role' => 'tool',
+                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                    'content' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+
+            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
+
+            $chatMessages = [
+                ...$this->mapMessagesToChat(
+                    $originalMessages,
+                    $this->composeInstructions($instructions, $schema),
+                ),
+                ...$updatedPriorMessages,
+            ];
+
+            $body = [
+                'model' => $model,
+                'messages' => $chatMessages,
+                'stream' => true,
+                'stream_options' => ['include_usage' => true],
+            ];
+
+            if (filled($tools)) {
+                $mappedTools = $this->mapTools($tools);
+
+                if (filled($mappedTools)) {
+                    $body['tool_choice'] = 'auto';
+                    $body['tools'] = $mappedTools;
+                }
+            }
+
+            if (filled($schema)) {
+                $body['response_format'] = $this->buildResponseFormat();
+            }
+
+            if (! is_null($options?->maxTokens)) {
+                $body['max_completion_tokens'] = $options->maxTokens;
+            }
+
+            $body = array_merge($body, Arr::whereNotNull([
+                'temperature' => $options?->temperature,
+                'top_p' => $options?->topP,
+            ]));
+
+            $providerOptions = $options?->providerOptions($provider->driver());
+
+            if (filled($providerOptions)) {
+                $body = array_merge($body, $providerOptions);
+            }
+
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)
+                    ->withOptions(['stream' => true])
+                    ->post('chat/completions', $body),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $updatedPriorMessages,
+                $timeout,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['name'] ?? '',
+            json_decode($toolCall['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+}

--- a/src/Gateway/Nvidia/Concerns/MapsAttachments.php
+++ b/src/Gateway/Nvidia/Concerns/MapsAttachments.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to Chat Completions content parts.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof Base64Image => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.$attachment->base64],
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => $attachment->url],
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(file_get_contents($attachment->path))],
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    )],
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
+                ],
+                default => throw new InvalidArgumentException('NVIDIA NIM does not support document attachments. Only image attachments are supported.'),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/Nvidia/Concerns/MapsMessages.php
+++ b/src/Gateway/Nvidia/Concerns/MapsMessages.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to Chat Completions messages format.
+     */
+    protected function mapMessagesToChat(array $messages, ?string $instructions = null): array
+    {
+        $chatMessages = [];
+
+        if (filled($instructions)) {
+            $chatMessages[] = [
+                'role' => 'system',
+                'content' => $instructions,
+            ];
+        }
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $chatMessages),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $chatMessages),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $chatMessages),
+            };
+        }
+
+        return $chatMessages;
+    }
+
+    /**
+     * Map a user message to Chat Completions format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof UserMessage || $message->attachments->isEmpty()) {
+            $chatMessages[] = [
+                'role' => 'user',
+                'content' => $message->content,
+            ];
+
+            return;
+        }
+
+        $chatMessages[] = [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => $message->content],
+                ...$this->mapAttachments($message->attachments),
+            ],
+        ];
+    }
+
+    /**
+     * Map an assistant message to Chat Completions format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$chatMessages): void
+    {
+        $msg = ['role' => 'assistant'];
+
+        if (filled($message->content)) {
+            $msg['content'] = $message->content;
+        }
+
+        if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+            $msg['tool_calls'] = $message->toolCalls->map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+            )->all();
+        }
+
+        $chatMessages[] = $msg;
+    }
+
+    /**
+     * Map a tool result message to Chat Completions format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        foreach ($message->toolResults as $toolResult) {
+            $chatMessages[] = [
+                'role' => 'tool',
+                'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                'content' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+    }
+
+    /**
+     * Serialize a tool call DTO to Chat Completions array format.
+     */
+    protected function serializeToolCallToChat(ToolCall $toolCall): array
+    {
+        return [
+            'id' => $toolCall->resultId ?? $toolCall->id,
+            'type' => 'function',
+            'function' => [
+                'name' => $toolCall->name,
+                'arguments' => json_encode($toolCall->arguments ?: (object) []),
+            ],
+        ];
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+}

--- a/src/Gateway/Nvidia/Concerns/MapsTools.php
+++ b/src/Gateway/Nvidia/Concerns/MapsTools.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Tools\ToolNameResolver;
+use RuntimeException;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to Chat Completions function definitions.
+     */
+    protected function mapTools(array $tools): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                throw new RuntimeException('NVIDIA NIM does not support ['.class_basename($tool).'] provider tools.');
+            }
+
+            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to a Chat Completions function definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $schemaArray = filled($schema)
+            ? (new ObjectSchema($schema))->toSchema()
+            : [];
+
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => ToolNameResolver::resolve($tool),
+                'description' => (string) $tool->description(),
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $schemaArray['properties'] ?? (object) [],
+                    'required' => $schemaArray['required'] ?? [],
+                    'additionalProperties' => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Gateway/Nvidia/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Nvidia/Concerns/ParsesTextResponses.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia\Concerns;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Validate the NVIDIA NIM response data.
+     *
+     * @throws AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || isset($data['error'])) {
+            throw new AiException(sprintf(
+                'NVIDIA NIM Error: [%s] %s',
+                $data['error']['type'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown NVIDIA NIM error.',
+            ));
+        }
+    }
+
+    /**
+     * Parse the NVIDIA NIM response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        ?int $timeout = null,
+    ): TextResponse {
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            instructions: $instructions,
+            originalMessages: $originalMessages,
+            maxSteps: $options?->maxSteps,
+            options: $options,
+            timeout: $timeout,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $choice = $data['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+        $model = $data['model'] ?? '';
+
+        $text = $message['content'] ?? '';
+        $rawToolCalls = $message['tool_calls'] ?? [];
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->extractFinishReason($choice);
+
+        $mappedToolCalls = array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['function']['name'] ?? '',
+            json_decode($toolCall['function']['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), $rawToolCalls);
+
+        $step = new Step(
+            $text,
+            $mappedToolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model),
+        );
+
+        $steps->push($step);
+
+        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+
+        $messages->push($assistantMessage);
+
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($mappedToolCalls) &&
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+
+            $steps->pop();
+
+            $steps->push(new Step(
+                $text,
+                $mappedToolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $options,
+                $timeout,
+            );
+        }
+
+        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
+        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
+
+        if ($structured) {
+            $structuredData = json_decode($text, true) ?? [];
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                $text,
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model),
+            ))->withToolCallsAndResults(
+                toolCalls: $allToolCalls,
+                toolResults: $allToolResults,
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        string $model,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $chatMessages = $this->mapMessagesToChat(
+            $originalMessages,
+            $this->composeInstructions($instructions, $schema),
+        );
+
+        foreach ($messages as $msg) {
+            if ($msg instanceof AssistantMessage) {
+                $mapped = ['role' => 'assistant'];
+
+                if (filled($msg->content)) {
+                    $mapped['content'] = $msg->content;
+                }
+
+                if ($msg->toolCalls->isNotEmpty()) {
+                    $mapped['tool_calls'] = $msg->toolCalls->map(
+                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+                    )->all();
+                }
+
+                $chatMessages[] = $mapped;
+            } elseif ($msg instanceof ToolResultMessage) {
+                foreach ($msg->toolResults as $toolResult) {
+                    $chatMessages[] = [
+                        'role' => 'tool',
+                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                        'content' => $this->serializeToolResultOutput($toolResult->result),
+                    ];
+                }
+            }
+        }
+
+        $body = [
+            'model' => $model,
+            'messages' => $chatMessages,
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat();
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        $body = array_merge($body, Arr::whereNotNull([
+            'temperature' => $options?->temperature,
+            'top_p' => $options?->topP,
+        ]));
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $instructions,
+            $originalMessages,
+            $depth,
+            $maxSteps,
+            $options,
+            $timeout,
+        );
+    }
+
+    /**
+     * Extract usage data from the response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+        $details = $usage['completion_tokens_details'] ?? [];
+
+        return new Usage(
+            promptTokens: $usage['prompt_tokens'] ?? 0,
+            completionTokens: $usage['completion_tokens'] ?? 0,
+            cacheReadInputTokens: $usage['prompt_cache_hit_tokens'] ?? 0,
+            reasoningTokens: $details['reasoning_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract and map the finish reason from the response.
+     */
+    protected function extractFinishReason(array $choice): FinishReason
+    {
+        return match ($choice['finish_reason'] ?? '') {
+            'stop' => FinishReason::Stop,
+            'tool_calls' => FinishReason::ToolCalls,
+            'length' => FinishReason::Length,
+            'content_filter' => FinishReason::ContentFilter,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+}

--- a/src/Gateway/Nvidia/NvidiaGateway.php
+++ b/src/Gateway/Nvidia/NvidiaGateway.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Nvidia;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\TextResponse;
+
+class NvidiaGateway implements TextGateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\CreatesNvidiaClient;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesFailoverErrors;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $instructions,
+            $messages,
+            $timeout,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $body['stream'] = true;
+        $body['stream_options'] = ['include_usage' => true];
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('chat/completions', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $instructions,
+            $messages,
+            0,
+            null,
+            [],
+            $timeout,
+        );
+    }
+}

--- a/src/Providers/NvidiaProvider.php
+++ b/src/Providers/NvidiaProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Nvidia\NvidiaGateway;
+
+class NvidiaProvider extends Provider implements TextProvider
+{
+    use Concerns\GeneratesText;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    public function __construct(protected array $config, protected Dispatcher $events)
+    {
+        //
+    }
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new NvidiaGateway($this->events);
+    }
+
+    /**
+     * Get the name of the default text model.
+     *
+     * Curated to NVIDIA build catalog free-tier models. Override via
+     * config('ai.providers.nvidia.models.text.default').
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['text']['default'] ?? 'meta/llama-3.3-70b-instruct';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['text']['cheapest'] ?? 'meta/llama-3.1-8b-instruct';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     *
+     * Held on the free tier. Heavier reasoning models on NVIDIA's catalog
+     * (e.g. nemotron-super-49b) are gated behind paid credits and so are
+     * not the default here.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['text']['smartest'] ?? 'meta/llama-3.3-70b-instruct';
+    }
+}

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -42,6 +42,7 @@ dataset('agent-providers', [
     'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
     'groq' => ['groq', 'GROQ_API_KEY', 'openai/gpt-oss-20b'],
     'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
+    'nvidia' => ['nvidia', 'NVIDIA_API_KEY', 'meta/llama-3.3-70b-instruct'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
     'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'anthropic/claude-haiku-4.5'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],

--- a/tests/Feature/Providers/Nvidia/AgentFakeTest.php
+++ b/tests/Feature/Providers/Nvidia/AgentFakeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Tests\Fixtures\Agents\NvidiaAgent;
+
+test('nvidia agent can be faked', function () {
+    NvidiaAgent::fake(['Test response']);
+
+    $response = (new NvidiaAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Test response');
+});
+
+test('nvidia agent fake with closure', function () {
+    NvidiaAgent::fake(fn (string $prompt) => "Echo: {$prompt}");
+
+    $response = (new NvidiaAgent)->prompt('Hello world');
+
+    expect($response->text)->toBe('Echo: Hello world');
+});
+
+test('nvidia agent fake with no predefined responses', function () {
+    NvidiaAgent::fake();
+
+    $response = (new NvidiaAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Fake response for prompt: Hello');
+});
+
+test('nvidia agent fake records prompts', function () {
+    NvidiaAgent::fake();
+
+    (new NvidiaAgent)->prompt('Hello');
+
+    NvidiaAgent::assertPrompted('Hello');
+    NvidiaAgent::assertNotPrompted('Goodbye');
+});
+
+test('nvidia agent stream can be faked', function () {
+    NvidiaAgent::fake(['Streamed response']);
+
+    $response = (new NvidiaAgent)->stream('Hello');
+    $response->each(fn () => true);
+
+    expect($response->text)->toBe('Streamed response');
+});

--- a/tests/Feature/Providers/Nvidia/BaseUrlTest.php
+++ b/tests/Feature/Providers/Nvidia/BaseUrlTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    $this->customUrl = 'http://localhost:8000/v1';
+});
+
+test('nvidia text requests use the configured base url', function () {
+    configureNvidiaProvider($this->customUrl);
+
+    Http::fake([
+        '*' => fakeNvidiaResponse('Hello from local NIM'),
+    ]);
+
+    $response = agent()->prompt('Hello', provider: 'nvidia');
+
+    expect($response->text)->toBe('Hello from local NIM');
+
+    Http::assertSentCount(1);
+    nvidiaAssertRequestSent('POST', "{$this->customUrl}/chat/completions");
+});
+
+test('nvidia requests fall back to the default base url', function () {
+    configureNvidiaProvider();
+
+    Http::fake([
+        '*' => fakeNvidiaResponse('Hello from NIM'),
+    ]);
+
+    $response = agent()->prompt('Hello', provider: 'nvidia');
+
+    expect($response->text)->toBe('Hello from NIM');
+
+    Http::assertSentCount(1);
+    nvidiaAssertRequestSent('POST', 'https://integrate.api.nvidia.com/v1/chat/completions');
+});
+
+function configureNvidiaProvider(?string $url = null): void
+{
+    config(['ai.providers.nvidia' => array_filter([
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+        'url' => $url,
+    ])]);
+}
+
+function nvidiaAssertRequestSent(string $method, string $url): void
+{
+    Http::assertSent(fn (Request $request) => $request->method() === $method
+        && $request->url() === $url);
+}

--- a/tests/Feature/Providers/Nvidia/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Nvidia/ErrorHandlingTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('http error response throws request exception', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'max_tokens: must be at least 1',
+            ],
+        ], 400),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'nvidia',
+    );
+})->throws(RequestException::class);
+
+test('rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response([
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'Rate limit exceeded',
+            ],
+        ], 429),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'nvidia',
+    );
+})->throws(RateLimitedException::class);
+
+test('overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response([
+            'error' => [
+                'type' => 'server_error',
+                'message' => 'The server is currently overloaded. Please try again later.',
+            ],
+        ], 503),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'nvidia',
+    );
+})->throws(ProviderOverloadedException::class);
+
+test('error in 200 response throws ai exception', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response([
+            'error' => [
+                'type' => 'api_error',
+                'message' => 'Internal server error',
+            ],
+        ], 200),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'nvidia',
+    );
+})->throws(AiException::class, 'NVIDIA NIM Error');

--- a/tests/Feature/Providers/Nvidia/MessageMappingTest.php
+++ b/tests/Feature/Providers/Nvidia/MessageMappingTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\ToolUsingAgent;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('user message maps to nvidia format', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => fakeNvidiaResponse(),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'What is Laravel?',
+        provider: 'nvidia',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['messages'])->firstWhere('role', 'user');
+
+        return $userMessage !== null
+            && $userMessage['content'] === 'What is Laravel?';
+    });
+});
+
+test('tool result follow up maps assistant and tool result messages', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::sequence([
+            fakeNvidiaToolCallResponse(),
+            fakeNvidiaResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'nvidia',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUpBody = json_decode($recorded[1][0]->body(), true);
+    $followUpMessages = $followUpBody['messages'];
+
+    $hasAssistantWithToolCalls = false;
+    $hasToolResult = false;
+
+    foreach ($followUpMessages as $msg) {
+        if ($msg['role'] === 'assistant' && isset($msg['tool_calls'])) {
+            $hasAssistantWithToolCalls = true;
+        }
+
+        if ($msg['role'] === 'tool') {
+            $hasToolResult = true;
+        }
+    }
+
+    expect($hasAssistantWithToolCalls)->toBeTrue()
+        ->and($hasToolResult)->toBeTrue();
+});
+
+test('image attachment maps to image url content block', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => fakeNvidiaResponse('I see an image'),
+    ]);
+
+    $image = new Base64Image(base64_encode('fake-image-data'), 'image/png');
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [$image],
+        provider: 'nvidia',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['messages'])->firstWhere('role', 'user');
+        $content = $userMessage['content'];
+
+        $imageBlock = collect($content)->firstWhere('type', 'image_url');
+
+        return $imageBlock !== null
+            && str_contains($imageBlock['image_url']['url'], 'image/png')
+            && str_contains($imageBlock['image_url']['url'], base64_encode('fake-image-data'));
+    });
+});
+
+test('document attachments throw exception', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => fakeNvidiaResponse(),
+    ]);
+
+    $pdf = new Base64Document(base64_encode('fake-pdf'), 'application/pdf');
+
+    agent('You are helpful.')->prompt(
+        'What is in this PDF?',
+        attachments: [$pdf],
+        provider: 'nvidia',
+    );
+})->throws(InvalidArgumentException::class);

--- a/tests/Feature/Providers/Nvidia/NvidiaHelpers.php
+++ b/tests/Feature/Providers/Nvidia/NvidiaHelpers.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Providers\Nvidia;
+
+use Tests\Fixtures\Agents\AssistantAgent;
+
+trait NvidiaHelpers
+{
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream(
+            'Hello',
+            provider: 'nvidia',
+        );
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            if ($event === '[DONE]') {
+                $lines[] = 'data: [DONE]';
+            } else {
+                $lines[] = 'data: '.json_encode($event);
+            }
+        }
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+
+    protected function chatChunk(array $delta, ?string $finishReason = null): array
+    {
+        return [
+            'id' => 'chatcmpl-nv-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'meta/llama-3.3-70b-instruct',
+            'choices' => [[
+                'index' => 0,
+                'delta' => $delta,
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+    }
+
+    protected function chatChunkFinish(string $finishReason, ?array $usage = null): array
+    {
+        $chunk = [
+            'id' => 'chatcmpl-nv-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'meta/llama-3.3-70b-instruct',
+            'choices' => [[
+                'index' => 0,
+                'delta' => (object) [],
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+
+        if ($usage) {
+            $chunk['usage'] = $usage;
+        }
+
+        return $chunk;
+    }
+
+    protected function chatChunkToolCallStart(int $index, string $id, string $name): array
+    {
+        return [
+            'id' => 'chatcmpl-nv-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'meta/llama-3.3-70b-instruct',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'id' => $id,
+                        'type' => 'function',
+                        'function' => ['name' => $name, 'arguments' => ''],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+
+    protected function chatChunkToolCallDelta(int $index, string $arguments): array
+    {
+        return [
+            'id' => 'chatcmpl-nv-123',
+            'object' => 'chat.completion.chunk',
+            'model' => 'meta/llama-3.3-70b-instruct',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'function' => ['arguments' => $arguments],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+}

--- a/tests/Feature/Providers/Nvidia/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Nvidia/ProviderOptionsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\ProviderOptionsAgent;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('request body does not contain provider options when agent does not implement interface', function () {
+    Http::fake([
+        '*' => fakeNvidiaResponse('Hello'),
+    ]);
+
+    agent()->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('frequency_penalty', $body)
+            && ! array_key_exists('presence_penalty', $body);
+    });
+});
+
+test('agent provider options are not leaked to nvidia when keyed for another driver', function () {
+    Http::fake([
+        '*' => fakeNvidiaResponse('Hello'),
+    ]);
+
+    (new ProviderOptionsAgent)->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('frequency_penalty', $body)
+            && ! array_key_exists('presence_penalty', $body);
+    });
+});

--- a/tests/Feature/Providers/Nvidia/RequestMappingTest.php
+++ b/tests/Feature/Providers/Nvidia/RequestMappingTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\StructuredAgent;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('request includes model and messages', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    agent()->prompt('Hi there', provider: 'nvidia', model: 'meta/llama-3.3-70b-instruct');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'meta/llama-3.3-70b-instruct'
+            && count($body['messages']) >= 1
+            && collect($body['messages'])->contains(fn ($m) => $m['role'] === 'user' && $m['content'] === 'Hi there');
+    });
+});
+
+test('system instructions are sent as system message', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    (new AssistantAgent)->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $systemMsg = collect($body['messages'])->firstWhere('role', 'system');
+
+        return $systemMsg !== null
+            && str_contains($systemMsg['content'], 'helpful assistant');
+    });
+});
+
+test('temperature and max tokens are included when set via attributes', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    (new AttributeAgent)->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'temperature') === 0.7
+            && data_get($body, 'max_completion_tokens') === 4096;
+    });
+});
+
+test('temperature and max tokens are excluded when not set', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('temperature', $body)
+            && ! array_key_exists('max_completion_tokens', $body);
+    });
+});
+
+test('tools include tool choice auto', function () {
+    Http::fake(['*' => fakeNvidiaResponse('42')]);
+
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['tool_choice'] === 'auto'
+            && is_array($body['tools'])
+            && count($body['tools']) > 0;
+    });
+});
+
+test('request without tools excludes tool fields', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('tools', $body)
+            && ! array_key_exists('tool_choice', $body);
+    });
+});
+
+test('structured output uses json object response format', function () {
+    Http::fake(['*' => fakeNvidiaResponse('{"symbol": "Au"}')]);
+
+    (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'response_format') === ['type' => 'json_object'];
+    });
+});
+
+test('request without schema excludes response format', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('response_format', $body);
+    });
+});
+
+test('request sends bearer token authorization', function () {
+    Http::fake(['*' => fakeNvidiaResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('Authorization', 'Bearer test-key');
+    });
+});
+
+test('response text and meta are correctly parsed', function () {
+    Http::fake(['*' => fakeNvidiaResponse('NIM is fast')]);
+
+    $response = agent()->prompt('Tell me about NIM', provider: 'nvidia');
+
+    expect($response->text)->toBe('NIM is fast')
+        ->and($response->meta->provider)->toBe('nvidia');
+});
+
+test('response usage is correctly parsed', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-nv-1',
+        'object' => 'chat.completion',
+        'model' => 'meta/llama-3.3-70b-instruct',
+        'choices' => [[
+            'index' => 0,
+            'message' => ['role' => 'assistant', 'content' => 'Hello'],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ])]);
+
+    $response = agent()->prompt('Hello', provider: 'nvidia');
+
+    expect($response->usage->promptTokens)->toBe(10)
+        ->and($response->usage->completionTokens)->toBe(5);
+});

--- a/tests/Feature/Providers/Nvidia/StreamingTest.php
+++ b/tests/Feature/Providers/Nvidia/StreamingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('streaming emits text events', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+                $this->chatChunk(['content' => ' world']),
+                $this->chatChunkFinish('stop', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+                '[DONE]',
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events[0])->toBeInstanceOf(StreamStart::class)
+        ->and($events[1])->toBeInstanceOf(TextStart::class)
+        ->and($events[2])->toBeInstanceOf(TextDelta::class)->delta->toBe('Hello')
+        ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
+        ->and($events[count($events) - 2])->toBeInstanceOf(TextEnd::class)
+        ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming handles tool calls', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::sequence([
+            Http::response(
+                body: $this->ssePayload([
+                    $this->chatChunkToolCallStart(0, 'call_1', 'FixedNumberGenerator'),
+                    $this->chatChunkToolCallDelta(0, '{}'),
+                    $this->chatChunkFinish('tool_calls', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+                    '[DONE]',
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+            Http::response(
+                body: $this->ssePayload([
+                    $this->chatChunk(['role' => 'assistant', 'content' => 'The number is 72019']),
+                    $this->chatChunkFinish('stop', ['prompt_tokens' => 20, 'completion_tokens' => 10]),
+                    '[DONE]',
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]),
+    ]);
+
+    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+    $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+
+    expect($toolCallEvents)->not->toBeEmpty()
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->id)->toBe('call_1');
+});
+
+test('streaming error event stops stream', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit exceeded']],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(Error::class)
+        ->and($events[0]->type)->toBe('rate_limit_exceeded')
+        ->and($events[0]->message)->toBe('Rate limit exceeded');
+});
+
+test('streaming captures usage from final chunk', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+                $this->chatChunkFinish('stop', ['prompt_tokens' => 42, 'completion_tokens' => 10]),
+                '[DONE]',
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+    expect($streamEnd->usage->promptTokens)->toBe(42)
+        ->and($streamEnd->usage->completionTokens)->toBe(10);
+});

--- a/tests/Feature/Providers/Nvidia/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Nvidia/ToolCallLoopTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\ToolUsingAgent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('tool calls trigger follow up request', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::sequence([
+            fakeUniqueNvidiaToolCallResponse(),
+            fakeNvidiaResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a random number',
+        provider: 'nvidia',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+    $hasAssistantWithToolCalls = false;
+    $hasToolResult = false;
+
+    foreach ($followUpBody['messages'] as $message) {
+        if ($message['role'] === 'assistant' && isset($message['tool_calls'])) {
+            $hasAssistantWithToolCalls = true;
+        }
+
+        if ($message['role'] === 'tool') {
+            $hasToolResult = true;
+        }
+    }
+
+    expect($hasAssistantWithToolCalls)->toBeTrue()
+        ->and($hasToolResult)->toBeTrue();
+});
+
+test('max steps limits tool call depth', function () {
+    Http::fake([
+        'integrate.api.nvidia.com/*' => Http::sequence([
+            fakeUniqueNvidiaToolCallResponse(),
+            fakeUniqueNvidiaToolCallResponse(),
+            fakeUniqueNvidiaToolCallResponse(),
+            fakeNvidiaResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate numbers',
+        provider: 'nvidia',
+    );
+
+    $recorded = Http::recorded();
+
+    expect(count($recorded))->toBeLessThanOrEqual(3);
+});
+
+function fakeUniqueNvidiaToolCallResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-nv-tool-'.uniqid(),
+        'object' => 'chat.completion',
+        'model' => 'meta/llama-3.3-70b-instruct',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_'.uniqid(),
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ]);
+}

--- a/tests/Feature/Providers/Nvidia/ToolMappingTest.php
+++ b/tests/Feature/Providers/Nvidia/ToolMappingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.nvidia' => [
+        ...config('ai.providers.nvidia'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('tool with parameters includes correct schema', function () {
+    Http::fake([
+        '*' => fakeNvidiaResponse('42'),
+    ]);
+
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a random number', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
+
+        return $function['parameters']['type'] === 'object'
+            && array_key_exists('min', $function['parameters']['properties'])
+            && array_key_exists('max', $function['parameters']['properties'])
+            && in_array('min', $function['parameters']['required'])
+            && in_array('max', $function['parameters']['required'])
+            && $function['parameters']['additionalProperties'] === false;
+    });
+});
+
+test('tool with empty schema includes parameters', function () {
+    Http::fake([
+        '*' => fakeNvidiaResponse('72019'),
+    ]);
+
+    agent(tools: [new FixedNumberGenerator])->prompt('Give me a number', provider: 'nvidia');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+        $function = $tool['function'] ?? [];
+
+        return array_key_exists('parameters', $function)
+            && $function['parameters']['type'] === 'object'
+            && $function['parameters']['properties'] === []
+            && $function['parameters']['required'] === []
+            && $function['parameters']['additionalProperties'] === false;
+    });
+});

--- a/tests/Fixtures/Agents/NvidiaAgent.php
+++ b/tests/Fixtures/Agents/NvidiaAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider('nvidia')]
+class NvidiaAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -189,3 +189,53 @@ function fakeDeepSeekToolCallResponse(): PromiseInterface
         ],
     ]);
 }
+
+function fakeNvidiaResponse(string $text = 'Hello'): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-nv-123',
+        'object' => 'chat.completion',
+        'model' => 'meta/llama-3.3-70b-instruct',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => $text,
+            ],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 1,
+            'completion_tokens' => 1,
+        ],
+    ]);
+}
+
+function fakeNvidiaToolCallResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-nv-tool-123',
+        'object' => 'chat.completion',
+        'model' => 'meta/llama-3.3-70b-instruct',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_nv_123',
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ]);
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -5,6 +5,7 @@ use Tests\Feature\Providers\AzureOpenAi\AzureOpenAiHelpers;
 use Tests\Feature\Providers\Gemini\GeminiHelpers;
 use Tests\Feature\Providers\Groq\GroqHelpers;
 use Tests\Feature\Providers\Mistral\MistralHelpers;
+use Tests\Feature\Providers\Nvidia\NvidiaHelpers;
 use Tests\Feature\Providers\Ollama\OllamaHelpers;
 use Tests\Feature\Providers\OpenAi\OpenAiHelpers;
 use Tests\Feature\Providers\OpenRouter\OpenRouterHelpers;
@@ -22,6 +23,7 @@ pest()->use(AzureOpenAiHelpers::class)->group('provider-azure')->in('Feature/Pro
 pest()->use(GeminiHelpers::class)->group('provider-gemini')->in('Feature/Providers/Gemini');
 pest()->use(GroqHelpers::class)->group('provider-groq')->in('Feature/Providers/Groq');
 pest()->use(MistralHelpers::class)->group('provider-mistral')->in('Feature/Providers/Mistral');
+pest()->use(NvidiaHelpers::class)->group('provider-nvidia')->in('Feature/Providers/Nvidia');
 pest()->use(OllamaHelpers::class)->group('provider-ollama')->in('Feature/Providers/Ollama');
 pest()->use(OpenAiHelpers::class)->group('provider-openai')->in('Feature/Providers/OpenAi');
 pest()->use(XaiHelpers::class)->group('provider-xai')->in('Feature/Providers/Xai');


### PR DESCRIPTION
Adds NVIDIA NIM as a Lab provider for text generation against https://integrate.api.nvidia.com/v1.            

Follows the DeepSeek provider pattern (NIM is OpenAI-compatible for chat completions):                        
              
- `Lab::Nvidia` enum + `AiManager::createNvidiaDriver()  `                                                        
- `NvidiaProvider implements TextProvider`
- `NvidiaGateway implements TextGateway` with streaming, tools, structured output, and image attachments        
-` config/ai.php` block with NVIDIA_API_KEY and overridable NVIDIA_NIM_URL
                                                                                                              
## Scope         
                                                                                                              
Text only. Embeddings, reranking and image generation live on a different host (ai.api.nvidia.com) and use    
vendor-specific request shapes, so they're cleaner as separate follow-up PRs.
                                                                                                              
## Defaults (free-tier build.nvidia.com)

- defaultTextModel: meta/llama-3.3-70b-instruct                                                               
- cheapestTextModel: meta/llama-3.1-8b-instruct
- smartestTextModel: same as default - heavier models on the catalog are credit-gated.                        
                                                                                                              
All overridable via `config('ai.providers.nvidia.models.text.*')`.
                                                                                                              
**Tested locally against a free API key - prompts, streaming, and tool calls all round-trip.**
