### PR TITLE
Introduce `Alias` Attribute for `Agent`

### DIFF
--- a/src/Attributes/Alias.php
+++ b/src/Attributes/Alias.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Alias
+{
+    public function __construct(public string $value)
+    {
+        //
+    }
+}

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Laravel\Ai\Attributes\Alias;
+use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
@@ -14,6 +16,7 @@ use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
+use ReflectionClass;
 
 class DatabaseConversationStore implements ConversationStore
 {
@@ -65,7 +68,7 @@ class DatabaseConversationStore implements ConversationStore
             'id' => $messageId,
             'conversation_id' => $conversationId,
             'user_id' => $userId,
-            'agent' => $prompt->agent::class,
+            'agent' => $this->aliasFor($prompt->agent),
             'role' => 'user',
             'content' => $prompt->prompt,
             'attachments' => $prompt->attachments->toJson(),
@@ -91,7 +94,7 @@ class DatabaseConversationStore implements ConversationStore
             'id' => $messageId,
             'conversation_id' => $conversationId,
             'user_id' => $userId,
-            'agent' => $prompt->agent::class,
+            'agent' => $this->aliasFor($prompt->agent),
             'role' => 'assistant',
             'content' => $response->text,
             'attachments' => '[]',
@@ -160,6 +163,18 @@ class DatabaseConversationStore implements ConversationStore
 
                 return [new AssistantMessage($record->content)];
             });
+    }
+
+    /**
+     * Resolve the alias used to persist the given agent.
+     */
+    protected function aliasFor(Agent $agent): string
+    {
+        $attributes = (new ReflectionClass($agent))->getAttributes(Alias::class);
+
+        return ! empty($attributes)
+            ? $attributes[0]->newInstance()->value
+            : $agent::class;
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -172,9 +172,7 @@ class DatabaseConversationStore implements ConversationStore
     {
         $attributes = (new ReflectionClass($agent))->getAttributes(Alias::class);
 
-        return ! empty($attributes)
-            ? $attributes[0]->newInstance()->value
-            : $agent::class;
+        return ! empty($attributes) ? $attributes[0]->newInstance()->value : $agent::class;
     }
 
     /**

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -105,6 +105,52 @@ test('it persists tool calls and results from a remembered agent prompt', functi
         ->and(json_decode($record->tool_results, true))->toBeList();
 });
 
+test('it stores the agent fully qualified class name on user messages', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Hello');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $store->storeUserMessage($conversationId, 1, $prompt);
+
+    $record = DB::table('agent_conversation_messages')
+        ->where('role', 'user')
+        ->first();
+
+    expect($record->agent)->toBe(ToolUsingAgent::class)
+        ->and($record->agent)->toBe('Tests\\Fixtures\\Agents\\ToolUsingAgent');
+});
+
+test('it stores the agent fully qualified class name on assistant messages', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Hello');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new AgentResponse('invocation-id', 'The order has shipped.', new Usage, new Meta);
+
+    $store->storeAssistantMessage($conversationId, 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')
+        ->where('role', 'assistant')
+        ->first();
+
+    expect($record->agent)->toBe(ToolUsingAgent::class)
+        ->and($record->agent)->toBe('Tests\\Fixtures\\Agents\\ToolUsingAgent');
+});
+
 test('it stores sparse keyed tool calls and results as JSON arrays', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Tool conversation');

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Tests\Fixtures\Agents\AliasedAgent;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -149,6 +150,50 @@ test('it stores the agent fully qualified class name on assistant messages', fun
 
     expect($record->agent)->toBe(ToolUsingAgent::class)
         ->and($record->agent)->toBe('Tests\\Fixtures\\Agents\\ToolUsingAgent');
+});
+
+test('it uses the Alias attribute value on user messages', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Hello');
+
+    $prompt = new AgentPrompt(
+        new AliasedAgent,
+        'Hi.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $store->storeUserMessage($conversationId, 1, $prompt);
+
+    $record = DB::table('agent_conversation_messages')
+        ->where('role', 'user')
+        ->first();
+
+    expect($record->agent)->toBe('aliased-agent');
+});
+
+test('it uses the Alias attribute value on assistant messages', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Hello');
+
+    $prompt = new AgentPrompt(
+        new AliasedAgent,
+        'Hi.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new AgentResponse('invocation-id', 'Hello back.', new Usage, new Meta);
+
+    $store->storeAssistantMessage($conversationId, 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')
+        ->where('role', 'assistant')
+        ->first();
+
+    expect($record->agent)->toBe('aliased-agent');
 });
 
 test('it stores sparse keyed tool calls and results as JSON arrays', function () {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -263,6 +263,32 @@ test('it reloads legacy sparse keyed tool calls and results as lists', function 
         ->and($messages[1]->toolResults->keys()->all())->toBe([0, 1]);
 });
 
+test('it reads messages back when the agent column holds an alias', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Aliased conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => 'aliased-agent',
+        'role' => 'user',
+        'content' => 'Hi.',
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]->content)->toBe('Hi.');
+});
+
 function createConversationSchema(?string $connection = null): void
 {
     $schema = Schema::connection($connection);

--- a/tests/Fixtures/Agents/AliasedAgent.php
+++ b/tests/Fixtures/Agents/AliasedAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Alias;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Alias('aliased-agent')]
+class AliasedAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}


### PR DESCRIPTION
This PR adds an `Alias` attribute that lets agent classes declare a stable identifier to be stored in the agent column on `agent_conversation_messages`, in place of the fully-qualified class name.

Currently, `DatabaseConversationStore` writes `$prompt->agent::class` to the agent column. This couples persisted conversation history to PHP class names, so renaming or relocating an agent class leaves historical rows referencing an outdated FQCN. By annotating an agent with `#[Alias('linear')]`, consumers can choose a stable identifier independent of class structure. Agents without the attribute continue to store their FQCN, so the change is fully backward compatible.