### PR TITLE
Add test for Anthropic 529 overloaded response

### DIFF
--- a/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -56,3 +57,20 @@ test('error in 200 response throws ai exception', function () {
         provider: 'anthropic',
     );
 })->throws(AiException::class, 'api_error');
+
+test('529 overloaded response throws provider overloaded exception', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'type' => 'error',
+            'error' => [
+                'type' => 'overloaded_error',
+                'message' => 'Overloaded',
+            ],
+        ], 529),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'anthropic',
+    );
+})->throws(ProviderOverloadedException::class);


### PR DESCRIPTION
`AnthropicGateway::overloadedStatusCodes()` overrides the default `[503]` from `HandlesFailoverErrors` to `[529]` — that's the status code Anthropic actually returns when its API is overloaded. The override has been in place for a while but has no test, so a regression that removed or changed it would only surface in production.

The existing `ErrorHandlingTest.php` covers 400 → `RequestException`, 429 → `RateLimitedException`, and 200-with-error → `AiException`, but not the Anthropic-specific 529 mapping.

## Coverage added

- 529 response with Anthropic's `overloaded_error` envelope → `ProviderOverloadedException`.

## Testing

```
vendor/bin/pest tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
# 4 passed (5 assertions)
```