### PR TITLE
Add error handling tests for embeddings (OpenAI, Gemini)

### DIFF
--- a/tests/Feature/Providers/Gemini/EmbeddingTest.php
+++ b/tests/Feature/Providers/Gemini/EmbeddingTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -138,6 +139,20 @@ test('rate limit response throws rate limited exception', function () {
 
     Embeddings::for(['Hello'])->generate(provider: 'gemini', model: 'gemini-embedding-001');
 })->throws(RateLimitedException::class);
+
+test('overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'error' => [
+                'code' => 503,
+                'message' => 'The model is overloaded. Please try again later.',
+                'status' => 'UNAVAILABLE',
+            ],
+        ], 503),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'gemini', model: 'gemini-embedding-001');
+})->throws(ProviderOverloadedException::class);
 
 test('http error response throws request exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/OpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/OpenAi/EmbeddingTest.php
@@ -5,6 +5,8 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
     config(['ai.providers.openai' => [
@@ -91,8 +93,41 @@ test('embeddings default to 1536 dimensions when none specified', function () {
     Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['dimensions'] === 1536);
 });
 
-test('embeddings throw when the API returns an error', function () {
-    Http::fake(['*' => Http::response(['error' => ['message' => 'unauthorized']], 401)]);
+test('embeddings rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => [
+                'type' => 'rate_limit_error',
+                'message' => 'Rate limit exceeded',
+            ],
+        ], 429),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+})->throws(RateLimitedException::class);
+
+test('embeddings overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => [
+                'type' => 'server_error',
+                'message' => 'The server is currently overloaded. Please try again later.',
+            ],
+        ], 503),
+    ]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
+})->throws(ProviderOverloadedException::class);
+
+test('embeddings http error response throws request exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'Unauthorized',
+            ],
+        ], 401),
+    ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
 })->throws(RequestException::class);


### PR DESCRIPTION
Follows the pattern established across other providers, adding rate limit (429), overloaded (503), and HTTP error (400/401) test coverage to the embedding operations that were missing it:

- **OpenAI**: had only a basic error test — adds rate limit and overloaded
- **Gemini**: had rate limit and HTTP error — adds overloaded