### PR TITLE
Remove stale @param and unused Request import in Vercel protocol trait

### DIFF
--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Ai\Responses\Concerns;
 
-use Illuminate\Http\Request;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\ToolCall;
@@ -14,7 +13,6 @@ trait CanStreamUsingVercelProtocol
     /**
      * Create an HTTP response that represents the object using the Vercel AI SDK protocol
      *
-     * @param  Request  $request
      * @return Response
      */
     protected function toVercelProtocolResponse()


### PR DESCRIPTION
The `toVercelProtocolResponse()` method in `CanStreamUsingVercelProtocol` takes zero parameters, but its docblock declared `@param Request \$request`. The corresponding `use Illuminate\Http\Request;` import was also unused.

Likely a leftover from an earlier API where the method accepted a request — the trait is now used by `StreamableAgentResponse::toResponse(\$request)`, which itself receives the Request and calls `\$this->toVercelProtocolResponse()` with no arguments.

### Changes

- Drop the `@param Request \$request` line from the docblock.
- Drop the unused `use Illuminate\Http\Request;` import.

`@return Response` is kept (it's accurate — the method returns `Symfony\Component\HttpFoundation\Response`).

No runtime behavior change — pure docblock/import cleanup. Static analyzers (PHPStan / Psalm) flag both issues as unused-param and unused-import respectively.