### PR TITLE
Document @throws on Image::of() and Embeddings::for()

### DIFF
--- a/src/Embeddings.php
+++ b/src/Embeddings.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai;
 
 use Closure;
+use InvalidArgumentException;
 use Laravel\Ai\Gateway\FakeEmbeddingGateway;
 use Laravel\Ai\PendingResponses\PendingEmbeddingsGeneration;
 
@@ -12,6 +13,8 @@ class Embeddings
      * Get embedding vectors representing the given inputs.
      *
      * @param  string[]  $inputs
+     *
+     * @throws InvalidArgumentException if the given inputs are not a list or are empty.
      */
     public static function for(array $inputs): PendingEmbeddingsGeneration
     {

--- a/src/Image.php
+++ b/src/Image.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai;
 
 use Closure;
+use InvalidArgumentException;
 use Laravel\Ai\Gateway\FakeImageGateway;
 use Laravel\Ai\PendingResponses\PendingImageGeneration;
 
@@ -10,6 +11,8 @@ class Image
 {
     /**
      * Generate an image.
+     *
+     * @throws InvalidArgumentException if the given prompt is empty or whitespace-only.
      */
     public static function of(string $prompt): PendingImageGeneration
     {


### PR DESCRIPTION
PR #564 made `Image::of('')` and `Embeddings::for([])` throw `InvalidArgumentException` at the entry point. The sibling factories on `Audio`, `Transcription`, and `Reranking` all gained `@throws InvalidArgumentException` docblock annotations as part of that PR, but `Image` and `Embeddings` did not — so IDE intellisense and static analyzers don't surface the new exception at those two call sites.

This is a pure docblock fix; no behavior change.

### Before

```php
// Image.php
/**
 * Generate an image.
 */
public static function of(string $prompt): PendingImageGeneration

// Embeddings.php
/**
 * Get embedding vectors representing the given inputs.
 *
 * @param  string[]  $inputs
 */
public static function for(array $inputs): PendingEmbeddingsGeneration
```

### After

```php
// Image.php
/**
 * Generate an image.
 *
 * @throws InvalidArgumentException if the given prompt is empty or whitespace-only.
 */
public static function of(string $prompt): PendingImageGeneration

// Embeddings.php
/**
 * Get embedding vectors representing the given inputs.
 *
 * @param  string[]  $inputs
 *
 * @throws InvalidArgumentException if the given inputs are not a list or are empty.
 */
public static function for(array $inputs): PendingEmbeddingsGeneration
```

The wording on each line matches the actual validation in `PendingImageGeneration::__construct()` (`blank($prompt)`) and `PendingEmbeddingsGeneration::__construct()` (`array_is_list` + `blank($inputs)`).