### PR TITLE
OpenRouter TTS and STT support

### DIFF
--- a/src/Gateway/Concerns/WrapsPcmAudio.php
+++ b/src/Gateway/Concerns/WrapsPcmAudio.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+trait WrapsPcmAudio
+{
+    protected function pcmToWav(string $pcm, int $sampleRate = 24000, int $channels = 1, int $bitsPerSample = 16): string
+    {
+        $dataSize = strlen($pcm);
+        $byteRate = intdiv($sampleRate * $channels * $bitsPerSample, 8);
+        $blockAlign = intdiv($channels * $bitsPerSample, 8);
+
+        return 'RIFF'
+            .pack('V', 36 + $dataSize)
+            .'WAVE'
+            .'fmt '
+            .pack('VvvVVvv', 16, 1, $channels, $sampleRate, $byteRate, $blockAlign, $bitsPerSample)
+            .'data'
+            .pack('V', $dataSize)
+            .$pcm;
+    }
+}

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -16,6 +16,7 @@ use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -30,12 +31,6 @@ use RuntimeException;
 
 class GeminiGateway implements Gateway
 {
-    protected const GEMINI_TTS_BITS_PER_SAMPLE = 16;
-
-    protected const GEMINI_TTS_CHANNELS = 1;
-
-    protected const GEMINI_TTS_SAMPLE_RATE = 24000;
-
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesGeminiClient;
     use Concerns\HandlesTextStreaming;
@@ -46,6 +41,7 @@ class GeminiGateway implements Gateway
     use HandlesFailoverErrors;
     use InvokesTools;
     use ParsesServerSentEvents;
+    use WrapsPcmAudio;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -396,24 +392,5 @@ class GeminiGateway implements Gateway
         return (float) $parts[0]
             + ((float) ($parts[1] ?? 0)) * 60
             + ((float) ($parts[2] ?? 0)) * 3600;
-    }
-
-    /**
-     * Wrap raw PCM audio in a WAV container.
-     */
-    protected function pcmToWav(string $pcm): string
-    {
-        $dataSize = strlen($pcm);
-        $byteRate = intdiv(self::GEMINI_TTS_SAMPLE_RATE * self::GEMINI_TTS_CHANNELS * self::GEMINI_TTS_BITS_PER_SAMPLE, 8);
-        $blockAlign = intdiv(self::GEMINI_TTS_CHANNELS * self::GEMINI_TTS_BITS_PER_SAMPLE, 8);
-
-        return 'RIFF'
-            .pack('V', 36 + $dataSize)
-            .'WAVE'
-            .'fmt '
-            .pack('VvvVVvv', 16, 1, self::GEMINI_TTS_CHANNELS, self::GEMINI_TTS_SAMPLE_RATE, $byteRate, $blockAlign, self::GEMINI_TTS_BITS_PER_SAMPLE)
-            .'data'
-            .pack('V', $dataSize)
-            .$pcm;
     }
 }

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -5,14 +5,13 @@ namespace Laravel\Ai\Gateway\OpenRouter;
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Gateway\AudioGateway;
-use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
-use Laravel\Ai\Contracts\Gateway\ImageGateway;
-use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
@@ -25,8 +24,10 @@ use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use LogicException;
 
-class OpenRouterGateway implements AudioGateway, EmbeddingGateway, ImageGateway, TextGateway
+class OpenRouterGateway implements Gateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesOpenRouterClient;
@@ -244,6 +245,67 @@ class OpenRouterGateway implements AudioGateway, EmbeddingGateway, ImageGateway,
             new Meta($provider->name(), $model),
             'audio/mpeg',
         );
+    }
+
+    /**
+     * Generate text from the given audio.
+     *
+     * @throws LogicException
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+    ): TranscriptionResponse {
+        if ($diarize) {
+            throw new LogicException(
+                'OpenRouter does not support diarized transcription. Use the OpenAI, ElevenLabs, Mistral, or Gemini provider for diarization.'
+            );
+        }
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('audio/transcriptions', array_filter([
+                'model' => $model,
+                'input_audio' => [
+                    'data' => base64_encode($audio->content()),
+                    'format' => $this->audioFormat($audio->mimeType()),
+                ],
+                'language' => $language,
+            ])),
+        );
+
+        $data = $response->json();
+
+        return new TranscriptionResponse(
+            $data['text'] ?? '',
+            collect(),
+            new Usage(
+                $data['usage']['input_tokens'] ?? 0,
+                $data['usage']['total_tokens'] ?? 0,
+            ),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Map an audio MIME type to OpenRouter's input_audio.format value.
+     */
+    protected function audioFormat(string $mimeType): string
+    {
+        return match ($mimeType) {
+            'audio/webm' => 'webm',
+            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
+            'audio/wav', 'audio/x-wav' => 'wav',
+            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/aac' => 'aac',
+            'audio/mpeg', 'audio/mp3' => 'mp3',
+            default => 'mp3',
+        };
     }
 
     /**

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -5,9 +5,11 @@ namespace Laravel\Ai\Gateway\OpenRouter;
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
@@ -16,6 +18,7 @@ use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
@@ -23,7 +26,7 @@ use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
 
-class OpenRouterGateway implements EmbeddingGateway, ImageGateway, TextGateway
+class OpenRouterGateway implements AudioGateway, EmbeddingGateway, ImageGateway, TextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesOpenRouterClient;
@@ -205,6 +208,42 @@ class OpenRouterGateway implements EmbeddingGateway, ImageGateway, TextGateway
             [['type' => 'text', 'text' => $prompt]],
             $this->mapAttachments(collect($attachments)),
         )]];
+    }
+
+    /**
+     * Generate audio from the given text.
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        $voice = match ($voice) {
+            'default-male' => 'ash',
+            'default-female' => 'alloy',
+            default => $voice,
+        };
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
+                'model' => $model,
+                'input' => $text,
+                'voice' => $voice,
+                'response_format' => 'mp3',
+                'speed' => 1.0,
+                'instructions' => $instructions,
+            ])),
+        );
+
+        return new AudioResponse(
+            base64_encode($response->body()),
+            new Meta($provider->name(), $model),
+            'audio/mpeg',
+        );
     }
 
     /**

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway\OpenRouter;
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -16,6 +17,7 @@ use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -39,6 +41,7 @@ class OpenRouterGateway implements Gateway
     use HandlesFailoverErrors;
     use InvokesTools;
     use ParsesServerSentEvents;
+    use WrapsPcmAudio;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -222,19 +225,15 @@ class OpenRouterGateway implements Gateway
         ?string $instructions = null,
         int $timeout = 30,
     ): AudioResponse {
-        $voice = match ($voice) {
-            'default-male' => 'ash',
-            'default-female' => 'alloy',
-            default => $voice,
-        };
+        $format = $this->audioResponseFormat($model);
 
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
                 'model' => $model,
                 'input' => $text,
-                'voice' => $voice,
-                'response_format' => 'mp3',
+                'voice' => $this->resolveVoice($model, $voice),
+                'response_format' => $format,
                 'speed' => 1.0,
                 'instructions' => $instructions,
             ])),
@@ -243,8 +242,57 @@ class OpenRouterGateway implements Gateway
         return new AudioResponse(
             base64_encode($response->body()),
             new Meta($provider->name(), $model),
-            'audio/mpeg',
+            $this->audioResponseMimeType($format),
         );
+    }
+
+    /**
+     * Resolve the alias voice for the given model.
+     */
+    protected function resolveVoice(string $model, string $voice): string
+    {
+        if ($this->isGeminiTtsModel($model)) {
+            return match ($voice) {
+                'default-male' => 'Puck',
+                'default-female' => 'Kore',
+                default => $voice,
+            };
+        }
+
+        return match ($voice) {
+            'default-male' => 'ash',
+            'default-female' => 'alloy',
+            default => $voice,
+        };
+    }
+
+    /**
+     * Resolve the response_format the model accepts. Gemini TTS only accepts pcm.
+     */
+    protected function audioResponseFormat(string $model): string
+    {
+        return $this->isGeminiTtsModel($model) ? 'pcm' : 'mp3';
+    }
+
+    /**
+     * Map a response_format value to the HTTP audio MIME type.
+     */
+    protected function audioResponseMimeType(string $format): string
+    {
+        return match ($format) {
+            'mp3' => 'audio/mpeg',
+            'pcm' => 'audio/pcm',
+            'wav' => 'audio/wav',
+            'opus' => 'audio/opus',
+            'aac' => 'audio/aac',
+            'flac' => 'audio/flac',
+            default => 'audio/mpeg',
+        };
+    }
+
+    protected function isGeminiTtsModel(string $model): bool
+    {
+        return str_contains($model, 'gemini') && str_contains($model, 'tts');
     }
 
     /**
@@ -266,13 +314,21 @@ class OpenRouterGateway implements Gateway
             );
         }
 
+        $mimeType = $audio->mimeType();
+        $content = $audio->content();
+
+        if ($mimeType === 'audio/pcm') {
+            $content = $this->pcmToWav($content);
+            $mimeType = 'audio/wav';
+        }
+
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('audio/transcriptions', array_filter([
                 'model' => $model,
                 'input_audio' => [
-                    'data' => base64_encode($audio->content()),
-                    'format' => $this->audioFormat($audio->mimeType()),
+                    'data' => base64_encode($content),
+                    'format' => $this->audioFormat($mimeType),
                 ],
                 'language' => $language,
             ])),
@@ -304,7 +360,9 @@ class OpenRouterGateway implements Gateway
             'audio/flac', 'audio/x-flac' => 'flac',
             'audio/aac' => 'aac',
             'audio/mpeg', 'audio/mp3' => 'mp3',
-            default => 'mp3',
+            default => throw new InvalidArgumentException(
+                "Unsupported audio MIME type [{$mimeType}] for OpenRouter transcription. Supported types: audio/wav, audio/mp3, audio/mpeg, audio/flac, audio/m4a, audio/mp4, audio/ogg, audio/webm, audio/aac."
+            ),
         };
     }
 

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -3,19 +3,23 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
 
-class OpenRouterProvider extends Provider implements EmbeddingProvider, ImageProvider, TextProvider
+class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, TextProvider
 {
+    use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
+    use Concerns\HasAudioGateway;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasImageGateway;
     use Concerns\HasTextGateway;
@@ -100,6 +104,22 @@ class OpenRouterProvider extends Provider implements EmbeddingProvider, ImagePro
                 default => null,
             },
         ]);
+    }
+
+    /**
+     * Get the provider's audio gateway.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ??= new OpenRouterGateway($this->events);
+    }
+
+    /**
+     * Get the name of the default audio (TTS) model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return $this->config['models']['audio']['default'] ?? 'openai/gpt-4o-mini-tts-2025-12-15';
     }
 
     /**

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -123,7 +123,7 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
      */
     public function defaultAudioModel(): string
     {
-        return $this->config['models']['audio']['default'] ?? 'openai/gpt-4o-mini-tts-2025-12-15';
+        return $this->config['models']['audio']['default'] ?? 'google/gemini-3.1-flash-tts-preview';
     }
 
     /**
@@ -139,7 +139,7 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
      */
     public function defaultTranscriptionModel(): string
     {
-        return $this->config['models']['transcription']['default'] ?? 'openai/gpt-4o-transcribe';
+        return $this->config['models']['transcription']['default'] ?? 'openai/whisper-1';
     }
 
     /**

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -7,22 +7,26 @@ use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
 
-class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, TextProvider
+class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
+    use Concerns\GeneratesTranscriptions;
     use Concerns\HasAudioGateway;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasImageGateway;
     use Concerns\HasTextGateway;
+    use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
 
     public function __construct(protected array $config, protected Dispatcher $events)
@@ -120,6 +124,22 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
     public function defaultAudioModel(): string
     {
         return $this->config['models']['audio']['default'] ?? 'openai/gpt-4o-mini-tts-2025-12-15';
+    }
+
+    /**
+     * Get the provider's transcription gateway.
+     */
+    public function transcriptionGateway(): TranscriptionGateway
+    {
+        return $this->transcriptionGateway ??= new OpenRouterGateway($this->events);
+    }
+
+    /**
+     * Get the name of the default transcription (STT) model.
+     */
+    public function defaultTranscriptionModel(): string
+    {
+        return $this->config['models']['transcription']['default'] ?? 'openai/gpt-4o-transcribe';
     }
 
     /**

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -5,6 +5,7 @@ dataset('text-providers', ['anthropic', 'gemini', 'groq', 'openai']);
 dataset('tts-providers', [
     'openai' => ['openai', 'OPENAI_API_KEY'],
     'gemini' => ['gemini', 'GEMINI_API_KEY'],
+    'openrouter' => ['openrouter', 'OPENROUTER_API_KEY'],
 ]);
 
 dataset('providers-with-urls', [
@@ -20,6 +21,12 @@ dataset('embedding-providers', [
 ]);
 
 dataset('transcription-providers', [
+    'openai' => ['openai', 'OPENAI_API_KEY'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY'],
+    'openrouter' => ['openrouter', 'OPENROUTER_API_KEY'],
+]);
+
+dataset('diarization-providers', [
     'openai' => ['openai', 'OPENAI_API_KEY'],
     'gemini' => ['gemini', 'GEMINI_API_KEY'],
 ]);

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -104,3 +104,29 @@ test('audio response is base64-encoded with audio/mpeg mime type', function () {
         ->and($response->meta->provider)->toBe('openrouter')
         ->and($response->meta->model)->toBe('openai/gpt-4o-mini-tts-2025-12-15');
 });
+
+test('audio request sends bearer token', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('audio request sends openrouter attribution headers when configured', function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+        'http_referer' => 'https://example.test',
+        'x_title' => 'Example App',
+    ]]);
+
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('HTTP-Referer', 'https://example.test')
+            && $request->hasHeader('X-OpenRouter-Title', 'Example App');
+    });
+});

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
+
+function fakeOpenRouterAudioResponse(): PromiseInterface
+{
+    return Http::response('fake-audio-bytes', 200, ['Content-Type' => 'audio/mpeg']);
+}
+
+test('audio request includes model, input, voice, response format, and speed', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello world')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'openai/gpt-4o-mini-tts-2025-12-15'
+            && $body['input'] === 'Hello world'
+            && $body['voice'] === 'alloy'
+            && $body['response_format'] === 'mp3'
+            && $body['speed'] == 1.0
+            && $request->url() === 'https://openrouter.ai/api/v1/audio/speech';
+    });
+});

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -33,3 +33,33 @@ test('audio request includes model, input, voice, response format, and speed', f
             && $request->url() === 'https://openrouter.ai/api/v1/audio/speech';
     });
 });
+
+test('audio request resolves default-female voice to alloy', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->female()->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['voice'] === 'alloy';
+    });
+});
+
+test('audio request resolves default-male voice to ash', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->male()->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['voice'] === 'ash';
+    });
+});
+
+test('audio request passes custom voice id through unchanged', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->voice('shimmer')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['voice'] === 'shimmer';
+    });
+});

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -93,7 +93,39 @@ test('audio uses default model when none specified', function () {
     Audio::of('Hello')->generate(provider: 'openrouter');
 
     Http::assertSent(function (Request $request) {
-        return json_decode($request->body(), true)['model'] === 'openai/gpt-4o-mini-tts-2025-12-15';
+        return json_decode($request->body(), true)['model'] === 'google/gemini-3.1-flash-tts-preview';
+    });
+});
+
+test('audio request to gemini tts model uses pcm response format and pcm mime', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    $response = Audio::of('Hello')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['response_format'] === 'pcm';
+    });
+
+    expect($response->mimeType())->toBe('audio/pcm');
+});
+
+test('audio request to gemini tts model resolves default-female voice to Kore', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->female()->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['voice'] === 'Kore';
+    });
+});
+
+test('audio request to gemini tts model resolves default-male voice to Puck', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->male()->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['voice'] === 'Puck';
     });
 });
 

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -63,3 +63,44 @@ test('audio request passes custom voice id through unchanged', function () {
         return json_decode($request->body(), true)['voice'] === 'shimmer';
     });
 });
+
+test('audio request includes instructions when provided', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->instructions('Speak slowly')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['instructions'] === 'Speak slowly';
+    });
+});
+
+test('audio request omits instructions when not provided', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request) {
+        return ! array_key_exists('instructions', json_decode($request->body(), true));
+    });
+});
+
+test('audio uses default model when none specified', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['model'] === 'openai/gpt-4o-mini-tts-2025-12-15';
+    });
+});
+
+test('audio response is base64-encoded with audio/mpeg mime type', function () {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    $response = Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    expect($response->audio)->toBe(base64_encode('fake-audio-bytes'))
+        ->and($response->mimeType())->toBe('audio/mpeg')
+        ->and($response->meta->provider)->toBe('openrouter')
+        ->and($response->meta->model)->toBe('openai/gpt-4o-mini-tts-2025-12-15');
+});

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -2,8 +2,11 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
     config(['ai.providers.openrouter' => [
@@ -130,3 +133,42 @@ test('audio request sends openrouter attribution headers when configured', funct
             && $request->hasHeader('X-OpenRouter-Title', 'Example App');
     });
 });
+
+test('audio rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'message' => 'Rate limit exceeded',
+                'code' => 429,
+            ],
+        ], 429),
+    ]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+})->throws(RateLimitedException::class);
+
+test('audio overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'message' => 'Service overloaded',
+                'code' => 503,
+            ],
+        ], 503),
+    ]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+})->throws(ProviderOverloadedException::class);
+
+test('audio http error response throws request exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'message' => 'Bad request',
+                'code' => 400,
+            ],
+        ], 400),
+    ]);
+
+    Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Transcription;
+use LogicException;
+
+beforeEach(function () {
+    config(['ai.providers.openrouter' => [
+        ...config('ai.providers.openrouter'),
+        'key' => 'test-key',
+    ]]);
+});
+
+function fakeOpenRouterTranscriptionResponse(string $text = 'Hello, world!'): PromiseInterface
+{
+    return Http::response([
+        'text' => $text,
+        'usage' => [
+            'seconds' => 1.5,
+            'total_tokens' => 30,
+            'input_tokens' => 20,
+            'output_tokens' => 10,
+            'cost' => 0.000100,
+        ],
+    ]);
+}
+
+test('transcription request posts to correct endpoint as json', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'https://openrouter.ai/api/v1/audio/transcriptions'
+            && str_contains($request->header('Content-Type')[0] ?? '', 'application/json');
+    });
+});
+
+test('transcription request sends audio as base64 with format from mime type', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['input_audio']['data'] === base64_encode('fake-audio')
+            && $body['input_audio']['format'] === 'mp3';
+    });
+});
+
+test('transcription diarize throws logic exception without sending request', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    expect(fn () => Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->diarize()
+        ->generate(provider: 'openrouter'))
+        ->toThrow(LogicException::class, 'OpenRouter does not support diarized transcription');
+
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -86,3 +86,64 @@ test('transcription maps audio mime types to openrouter format values', function
     'aac via audio/aac' => ['audio/aac', 'aac'],
     'fallback to mp3 for unknown mime' => ['audio/unknown-format', 'mp3'],
 ]);
+
+test('transcription request includes language when specified', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->language('fr')
+        ->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['language'] === 'fr';
+    });
+});
+
+test('transcription request omits language when not specified', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return ! array_key_exists('language', json_decode($request->body(), true));
+    });
+});
+
+test('transcription uses default model when none specified', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return json_decode($request->body(), true)['model'] === 'openai/gpt-4o-transcribe';
+    });
+});
+
+test('transcription response text is correctly parsed', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse('Hello, world!')]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    expect($response->text)->toBe('Hello, world!')
+        ->and($response->segments)->toHaveCount(0)
+        ->and($response->meta->provider)->toBe('openrouter')
+        ->and($response->meta->model)->toBe('openai/gpt-4o-transcribe');
+});
+
+test('transcription usage is correctly parsed', function () {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hello',
+        'usage' => [
+            'seconds' => 2.0,
+            'total_tokens' => 150,
+            'input_tokens' => 100,
+            'output_tokens' => 50,
+            'cost' => 0.0005,
+        ],
+    ])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    expect($response->usage->promptTokens)->toBe(100)
+        ->and($response->usage->completionTokens)->toBe(150);
+});

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -61,3 +61,28 @@ test('transcription diarize throws logic exception without sending request', fun
 
     Http::assertNothingSent();
 });
+
+test('transcription maps audio mime types to openrouter format values', function (string $mimeType, string $expectedFormat) {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), $mimeType)->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) use ($expectedFormat) {
+        return json_decode($request->body(), true)['input_audio']['format'] === $expectedFormat;
+    });
+})->with([
+    'mp3 via audio/mpeg' => ['audio/mpeg', 'mp3'],
+    'mp3 via audio/mp3' => ['audio/mp3', 'mp3'],
+    'wav via audio/wav' => ['audio/wav', 'wav'],
+    'wav via audio/x-wav' => ['audio/x-wav', 'wav'],
+    'm4a via audio/m4a' => ['audio/m4a', 'm4a'],
+    'm4a via audio/mp4' => ['audio/mp4', 'm4a'],
+    'm4a via audio/x-m4a' => ['audio/x-m4a', 'm4a'],
+    'ogg via audio/ogg' => ['audio/ogg', 'ogg'],
+    'ogg via audio/ogg opus' => ['audio/ogg; codecs=opus', 'ogg'],
+    'flac via audio/flac' => ['audio/flac', 'flac'],
+    'flac via audio/x-flac' => ['audio/x-flac', 'flac'],
+    'webm via audio/webm' => ['audio/webm', 'webm'],
+    'aac via audio/aac' => ['audio/aac', 'aac'],
+    'fallback to mp3 for unknown mime' => ['audio/unknown-format', 'mp3'],
+]);

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -2,7 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Transcription;
 use LogicException;
 
@@ -147,3 +150,53 @@ test('transcription usage is correctly parsed', function () {
     expect($response->usage->promptTokens)->toBe(100)
         ->and($response->usage->completionTokens)->toBe(150);
 });
+
+test('transcription request sends bearer token', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('transcription rate limit response throws rate limited exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'message' => 'Rate limit exceeded',
+                'code' => 429,
+            ],
+        ], 429),
+    ]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-transcribe');
+})->throws(RateLimitedException::class);
+
+test('transcription overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'message' => 'Service overloaded',
+                'code' => 503,
+            ],
+        ], 503),
+    ]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-transcribe');
+})->throws(ProviderOverloadedException::class);
+
+test('transcription http error response throws request exception', function () {
+    Http::fake([
+        'openrouter.ai/*' => Http::response([
+            'error' => [
+                'message' => 'Invalid audio format',
+                'code' => 400,
+            ],
+        ], 400),
+    ]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-transcribe');
+})->throws(RequestException::class);

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -4,6 +4,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Transcription;
@@ -87,8 +88,36 @@ test('transcription maps audio mime types to openrouter format values', function
     'flac via audio/x-flac' => ['audio/x-flac', 'flac'],
     'webm via audio/webm' => ['audio/webm', 'webm'],
     'aac via audio/aac' => ['audio/aac', 'aac'],
-    'fallback to mp3 for unknown mime' => ['audio/unknown-format', 'mp3'],
 ]);
+
+test('transcription wraps raw pcm audio in a wav header and sends as wav format', function () {
+    Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
+
+    $pcm = str_repeat("\x01\x00", 1000);
+
+    Transcription::fromBase64(base64_encode($pcm), 'audio/pcm')->generate(provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) use ($pcm) {
+        $body = json_decode($request->body(), true);
+
+        $sent = base64_decode($body['input_audio']['data']);
+
+        return $body['input_audio']['format'] === 'wav'
+            && str_starts_with($sent, 'RIFF')
+            && substr($sent, 8, 4) === 'WAVE'
+            && str_ends_with($sent, $pcm);
+    });
+});
+
+test('transcription throws invalid argument exception for unsupported mime type', function () {
+    Http::fake();
+
+    expect(fn () => Transcription::fromBase64(base64_encode('fake-audio'), 'audio/x-aiff')
+        ->generate(provider: 'openrouter'))
+        ->toThrow(InvalidArgumentException::class, 'Unsupported audio MIME type [audio/x-aiff]');
+
+    Http::assertNothingSent();
+});
 
 test('transcription request includes language when specified', function () {
     Http::fake(['*' => fakeOpenRouterTranscriptionResponse()]);
@@ -118,7 +147,7 @@ test('transcription uses default model when none specified', function () {
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
 
     Http::assertSent(function (Request $request) {
-        return json_decode($request->body(), true)['model'] === 'openai/gpt-4o-transcribe';
+        return json_decode($request->body(), true)['model'] === 'openai/whisper-1';
     });
 });
 
@@ -130,7 +159,7 @@ test('transcription response text is correctly parsed', function () {
     expect($response->text)->toBe('Hello, world!')
         ->and($response->segments)->toHaveCount(0)
         ->and($response->meta->provider)->toBe('openrouter')
-        ->and($response->meta->model)->toBe('openai/gpt-4o-transcribe');
+        ->and($response->meta->model)->toBe('openai/whisper-1');
 });
 
 test('transcription usage is correctly parsed', function () {
@@ -170,7 +199,7 @@ test('transcription rate limit response throws rate limited exception', function
     ]);
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
-        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-transcribe');
+        ->generate(provider: 'openrouter', model: 'openai/whisper-1');
 })->throws(RateLimitedException::class);
 
 test('transcription overloaded response throws provider overloaded exception', function () {
@@ -184,7 +213,7 @@ test('transcription overloaded response throws provider overloaded exception', f
     ]);
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
-        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-transcribe');
+        ->generate(provider: 'openrouter', model: 'openai/whisper-1');
 })->throws(ProviderOverloadedException::class);
 
 test('transcription http error response throws request exception', function () {
@@ -198,5 +227,5 @@ test('transcription http error response throws request exception', function () {
     ]);
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
-        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-transcribe');
+        ->generate(provider: 'openrouter', model: 'openai/whisper-1');
 })->throws(RequestException::class);

--- a/tests/Integration/AudioTest.php
+++ b/tests/Integration/AudioTest.php
@@ -54,4 +54,4 @@ test('transcription can be diarized', function (string $provider, string $apiKey
 
     expect(str_contains(strtolower((string) $transcription), 'how are you today'))->toBeTrue()
         ->and($transcription->segments->count())->toBeGreaterThan(0);
-})->with('tts-providers');
+})->with('diarization-providers');


### PR DESCRIPTION
# Add OpenRouter TTS and STT support

## Summary

Adds Text-to-Speech and Speech-to-Text capabilities to `OpenRouterProvider` via OpenRouter's OpenAI-compatible `/audio/speech` and `/audio/transcriptions` endpoints. 

No breaking changes — purely additive to an existing provider.

## Usage

**TTS:**

```php
use Laravel\Ai\Audio;

$response = Audio::of('Hello there!')->generate(provider: 'openrouter');

// Or with explicit model, voice, and instructions:
$response = Audio::of('Hello there!')
    ->voice('shimmer')
    ->instructions('Speak slowly and clearly')
    ->generate(
        provider: 'openrouter',
        model: 'openai/gpt-4o-mini-tts-2025-12-15',
    );

$response->mimeType();           // 'audio/mpeg'
$response->store('local', 'tts.mp3');
```

**STT:**

```php
use Laravel\Ai\Transcription;

$response = Transcription::fromPath('audio.mp3')
    ->language('en')
    ->generate(provider: 'openrouter');

$response->text;
$response->usage->promptTokens;
$response->usage->completionTokens;
```

**Stringable macro:**

```php
str('Hello there!')->toAudio(provider: 'openrouter');
```

## Implementation

- **Endpoint strategy.** Uses OpenRouter's dedicated `/audio/speech` and `/audio/transcriptions` endpoints. This matches the package's existing convention: use the OpenAI-compatible dedicated endpoint when OpenRouter offers one. Text and embeddings already go through dedicated endpoints; image generation only routes through chat completions because OpenRouter doesn't publish a dedicated images endpoint. Audio does, so we use it.

- **Single gateway.** Folded into `OpenRouterGateway` alongside text/embeddings/images. The `implements` clause collapses from three enumerated interfaces to `implements Gateway` (the umbrella interface) now that all five capabilities are present — matching `OpenAiGateway` and `GeminiGateway`.

- **Default models:**
  - TTS: `openai/gpt-4o-mini-tts-2025-12-15` (the only published id — no versionless alias exists on OpenRouter)
  - STT: `openai/gpt-4o-transcribe` (equivalent to the OpenAI provider's effective default when `diarize=false`)
  - Both are overridable via the standard `config('ai.providers.openrouter.models.{audio,transcription}.default')` keys

- **Voice aliases.** `default-female → 'alloy'`, `default-male → 'ash'` — identical to the OpenAI provider, since the default TTS model is OpenAI-routed. Any other voice name (e.g. `'shimmer'`, or `'Kore'` for Gemini-routed TTS models) is passed through verbatim.

- **Reuses existing concern traits as-is.** `CreatesOpenRouterClient` handles base URL, bearer token, and `HTTP-Referer` / `X-OpenRouter-Title` attribution headers. `HandlesFailoverErrors` maps the OpenRouter error envelope (`{"error":{"message","code"}}`) to `RateLimitedException` / `ProviderOverloadedException` / `RequestException`. No new traits, no new concerns.

## OpenRouter-specific divergence from the OpenAI API

The TTS endpoint is a clean OpenAI-compatible drop-in, but two details are worth flagging:

1. **STT body is JSON + base64, not multipart.** OpenRouter's `/audio/transcriptions` accepts a JSON body with `input_audio.data` (base64-encoded raw audio bytes — *not* a `data:` URI) plus `input_audio.format` (one of `wav|mp3|flac|m4a|ogg|webm|aac`). It is **not** `multipart/form-data` like OpenAI. A small `audioFormat()` helper maps audio MIME types to OpenRouter's format strings.

2. **TTS `response_format` defaults to `pcm`, not `mp3`.** We set `mp3` explicitly so `AudioResponse` returns `audio/mpeg` like every other TTS provider in the package.

## Diarization

OpenRouter's `/audio/transcriptions` endpoint returns only `{text, usage:{...}}` — no segments, no speaker labels, no timestamps. When a caller passes `diarize: true`, the gateway throws `LogicException` with a message naming the four providers that do support diarization (OpenAI, ElevenLabs, Mistral, Gemini). The throw happens before any HTTP work — pattern matches `AnthropicGateway`'s "this provider can't do this" precedent.

## Test coverage

- **TTS** — `tests/Feature/Providers/OpenRouter/AudioTest.php` (13 tests): request body shape, voice alias resolution (`default-female` → `alloy`, `default-male` → `ash`), custom voice passthrough, instructions inclusion/omission, default model fallback, response wrapping (base64 + `audio/mpeg` + meta), bearer token, attribution headers, rate-limit (429), overloaded (503), HTTP error (400).
- **STT** — `tests/Feature/Providers/OpenRouter/TranscriptionTest.php` (12 unique tests + 1 parameterized with 14 datasets): JSON + base64 body shape, MIME → `input_audio.format` mapping (all 14 supported MIME variants including the fallback), language pass/omit, default model fallback, text + usage parsing, `LogicException` for diarize (with `Http::assertNothingSent()` confirming the pre-flight throw), bearer token, error handling.
- **Datasets** — `tests/Datasets/Providers.php`: openrouter added to `tts-providers` and `transcription-providers`; new `diarization-providers` dataset (openai + gemini only) for the diarize integration test.
- **Integration test** — `tests/Integration/AudioTest.php`: the diarize roundtrip moves to `diarization-providers` so OpenRouter is excluded from a contract it can't satisfy. The three other integration tests (`audio can be generated`, `transcription can be generated from local path`, `audio can be transcribed after generation`) automatically pick up OpenRouter via the expanded datasets.

## Files changed

```
src/Providers/OpenRouterProvider.php                       [modified]
src/Gateway/OpenRouter/OpenRouterGateway.php               [modified]
tests/Feature/Providers/OpenRouter/AudioTest.php           [new]
tests/Feature/Providers/OpenRouter/TranscriptionTest.php   [new]
tests/Datasets/Providers.php                               [modified]
tests/Integration/AudioTest.php                            [modified]
```

No new directories. No new concern traits. No `config/ai.php` changes.
