### PR TITLE
Gemini multi-speaker audio support reintroduction

### DIFF
--- a/src/Contracts/Gateway/AudioGateway.php
+++ b/src/Contracts/Gateway/AudioGateway.php
@@ -9,6 +9,8 @@ interface AudioGateway
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -17,5 +19,6 @@ interface AudioGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse;
 }

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -152,6 +152,8 @@ class AnthropicGateway implements Gateway
     /**
      * Generate audio from the given text.
      *
+     * @param  array<string, mixed>  $providerOptions
+     *
      * @throws LogicException
      */
     public function generateAudio(
@@ -161,6 +163,7 @@ class AnthropicGateway implements Gateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         throw new LogicException('Anthropic does not support audio generation.');
     }

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -23,6 +23,8 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -31,6 +33,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'onwK4e9ZLuTAKqWW03F9',

--- a/src/Gateway/FakeAudioGateway.php
+++ b/src/Gateway/FakeAudioGateway.php
@@ -22,6 +22,8 @@ class FakeAudioGateway implements AudioGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -30,8 +32,9 @@ class FakeAudioGateway implements AudioGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
-        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout);
+        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout, $providerOptions);
 
         return $this->nextResponse($provider, $model, $audioPrompt);
     }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway\Gemini;
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -222,6 +223,8 @@ class GeminiGateway implements Gateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -230,6 +233,7 @@ class GeminiGateway implements Gateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -244,17 +248,7 @@ class GeminiGateway implements Gateway
                 ]],
                 'generationConfig' => [
                     'responseModalities' => ['AUDIO'],
-                    'speechConfig' => [
-                        'voiceConfig' => [
-                            'prebuiltVoiceConfig' => [
-                                'voiceName' => match ($voice) {
-                                    'default-female' => 'Kore',
-                                    'default-male' => 'Puck',
-                                    default => $voice,
-                                },
-                            ],
-                        ],
-                    ],
+                    'speechConfig' => $this->buildSpeechConfig($voice, $providerOptions),
                 ],
             ]),
         );
@@ -278,6 +272,71 @@ class GeminiGateway implements Gateway
             new Meta($provider->name(), $model),
             'audio/wav',
         );
+    }
+
+    /**
+     * Build the speech configuration for a single- or multi-speaker request.
+     *
+     * @param  array<string, mixed>  $providerOptions
+     * @return array<string, mixed>
+     */
+    protected function buildSpeechConfig(string $voice, array $providerOptions): array
+    {
+        if (isset($providerOptions['speakers'])) {
+            return ['multiSpeakerVoiceConfig' => [
+                'speakerVoiceConfigs' => $this->buildSpeakerVoiceConfigs($providerOptions['speakers']),
+            ]];
+        }
+
+        return ['voiceConfig' => [
+            'prebuiltVoiceConfig' => ['voiceName' => $this->resolveVoiceName($voice)],
+        ]];
+    }
+
+    /**
+     * Build the per-speaker voice configurations for a multi-speaker request.
+     *
+     * @param  array<int, array<string, string>>  $speakers
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildSpeakerVoiceConfigs(array $speakers): array
+    {
+        if (count($speakers) < 2) {
+            throw new InvalidArgumentException('Gemini multi-speaker audio requires at least two speakers.');
+        }
+
+        return array_map(fn (array $speaker) => [
+            'speaker' => $this->requireSpeakerKey($speaker, 'name'),
+            'voiceConfig' => [
+                'prebuiltVoiceConfig' => [
+                    'voiceName' => $this->resolveVoiceName($this->requireSpeakerKey($speaker, 'voice')),
+                ],
+            ],
+        ], $speakers);
+    }
+
+    /**
+     * Read a required key from a speaker definition.
+     *
+     * @param  array<string, string>  $speaker
+     */
+    protected function requireSpeakerKey(array $speaker, string $key): string
+    {
+        return $speaker[$key] ?? throw new InvalidArgumentException(
+            sprintf('Each speaker must define a "%s".', $key),
+        );
+    }
+
+    /**
+     * Resolve a voice alias to its underlying Gemini voice name.
+     */
+    protected function resolveVoiceName(string $voice): string
+    {
+        return match ($voice) {
+            'default-female' => 'Kore',
+            'default-male' => 'Puck',
+            default => $voice,
+        };
     }
 
     /**

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -225,6 +225,8 @@ class OpenAiGateway implements Gateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -233,6 +235,7 @@ class OpenAiGateway implements Gateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'ash',

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -25,6 +25,11 @@ class PendingAudioGeneration
 
     protected int $timeout = 30;
 
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $providerOptions = [];
+
     public function __construct(
         protected string $text,
     ) {}
@@ -80,6 +85,18 @@ class PendingAudioGeneration
     }
 
     /**
+     * Specify provider-specific options for the audio generation.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function providerOptions(array $options): self
+    {
+        $this->providerOptions = $options;
+
+        return $this;
+    }
+
+    /**
      * Generate the audio.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): AudioResponse
@@ -97,7 +114,7 @@ class PendingAudioGeneration
 
             try {
                 return $provider->audio(
-                    $this->text, $this->voice, $this->instructions, $model, $this->timeout
+                    $this->text, $this->voice, $this->instructions, $model, $this->timeout, $this->providerOptions,
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -125,6 +142,7 @@ class PendingAudioGeneration
                     $provider,
                     $model,
                     $this->timeout,
+                    $this->providerOptions,
                 )
             );
 

--- a/src/Prompts/AudioPrompt.php
+++ b/src/Prompts/AudioPrompt.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Contracts\Providers\AudioProvider;
 
 class AudioPrompt
 {
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $text,
         public readonly string $voice,
@@ -14,6 +17,7 @@ class AudioPrompt
         public readonly AudioProvider $provider,
         public readonly string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Prompts/QueuedAudioPrompt.php
+++ b/src/Prompts/QueuedAudioPrompt.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Enums\Lab;
 
 class QueuedAudioPrompt
 {
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $text,
         public readonly string $voice,
@@ -14,6 +17,7 @@ class QueuedAudioPrompt
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesAudio.php
+++ b/src/Providers/Concerns/GeneratesAudio.php
@@ -13,6 +13,8 @@ trait GeneratesAudio
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function audio(
         string $text,
@@ -20,12 +22,13 @@ trait GeneratesAudio
         ?string $instructions = null,
         ?string $model = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultAudioModel();
 
-        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout);
+        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout, $providerOptions);
 
         if (Ai::audioIsFaked()) {
             Ai::recordAudioGeneration($prompt);
@@ -36,7 +39,7 @@ trait GeneratesAudio
         ));
 
         return tap($this->audioGateway()->generateAudio(
-            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout,
+            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout, $prompt->providerOptions,
         ), function (AudioResponse $response) use ($invocationId, $model, $prompt) {
             $this->events->dispatch(new AudioGenerated(
                 $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/Providers/Gemini/AudioTest.php
+++ b/tests/Feature/Providers/Gemini/AudioTest.php
@@ -102,6 +102,88 @@ test('audio uses default model when none specified', function () {
     Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-2.5-flash-preview-tts:generateContent'));
 });
 
+test('multi-speaker audio request builds a multi-speaker speech config', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiAudioResponse(),
+    ]);
+
+    Audio::of("Host: Welcome.\nGuest: Thanks!")
+        ->providerOptions([
+            'speakers' => [
+                ['name' => 'Host', 'voice' => 'Kore'],
+                ['name' => 'Guest', 'voice' => 'Puck'],
+            ],
+        ])
+        ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');
+
+    Http::assertSent(function (Request $request) {
+        $speechConfig = $request->data()['generationConfig']['speechConfig'];
+
+        return ! isset($speechConfig['voiceConfig'])
+            && $speechConfig['multiSpeakerVoiceConfig']['speakerVoiceConfigs'] === [
+                [
+                    'speaker' => 'Host',
+                    'voiceConfig' => ['prebuiltVoiceConfig' => ['voiceName' => 'Kore']],
+                ],
+                [
+                    'speaker' => 'Guest',
+                    'voiceConfig' => ['prebuiltVoiceConfig' => ['voiceName' => 'Puck']],
+                ],
+            ];
+    });
+});
+
+test('multi-speaker audio resolves default voice aliases per speaker', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiAudioResponse(),
+    ]);
+
+    Audio::of("Host: Hi.\nGuest: Hello.")
+        ->providerOptions([
+            'speakers' => [
+                ['name' => 'Host', 'voice' => 'default-female'],
+                ['name' => 'Guest', 'voice' => 'default-male'],
+            ],
+        ])
+        ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');
+
+    Http::assertSent(function (Request $request) {
+        $configs = $request->data()['generationConfig']['speechConfig']['multiSpeakerVoiceConfig']['speakerVoiceConfigs'];
+
+        return $configs[0]['voiceConfig']['prebuiltVoiceConfig']['voiceName'] === 'Kore'
+            && $configs[1]['voiceConfig']['prebuiltVoiceConfig']['voiceName'] === 'Puck';
+    });
+});
+
+test('multi-speaker audio rejects fewer than two speakers', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiAudioResponse(),
+    ]);
+
+    Audio::of('Host: Solo show.')
+        ->providerOptions([
+            'speakers' => [
+                ['name' => 'Host', 'voice' => 'Kore'],
+            ],
+        ])
+        ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');
+})->throws(InvalidArgumentException::class, 'at least two speakers');
+
+test('multi-speaker audio rejects speakers missing required keys', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiAudioResponse(),
+    ]);
+
+    Audio::of('Host: Hi.')
+        ->providerOptions([
+            'speakers' => [
+                ['name' => 'Host'],
+                ['name' => 'Guest', 'voice' => 'Puck'],
+            ],
+        ])
+        ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');
+})->throws(InvalidArgumentException::class, 'Each speaker must define a "voice"');
+
 function fakeGeminiAudioResponse(string $pcm = "\x00\x00"): PromiseInterface
 {
     return Http::response([


### PR DESCRIPTION
Adds `array $providerOptions` to the AudioGateway contract and a matching fluent setter on PendingAudioGeneration. GeminiGateway uses `providerOptions['speakers']` to emit `multiSpeakerVoiceConfig` instead of the single-voice `voiceConfig`, with the same `default-female`/`default-male` aliases and up-front validation. Other audio gateways accept the parameter for interface conformance and ignore it.

Example — a two-host podcast intro:

    Audio::of("Host: Welcome to Laravel Weekly.\nGuest: Glad to be here!")
        ->providerOptions([
            'speakers' => [
                ['name' => 'Host',  'voice' => 'Kore'],
                ['name' => 'Guest', 'voice' => 'Puck'],
            ],
        ])
        ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');