### PR TITLE
Add rate limit and overloaded error tests for Cohere reranking

### DIFF
--- a/tests/Feature/Providers/Cohere/RerankingTest.php
+++ b/tests/Feature/Providers/Cohere/RerankingTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
 
@@ -97,6 +99,18 @@ test('reranking throws when the API returns an error', function () {
 
     Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
 })->throws(RequestException::class);
+
+test('reranking rate limit response throws rate limited exception', function () {
+    Http::fake(['api.cohere.com/*' => Http::response(['message' => 'rate limit exceeded'], 429)]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+})->throws(RateLimitedException::class);
+
+test('reranking overloaded response throws provider overloaded exception', function () {
+    Http::fake(['api.cohere.com/*' => Http::response(['message' => 'service unavailable'], 503)]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+})->throws(ProviderOverloadedException::class);
 
 function fakeCohereRerankingResponse()
 {


### PR DESCRIPTION
## Summary

Extends the Cohere reranking error-handling test coverage. The existing file already had a 401 → `RequestException` test, but did not cover the failover-relevant exceptions raised by `HandlesFailoverErrors`.

## Coverage added

- 429 rate-limit response → `RateLimitedException`
- 503 overloaded response → `ProviderOverloadedException`

These are the same exception mappings asserted for other providers' endpoints (e.g., #498 OpenRouter embeddings, #527 VoyageAI reranking).

## Testing

```
vendor/bin/pest tests/Feature/Providers/Cohere/RerankingTest.php
# 9 passed (19 assertions)
```