### PR TITLE
PHP 8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,68 +1,68 @@
 {
-    "name": "laravel/ai",
-    "description": "The official AI SDK for Laravel.",
-    "license": "MIT",
-    "keywords": [
-        "laravel",
-        "ai"
-    ],
-    "homepage": "https://github.com/laravel/ai",
-    "support": {
-        "issues": "https://github.com/laravel/ai/issues",
-        "source": "https://github.com/laravel/ai"
-    },
-    "require": {
-        "php": "^8.2",
-        "aws/aws-sdk-php": "^3.339",
-        "illuminate/console": "^12.0",
-        "illuminate/container": "^12.0",
-        "illuminate/contracts": "^12.0",
-        "illuminate/filesystem": "^12.0",
-        "illuminate/json-schema": "^12.0",
-        "illuminate/support": "^12.0",
-        "laravel/prompts": "^0.3.6",
-        "laravel/serializable-closure": "^2.0"
-    },
-    "require-dev": {
-        "laravel/pint": "^1.26",
-        "mockery/mockery": "^1.6.12",
-        "orchestra/testbench": "^10.6|^11.0",
-        "pestphp/pest": "^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0|^4.0"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "autoload": {
-        "psr-4": {
-            "Laravel\\Ai\\": "src/"
-        },
-        "files": [
-            "functions.php"
-        ]
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
-    },
-    "scripts": {
-        "test": "pest",
-        "lint": "pint"
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        },
-        "laravel": {
-            "providers": [
-                "Laravel\\Ai\\AiServiceProvider"
-            ]
-        }
-    }
+	"name": "laravel/ai",
+	"description": "The official AI SDK for Laravel.",
+	"license": "MIT",
+	"keywords": [
+		"laravel",
+		"ai"
+	],
+	"homepage": "https://github.com/laravel/ai",
+	"support": {
+		"issues": "https://github.com/laravel/ai/issues",
+		"source": "https://github.com/laravel/ai"
+	},
+	"require": {
+		"php": "^8.2",
+		"aws/aws-sdk-php": "^3.339",
+		"illuminate/console": "^12.0|^13.0",
+		"illuminate/container": "^12.0|^13.0",
+		"illuminate/contracts": "^12.0|^13.0",
+		"illuminate/filesystem": "^12.0|^13.0",
+		"illuminate/json-schema": "^12.0|^13.0",
+		"illuminate/support": "^12.0|^13.0",
+		"laravel/prompts": "^0.3.6",
+		"laravel/serializable-closure": "^2.0"
+	},
+	"require-dev": {
+		"laravel/pint": "^1.26",
+		"mockery/mockery": "^1.6.12",
+		"orchestra/testbench": "^10.6|^11.0",
+		"pestphp/pest": "^3.0|^4.0",
+		"pestphp/pest-plugin-laravel": "^3.0|^4.0"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"psr-4": {
+			"Laravel\\Ai\\": "src/"
+		},
+		"files": [
+			"functions.php"
+		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Tests\\": "tests/"
+		}
+	},
+	"scripts": {
+		"test": "pest",
+		"lint": "pint"
+	},
+	"config": {
+		"sort-packages": true,
+		"allow-plugins": {
+			"pestphp/pest-plugin": true
+		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.x-dev"
+		},
+		"laravel": {
+			"providers": [
+				"Laravel\\Ai\\AiServiceProvider"
+			]
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,68 +1,68 @@
 {
-	"name": "laravel/ai",
-	"description": "The official AI SDK for Laravel.",
-	"license": "MIT",
-	"keywords": [
-		"laravel",
-		"ai"
-	],
-	"homepage": "https://github.com/laravel/ai",
-	"support": {
-		"issues": "https://github.com/laravel/ai/issues",
-		"source": "https://github.com/laravel/ai"
-	},
-	"require": {
-		"php": "^8.2",
-		"aws/aws-sdk-php": "^3.339",
-		"illuminate/console": "^12.0|^13.0",
-		"illuminate/container": "^12.0|^13.0",
-		"illuminate/contracts": "^12.0|^13.0",
-		"illuminate/filesystem": "^12.0|^13.0",
-		"illuminate/json-schema": "^12.0|^13.0",
-		"illuminate/support": "^12.0|^13.0",
-		"laravel/prompts": "^0.3.6",
-		"laravel/serializable-closure": "^2.0"
-	},
-	"require-dev": {
-		"laravel/pint": "^1.26",
-		"mockery/mockery": "^1.6.12",
-		"orchestra/testbench": "^10.6|^11.0",
-		"pestphp/pest": "^3.0|^4.0",
-		"pestphp/pest-plugin-laravel": "^3.0|^4.0"
-	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
-	"autoload": {
-		"psr-4": {
-			"Laravel\\Ai\\": "src/"
-		},
-		"files": [
-			"functions.php"
-		]
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Tests\\": "tests/"
-		}
-	},
-	"scripts": {
-		"test": "pest",
-		"lint": "pint"
-	},
-	"config": {
-		"sort-packages": true,
-		"allow-plugins": {
-			"pestphp/pest-plugin": true
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "1.x-dev"
-		},
-		"laravel": {
-			"providers": [
-				"Laravel\\Ai\\AiServiceProvider"
-			]
-		}
-	}
+    "name": "laravel/ai",
+    "description": "The official AI SDK for Laravel.",
+    "license": "MIT",
+    "keywords": [
+        "laravel",
+        "ai"
+    ],
+    "homepage": "https://github.com/laravel/ai",
+    "support": {
+        "issues": "https://github.com/laravel/ai/issues",
+        "source": "https://github.com/laravel/ai"
+    },
+    "require": {
+        "php": "^8.2",
+        "aws/aws-sdk-php": "^3.339",
+        "illuminate/console": "^12.0|^13.0",
+        "illuminate/container": "^12.0|^13.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/filesystem": "^12.0|^13.0",
+        "illuminate/json-schema": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "laravel/prompts": "^0.3.6",
+        "laravel/serializable-closure": "^2.0"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.26",
+        "mockery/mockery": "^1.6.12",
+        "orchestra/testbench": "^10.6|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Laravel\\Ai\\": "src/"
+        },
+        "files": [
+            "functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "pest",
+        "lint": "pint"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Laravel\\Ai\\AiServiceProvider"
+            ]
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         "source": "https://github.com/laravel/ai"
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "aws/aws-sdk-php": "^3.339",
-        "illuminate/console": "^12.0|^13.0",
-        "illuminate/container": "^12.0|^13.0",
-        "illuminate/contracts": "^12.0|^13.0",
-        "illuminate/filesystem": "^12.0|^13.0",
-        "illuminate/json-schema": "^12.0|^13.0",
-        "illuminate/support": "^12.0|^13.0",
+        "illuminate/console": "^12.0",
+        "illuminate/container": "^12.0",
+        "illuminate/contracts": "^12.0",
+        "illuminate/filesystem": "^12.0",
+        "illuminate/json-schema": "^12.0",
+        "illuminate/support": "^12.0",
         "laravel/prompts": "^0.3.6",
         "laravel/serializable-closure": "^2.0"
     },

--- a/src/Prompts/EmbeddingsPrompt.php
+++ b/src/Prompts/EmbeddingsPrompt.php
@@ -21,7 +21,13 @@ class EmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
+        foreach ($this->inputs as $input) {
+            if (Str::contains($input, $string)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Prompts/QueuedEmbeddingsPrompt.php
+++ b/src/Prompts/QueuedEmbeddingsPrompt.php
@@ -21,7 +21,13 @@ class QueuedEmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
+        foreach ($this->inputs as $input) {
+            if (Str::contains($input, $string)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Prompts/RerankingPrompt.php
+++ b/src/Prompts/RerankingPrompt.php
@@ -34,7 +34,13 @@ class RerankingPrompt implements Countable
      */
     public function documentsContain(string $string): bool
     {
-        return array_any($this->documents, fn ($document) => Str::contains($document, $string));
+        foreach ($this->documents as $document) {
+            if (Str::contains($document, $string)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
# Summary

Adds support for PHP 8.2; useful for Laravel 12 users who are running on PHP 8.2.

The only feature in the  project I found that's not supported in PHP 8.2 is the use of `array_any`. This has been replaced with `foreach` loops in usage sites.