### PR TITLE
Add tests for Anthropic insufficient credits patterns

### DIFF
--- a/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
@@ -40,6 +41,29 @@ test('rate limit response throws rate limited exception', function () {
         provider: 'anthropic',
     );
 })->throws(RateLimitedException::class);
+
+test('insufficient credit response throws insufficient credits exception', function (string $message) {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'type' => 'error',
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => $message,
+            ],
+        ], 400),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'anthropic',
+    );
+})->with([
+    'credit balance' => ['Your credit balance is too low to access the API.'],
+    'insufficient' => ['You have insufficient funds to complete this request.'],
+    'quota exceeded' => ['Your monthly quota exceeded the configured limit.'],
+    'exceeded your current quota' => ['You have exceeded your current quota, please check your plan.'],
+    'billing' => ['There is a billing issue with your account; please update your payment method.'],
+])->throws(InsufficientCreditsException::class);
 
 test('error in 200 response throws ai exception', function () {
     Http::fake([


### PR DESCRIPTION
`AnthropicGateway::insufficientCreditPatterns()` declares five strings — `credit balance`, `insufficient`, `quota exceeded`, `exceeded your current quota`, and `billing` — that the failover layer matches against `error.message` to route the response into `InsufficientCreditsException`. None of those five patterns have a test, so a typo or accidental removal would silently downgrade the exception to a generic `RequestException` and break failover handling on Anthropic billing errors.

This adds a parameterized test that exercises each pattern with a representative error message and asserts the right exception is thrown.

## Coverage added

| Pattern | Sample message |
|---|---|
| `credit balance` | `Your credit balance is too low to access the API.` |
| `insufficient` | `You have insufficient funds to complete this request.` |
| `quota exceeded` | `Your monthly quota exceeded the configured limit.` |
| `exceeded your current quota` | `You have exceeded your current quota, please check your plan.` |
| `billing` | `There is a billing issue with your account; please update your payment method.` |

All five datasets run the same flow: 400 response with the message in `error.message`, agent prompt fails with `InsufficientCreditsException`.

## Testing

```
vendor/bin/pest tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
# 8 passed (9 assertions)
```