### PR TITLE
Add tests for Gemini image generation safety blocks

### DIFF
--- a/tests/Feature/Providers/Gemini/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Gemini/ImageGenerationTest.php
@@ -269,3 +269,32 @@ test('image http error response throws request exception', function () {
 
     Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
 })->throws(RequestException::class);
+
+test('image response is empty when prompt is blocked and candidates array is empty', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'candidates' => [],
+            'promptFeedback' => [
+                'blockReason' => 'SAFETY',
+            ],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+
+    expect($response->images)->toHaveCount(0);
+});
+
+test('image response is empty when candidate is blocked with no content parts', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'candidates' => [[
+                'finishReason' => 'PROHIBITED_CONTENT',
+            ]],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+
+    expect($response->images)->toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

Extends Gemini image generation test coverage with two safety-block scenarios that #545 didn't cover. These exercise behavior that's already supported by `GeminiGateway::generateImage()` (the parser tolerates missing/empty candidates) but wasn't pinned by tests.

## Coverage added

- **Empty candidates with `promptFeedback.blockReason`** — when the prompt itself is rejected (e.g., `SAFETY`), Gemini returns `candidates: []` plus a `promptFeedback` object. The response should produce an empty images collection.
- **Candidate with `finishReason: PROHIBITED_CONTENT` and no `content.parts`** — when generation is mid-blocked, Gemini returns a candidate without `content`. The response should still produce an empty images collection without errors.

These complement #545 (429/503/4xx HTTP errors) by covering the in-band block paths that are specific to Gemini.

## Testing

```
vendor/bin/pest tests/Feature/Providers/Gemini/ImageGenerationTest.php
# 19 passed (25 assertions)
```