### PR TITLE
Add PHPStan

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,34 @@
+name: static analysis
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+
+    name: Static Analysis
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Execute type checking
+        run: vendor/bin/phpstan --verbose

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.6|^11.0",
         "pestphp/pest": "^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0|^4.0"
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "phpstan/phpstan": "^2.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -46,8 +47,17 @@
         }
     },
     "scripts": {
+        "lint": [
+            "pint --format agent",
+            "phpstan --memory-limit=-1"
+        ],
         "test": "pest",
-        "lint": "pint"
+        "test:lint": "pint --test --format agent",
+        "test:types": "phpstan",
+        "check": [
+            "@composer lint",
+            "@composer test"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  paths:
+    - config
+    - src
+    - database
+
+  level: 0

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -48,7 +48,7 @@ class AiServiceProvider extends ServiceProvider
             bool|int|null $cache = null,
             ?int $timeout = null,
         ) {
-            $request = Embeddings::for([$this->value]);
+            $request = Embeddings::for([$this->value()]);
 
             if ($dimensions) {
                 $request->dimensions($dimensions);
@@ -73,7 +73,7 @@ class AiServiceProvider extends ServiceProvider
             ?string $model = null,
             ?int $timeout = null,
         ) {
-            $request = Audio::of($this->value);
+            $request = Audio::of($this->value());
 
             if (! is_null($voice)) {
                 $request->voice($voice);

--- a/src/AnonymousAgent.php
+++ b/src/AnonymousAgent.php
@@ -6,6 +6,9 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
 
+/**
+ * @phpstan-consistent-constructor
+ */
 class AnonymousAgent implements Agent, Conversational, HasTools
 {
     use Promptable;

--- a/src/Exceptions/InsufficientCreditsException.php
+++ b/src/Exceptions/InsufficientCreditsException.php
@@ -8,7 +8,7 @@ class InsufficientCreditsException extends AiException implements FailoverableEx
 {
     public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
     {
-        return new static(
+        return new self(
             'AI provider ['.$provider.'] has insufficient credits or quota.',
             $code,
             $previous

--- a/src/Exceptions/ProviderOverloadedException.php
+++ b/src/Exceptions/ProviderOverloadedException.php
@@ -8,7 +8,7 @@ class ProviderOverloadedException extends AiException implements FailoverableExc
 {
     public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
     {
-        return new static(
+        return new self(
             'AI provider ['.$provider.'] is overloaded.',
             $code,
             $previous,

--- a/src/Exceptions/RateLimitedException.php
+++ b/src/Exceptions/RateLimitedException.php
@@ -8,7 +8,7 @@ class RateLimitedException extends AiException implements FailoverableException
 {
     public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
     {
-        return new static(
+        return new self(
             'Application rate limited by AI provider ['.$provider.'].',
             $code,
             $previous

--- a/src/Files/Base64Audio.php
+++ b/src/Files/Base64Audio.php
@@ -25,7 +25,7 @@ class Base64Audio extends Audio implements Arrayable, JsonSerializable, Storable
      */
     public static function fromUpload(UploadedFile $file, ?string $mimeType = null): self
     {
-        return new static(
+        return new self(
             base64_encode($file->getContent()),
             mimeType: $mimeType ?? $file->getClientMimeType(),
         );

--- a/src/Files/Base64Document.php
+++ b/src/Files/Base64Document.php
@@ -22,7 +22,7 @@ class Base64Document extends Document implements Arrayable, JsonSerializable, St
      */
     public static function fromUpload(UploadedFile $file, ?string $mimeType = null): self
     {
-        return new static(
+        return new self(
             base64_encode($file->getContent()),
             mimeType: $mimeType ?? $file->getClientMimeType(),
         );

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -31,12 +31,12 @@ class Message
     /**
      * Attempt to create a new message instance from the given value.
      */
-    public static function tryFrom(mixed $message): static
+    public static function tryFrom(mixed $message): self
     {
         return match (true) {
             $message instanceof self => $message,
-            is_array($message) => new static($message['role'], $message['content']),
-            is_object($message) => new static($message->role, $message->content),
+            is_array($message) => new self($message['role'], $message['content']),
+            is_object($message) => new self($message->role, $message->content),
             default => throw new InvalidArgumentException('Unable to create message from given value.'),
         };
     }

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -63,7 +63,7 @@ class AgentPrompt extends Prompt
             $attachments = new Collection($attachments);
         }
 
-        return new static(
+        return new self(
             $this->agent,
             $prompt,
             $attachments ?? $this->attachments,

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -29,7 +29,7 @@ class Schema implements Schemable
      */
     public function withName(string $name): self
     {
-        return new static(
+        return new self(
             $this->schema,
             $name,
             $this->strict,

--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -10,6 +10,13 @@ abstract class StreamEvent
     public ?string $invocationId = null;
 
     /**
+     * Get the array representation of the event.
+     *
+     * @return array<string, mixed>
+     */
+    abstract public function toArray(): array;
+
+    /**
      * Broadcast the stream event using the queue.
      */
     public function broadcast(Channel|array $channels, bool $now = false): void

--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -17,7 +17,7 @@ class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOu
         public iterable $tools,
         ?Closure $schema = null,
     ) {
-        $this->schema = $schema !== null ? new SerializableClosure($schema) : null;
+        $this->schema = $schema ? new SerializableClosure($schema) : null;
     }
 
     public function schema(JsonSchema $schema): array

--- a/src/StructuredAnonymousAgent.php
+++ b/src/StructuredAnonymousAgent.php
@@ -15,9 +15,9 @@ class StructuredAnonymousAgent extends AnonymousAgent implements HasStructuredOu
         public string $instructions,
         public iterable $messages,
         public iterable $tools,
-        Closure $schema,
+        ?Closure $schema = null,
     ) {
-        $this->schema = new SerializableClosure($schema);
+        $this->schema = $schema !== null ? new SerializableClosure($schema) : null;
     }
 
     public function schema(JsonSchema $schema): array

--- a/src/Tools/SimilaritySearch.php
+++ b/src/Tools/SimilaritySearch.php
@@ -32,7 +32,7 @@ class SimilaritySearch implements Tool
         int $limit = 15,
         ?Closure $query = null): self
     {
-        return new static(function (string $queryString) use ($model, $column, $minSimilarity, $limit, $query) {
+        return new self(function (string $queryString) use ($model, $column, $minSimilarity, $limit, $query) {
             $pendingQuery = $model::query()->whereVectorSimilarTo($column, $queryString, $minSimilarity);
 
             if ($query) {


### PR DESCRIPTION
The package has no static analyzer wired up, so type-level bugs (undefined methods, unsafe `new static()`, protected property access, mismatched docblocks) only surface at runtime. This PR introduces PHPStan at level 0 and fixes the issues it caught.