### PR TITLE
Support provider options in embeddings

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -47,7 +47,7 @@ class AiServiceProvider extends ServiceProvider
             ?string $model = null,
             bool|int|null $cache = null,
             ?int $timeout = null,
-            array $providerOptions = [],
+            array|Closure $providerOptions = [],
         ) {
             $request = Embeddings::for([$this->value]);
 

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -47,6 +47,7 @@ class AiServiceProvider extends ServiceProvider
             ?string $model = null,
             bool|int|null $cache = null,
             ?int $timeout = null,
+            array $providerOptions = [],
         ) {
             $request = Embeddings::for([$this->value]);
 
@@ -60,6 +61,10 @@ class AiServiceProvider extends ServiceProvider
 
             if (! is_null($timeout)) {
                 $request->timeout($timeout);
+            }
+
+            if (filled($providerOptions)) {
+                $request->providerOptions($providerOptions);
             }
 
             return $request->generate(provider: $provider, model: $model)->embeddings[0];

--- a/src/Contracts/Gateway/EmbeddingGateway.php
+++ b/src/Contracts/Gateway/EmbeddingGateway.php
@@ -12,5 +12,5 @@ interface EmbeddingGateway
      *
      * @param  string[]  $inputs
      */
-    public function generateEmbeddings(EmbeddingProvider $provider, string $model, array $inputs, int $dimensions, int $timeout = 30): EmbeddingsResponse;
+    public function generateEmbeddings(EmbeddingProvider $provider, string $model, array $inputs, int $dimensions, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse;
 }

--- a/src/Contracts/Gateway/EmbeddingGateway.php
+++ b/src/Contracts/Gateway/EmbeddingGateway.php
@@ -11,6 +11,7 @@ interface EmbeddingGateway
      * Generate embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateEmbeddings(EmbeddingProvider $provider, string $model, array $inputs, int $dimensions, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse;
 }

--- a/src/Contracts/Providers/EmbeddingProvider.php
+++ b/src/Contracts/Providers/EmbeddingProvider.php
@@ -11,6 +11,7 @@ interface EmbeddingProvider
      * Get embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse;
 

--- a/src/Contracts/Providers/EmbeddingProvider.php
+++ b/src/Contracts/Providers/EmbeddingProvider.php
@@ -12,7 +12,7 @@ interface EmbeddingProvider
      *
      * @param  string[]  $inputs
      */
-    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse;
+    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse;
 
     /**
      * Get the provider's embedding gateway.

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -192,6 +192,7 @@ class AnthropicGateway implements Gateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         throw new LogicException('Anthropic does not support embeddings.');
     }

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -143,6 +143,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -147,11 +147,11 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge([
+            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge($providerOptions, [
                 'model' => $model,
                 'input' => $inputs,
                 'dimensions' => $dimensions,
-            ], $providerOptions)),
+            ])),
         );
 
         $data = $response->json();

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -147,11 +147,11 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('embeddings', [
+            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge([
                 'model' => $model,
                 'input' => $inputs,
                 'dimensions' => $dimensions,
-            ]),
+            ], $providerOptions)),
         );
 
         $data = $response->json();

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -388,7 +388,10 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                         'modelId' => $model,
                         'contentType' => 'application/json',
                         'accept' => 'application/json',
-                        'body' => json_encode(['inputText' => $input, 'dimensions' => $dimensions]),
+                        'body' => json_encode(array_merge($providerOptions, [
+                            'inputText' => $input,
+                            'dimensions' => $dimensions,
+                        ])),
                     ]),
                 );
 
@@ -430,10 +433,11 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                     'modelId' => $model,
                     'contentType' => 'application/json',
                     'accept' => 'application/json',
-                    'body' => json_encode(array_merge([
-                        'texts' => array_values($inputs),
-                        'input_type' => 'search_document',
-                    ], $providerOptions)),
+                    'body' => json_encode(array_merge(
+                        ['input_type' => 'search_document'],
+                        $providerOptions,
+                        ['texts' => array_values($inputs)],
+                    )),
                 ]),
             );
 

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -369,6 +369,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $client = $this->createBedrockClient($provider, $timeout);
 

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -374,7 +374,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         $client = $this->createBedrockClient($provider, $timeout);
 
         if (str_starts_with($model, 'cohere.')) {
-            return $this->generateCohereEmbeddings($provider, $model, $client, $inputs);
+            return $this->generateCohereEmbeddings($provider, $model, $client, $inputs, $providerOptions);
         }
 
         $embeddings = [];
@@ -421,6 +421,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
         string $model,
         $client,
         array $inputs,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         try {
             $response = $this->withErrorHandling(
@@ -429,10 +430,10 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                     'modelId' => $model,
                     'contentType' => 'application/json',
                     'accept' => 'application/json',
-                    'body' => json_encode([
+                    'body' => json_encode(array_merge([
                         'texts' => array_values($inputs),
                         'input_type' => 'search_document',
-                    ]),
+                    ], $providerOptions)),
                 ]),
             );
 

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -23,6 +23,7 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
      * Generate embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateEmbeddings(
         EmbeddingProvider $provider,
@@ -34,12 +35,17 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/embed', array_merge([
-                'model' => $model,
-                'texts' => $inputs,
-                'input_type' => 'search_document',
-                'embedding_types' => ['float'],
-            ], $providerOptions)),
+            fn () => $this->client($provider, $timeout)->post('/embed', array_merge(
+                [
+                    'input_type' => 'search_document',
+                    'embedding_types' => ['float'],
+                ],
+                $providerOptions,
+                [
+                    'model' => $model,
+                    'texts' => $inputs,
+                ],
+            )),
         );
 
         $data = $response->json();

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -34,12 +34,12 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/embed', [
+            fn () => $this->client($provider, $timeout)->post('/embed', array_merge([
                 'model' => $model,
                 'texts' => $inputs,
                 'input_type' => 'search_document',
                 'embedding_types' => ['float'],
-            ]),
+            ], $providerOptions)),
         );
 
         $data = $response->json();

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -30,6 +30,7 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/FakeEmbeddingGateway.php
+++ b/src/Gateway/FakeEmbeddingGateway.php
@@ -25,6 +25,7 @@ class FakeEmbeddingGateway implements EmbeddingGateway
      * Generate embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateEmbeddings(
         EmbeddingProvider $provider,
@@ -34,7 +35,7 @@ class FakeEmbeddingGateway implements EmbeddingGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $provider, $model, $timeout);
+        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $provider, $model, $timeout, $providerOptions);
 
         return $this->nextResponse($provider, $model, $prompt);
     }

--- a/src/Gateway/FakeEmbeddingGateway.php
+++ b/src/Gateway/FakeEmbeddingGateway.php
@@ -32,6 +32,7 @@ class FakeEmbeddingGateway implements EmbeddingGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $prompt = new EmbeddingsPrompt($inputs, $dimensions, $provider, $model, $timeout);
 

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -207,9 +207,9 @@ class GeminiGateway implements Gateway
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post("models/{$model}:batchEmbedContents", [
+            fn () => $this->client($provider, $timeout)->post("models/{$model}:batchEmbedContents", array_merge([
                 'requests' => $requests,
-            ]),
+            ], $providerOptions)),
         );
 
         $data = $response->json();

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -197,6 +197,7 @@ class GeminiGateway implements Gateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $requests = array_map(fn (string $input) => [
             'model' => "models/{$model}",

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -196,17 +196,17 @@ class GeminiGateway implements Gateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $requests = array_map(fn (string $input) => [
+        $requests = array_map(fn (string $input) => array_merge($providerOptions, [
             'model' => "models/{$model}",
             'content' => ['parts' => [['text' => $input]]],
             'output_dimensionality' => $dimensions,
-        ], $inputs);
+        ]), $inputs);
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post("models/{$model}:batchEmbedContents", array_merge([
+            fn () => $this->client($provider, $timeout)->post("models/{$model}:batchEmbedContents", [
                 'requests' => $requests,
-            ], $providerOptions)),
+            ]),
         );
 
         $data = $response->json();

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -30,6 +30,7 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -23,6 +23,7 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
      * Generate embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateEmbeddings(
         EmbeddingProvider $provider,
@@ -34,12 +35,15 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge([
-                'model' => $model,
-                'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
-                'dimensions' => $dimensions,
-                'task' => 'retrieval.passage',
-            ], $providerOptions)),
+            fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge(
+                ['task' => 'retrieval.passage'],
+                $providerOptions,
+                [
+                    'model' => $model,
+                    'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
+                    'dimensions' => $dimensions,
+                ],
+            )),
         );
 
         $data = $response->json();

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -34,12 +34,12 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/embeddings', [
+            fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge([
                 'model' => $model,
                 'input' => array_map(fn (string $text) => ['text' => $text], $inputs),
                 'dimensions' => $dimensions,
                 'task' => 'retrieval.passage',
-            ]),
+            ], $providerOptions)),
         );
 
         $data = $response->json();

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -143,6 +143,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -147,10 +147,10 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('embeddings', [
+            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge([
                 'model' => $model,
                 'input' => $inputs,
-            ]),
+            ], $providerOptions)),
         );
 
         $data = $response->json();

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -147,10 +147,10 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge([
+            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge($providerOptions, [
                 'model' => $model,
                 'input' => $inputs,
-            ], $providerOptions)),
+            ])),
         );
 
         $data = $response->json();

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -139,11 +139,11 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $body = array_merge(array_filter([
+        $body = array_merge($providerOptions, array_filter([
             'model' => $model,
             'input' => $inputs,
             'dimensions' => $dimensions ?: null,
-        ]), $providerOptions);
+        ]));
 
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -137,6 +137,7 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $body = array_filter([
             'model' => $model,

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -139,11 +139,11 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $body = array_filter([
+        $body = array_merge(array_filter([
             'model' => $model,
             'input' => $inputs,
             'dimensions' => $dimensions ?: null,
-        ]);
+        ]), $providerOptions);
 
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -339,11 +339,11 @@ class OpenAiGateway implements Gateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('embeddings', [
+            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge([
                 'model' => $model,
                 'input' => $inputs,
                 'dimensions' => $dimensions,
-            ]),
+            ], $providerOptions)),
         );
 
         $data = $response->json();

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -339,11 +339,11 @@ class OpenAiGateway implements Gateway
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge([
+            fn () => $this->client($provider, $timeout)->post('embeddings', array_merge($providerOptions, [
                 'model' => $model,
                 'input' => $inputs,
                 'dimensions' => $dimensions,
-            ], $providerOptions)),
+            ])),
         );
 
         $data = $response->json();

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -335,6 +335,7 @@ class OpenAiGateway implements Gateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -218,11 +218,11 @@ class OpenRouterGateway implements EmbeddingGateway, ImageGateway, TextGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $body = [
+        $body = array_merge([
             'model' => $model,
             'input' => $inputs,
             'dimensions' => $dimensions,
-        ];
+        ], $providerOptions);
 
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -216,6 +216,7 @@ class OpenRouterGateway implements EmbeddingGateway, ImageGateway, TextGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $body = [
             'model' => $model,

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -377,11 +377,11 @@ class OpenRouterGateway implements Gateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $body = array_merge([
+        $body = array_merge($providerOptions, [
             'model' => $model,
             'input' => $inputs,
             'dimensions' => $dimensions,
-        ], $providerOptions);
+        ]);
 
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -22,6 +22,7 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
      * Generate embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateEmbeddings(
         EmbeddingProvider $provider,
@@ -33,11 +34,11 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
     ): EmbeddingsResponse {
         $data = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge([
+            fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge($providerOptions, [
                 'model' => $model,
                 'input' => $inputs,
                 'output_dimension' => $dimensions,
-            ], $providerOptions)),
+            ])),
         )->json();
 
         return new EmbeddingsResponse(

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -29,14 +29,15 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
         $data = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/embeddings', [
+            fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge([
                 'model' => $model,
                 'input' => $inputs,
                 'output_dimension' => $dimensions,
-            ]),
+            ], $providerOptions)),
         )->json();
 
         return new EmbeddingsResponse(

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -27,6 +27,8 @@ class PendingEmbeddingsGeneration
 
     protected int $timeout = 30;
 
+    protected array $providerOptions = [];
+
     public function __construct(
         protected array $inputs,
     ) {}
@@ -62,6 +64,16 @@ class PendingEmbeddingsGeneration
     }
 
     /**
+     * Specify provider-specific options for embeddings generation.
+     */
+    public function providerOptions(array $options): self
+    {
+        $this->providerOptions = $options;
+
+        return $this;
+    }
+
+    /**
      * Generate the embeddings.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): EmbeddingsResponse
@@ -85,7 +97,7 @@ class PendingEmbeddingsGeneration
 
             try {
                 return tap(
-                    $provider->embeddings($this->inputs, $dimensions, $model, $this->timeout),
+                    $provider->embeddings($this->inputs, $dimensions, $model, $this->timeout, $this->providerOptions),
                     fn ($response) => $this->cacheEmbeddings($provider, $model, $dimensions, $response)
                 );
             } catch (FailoverableException $e) {

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\PendingResponses;
 
+use Closure;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Traits\Conditionable;
@@ -27,7 +28,8 @@ class PendingEmbeddingsGeneration
 
     protected int $timeout = 30;
 
-    protected array $providerOptions = [];
+    /** @var array<string, mixed>|Closure(Provider): array<string, mixed> */
+    protected array|Closure $providerOptions = [];
 
     public function __construct(
         protected array $inputs,
@@ -65,12 +67,32 @@ class PendingEmbeddingsGeneration
 
     /**
      * Specify provider-specific options for embeddings generation.
+     *
+     * Pass a flat array to apply the same options to every selected provider,
+     * or a closure that receives the resolved Provider and returns the options
+     * for that provider (useful when failover targets need different options).
+     *
+     * @param  array<string, mixed>|Closure(Provider): array<string, mixed>  $options
      */
-    public function providerOptions(array $options): self
+    public function providerOptions(array|Closure $options): self
     {
         $this->providerOptions = $options;
 
         return $this;
+    }
+
+    /**
+     * Resolve provider options for the given provider.
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveProviderOptions(Provider $provider): array
+    {
+        if ($this->providerOptions instanceof Closure) {
+            return ($this->providerOptions)($provider) ?: [];
+        }
+
+        return $this->providerOptions;
     }
 
     /**
@@ -91,14 +113,16 @@ class PendingEmbeddingsGeneration
 
             $dimensions = $this->dimensions ?: $provider->defaultEmbeddingsDimensions();
 
-            if ($cached = $this->generateFromCache($provider, $model, $dimensions)) {
+            $providerOptions = $this->resolveProviderOptions($provider);
+
+            if ($cached = $this->generateFromCache($provider, $model, $dimensions, $providerOptions)) {
                 return $cached;
             }
 
             try {
                 return tap(
-                    $provider->embeddings($this->inputs, $dimensions, $model, $this->timeout, $this->providerOptions),
-                    fn ($response) => $this->cacheEmbeddings($provider, $model, $dimensions, $response)
+                    $provider->embeddings($this->inputs, $dimensions, $model, $this->timeout, $providerOptions),
+                    fn ($response) => $this->cacheEmbeddings($provider, $model, $dimensions, $providerOptions, $response)
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -114,14 +138,16 @@ class PendingEmbeddingsGeneration
 
     /**
      * Generate the embeddings from a cached response if possible.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
-    protected function generateFromCache(Provider $provider, string $model, int $dimensions): ?EmbeddingsResponse
+    protected function generateFromCache(Provider $provider, string $model, int $dimensions, array $providerOptions): ?EmbeddingsResponse
     {
         if (! $this->shouldCache()) {
             return null;
         }
 
-        $response = $this->cacheStore()->get($this->cacheKey($provider, $model, $dimensions));
+        $response = $this->cacheStore()->get($this->cacheKey($provider, $model, $dimensions, $providerOptions));
 
         if (! is_null($response)) {
             $response = json_decode($response, true);
@@ -137,15 +163,17 @@ class PendingEmbeddingsGeneration
 
     /**
      * Cache the given embeddings response.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
-    protected function cacheEmbeddings(Provider $provider, string $model, int $dimensions, EmbeddingsResponse $response): void
+    protected function cacheEmbeddings(Provider $provider, string $model, int $dimensions, array $providerOptions, EmbeddingsResponse $response): void
     {
         if (! $this->shouldCache()) {
             return;
         }
 
         $this->cacheStore()->put(
-            $this->cacheKey($provider, $model, $dimensions),
+            $this->cacheKey($provider, $model, $dimensions, $providerOptions),
             json_encode($response),
             now()->addSeconds($this->cacheSeconds ?? config('ai.caching.embeddings.seconds', 60 * 60 * 24 * 30))
         );
@@ -153,10 +181,51 @@ class PendingEmbeddingsGeneration
 
     /**
      * Get the cache key for the given embeddings request.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
-    protected function cacheKey(Provider $provider, string $model, int $dimensions): string
+    protected function cacheKey(Provider $provider, string $model, int $dimensions, array $providerOptions): string
     {
-        return 'laravel-embeddings:'.hash('sha256', $provider->driver().'-'.$model.'-'.$dimensions.'-'.implode('-', $this->inputs));
+        $optionsFingerprint = $this->fingerprintProviderOptions($providerOptions);
+
+        return 'laravel-embeddings:'.hash(
+            'sha256',
+            $provider->driver().'-'.$model.'-'.$dimensions.'-'.$optionsFingerprint.'-'.implode('-', $this->inputs),
+        );
+    }
+
+    /**
+     * Produce a deterministic fingerprint for the given provider options.
+     *
+     * @param  array<string, mixed>  $providerOptions
+     */
+    protected function fingerprintProviderOptions(array $providerOptions): string
+    {
+        if ($providerOptions === []) {
+            return '';
+        }
+
+        $normalized = $this->normalizeForFingerprint($providerOptions);
+
+        return hash('sha256', json_encode($normalized));
+    }
+
+    /**
+     * Recursively sort array keys so fingerprinting is insensitive to key order.
+     */
+    protected function normalizeForFingerprint(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map(fn ($item) => $this->normalizeForFingerprint($item), $value);
+        }
+
+        ksort($value);
+
+        return array_map(fn ($item) => $this->normalizeForFingerprint($item), $value);
     }
 
     /**
@@ -172,6 +241,7 @@ class PendingEmbeddingsGeneration
                     $provider,
                     $model,
                     $this->timeout,
+                    is_array($this->providerOptions) ? $this->providerOptions : [],
                 )
             );
 

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -71,6 +71,7 @@ class PendingEmbeddingsGeneration
      * Pass a flat array to apply the same options to every selected provider,
      * or a closure that receives the resolved Provider and returns the options
      * for that provider (useful when failover targets need different options).
+     * If you intend to call queue(), the closure must be queue-serializable.
      *
      * @param  array<string, mixed>|Closure(Provider): array<string, mixed>  $options
      */
@@ -195,8 +196,6 @@ class PendingEmbeddingsGeneration
     }
 
     /**
-     * Produce a deterministic fingerprint for the given provider options.
-     *
      * @param  array<string, mixed>  $providerOptions
      */
     protected function fingerprintProviderOptions(array $providerOptions): string
@@ -207,11 +206,11 @@ class PendingEmbeddingsGeneration
 
         $normalized = $this->normalizeForFingerprint($providerOptions);
 
-        return hash('sha256', json_encode($normalized));
+        return hash('sha256', json_encode($normalized, JSON_THROW_ON_ERROR));
     }
 
     /**
-     * Recursively sort array keys so fingerprinting is insensitive to key order.
+     * Recursively sort associative keys so the fingerprint is insensitive to key order.
      */
     protected function normalizeForFingerprint(mixed $value): mixed
     {

--- a/src/Prompts/EmbeddingsPrompt.php
+++ b/src/Prompts/EmbeddingsPrompt.php
@@ -8,12 +8,17 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 
 class EmbeddingsPrompt implements Countable
 {
+    /**
+     * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly array $inputs,
         public readonly int $dimensions,
         public readonly EmbeddingProvider $provider,
         public readonly string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Prompts/QueuedEmbeddingsPrompt.php
+++ b/src/Prompts/QueuedEmbeddingsPrompt.php
@@ -8,12 +8,17 @@ use Laravel\Ai\Enums\Lab;
 
 class QueuedEmbeddingsPrompt implements Countable
 {
+    /**
+     * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly array $inputs,
         public readonly ?int $dimensions,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -17,7 +17,7 @@ trait GeneratesEmbeddings
      *
      * @param  string[]  $input
      */
-    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30): EmbeddingsResponse
+    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse
     {
         if (! is_null($model) && is_null($dimensions)) {
             throw new InvalidArgumentException('Dimensions must be provided when model is specified.');
@@ -44,6 +44,7 @@ trait GeneratesEmbeddings
             $inputs,
             $dimensions,
             $timeout,
+            $providerOptions,
         ), fn (EmbeddingsResponse $response) => $this->events->dispatch(new EmbeddingsGenerated(
             $invocationId, $this, $model, $prompt, $response,
         )));

--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -16,6 +16,7 @@ trait GeneratesEmbeddings
      * Get embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     * @param  array<string, mixed>  $providerOptions
      */
     public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse
     {
@@ -28,7 +29,7 @@ trait GeneratesEmbeddings
         $model ??= $this->defaultEmbeddingsModel();
         $dimensions ??= $this->defaultEmbeddingsDimensions();
 
-        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $this, $model, $timeout);
+        $prompt = new EmbeddingsPrompt($inputs, $dimensions, $this, $model, $timeout, $providerOptions);
 
         if (Ai::embeddingsAreFaked()) {
             Ai::recordEmbeddingsGeneration($prompt);

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -79,6 +79,30 @@ describe('generating embeddings', function () {
         Embeddings::for(['Hello world'])->timeout(45)->generate();
     });
 
+    test('fake embeddings prompt carries provider options', function () {
+        Embeddings::fake();
+
+        Embeddings::for(['Hello'])
+            ->providerOptions(['input_type' => 'search_query'])
+            ->generate();
+
+        Embeddings::assertGenerated(
+            fn (EmbeddingsPrompt $prompt) => $prompt->providerOptions === ['input_type' => 'search_query'],
+        );
+    });
+
+    test('fake queued embeddings prompt carries provider options', function () {
+        Embeddings::fake();
+
+        Embeddings::for(['Hello'])
+            ->providerOptions(['input_type' => 'search_query'])
+            ->queue();
+
+        Embeddings::assertQueued(
+            fn (QueuedEmbeddingsPrompt $prompt) => $prompt->providerOptions === ['input_type' => 'search_query'],
+        );
+    });
+
     test('fake embeddings are normalized', function () {
         $embedding = Embeddings::fakeEmbedding(100);
 

--- a/tests/Feature/EmbeddingsProviderOptionsTest.php
+++ b/tests/Feature/EmbeddingsProviderOptionsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Prompts\QueuedEmbeddingsPrompt;
 use Laravel\Ai\Providers\Provider;
 
 beforeEach(function () {
@@ -112,6 +113,18 @@ test('closure resolver receives the resolved provider and applies per-provider o
 
         return ($body['input_type'] ?? null) === 'search_query';
     });
+});
+
+test('closure provider options are not recorded on the queued prompt fake', function () {
+    Embeddings::fake();
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(fn (Provider $provider) => ['input_type' => 'search_query'])
+        ->queue(provider: 'cohere', model: 'embed-v4.0');
+
+    Embeddings::assertQueued(
+        fn (QueuedEmbeddingsPrompt $prompt) => $prompt->providerOptions === [],
+    );
 });
 
 test('closure resolver returning null is treated as no options', function () {

--- a/tests/Feature/EmbeddingsProviderOptionsTest.php
+++ b/tests/Feature/EmbeddingsProviderOptionsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+use Laravel\Ai\Providers\Provider;
+
+beforeEach(function () {
+    config([
+        'ai.providers.cohere' => [...config('ai.providers.cohere'), 'key' => 'test-key'],
+        'ai.providers.openai' => [...config('ai.providers.openai'), 'key' => 'test-key'],
+        'ai.caching.embeddings.store' => 'array',
+    ]);
+});
+
+test('cache key differs by provider options so distinct option sets do not collide', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1, 0.2, 0.3]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+    ]);
+
+    Embeddings::for(['Hello'])
+        ->cache(3600)
+        ->providerOptions(['input_type' => 'search_document'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Embeddings::for(['Hello'])
+        ->cache(3600)
+        ->providerOptions(['input_type' => 'search_query'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    $observed = collect(Http::recorded())
+        ->map(fn (array $pair) => json_decode($pair[0]->body(), true)['input_type'] ?? null)
+        ->all();
+
+    expect($observed)->toBe(['search_document', 'search_query']);
+});
+
+test('cache key is stable for the same provider options', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1, 0.2, 0.3]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+    ]);
+
+    Embeddings::for(['Hello'])
+        ->cache(3600)
+        ->providerOptions(['input_type' => 'search_query'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Embeddings::for(['Hello'])
+        ->cache(3600)
+        ->providerOptions(['input_type' => 'search_query'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
+test('cache key is insensitive to provider option key order', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1, 0.2, 0.3]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+    ]);
+
+    Embeddings::for(['Hello'])
+        ->cache(3600)
+        ->providerOptions(['input_type' => 'search_query', 'truncate' => 'END'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Embeddings::for(['Hello'])
+        ->cache(3600)
+        ->providerOptions(['truncate' => 'END', 'input_type' => 'search_query'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
+test('closure resolver receives the resolved provider and applies per-provider options', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+        'api.openai.com/*' => Http::response([
+            'object' => 'list',
+            'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+            'usage' => ['prompt_tokens' => 1],
+        ]),
+    ]);
+
+    $seen = [];
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(function (Provider $provider) use (&$seen) {
+            $seen[] = $provider->driver();
+
+            return $provider->driver() === 'cohere'
+                ? ['input_type' => 'search_query']
+                : ['encoding_format' => 'base64'];
+        })
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect($seen)->toBe(['cohere']);
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['input_type'] ?? null) === 'search_query';
+    });
+});
+
+test('closure resolver returning null is treated as no options', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+    ]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(fn () => null)
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['input_type'] ?? null) === 'search_document';
+    });
+});

--- a/tests/Feature/Providers/AzureOpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/EmbeddingTest.php
@@ -128,6 +128,22 @@ test('embeddings http error response throws request exception', function () {
     Embeddings::for(['Hello'])->generate(provider: 'azure', model: 'text-embedding-3-small');
 })->throws(RequestException::class);
 
+test('embeddings request includes provider options in the request body', function () {
+    Http::fake(['*' => fakeAzureEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['encoding_format' => 'base64', 'user' => 'tester'])
+        ->generate(provider: 'azure', model: 'text-embedding-3-small');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['encoding_format'] === 'base64'
+            && $body['user'] === 'tester'
+            && $body['model'] === 'text-embedding-3-small';
+    });
+});
+
 function fakeAzureEmbeddingsResponse()
 {
     return Http::response([

--- a/tests/Feature/Providers/Cohere/EmbeddingTest.php
+++ b/tests/Feature/Providers/Cohere/EmbeddingTest.php
@@ -68,6 +68,37 @@ test('multiple inputs return multiple embeddings', function () {
         ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6]);
 });
 
+test('embeddings request includes provider options and lets them override default input_type', function () {
+    Http::fake(['*' => fakeCohereEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['input_type' => 'search_query', 'truncate' => 'END'])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['input_type'] === 'search_query'
+            && $body['truncate'] === 'END'
+            && $body['model'] === 'embed-v4.0'
+            && $body['texts'] === ['Hello'];
+    });
+});
+
+test('provider options cannot override framework controlled keys', function () {
+    Http::fake(['*' => fakeCohereEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['model' => 'hijacked', 'texts' => ['hijacked']])
+        ->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'embed-v4.0' && $body['texts'] === ['Hello'];
+    });
+});
+
 test('embeddings throw when the API returns an error', function () {
     Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
 

--- a/tests/Feature/Providers/Gemini/EmbeddingTest.php
+++ b/tests/Feature/Providers/Gemini/EmbeddingTest.php
@@ -173,3 +173,56 @@ test('request sends x-goog-api-key header', function () {
         return $request->hasHeader('x-goog-api-key', 'test-key');
     });
 });
+
+test('embeddings request merges provider options into each per-input request', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingsResponse(),
+    ]);
+
+    Embeddings::for(['Hello', 'World'])
+        ->providerOptions(['taskType' => 'RETRIEVAL_QUERY', 'title' => 'doc'])
+        ->generate(provider: 'gemini', model: 'gemini-embedding-001');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        if (array_key_exists('taskType', $body) || array_key_exists('title', $body)) {
+            return false;
+        }
+
+        foreach ($body['requests'] as $req) {
+            if (($req['taskType'] ?? null) !== 'RETRIEVAL_QUERY' || ($req['title'] ?? null) !== 'doc') {
+                return false;
+            }
+
+            if (! isset($req['model'], $req['content'], $req['output_dimensionality'])) {
+                return false;
+            }
+        }
+
+        return count($body['requests']) === 2;
+    });
+});
+
+test('gemini provider options cannot override framework controlled per-request keys', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingsResponse(),
+    ]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions([
+            'model' => 'hijacked',
+            'content' => ['hijacked'],
+            'output_dimensionality' => 1,
+        ])
+        ->generate(provider: 'gemini', model: 'gemini-embedding-001');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $req = $body['requests'][0];
+
+        return $req['model'] === 'models/gemini-embedding-001'
+            && $req['content'] === ['parts' => [['text' => 'Hello']]]
+            && $req['output_dimensionality'] === 3072;
+    });
+});

--- a/tests/Feature/Providers/Jina/EmbeddingTest.php
+++ b/tests/Feature/Providers/Jina/EmbeddingTest.php
@@ -87,6 +87,22 @@ test('embeddings default to 2048 dimensions when none specified', function () {
     Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['dimensions'] === 2048);
 });
 
+test('embeddings request includes provider options and overrides default task', function () {
+    Http::fake(['*' => fakeJinaEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['task' => 'retrieval.query', 'late_chunking' => true])
+        ->generate(provider: 'jina', model: 'jina-embeddings-v4');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['task'] === 'retrieval.query'
+            && $body['late_chunking'] === true
+            && $body['model'] === 'jina-embeddings-v4';
+    });
+});
+
 function fakeJinaEmbeddingsResponse()
 {
     return Http::response([

--- a/tests/Feature/Providers/Mistral/EmbeddingTest.php
+++ b/tests/Feature/Providers/Mistral/EmbeddingTest.php
@@ -102,6 +102,22 @@ test('embeddings http error response throws request exception', function () {
     Embeddings::for(['Hello'])->generate(provider: 'mistral', model: 'mistral-embed');
 })->throws(RequestException::class);
 
+test('embeddings request includes provider options in the request body', function () {
+    Http::fake(['*' => fakeEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['output_dimension' => 256, 'output_dtype' => 'float'])
+        ->generate(provider: 'mistral', model: 'mistral-embed');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['output_dimension'] === 256
+            && $body['output_dtype'] === 'float'
+            && $body['model'] === 'mistral-embed';
+    });
+});
+
 function fakeEmbeddingsResponse()
 {
     return Http::response([

--- a/tests/Feature/Providers/Ollama/EmbeddingTest.php
+++ b/tests/Feature/Providers/Ollama/EmbeddingTest.php
@@ -109,6 +109,22 @@ test('embeddings http error response throws request exception', function () {
     Embeddings::for(['Hello'])->generate(provider: 'ollama', model: 'nomic-embed-text');
 })->throws(RequestException::class);
 
+test('embeddings request includes provider options in the request body', function () {
+    Http::fake(['*' => fakeOllamaEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['truncate' => false, 'keep_alive' => '5m'])
+        ->generate(provider: 'ollama', model: 'nomic-embed-text');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['truncate'] === false
+            && $body['keep_alive'] === '5m'
+            && $body['model'] === 'nomic-embed-text';
+    });
+});
+
 function fakeOllamaEmbeddingsResponse()
 {
     return Http::response([

--- a/tests/Feature/Providers/OpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/OpenAi/EmbeddingTest.php
@@ -93,6 +93,38 @@ test('embeddings default to 1536 dimensions when none specified', function () {
     Http::assertSent(fn (Request $request) => json_decode($request->body(), true)['dimensions'] === 1536);
 });
 
+test('embeddings request includes provider options in the request body', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['encoding_format' => 'base64', 'user' => 'tester'])
+        ->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['encoding_format'] === 'base64'
+            && $body['user'] === 'tester'
+            && $body['model'] === 'text-embedding-3-small';
+    });
+});
+
+test('provider options cannot override framework controlled keys', function () {
+    Http::fake(['*' => fakeOpenAiEmbeddingResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['model' => 'hijacked', 'input' => ['hijacked'], 'dimensions' => 1])
+        ->generate(provider: 'openai', model: 'text-embedding-3-small');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'text-embedding-3-small'
+            && $body['input'] === ['Hello']
+            && $body['dimensions'] === 1536;
+    });
+});
+
 test('embeddings rate limit response throws rate limited exception', function () {
     Http::fake([
         'api.openai.com/*' => Http::response([

--- a/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenRouter/EmbeddingsTest.php
@@ -77,6 +77,26 @@ test('embeddings request uses openrouter base url', function () {
     Http::assertSent(fn (Request $request) => $request->url() === 'https://openrouter.ai/api/v1/embeddings');
 });
 
+test('embeddings request includes provider options in the request body', function () {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    Ai::instance('openrouter')->embeddings(
+        inputs: ['Hello'],
+        providerOptions: ['encoding_format' => 'base64'],
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['encoding_format'] === 'base64'
+            && $body['input'] === ['Hello'];
+    });
+});
+
 test('embeddings rate limit response throws rate limited exception', function () {
     Http::fake([
         'openrouter.ai/*' => Http::response(['error' => ['message' => 'Rate limited']], 429),

--- a/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
@@ -100,6 +100,21 @@ test('embeddings http error response throws request exception', function () {
     Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
 })->throws(RequestException::class);
 
+test('embeddings request includes provider options in the request body', function () {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])
+        ->providerOptions(['input_type' => 'query', 'truncation' => true])
+        ->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['input_type'] === 'query'
+            && $body['truncation'] === true;
+    });
+});
+
 function fakeVoyageEmbeddingsResponse()
 {
     return Http::response([


### PR DESCRIPTION
Adds support for provider-specific options when generating embeddings. Every provider has knobs the SDK was hardcoding or omitting — Cohere and Voyage hardcode `input_type: 'search_document'`, so today there is no way to send `search_query` for the query side of a RAG retrieval. This patches that escape hatch and adds per-provider scoping for failover.

Supports: #508
Is useful for: #358

### Usage

Same options for whichever provider runs:

```php
// Indexing pass — documents
Embeddings::for($chunks)
    ->providerOptions(['input_type' => 'search_document'])
    ->generate(provider: 'cohere', model: 'embed-v4.0');

// Query pass — MUST be search_query for retrieval to work correctly
Embeddings::for([$userQuery])
    ->providerOptions(['input_type' => 'search_query'])
    ->generate(provider: 'cohere', model: 'embed-v4.0');
```

Per-provider options for failover (each provider names the same knob differently):

```php
Embeddings::for([$userQuery])
    ->providerOptions(fn ($provider) => match ($provider->driver()) {
        'cohere'   => ['input_type' => 'search_query'],
        'voyageai' => ['input_type' => 'query'],
        'jina'     => ['task' => 'retrieval.query'],
        default    => [],
    })
    ->generate(provider: ['cohere', 'voyageai', 'jina']);
```

Via the Stringable macro:

```php
Str::of($userQuery)->toEmbeddings(
    provider: Lab::VoyageAI,
    dimensions: 1024,
    model: 'voyage-4-large',
    providerOptions: ['input_type' => 'query'],
);
```

### Approach

- Threaded a `providerOptions` parameter through the embeddings pipeline (contracts, providers, gateways, pending responses, prompts, fake) so it reaches the HTTP body of every provider.
- Provisioned every embeddings gateway: OpenAI, Azure OpenAI, Cohere, Voyage, Jina, Mistral, Gemini, Ollama, OpenRouter, and Bedrock (both Titan and Cohere branches).
- Framework-controlled keys (`model`, `input`, `dimensions`) always win over user-supplied options; provider defaults that callers might legitimately want to override (Cohere `input_type`, Jina `task`) remain overridable.
- Gemini merges options into each per-input request, matching its `batchEmbedContents` contract where `taskType`, `title`, and `outputDimensionality` live per request, not top-level.
- Cache keys mix in a deterministic, key-order-insensitive fingerprint of the resolved options so `input_type=query` and `input_type=document` no longer collide.
- `providerOptions()` accepts an array or a closure resolver that receives the active provider, so failover targets get options scoped to their own API.
- Options are carried on `EmbeddingsPrompt`, `QueuedEmbeddingsPrompt`, and the fake gateway so they're assertable in tests and visible to event listeners.