### PR TITLE
Add unit test for Strict attribute

### DIFF
--- a/tests/Unit/Attributes/StrictTest.php
+++ b/tests/Unit/Attributes/StrictTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Laravel\Ai\Attributes\Strict;
+use Tests\Fixtures\Tools\NonStrictTool;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
+
+test('isAppliedTo returns true when target has the attribute', function () {
+    expect(Strict::isAppliedTo(new RandomNumberGenerator))->toBeTrue();
+});
+
+test('isAppliedTo returns false when target does not have the attribute', function () {
+    expect(Strict::isAppliedTo(new NonStrictTool))->toBeFalse();
+});
+
+test('isAppliedTo returns false when target is null', function () {
+    expect(Strict::isAppliedTo(null))->toBeFalse();
+});


### PR DESCRIPTION
The `#[Strict]` attribute introduced in #530 has no direct unit test. The OpenAI gateway concerns rely on `Strict::isAppliedTo(\$target)` to decide whether to send `strict: true` or `strict: false`, so the contract is worth pinning at the attribute level rather than only at the integration boundaries.

## Coverage added

- Returns `true` when the target's class has the `#[Strict]` attribute (uses existing `RandomNumberGenerator` fixture).
- Returns `false` when the target's class does not have the attribute (uses existing `NonStrictTool` fixture).
- Returns `false` when the target is `null` — the explicit early-return path.

## Testing

```
vendor/bin/pest tests/Unit/Attributes/StrictTest.php
# 3 passed (3 assertions)
```