### PR TITLE
Add missing type declaration to StructuredAnonymousAgent $schema property

### DIFF
--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -5,8 +5,10 @@ namespace Laravel\Ai\Jobs;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 
 class BroadcastAgent implements ShouldQueue
@@ -40,6 +42,20 @@ class BroadcastAgent implements ShouldQueue
             });
 
         $this->withCallbacks(fn () => $streamedResponse);
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(\Throwable $exception): void
+    {
+        (new Error(
+            id: (string) Str::uuid(),
+            type: 'stream_failed',
+            message: $exception->getMessage(),
+            recoverable: false,
+            timestamp: now()->timestamp,
+        ))->broadcastNow($this->channels);
     }
 
     /**

--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -9,7 +9,7 @@ use Laravel\SerializableClosure\SerializableClosure;
 
 class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOutput
 {
-    public $schema;
+    public SerializableClosure $schema;
 
     public function __construct(
         public string $instructions,


### PR DESCRIPTION
`StructuredAnonymousAgent::$schema` is always assigned a `SerializableClosure` instance in the constructor but the property lacks an explicit type declaration.