### PR TITLE
Skip temperature and top_p for OpenAI reasoning models

### DIFF
--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -39,10 +39,12 @@ trait BuildsTextRequests
             $body['max_output_tokens'] = $options->maxTokens;
         }
 
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-        ]));
+        if ($this->modelSupportsTemperature($model)) {
+            $body = array_merge($body, Arr::whereNotNull([
+                'temperature' => $options?->temperature,
+                'top_p' => $options?->topP,
+            ]));
+        }
 
         $providerOptions = $options?->providerOptions(
             Lab::tryFrom($provider->driver()) ?? $provider->driver()
@@ -53,6 +55,15 @@ trait BuildsTextRequests
         }
 
         return $body;
+    }
+
+    /**
+     * Determine whether the given model supports temperature / top_p parameters.
+     * OpenAI reasoning models (o1, o3 series) reject these parameters.
+     */
+    protected function modelSupportsTemperature(string $model): bool
+    {
+        return ! preg_match('/^o\d/', $model);
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -377,10 +377,15 @@ trait HandlesTextStreaming
             }
 
             $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
                 'max_output_tokens' => $options?->maxTokens,
             ]));
+
+            if ($this->modelSupportsTemperature($model)) {
+                $body = array_merge($body, Arr::whereNotNull([
+                    'temperature' => $options?->temperature,
+                    'top_p' => $options?->topP,
+                ]));
+            }
 
             $providerOptions = $options?->providerOptions(
                 Lab::tryFrom($provider->driver()) ?? $provider->driver()

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -247,10 +247,15 @@ trait ParsesTextResponses
         }
 
         $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
             'max_output_tokens' => $options?->maxTokens,
         ]));
+
+        if ($this->modelSupportsTemperature($model)) {
+            $body = array_merge($body, Arr::whereNotNull([
+                'temperature' => $options?->temperature,
+                'top_p' => $options?->topP,
+            ]));
+        }
 
         $providerOptions = $options?->providerOptions(
             Lab::tryFrom($provider->driver()) ?? $provider->driver()

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -73,6 +73,19 @@ test('temperature, max tokens, and top_p are excluded when not set', function ()
     });
 });
 
+test('temperature and top_p are excluded for reasoning models', function (string $model) {
+    Http::fake(['*' => fakeOpenAiResponse('Hello')]);
+
+    (new AttributeAgent)->prompt('Hello', provider: 'openai', model: $model);
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('temperature', $body)
+            && ! array_key_exists('top_p', $body);
+    });
+})->with(['o1', 'o1-mini', 'o1-preview', 'o3', 'o3-mini', 'o3-pro']);
+
 test('tools include tool choice auto', function () {
     Http::fake(['*' => fakeOpenAiResponse('42')]);
 


### PR DESCRIPTION
## Summary

- OpenAI reasoning models (`o1`, `o1-mini`, `o1-preview`, `o3`, `o3-mini`, `o3-pro`) reject `temperature` and `top_p` with a 400 error
- Adds a `modelSupportsTemperature()` helper to `BuildsTextRequests` that returns `false` for models matching the `o\d` prefix pattern
- Uses this guard in all three request-building paths: initial requests, non-streaming tool loop continuations, and streaming tool loop continuations
- Also fixes the same issue for `AzureOpenAiGateway`, which reuses the same concerns
- Adds a dataset test asserting that `temperature` and `top_p` are excluded from the request for all known reasoning model variants

Fixes #317.

## Test plan

- [x] New dataset test covers `o1`, `o1-mini`, `o1-preview`, `o3`, `o3-mini`, `o3-pro`
- [x] Existing test confirms temperature is still sent for standard models (`gpt-*`)
- [x] Full OpenAI provider test suite passes (105 tests)