### PR TITLE
Fix buffering for server_tool_use input in streamed responses

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -60,6 +60,7 @@ trait HandlesTextStreaming
         $currentToolIndex = -1;
         $currentServerToolInput = '';
         $pendingToolCalls = [];
+        $serverToolInputBuffers = [];
         $responseContent = [];
 
         $inputTokens = 0;
@@ -245,6 +246,8 @@ trait HandlesTextStreaming
                     } elseif ($currentBlockType === 'server_tool_use') {
                         $currentServerToolInput .= $partial;
                     }
+                } elseif ($deltaType === 'input_json_delta' && $currentBlockType === 'server_tool_use') {
+                    $serverToolInputBuffers[$currentBlockIndex] = ($serverToolInputBuffers[$currentBlockIndex] ?? '').($data['delta']['partial_json'] ?? '');
                 }
 
                 continue;
@@ -301,7 +304,15 @@ trait HandlesTextStreaming
                         time(),
                     ))->withInvocationId($invocationId);
                 } elseif ($currentBlockType === 'server_tool_use') {
-                    $index = $data['index'] ?? count($responseContent) - 1;
+                    $index = $data['index'] ?? $currentBlockIndex;
+
+                    if (isset($serverToolInputBuffers[$index])) {
+                        $parsed = json_decode($serverToolInputBuffers[$index], true);
+
+                        if (is_array($parsed)) {
+                            $responseContent[$index]['input'] = $parsed;
+                        }
+                    }
 
                     if ($currentServerToolInput !== '' && isset($responseContent[$index])) {
                         $responseContent[$index]['input'] = json_decode($currentServerToolInput, true) ?? [];

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -136,6 +136,35 @@ describe('thinking blocks', function () {
             ->and($providerEvents[1]->status)->toBe('completed');
     });
 
+    test('streaming assembles server_tool_use input from deltas', function () {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'server_tool_use', 'id' => 'srvtoolu_1', 'name' => 'web_search', 'input' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'input_json_delta', 'partial_json' => '{"qu']),
+                    $this->contentBlockDelta(0, ['type' => 'input_json_delta', 'partial_json' => 'ery": "laravel ai"}']),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(1, ['type' => 'text_delta', 'text' => 'Found it']),
+                    $this->contentBlockStop(1),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $completed = collect($events)
+            ->filter(fn ($e) => $e instanceof ProviderToolEvent && $e->status === 'completed')
+            ->first();
+
+        expect($completed)->not->toBeNull()
+            ->and($completed->data['input'])->toBe(['query' => 'laravel ai']);
+    });
+
     test('streaming handles provider tool results', function () {
         Http::fake([
             'api.anthropic.com/*' => Http::response(


### PR DESCRIPTION
`HandlesTextStreaming` was only buffering `input_json_delta` for client `tool_use` blocks.

That meant `server_tool_use` blocks like `web_search` and `advisor` could stream input deltas, but the SDK would drop them. By the time the completed `ProviderToolEvent` fired, and by the time the block was written into `$responseContent`, the tool input was still empty.

This change adds a parallel `$serverToolInputBuffers` accumulator for `server_tool_use` blocks and assembles the final input before emitting the completed `ProviderToolEvent`, following the same pattern we already use for client tools via `$pendingToolCalls`.

I also used `$currentBlockIndex` as the fallback index instead of `count($responseContent) - 1`, which is safer while blocks are still being streamed.

Includes a streaming test that feeds a `server_tool_use` block with multiple `input_json_delta` chunks and asserts that the completed `ProviderToolEvent` contains the fully assembled input.

I ran into this while trying to capture streamed `web_search` queries: the `ProviderToolEvent` was always arriving with empty input.
