### PR TITLE
Add tests for OpenRouter image generation response edge cases

### DIFF
--- a/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
@@ -236,3 +236,55 @@ test('image http error response throws request exception', function () {
 
     Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
 })->throws(RequestException::class);
+
+test('image response is empty when choices array is empty', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'choices' => [],
+            'model' => 'google/gemini-2.5-flash-image',
+        ]),
+    ]);
+
+    $response = Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+
+    expect($response->images)->toHaveCount(0);
+});
+
+test('image with non base64 url is filtered out of response', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'choices' => [[
+                'message' => [
+                    'images' => [
+                        ['image_url' => ['url' => 'https://cdn.example.com/generated/abc123.png']],
+                        ['image_url' => ['url' => 'data:image/png;base64,'.base64_encode('valid')]],
+                    ],
+                ],
+            ]],
+        ]),
+    ]);
+
+    $response = Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+
+    expect($response->images)->toHaveCount(1)
+        ->and($response->images->first()->image)->toBe(base64_encode('valid'))
+        ->and($response->images->first()->mime)->toBe('image/png');
+});
+
+test('image response falls back to requested model when response omits model', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'choices' => [[
+                'message' => [
+                    'images' => [
+                        ['image_url' => ['url' => 'data:image/png;base64,'.base64_encode('img')]],
+                    ],
+                ],
+            ]],
+        ]),
+    ]);
+
+    $response = Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+
+    expect($response->meta->model)->toBe('google/gemini-2.5-flash-image');
+});


### PR DESCRIPTION
## Summary

Extends OpenRouter image generation test coverage with three response-shape scenarios that #545 didn't cover. These exercise behavior already implemented in `OpenRouterGateway::generateImage()` but not previously pinned by tests.

## Coverage added

- **Empty `choices` array** — when the upstream model returns an empty `choices: []`, the parser tolerates it via `?? []` and produces an empty images collection without errors.
- **Non-base64 image URL** — the parser only matches `data:image/...;base64,...` URLs (line 177 regex). When OpenRouter routes to a provider that returns a direct https URL, that image is filtered out via `->filter()`. This pins that the regex-mismatch path works.
- **Missing `model` in response** — the response model field falls back to the requested model via `$data['model'] ?? $model` when omitted by the upstream provider.

These complement #545 (429/503/4xx HTTP errors) by covering in-band response edge cases specific to OpenRouter's chat-completions-style image API.

## Testing

```
vendor/bin/pest tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
# 19 passed (30 assertions)
```