### PR TITLE
Support closure provider options in queued embeddings

### DIFF
--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -69,7 +69,11 @@ class PendingEmbeddingsGeneration
     /**
      * Specify provider-specific options for embeddings generation.
      *
-     * @param  array<string, mixed>|Closure(Provider): array<string, mixed>  $options
+     * Pass a flat array to apply the same options to every selected provider,
+     * or a closure that receives the resolved Provider and returns the options
+     * for that provider. Queued closures may only capture serializable values.
+     *
+     * @param  array<string, mixed>|Closure(Provider): ?array<string, mixed>  $options
      */
     public function providerOptions(array|Closure $options): self
     {

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -17,6 +17,7 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\QueuedEmbeddingsResponse;
+use Laravel\SerializableClosure\SerializableClosure;
 
 class PendingEmbeddingsGeneration
 {
@@ -28,8 +29,8 @@ class PendingEmbeddingsGeneration
 
     protected int $timeout = 30;
 
-    /** @var array<string, mixed>|Closure(Provider): array<string, mixed> */
-    protected array|Closure $providerOptions = [];
+    /** @var array<string, mixed>|SerializableClosure */
+    protected array|SerializableClosure $providerOptions = [];
 
     public function __construct(
         protected array $inputs,
@@ -68,16 +69,13 @@ class PendingEmbeddingsGeneration
     /**
      * Specify provider-specific options for embeddings generation.
      *
-     * Pass a flat array to apply the same options to every selected provider,
-     * or a closure that receives the resolved Provider and returns the options
-     * for that provider (useful when failover targets need different options).
-     * If you intend to call queue(), the closure must be queue-serializable.
-     *
      * @param  array<string, mixed>|Closure(Provider): array<string, mixed>  $options
      */
     public function providerOptions(array|Closure $options): self
     {
-        $this->providerOptions = $options;
+        $this->providerOptions = $options instanceof Closure
+            ? new SerializableClosure($options)
+            : $options;
 
         return $this;
     }
@@ -89,7 +87,7 @@ class PendingEmbeddingsGeneration
      */
     protected function resolveProviderOptions(Provider $provider): array
     {
-        if ($this->providerOptions instanceof Closure) {
+        if ($this->providerOptions instanceof SerializableClosure) {
             return ($this->providerOptions)($provider) ?: [];
         }
 

--- a/tests/Feature/EmbeddingsProviderOptionsTest.php
+++ b/tests/Feature/EmbeddingsProviderOptionsTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Jobs\GenerateEmbeddings;
+use Laravel\Ai\PendingResponses\PendingEmbeddingsGeneration;
 use Laravel\Ai\Prompts\QueuedEmbeddingsPrompt;
 use Laravel\Ai\Providers\Provider;
 
@@ -125,6 +127,32 @@ test('closure provider options are not recorded on the queued prompt fake', func
     Embeddings::assertQueued(
         fn (QueuedEmbeddingsPrompt $prompt) => $prompt->providerOptions === [],
     );
+});
+
+test('closure provider options survive queue serialization round-trip', function () {
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+    ]);
+
+    $pending = Embeddings::for(['Hello'])
+        ->providerOptions(fn (Provider $provider) => ['input_type' => 'search_query']);
+
+    $job = new GenerateEmbeddings($pending, 'cohere', 'embed-v4.0');
+
+    $restored = unserialize(serialize($job));
+
+    expect($restored->pendingEmbeddings)->toBeInstanceOf(PendingEmbeddingsGeneration::class);
+
+    $restored->handle();
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['input_type'] ?? null) === 'search_query';
+    });
 });
 
 test('closure resolver returning null is treated as no options', function () {

--- a/tests/Integration/EmbeddingsTest.php
+++ b/tests/Integration/EmbeddingsTest.php
@@ -1,9 +1,14 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Events\EmbeddingsGenerated;
 use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 
 test('embeddings can be generated', function (string $provider, string $apiKey, int $dimensions) {
@@ -30,4 +35,51 @@ test('embeddings can be generated with custom dimensions', function (string $pro
 
     expect($response)->toBeInstanceOf(EmbeddingsResponse::class)
         ->and($response->embeddings[0])->toHaveCount(256);
+})->with('embedding-providers');
+
+test('queued embeddings with closure provider options run end-to-end through a real queue driver', function (string $provider, string $apiKey, int $dimensions) {
+    requiresApiKey($apiKey);
+
+    config([
+        'queue.default' => 'database',
+        'queue.connections.database' => [
+            'driver' => 'database',
+            'connection' => null,
+            'table' => 'jobs',
+            'queue' => 'default',
+            'retry_after' => 90,
+            'after_commit' => false,
+        ],
+    ]);
+
+    Schema::create('jobs', function (Blueprint $table) {
+        $table->bigIncrements('id');
+        $table->string('queue')->index();
+        $table->longText('payload');
+        $table->unsignedTinyInteger('attempts');
+        $table->unsignedInteger('reserved_at')->nullable();
+        $table->unsignedInteger('available_at');
+        $table->unsignedInteger('created_at');
+    });
+
+    Event::fake([EmbeddingsGenerated::class]);
+
+    Embeddings::for(['I love to watch Star Trek.'])
+        ->providerOptions(fn (Provider $resolved) => match ($resolved->driver()) {
+            'voyageai' => ['input_type' => 'query'],
+            default => [],
+        })
+        ->queue(provider: $provider);
+
+    expect(DB::table('jobs')->count())->toBe(1);
+
+    Artisan::call('queue:work', ['--once' => true, '--stop-when-empty' => true]);
+
+    expect(DB::table('jobs')->count())->toBe(0);
+
+    Event::assertDispatched(
+        EmbeddingsGenerated::class,
+        fn (EmbeddingsGenerated $event) => $event->response->meta->provider === $provider
+            && count($event->response->embeddings[0]) === $dimensions,
+    );
 })->with('embedding-providers');


### PR DESCRIPTION
Closure-form `providerOptions` were added in #555, but calling `->queue()` with one blew up at dispatch time with PHP's generic `Serialization of 'Closure' is not allowed` from inside the queue layer. This made the closure resolver effectively unusable in the queued path — the most natural use case (different `input_type` per failover provider).

### Usage

```php
Embeddings::for(['Hello'])
    ->providerOptions(fn (Provider $p) => match ($p->driver()) {
        'cohere'  => ['input_type' => 'search_query'],
        'voyageai' => ['input_type' => 'query'],
        default   => [],
    })
    ->queue(provider: ['cohere', 'voyageai']);
```
