### PR TITLE
Add unit test for WrapsPcmAudio trait

### DIFF
--- a/tests/Unit/Gateway/Concerns/WrapsPcmAudioTest.php
+++ b/tests/Unit/Gateway/Concerns/WrapsPcmAudioTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
+
+beforeEach(function () {
+    $this->trait = new class
+    {
+        use WrapsPcmAudio {
+            pcmToWav as public;
+        }
+    };
+});
+
+test('wav header begins with RIFF/WAVE container and includes fmt and data chunks', function () {
+    $pcm = str_repeat("\x00", 64);
+
+    $wav = $this->trait->pcmToWav($pcm);
+
+    expect(substr($wav, 0, 4))->toBe('RIFF')
+        ->and(substr($wav, 8, 4))->toBe('WAVE')
+        ->and(substr($wav, 12, 4))->toBe('fmt ')
+        ->and(substr($wav, 36, 4))->toBe('data')
+        ->and(substr($wav, 44))->toBe($pcm);
+});
+
+test('wav header reports the correct riff and data chunk sizes', function () {
+    $pcm = str_repeat("\xAB", 100);
+
+    $wav = $this->trait->pcmToWav($pcm);
+
+    $riffSize = unpack('V', substr($wav, 4, 4))[1];
+    $dataSize = unpack('V', substr($wav, 40, 4))[1];
+
+    expect($riffSize)->toBe(36 + strlen($pcm))
+        ->and($dataSize)->toBe(strlen($pcm));
+});
+
+test('wav header encodes pcm format defaults (mono 16-bit at 24kHz)', function () {
+    $wav = $this->trait->pcmToWav("\x00\x00");
+
+    $fmt = unpack('Vchunk/vformat/vchannels/Vrate/Vbyte/valign/vbits', substr($wav, 16, 20));
+
+    expect($fmt['chunk'])->toBe(16)
+        ->and($fmt['format'])->toBe(1)
+        ->and($fmt['channels'])->toBe(1)
+        ->and($fmt['rate'])->toBe(24000)
+        ->and($fmt['bits'])->toBe(16)
+        ->and($fmt['byte'])->toBe(48000)
+        ->and($fmt['align'])->toBe(2);
+});
+
+test('wav header honors custom sample rate, channels, and bit depth', function () {
+    $wav = $this->trait->pcmToWav("\x00\x00", sampleRate: 44100, channels: 2, bitsPerSample: 24);
+
+    $fmt = unpack('Vchunk/vformat/vchannels/Vrate/Vbyte/valign/vbits', substr($wav, 16, 20));
+
+    expect($fmt['channels'])->toBe(2)
+        ->and($fmt['rate'])->toBe(44100)
+        ->and($fmt['bits'])->toBe(24)
+        ->and($fmt['byte'])->toBe(44100 * 2 * 24 / 8)
+        ->and($fmt['align'])->toBe(2 * 24 / 8);
+});


### PR DESCRIPTION
The `WrapsPcmAudio` trait introduced in #559 wraps raw PCM audio in a WAV container so OpenRouter can accept it as `audio/wav`. The header construction is bit-precise (RIFF/WAVE/fmt/data chunks with little-endian packed integers), and a silent regression here would corrupt every PCM-source TTS or STT call routed through OpenRouter.

The trait is currently exercised only via integration through `OpenRouterGateway::transcribe()` and `GeminiGateway::generateAudio()`, which assert end-to-end behavior but not the byte layout. This PR adds a direct unit test that pins the header structure.

## Coverage added

- RIFF/WAVE container with `fmt ` and `data` chunks at the expected offsets, and PCM payload appended after the 44-byte header.
- `RIFF` chunk size and `data` chunk size correctly report `36 + dataSize` and `dataSize` respectively.
- Default PCM-format fields: mono, 16-bit, 24kHz (the format Gemini and OpenRouter currently emit), with derived `byteRate` and `blockAlign`.
- Custom sample rate / channels / bit depth (44.1kHz stereo 24-bit) correctly recompute `byteRate` and `blockAlign`.

## Testing

```
vendor/bin/pest tests/Unit/Gateway/Concerns/WrapsPcmAudioTest.php
# 4 passed (19 assertions)
```