### PR TITLE
Fix parameter name in GeneratesEmbeddings PHPDoc

### DIFF
--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -15,7 +15,7 @@ trait GeneratesEmbeddings
     /**
      * Get embedding vectors representing the given inputs.
      *
-     * @param  string[]  $input
+     * @param  string[]  $inputs
      */
     public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
     {


### PR DESCRIPTION
The `@param` annotation for the `embeddings()` method on the `GeneratesEmbeddings` trait used the singular `\$input`, but the actual parameter is `\$inputs`. IDEs and static analyzers (PHPStan / Psalm) treat the docblock as orphaned because no parameter matches that name.

Mirrors the fix merged in #517 for `EmbeddingsResponse`.

### Before
```php
/**
 * @param  string[]  \$input
 */
public function embeddings(array \$inputs, ...)
```

### After
```php
/**
 * @param  string[]  \$inputs
 */
public function embeddings(array \$inputs, ...)
```

The contract `Laravel\Ai\Contracts\Providers\EmbeddingProvider` already uses the correct `\$inputs` name, so this aligns the trait with the interface it implements.