### PR TITLE
Validate empty inputs across generation entry points

### DIFF
--- a/src/Audio.php
+++ b/src/Audio.php
@@ -11,13 +11,11 @@ class Audio
 {
     /**
      * Generate audio from the given text.
+     *
+     * @throws InvalidArgumentException if the given text is empty or whitespace-only.
      */
     public static function of(string $text): PendingAudioGeneration
     {
-        if (trim($text) === '') {
-            throw new InvalidArgumentException('Text content is required to generate audio.');
-        }
-
         return new PendingAudioGeneration($text);
     }
 

--- a/src/Audio.php
+++ b/src/Audio.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai;
 
 use Closure;
+use InvalidArgumentException;
 use Laravel\Ai\Gateway\FakeAudioGateway;
 use Laravel\Ai\PendingResponses\PendingAudioGeneration;
 
@@ -13,6 +14,10 @@ class Audio
      */
     public static function of(string $text): PendingAudioGeneration
     {
+        if (trim($text) === '') {
+            throw new InvalidArgumentException('Text content is required to generate audio.');
+        }
+
         return new PendingAudioGeneration($text);
     }
 

--- a/src/Files/Base64Audio.php
+++ b/src/Files/Base64Audio.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\UploadedFile;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
@@ -17,6 +18,10 @@ class Base64Audio extends Audio implements Arrayable, JsonSerializable, Storable
 
     public function __construct(public string $base64, ?string $mimeType = null)
     {
+        if (blank($base64)) {
+            throw new InvalidArgumentException('Audio content is required to generate a transcription.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/Base64Audio.php
+++ b/src/Files/Base64Audio.php
@@ -19,7 +19,7 @@ class Base64Audio extends Audio implements Arrayable, JsonSerializable, Storable
     public function __construct(public string $base64, ?string $mimeType = null)
     {
         if (blank($base64)) {
-            throw new InvalidArgumentException('Audio content is required to generate a transcription.');
+            throw new InvalidArgumentException('Base64 audio content cannot be empty.');
         }
 
         $this->mime = $mimeType;

--- a/src/Files/LocalAudio.php
+++ b/src/Files/LocalAudio.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
@@ -18,6 +19,10 @@ class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableF
 
     public function __construct(public string $path, ?string $mimeType = null)
     {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Audio file path cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/LocalImage.php
+++ b/src/Files/LocalImage.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -15,6 +16,10 @@ class LocalImage extends Image implements Arrayable, JsonSerializable, StorableF
 
     public function __construct(public string $path, ?string $mimeType = null)
     {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Image file path cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/StoredAudio.php
+++ b/src/Files/StoredAudio.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
@@ -16,7 +17,12 @@ class StoredAudio extends Audio implements Arrayable, JsonSerializable, Storable
 {
     use CanBeUploadedToProvider;
 
-    public function __construct(public string $path, public ?string $disk = null) {}
+    public function __construct(public string $path, public ?string $disk = null)
+    {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Audio file path cannot be empty.');
+        }
+    }
 
     /**
      * Get the raw representation of the file.

--- a/src/Files/StoredImage.php
+++ b/src/Files/StoredImage.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -13,7 +14,12 @@ class StoredImage extends Image implements Arrayable, JsonSerializable, Storable
 {
     use CanBeUploadedToProvider;
 
-    public function __construct(public string $path, public ?string $disk = null) {}
+    public function __construct(public string $path, public ?string $disk = null)
+    {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Image file path cannot be empty.');
+        }
+    }
 
     /**
      * Get the raw representation of the file.

--- a/src/Image.php
+++ b/src/Image.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai;
 
 use Closure;
+use InvalidArgumentException;
 use Laravel\Ai\Gateway\FakeImageGateway;
 use Laravel\Ai\PendingResponses\PendingImageGeneration;
 
@@ -13,6 +14,10 @@ class Image
      */
     public static function of(string $prompt): PendingImageGeneration
     {
+        if (trim($prompt) === '') {
+            throw new InvalidArgumentException('A prompt is required to generate an image.');
+        }
+
         return new PendingImageGeneration($prompt);
     }
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai;
 
 use Closure;
-use InvalidArgumentException;
 use Laravel\Ai\Gateway\FakeImageGateway;
 use Laravel\Ai\PendingResponses\PendingImageGeneration;
 
@@ -14,10 +13,6 @@ class Image
      */
     public static function of(string $prompt): PendingImageGeneration
     {
-        if (trim($prompt) === '') {
-            throw new InvalidArgumentException('A prompt is required to generate an image.');
-        }
-
         return new PendingImageGeneration($prompt);
     }
 

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\PendingResponses;
 
 use BackedEnum;
 use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
@@ -27,7 +28,11 @@ class PendingAudioGeneration
 
     public function __construct(
         protected string $text,
-    ) {}
+    ) {
+        if (blank($text)) {
+            throw new InvalidArgumentException('Text content is required to generate audio.');
+        }
+    }
 
     /**
      * Specify a specific voice for the generated audio.

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
@@ -32,9 +33,21 @@ class PendingEmbeddingsGeneration
     /** @var array<string, mixed>|SerializableClosure */
     protected array|SerializableClosure $providerOptions = [];
 
-    public function __construct(
-        protected array $inputs,
-    ) {}
+    /**
+     * Create a new pending embeddings generation instance.
+     *
+     * @param  string[]  $inputs
+     */
+    public function __construct(protected array $inputs)
+    {
+        if (! array_is_list($inputs)) {
+            throw new InvalidArgumentException('Inputs to embed must be a list, not an associative array.');
+        }
+
+        if (blank($inputs)) {
+            throw new InvalidArgumentException('At least one input is required to generate embeddings.');
+        }
+    }
 
     /**
      * Specify the dimensions for the embeddings.

--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\PendingResponses;
 
 use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
@@ -30,9 +31,12 @@ class PendingImageGeneration
 
     public ?int $timeout = null;
 
-    public function __construct(
-        public string $prompt,
-    ) {}
+    public function __construct(public string $prompt)
+    {
+        if (blank($prompt)) {
+            throw new InvalidArgumentException('A prompt is required to generate an image.');
+        }
+    }
 
     /**
      * Provide the reference images that should be sent with the request.

--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\PendingResponses;
 
 use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
@@ -23,7 +24,15 @@ class PendingReranking
      */
     public function __construct(
         protected array $documents,
-    ) {}
+    ) {
+        if (! array_is_list($documents)) {
+            throw new InvalidArgumentException('Documents to rerank must be a list, not an associative array.');
+        }
+
+        if (blank($documents)) {
+            throw new InvalidArgumentException('At least one document is required to rerank.');
+        }
+    }
 
     /**
      * Limit the number of results to return.

--- a/src/Reranking.php
+++ b/src/Reranking.php
@@ -14,19 +14,13 @@ class Reranking
      * Create a new pending reranking for the given documents.
      *
      * @param  Collection<int, string>|array<int, string>  $documents
+     *
+     * @throws InvalidArgumentException if the given documents are not a list or are empty.
      */
     public static function of(Collection|array $documents): PendingReranking
     {
         if ($documents instanceof Collection) {
             $documents = $documents->values()->all();
-        }
-
-        if (! array_is_list($documents)) {
-            throw new InvalidArgumentException('Documents to rerank must be a list, not an associative array.');
-        }
-
-        if ($documents === []) {
-            throw new InvalidArgumentException('At least one document is required to rerank.');
         }
 
         return new PendingReranking($documents);

--- a/src/Transcription.php
+++ b/src/Transcription.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai;
 
 use Closure;
 use Illuminate\Http\UploadedFile;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Files\Base64Audio;
 use Laravel\Ai\Files\LocalAudio;
@@ -15,6 +16,8 @@ class Transcription
 {
     /**
      * Generate a transcription of the given audio.
+     *
+     * @throws InvalidArgumentException if the given base64 audio string is empty.
      */
     public static function of(TranscribableAudio|UploadedFile|string $audio): PendingTranscriptionGeneration
     {
@@ -29,6 +32,8 @@ class Transcription
 
     /**
      * Generate a transcription of the given audio.
+     *
+     * @throws InvalidArgumentException if the given base64 audio string is empty.
      */
     public static function fromBase64(string $base64, ?string $mimeType = null): PendingTranscriptionGeneration
     {

--- a/tests/Feature/AudioFakeTest.php
+++ b/tests/Feature/AudioFakeTest.php
@@ -9,6 +9,18 @@ use Laravel\Ai\Providers\ElevenLabsProvider;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\Meta;
 
+test('audio rejects empty text', function () {
+    Audio::fake();
+
+    Audio::of('')->generate();
+})->throws(InvalidArgumentException::class, 'Text content is required to generate audio.');
+
+test('audio rejects whitespace-only text', function () {
+    Audio::fake();
+
+    Audio::of(" \t\n")->generate();
+})->throws(InvalidArgumentException::class, 'Text content is required to generate audio.');
+
 test('audio can be faked', function () {
     Audio::fake([
         base64_encode('first-audio'),

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -5,6 +5,18 @@ use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Prompts\EmbeddingsPrompt;
 use Laravel\Ai\Prompts\QueuedEmbeddingsPrompt;
 
+test('embeddings reject empty input list', function () {
+    Embeddings::fake();
+
+    Embeddings::for([])->generate();
+})->throws(InvalidArgumentException::class, 'At least one input is required to generate embeddings.');
+
+test('embeddings reject associative input array', function () {
+    Embeddings::fake();
+
+    Embeddings::for(['first' => 'Hello world'])->generate();
+})->throws(InvalidArgumentException::class, 'Inputs to embed must be a list, not an associative array.');
+
 describe('generating embeddings', function () {
     test('can fake embeddings', function () {
         Embeddings::fake();

--- a/tests/Feature/ImageFakeTest.php
+++ b/tests/Feature/ImageFakeTest.php
@@ -10,6 +10,18 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\ImageResponse;
 
+test('image rejects empty prompt', function () {
+    Image::fake();
+
+    Image::of('')->generate();
+})->throws(InvalidArgumentException::class, 'A prompt is required to generate an image.');
+
+test('image rejects whitespace-only prompt', function () {
+    Image::fake();
+
+    Image::of('   ')->generate();
+})->throws(InvalidArgumentException::class, 'A prompt is required to generate an image.');
+
 test('images can be faked', function () {
     Image::fake([
         base64_encode('first-image'),

--- a/tests/Feature/TranscriptionFakeTest.php
+++ b/tests/Feature/TranscriptionFakeTest.php
@@ -14,13 +14,13 @@ test('transcription rejects empty audio string', function () {
     Transcription::fake();
 
     Transcription::of('')->generate();
-})->throws(InvalidArgumentException::class, 'Audio content is required to generate a transcription.');
+})->throws(InvalidArgumentException::class, 'Base64 audio content cannot be empty.');
 
 test('transcription rejects empty base64 audio', function () {
     Transcription::fake();
 
     Transcription::fromBase64('')->generate();
-})->throws(InvalidArgumentException::class, 'Audio content is required to generate a transcription.');
+})->throws(InvalidArgumentException::class, 'Base64 audio content cannot be empty.');
 
 test('transcriptions can be faked', function () {
     Transcription::fake([

--- a/tests/Feature/TranscriptionFakeTest.php
+++ b/tests/Feature/TranscriptionFakeTest.php
@@ -10,6 +10,18 @@ use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use Laravel\Ai\Transcription;
 
+test('transcription rejects empty audio string', function () {
+    Transcription::fake();
+
+    Transcription::of('')->generate();
+})->throws(InvalidArgumentException::class, 'Audio content is required to generate a transcription.');
+
+test('transcription rejects empty base64 audio', function () {
+    Transcription::fake();
+
+    Transcription::fromBase64('')->generate();
+})->throws(InvalidArgumentException::class, 'Audio content is required to generate a transcription.');
+
 test('transcriptions can be faked', function () {
     Transcription::fake([
         'First transcription',

--- a/tests/Unit/Files/Base64AudioTest.php
+++ b/tests/Unit/Files/Base64AudioTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use Laravel\Ai\Files\Base64Audio;
+
+test('base64 audio rejects empty content', function () {
+    new Base64Audio('');
+})->throws(InvalidArgumentException::class, 'Base64 audio content cannot be empty.');


### PR DESCRIPTION
`Audio::of()`, `Image::of()`, `Embeddings::for()`, `Reranking::of()`, and `Transcription::of()` / `fromBase64()` now reject empty and whitespace-only input with a clear `InvalidArgumentException` before hitting providers or the queue. The same guard now lives in `Base64Audio`, `LocalAudio`, `LocalImage`, `StoredAudio`, and `StoredImage` constructors, so empty paths / content fail fast instead of blowing up downstream.

Tests cover empty and whitespace-only strings for each API.

### ⚠️ Possible breaking change

Constructing any of the following with an empty value previously succeeded and failed lazily; it now throws `InvalidArgumentException` at construction time:

- `Audio::of('')`, `Image::of('')`, `Embeddings::for([])`, `Reranking::of([])`, `Transcription::of('')` / `Transcription::fromBase64('')`
- `new Base64Audio('')`, `new LocalAudio('')`, `new LocalImage('')`, `new StoredAudio('')`, `new StoredImage('')`

