### PR TITLE
Add error handling tests for image generation (Gemini, AzureOpenAI, OpenRouter)

### DIFF
--- a/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
@@ -2,7 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Image;
 
@@ -205,3 +208,42 @@ test('default image model falls back to gpt-image-1', function () {
         return $body['model'] === 'gpt-image-1';
     });
 });
+
+test('image rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'test-resource.openai.azure.com/*' => Http::response([
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'Rate limit exceeded',
+            ],
+        ], 429),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+})->throws(RateLimitedException::class);
+
+test('image overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'test-resource.openai.azure.com/*' => Http::response([
+            'error' => [
+                'type' => 'server_error',
+                'message' => 'The server is currently overloaded. Please try again later.',
+            ],
+        ], 503),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+})->throws(ProviderOverloadedException::class);
+
+test('image http error response throws request exception', function () {
+    Http::fake([
+        'test-resource.openai.azure.com/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'Invalid model',
+            ],
+        ], 400),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/Gemini/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Gemini/ImageGenerationTest.php
@@ -2,7 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Image;
 
@@ -224,3 +227,45 @@ test('image response defaults to zero usage when usage metadata absent', functio
     expect($response->usage->promptTokens)->toBe(0)
         ->and($response->usage->completionTokens)->toBe(0);
 });
+
+test('image rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'error' => [
+                'code' => 429,
+                'message' => 'Resource has been exhausted',
+                'status' => 'RESOURCE_EXHAUSTED',
+            ],
+        ], 429),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+})->throws(RateLimitedException::class);
+
+test('image overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'error' => [
+                'code' => 503,
+                'message' => 'The model is overloaded. Please try again later.',
+                'status' => 'UNAVAILABLE',
+            ],
+        ], 503),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+})->throws(ProviderOverloadedException::class);
+
+test('image http error response throws request exception', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'error' => [
+                'code' => 400,
+                'message' => 'Invalid value at prompt',
+                'status' => 'INVALID_ARGUMENT',
+            ],
+        ], 400),
+    ]);
+
+    Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
@@ -2,7 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\RemoteImage;
 use Laravel\Ai\Image;
@@ -194,3 +197,42 @@ test('request sends bearer token authorization', function () {
         return $request->hasHeader('Authorization', 'Bearer test-key');
     });
 });
+
+test('image rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'Rate limit exceeded',
+            ],
+        ], 429),
+    ]);
+
+    Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+})->throws(RateLimitedException::class);
+
+test('image overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'type' => 'server_error',
+                'message' => 'The server is currently overloaded. Please try again later.',
+            ],
+        ], 503),
+    ]);
+
+    Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+})->throws(ProviderOverloadedException::class);
+
+test('image http error response throws request exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'Invalid model',
+            ],
+        ], 400),
+    ]);
+
+    Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+})->throws(RequestException::class);


### PR DESCRIPTION
Follows the pattern established in #528, adding rate limit (429), overloaded (503), and HTTP error (400) test coverage to the three image generation providers that were missing it: Gemini, AzureOpenAI, and OpenRouter.