### PR TITLE
Reject empty reranking document lists

### DIFF
--- a/src/Reranking.php
+++ b/src/Reranking.php
@@ -25,6 +25,10 @@ class Reranking
             throw new InvalidArgumentException('Documents to rerank must be a list, not an associative array.');
         }
 
+        if ($documents === []) {
+            throw new InvalidArgumentException('At least one document is required to rerank.');
+        }
+
         return new PendingReranking($documents);
     }
 

--- a/tests/Feature/RerankingFakeTest.php
+++ b/tests/Feature/RerankingFakeTest.php
@@ -6,6 +6,18 @@ use Laravel\Ai\Prompts\RerankingPrompt;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
 
+test('rerank rejects empty document list', function () {
+    Reranking::fake();
+
+    Reranking::of([])->rerank('What is Laravel?');
+})->throws(InvalidArgumentException::class, 'At least one document is required to rerank.');
+
+test('rerank rejects empty collection of documents', function () {
+    Reranking::fake();
+
+    Reranking::of(collect([]))->rerank('What is Laravel?');
+})->throws(InvalidArgumentException::class, 'At least one document is required to rerank.');
+
 test('can fake reranking', function () {
     Reranking::fake();
 


### PR DESCRIPTION
`Reranking::of([])` and `Reranking::of(collect([]))` now throw `InvalidArgumentException` with a clear message instead of sending an empty document list to providers.