### PR TITLE
Add test for structured agent without Strict sends strict false

### DIFF
--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
@@ -113,6 +114,20 @@ test('structured output includes json schema text format', function () {
             && isset($format['name'])
             && isset($format['schema'])
             && $format['strict'] === true;
+    });
+});
+
+test('structured agent without Strict attribute sends strict false in text format', function () {
+    Http::fake(['*' => fakeOpenAiResponse('{"elements": []}')]);
+
+    (new NestedStructuredAgent)->prompt('List elements.', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $format = data_get($body, 'text.format');
+
+        return $format['type'] === 'json_schema'
+            && $format['strict'] === false;
     });
 });
 


### PR DESCRIPTION
PR #530 introduced opt-in strict mode via the `#[Strict]` attribute and added tests in `OpenAi/ToolMappingTest.php` covering both the strict and non-strict paths for **tools**. The equivalent non-strict path for **structured output** was not tested — the existing structured-output test in `OpenAi/RequestMappingTest.php` only exercises a structured agent that has `#[Strict]`, so `\$format['strict'] === true` is the only assertion.

This adds the missing inverse: a structured agent without `#[Strict]` should send `strict: false` in the JSON schema text format payload.

The fixture used (`NestedStructuredAgent`) is an existing test fixture that does **not** carry `#[Strict]`, so no new fixtures are introduced.

## Coverage added

- `(new NestedStructuredAgent)->prompt(...)` produces a request whose `text.format.strict` is `false` while still being a `json_schema` payload.

## Testing

```
vendor/bin/pest tests/Feature/Providers/OpenAi/RequestMappingTest.php
# 15 passed (26 assertions)
```