### PR TITLE
Handle BroadcastException during stream event broadcast

### DIFF
--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Streaming\Events;
 
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Facades\Broadcast;
 
@@ -14,10 +15,14 @@ abstract class StreamEvent
      */
     public function broadcast(Channel|array $channels, bool $now = false): void
     {
-        Broadcast::on($channels)
-            ->as($this->type())
-            ->with($this->toArray())
-            ->{$now ? 'sendNow' : 'send'}();
+        try {
+            Broadcast::on($channels)
+                ->as($this->type())
+                ->with($this->toArray())
+                ->{$now ? 'sendNow' : 'send'}();
+        } catch (BroadcastException $e) {
+            report($e);
+        }
     }
 
     /**

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -1,10 +1,14 @@
 <?php
 
 use Illuminate\Broadcasting\AnonymousEvent;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Responses\StreamedAgentResponse;
+use Laravel\Ai\Streaming\Events\TextDelta;
 use Tests\Fixtures\Agents\AssistantAgent;
 
 test('then callback receives streamed agent response', function () {
@@ -126,6 +130,52 @@ test('failed event shares the invocation id with broadcasts from handle', functi
     });
 
     expect(array_values(array_unique($broadcastIds)))->toBe([$invocationId]);
+});
+
+test('broadcast swallows BroadcastException so one oversized event does not kill the stream', function () {
+    $reported = [];
+    app()->bind(ExceptionHandler::class, function () use (&$reported) {
+        return new class($reported) implements ExceptionHandler
+        {
+            public function __construct(public array &$reported) {}
+
+            public function report(Throwable $e): void
+            {
+                $this->reported[] = $e;
+            }
+
+            public function shouldReport(Throwable $e): bool
+            {
+                return true;
+            }
+
+            public function render($request, Throwable $e): mixed
+            {
+                return null;
+            }
+
+            public function renderForConsole($output, Throwable $e): void {}
+        };
+    });
+
+    $pending = Mockery::mock(AnonymousEvent::class);
+    $pending->shouldReceive('as')->andReturnSelf();
+    $pending->shouldReceive('with')->andReturnSelf();
+    $pending->shouldReceive('sendNow')->andThrow(new BroadcastException('Payload too large'));
+
+    Broadcast::shouldReceive('on')->andReturn($pending);
+
+    $event = new TextDelta(
+        id: 'evt_1',
+        messageId: 'msg_1',
+        delta: 'hello',
+        timestamp: 1_700_000_000,
+    );
+
+    $event->broadcastNow(new Channel('test-channel'));
+
+    expect($reported)->toHaveCount(1)
+        ->and($reported[0])->toBeInstanceOf(BroadcastException::class);
 });
 
 test('streamed response passed to then is fully resolved', function () {


### PR DESCRIPTION
Currently, a single oversized broadcast event (e.g. a tool result over the Pusher/Reverb 10KB WebSocket frame limit) throws `BroadcastException` and fails the entire queued `BroadcastAgent` job. The user sees a broken/hanging chat because `stream_completed` never arrives.

Fixes #174

### Approach

- Wrap the broadcast call in `StreamEvent` so that `BroadcastException` is caught and reported via the application's exception handler instead of propagating.
- One bad event no longer kills the rest of the stream — text deltas and the final stream end event still reach the client.
- No new config, no lossy defaults, no API changes. Frontends that need to filter or shape large events can still do so in user space.