### PR TITLE
Broadcast stream_failed event when BroadcastAgent job fails

### DIFF
--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Jobs;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Streaming\Events\Error;
@@ -17,10 +18,9 @@ class BroadcastAgent implements ShouldQueue
 {
     use Concerns\InvokesQueuedResponseCallbacks, Queueable;
 
-    /**
-     * The job-level invocation ID used to correlate broadcasts with their failure event.
-     */
-    public ?string $invocationId = null;
+    public int $tries = 1;
+
+    public string $invocationId;
 
     /**
      * Create a new job instance.
@@ -31,15 +31,16 @@ class BroadcastAgent implements ShouldQueue
         public Channel|array $channels,
         public array $attachments = [],
         public Lab|array|string|null $provider = null,
-        public ?string $model = null) {}
+        public ?string $model = null,
+    ) {
+        $this->invocationId = (string) Str::uuid7();
+    }
 
     /**
      * Execute the job.
      */
     public function handle(): void
     {
-        $this->invocationId = ulid();
-
         $streamedResponse = null;
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
@@ -61,10 +62,10 @@ class BroadcastAgent implements ShouldQueue
         (new Error(
             id: ulid(),
             type: 'stream_failed',
-            message: $exception::class,
+            message: 'The stream failed.',
             recoverable: false,
             timestamp: time(),
-        ))->withInvocationId($this->invocationId ?? ulid())
+        ))->withInvocationId($this->invocationId)
             ->broadcastNow($this->channels);
     }
 

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -5,15 +5,22 @@ namespace Laravel\Ai\Jobs;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
+use Throwable;
+
+use function Laravel\Ai\ulid;
 
 class BroadcastAgent implements ShouldQueue
 {
     use Concerns\InvokesQueuedResponseCallbacks, Queueable;
+
+    /**
+     * The job-level invocation ID used to correlate broadcasts with their failure event.
+     */
+    public ?string $invocationId = null;
 
     /**
      * Create a new job instance.
@@ -31,11 +38,13 @@ class BroadcastAgent implements ShouldQueue
      */
     public function handle(): void
     {
+        $this->invocationId = ulid();
+
         $streamedResponse = null;
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
             ->each(function (StreamEvent $event) {
-                $event->broadcastNow($this->channels);
+                $event->withInvocationId($this->invocationId)->broadcastNow($this->channels);
             })
             ->then(function ($response) use (&$streamedResponse) {
                 $streamedResponse = $response;
@@ -47,15 +56,16 @@ class BroadcastAgent implements ShouldQueue
     /**
      * Handle a job failure.
      */
-    public function failed(\Throwable $exception): void
+    public function failed(Throwable $exception): void
     {
         (new Error(
-            id: (string) Str::uuid(),
+            id: ulid(),
             type: 'stream_failed',
-            message: 'The agent stream failed.',
+            message: $exception::class,
             recoverable: false,
-            timestamp: now()->timestamp,
-        ))->broadcastNow($this->channels);
+            timestamp: time(),
+        ))->withInvocationId($this->invocationId ?? ulid())
+            ->broadcastNow($this->channels);
     }
 
     /**

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -12,6 +12,8 @@ use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Throwable;
 
+use function Laravel\Ai\ulid;
+
 class BroadcastAgent implements ShouldQueue
 {
     use Concerns\InvokesQueuedResponseCallbacks, Queueable;

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -5,8 +5,10 @@ namespace Laravel\Ai\Jobs;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 
 class BroadcastAgent implements ShouldQueue
@@ -40,6 +42,20 @@ class BroadcastAgent implements ShouldQueue
             });
 
         $this->withCallbacks(fn () => $streamedResponse);
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(\Throwable $exception): void
+    {
+        (new Error(
+            id: (string) Str::uuid(),
+            type: 'stream_failed',
+            message: $exception->getMessage(),
+            recoverable: false,
+            timestamp: now()->timestamp,
+        ))->broadcastNow($this->channels);
     }
 
     /**

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -12,8 +12,6 @@ use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Throwable;
 
-use function Laravel\Ai\ulid;
-
 class BroadcastAgent implements ShouldQueue
 {
     use Concerns\InvokesQueuedResponseCallbacks, Queueable;

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -52,7 +52,7 @@ class BroadcastAgent implements ShouldQueue
         (new Error(
             id: (string) Str::uuid(),
             type: 'stream_failed',
-            message: $exception->getMessage(),
+            message: 'The agent stream failed.',
             recoverable: false,
             timestamp: now()->timestamp,
         ))->broadcastNow($this->channels);

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Broadcasting\AnonymousEvent;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Jobs\BroadcastAgent;
@@ -54,6 +55,24 @@ test('multiple then callbacks all receive streamed agent response', function () 
 
     expect($receivedA)->toBeInstanceOf(StreamedAgentResponse::class)
         ->and($receivedB)->toBeInstanceOf(StreamedAgentResponse::class);
+});
+
+test('failed broadcasts a stream_failed event with recoverable false', function () {
+    Event::fake();
+
+    $job = new BroadcastAgent(
+        agent: new AssistantAgent,
+        prompt: 'Say hello',
+        channels: new Channel('test-channel'),
+    );
+
+    $job->failed(new RuntimeException('Something went wrong'));
+
+    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) {
+        return $event->broadcastAs() === 'stream_failed'
+            && $event->broadcastWith()['recoverable'] === false
+            && $event->broadcastWith()['message'] === 'The agent stream failed.';
+    });
 });
 
 test('streamed response passed to then is fully resolved', function () {

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -68,15 +68,19 @@ test('failed broadcasts a stream_failed event with recoverable false on the conf
         channels: $channel,
     );
 
+    $invocationId = $job->invocationId;
+    $job = unserialize(serialize($job));
+
     $job->failed(new RuntimeException('Something went wrong'));
 
-    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) use ($channel) {
+    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) use ($channel, $invocationId) {
         $payload = $event->broadcastWith();
 
         return $event->broadcastAs() === 'stream_failed'
+            && $payload['invocation_id'] === $invocationId
             && $payload['recoverable'] === false
-            && $payload['message'] === RuntimeException::class
-            && $event->broadcastOn() === [$channel];
+            && $payload['message'] === 'The stream failed.'
+            && $event->broadcastOn() == [$channel];
     });
 });
 
@@ -112,9 +116,6 @@ test('failed event shares the invocation id with broadcasts from handle', functi
     $job->handle();
 
     $invocationId = $job->invocationId;
-    expect($invocationId)->not->toBeNull();
-
-    $job->failed(new RuntimeException('boom'));
 
     $broadcastIds = [];
 
@@ -124,7 +125,7 @@ test('failed event shares the invocation id with broadcasts from handle', functi
         return true;
     });
 
-    expect(array_unique($broadcastIds))->toBe([$invocationId]);
+    expect(array_values(array_unique($broadcastIds)))->toBe([$invocationId]);
 });
 
 test('streamed response passed to then is fully resolved', function () {

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -57,8 +57,51 @@ test('multiple then callbacks all receive streamed agent response', function () 
         ->and($receivedB)->toBeInstanceOf(StreamedAgentResponse::class);
 });
 
-test('failed broadcasts a stream_failed event with recoverable false', function () {
+test('failed broadcasts a stream_failed event with recoverable false on the configured channel', function () {
     Event::fake();
+
+    $channel = new Channel('test-channel');
+
+    $job = new BroadcastAgent(
+        agent: new AssistantAgent,
+        prompt: 'Say hello',
+        channels: $channel,
+    );
+
+    $job->failed(new RuntimeException('Something went wrong'));
+
+    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) use ($channel) {
+        $payload = $event->broadcastWith();
+
+        return $event->broadcastAs() === 'stream_failed'
+            && $payload['recoverable'] === false
+            && $payload['message'] === RuntimeException::class
+            && $event->broadcastOn() === [$channel];
+    });
+});
+
+test('failed broadcasts on every channel when given an array', function () {
+    Event::fake();
+
+    $channels = [new Channel('a'), new Channel('b')];
+
+    $job = new BroadcastAgent(
+        agent: new AssistantAgent,
+        prompt: 'Say hello',
+        channels: $channels,
+    );
+
+    $job->failed(new RuntimeException('boom'));
+
+    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) use ($channels) {
+        return $event->broadcastAs() === 'stream_failed'
+            && $event->broadcastOn() === $channels;
+    });
+});
+
+test('failed event shares the invocation id with broadcasts from handle', function () {
+    Event::fake();
+    AssistantAgent::fake(['Hello world']);
 
     $job = new BroadcastAgent(
         agent: new AssistantAgent,
@@ -66,13 +109,22 @@ test('failed broadcasts a stream_failed event with recoverable false', function 
         channels: new Channel('test-channel'),
     );
 
-    $job->failed(new RuntimeException('Something went wrong'));
+    $job->handle();
 
-    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) {
-        return $event->broadcastAs() === 'stream_failed'
-            && $event->broadcastWith()['recoverable'] === false
-            && $event->broadcastWith()['message'] === 'The agent stream failed.';
+    $invocationId = $job->invocationId;
+    expect($invocationId)->not->toBeNull();
+
+    $job->failed(new RuntimeException('boom'));
+
+    $broadcastIds = [];
+
+    Event::assertDispatched(AnonymousEvent::class, function (AnonymousEvent $event) use (&$broadcastIds) {
+        $broadcastIds[] = $event->broadcastWith()['invocation_id'] ?? null;
+
+        return true;
     });
+
+    expect(array_unique($broadcastIds))->toBe([$invocationId]);
 });
 
 test('streamed response passed to then is fully resolved', function () {


### PR DESCRIPTION
Fixes #341.

When `BroadcastAgent` throws an unhandled exception the frontend has no way to know the stream failed — leaving the user with a permanently loading UI. Laravel's `failed()` hook is now used to broadcast a `stream_failed` `Error` event to the configured channels so clients can handle the failure gracefully.