### PR TITLE
Document conversations and embeddings caching config keys

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -35,6 +35,29 @@ return [
         'embeddings' => [
             'cache' => false,
             'store' => env('CACHE_STORE', 'database'),
+            'seconds' => 60 * 60 * 24 * 30,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Conversations
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure how the database-backed conversation store
+    | persists conversations and their messages. The "connection" value
+    | controls which database connection is used; the "tables" values
+    | let you customize the table names if they collide with your own.
+    | "generate_title" toggles the automatic LLM-generated title.
+    |
+    */
+
+    'conversations' => [
+        'connection' => null,
+        'generate_title' => true,
+        'tables' => [
+            'conversations' => 'agent_conversations',
+            'messages' => 'agent_conversation_messages',
         ],
     ],
 


### PR DESCRIPTION
The package reads several `ai.*` config keys that aren't declared in `config/ai.php`. The `config()` fallback defaults make them work, but users who want to customize have to grep the source code to find the keys.

This PR adds the missing entries with values that match the in-source defaults, so it's a documentation / discoverability change with no behavior change.

### Keys added

| Key | Default | Read from |
|---|---|---|
| `caching.embeddings.seconds` | `60 * 60 * 24 * 30` | `PendingResponses/PendingEmbeddingsGeneration::cache()` and `cacheStore()` |
| `conversations.connection` | `null` | `Migrations/AiMigration` and `AiServiceProvider` |
| `conversations.generate_title` | `true` | `Middleware/RememberConversation` |
| `conversations.tables.conversations` | `agent_conversations` | `Storage/DatabaseConversationStore`, `Models/Conversation`, the conversations migration |
| `conversations.tables.messages` | `agent_conversation_messages` | `Storage/DatabaseConversationStore`, `Models/ConversationMessage`, the conversations migration |

A new "Conversations" comment block is added in the same style as the existing "Caching" and "AI Providers" blocks.