### PR TITLE
Gemini context cache support via cachedContent param in agent provider options

### DIFF
--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -83,7 +83,16 @@ trait BuildsTextRequests
             'topP' => $options?->topP,
         ]));
 
-        $providerOptions = $options?->providerOptions(Lab::tryFrom($provider->driver()) ?? $provider->driver());
+        $providerOptions = $options?->providerOptions(Lab::tryFrom($provider->driver()) ?? $provider->driver()) ?? [];
+
+        // Hoist keys that need to be passed at top level, as everything else is passed in generationConfig
+        $topLevelKeys = ['cachedContent'];
+        foreach ($topLevelKeys as $key) {
+            if (array_key_exists($key, $providerOptions)) {
+                $body[$key] = $providerOptions[$key];
+                unset($providerOptions[$key]);
+            }
+        }
 
         if (filled($providerOptions)) {
             $generationConfig = array_merge($generationConfig, $providerOptions);

--- a/tests/Feature/Providers/Gemini/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Gemini/ProviderOptionsTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
@@ -66,4 +70,38 @@ test('provider options are persisted in tool call follow up requests', function 
     $secondConfig = $recorded[1][0]->data()['generationConfig'] ?? [];
     expect($secondConfig)->toHaveKey('thinkingConfig')
         ->and($secondConfig['thinkingConfig']['thinkingBudget'])->toBe(10000);
+});
+
+test('cachedContent is placed at top level of request body, not in generationConfig', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $agent = new class implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return match ($provider) {
+                Lab::Gemini => ['cachedContent' => 'cachedContents/test-cache-123'],
+                default => [],
+            };
+        }
+    };
+
+    $agent->prompt('Hi', provider: 'gemini');
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return isset($body['cachedContent'])
+            && $body['cachedContent'] === 'cachedContents/test-cache-123'
+            && ! isset($body['generationConfig']['cachedContent']);
+    });
 });


### PR DESCRIPTION
This change allows users to pass name of previously created cache in agent prompts via the cachedContent param, [see this](https://ai.google.dev/gemini-api/docs/caching#rest). 

Resolves https://github.com/laravel/ai/issues/372

### Usage

```php

// assuming user has already cached content
// pass the name of cache in agent provider options

class MyAgent implements Agent, HasProviderOptions
{
    use Promptable;

    public function instructions(): string
    {
        return 'You are a helpful assistant.';
    }

    public function providerOptions(Lab|string $provider): array
    {
        return match ($provider) {
            Lab::Gemini => ['cachedContent' => '<name of cached item>'],
            default => [],
        };
    }
};

```

### Approach

1. The approach is slightly imperfect because all of the provider options are already being passed in Gemini API body param`generationConfig`, where as `cachedContent` is a different top level param.
2. To avoid breaking change i extracted this property from provider options and pass it in the request body.
