### PR TITLE
Add rate limit and overloaded error tests for ElevenLabs audio

### DIFF
--- a/tests/Feature/Providers/ElevenLabs/AudioTest.php
+++ b/tests/Feature/Providers/ElevenLabs/AudioTest.php
@@ -4,6 +4,8 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
     config(['ai.providers.eleven' => [
@@ -74,6 +76,18 @@ test('audio throws when the API returns an error', function () {
 
     Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
 })->throws(RequestException::class);
+
+test('audio rate limit response throws rate limited exception', function () {
+    Http::fake(['api.elevenlabs.io/*' => Http::response(['detail' => 'rate limit exceeded'], 429)]);
+
+    Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+})->throws(RateLimitedException::class);
+
+test('audio overloaded response throws provider overloaded exception', function () {
+    Http::fake(['api.elevenlabs.io/*' => Http::response(['detail' => 'service unavailable'], 503)]);
+
+    Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+})->throws(ProviderOverloadedException::class);
 
 function fakeElevenAudioResponse()
 {


### PR DESCRIPTION
## Summary

Extends the ElevenLabs audio (text-to-speech) error-handling test coverage. The existing file already had a 401 → `RequestException` test, but did not cover the failover-relevant exceptions raised by `HandlesFailoverErrors`.

## Coverage added

- 429 rate-limit response → `RateLimitedException`
- 503 overloaded response → `ProviderOverloadedException`

These match the exception mappings asserted for other providers' endpoints (e.g., #498 OpenRouter embeddings, #527 VoyageAI reranking, #540 Cohere reranking, #541 Jina reranking).

## Testing

```
vendor/bin/pest tests/Feature/Providers/ElevenLabs/AudioTest.php
# 9 passed (12 assertions)
```