### PR TITLE
Add rate limit and overloaded error tests for Jina reranking

### DIFF
--- a/tests/Feature/Providers/Jina/RerankingTest.php
+++ b/tests/Feature/Providers/Jina/RerankingTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
 
@@ -99,6 +101,18 @@ test('reranking throws when the API returns an error', function () {
 
     Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
 })->throws(RequestException::class);
+
+test('reranking rate limit response throws rate limited exception', function () {
+    Http::fake(['api.jina.ai/*' => Http::response(['detail' => 'rate limit exceeded'], 429)]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
+})->throws(RateLimitedException::class);
+
+test('reranking overloaded response throws provider overloaded exception', function () {
+    Http::fake(['api.jina.ai/*' => Http::response(['detail' => 'service unavailable'], 503)]);
+
+    Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
+})->throws(ProviderOverloadedException::class);
 
 function fakeJinaRerankingResponse()
 {


### PR DESCRIPTION
## Summary

Extends the Jina reranking error-handling test coverage. The existing file already had a 401 → `RequestException` test, but did not cover the failover-relevant exceptions raised by `HandlesFailoverErrors`.

## Coverage added

- 429 rate-limit response → `RateLimitedException`
- 503 overloaded response → `ProviderOverloadedException`

These match the exception mappings asserted for other providers' endpoints (e.g., #498 OpenRouter embeddings, #527 VoyageAI reranking, #540 Cohere reranking).

## Testing

```
vendor/bin/pest tests/Feature/Providers/Jina/RerankingTest.php
# 9 passed (19 assertions)
```