### PR TITLE
Pass mime type through Image::fromUrl() and Document::fromUrl()

### DIFF
--- a/src/Files/Document.php
+++ b/src/Files/Document.php
@@ -41,9 +41,9 @@ abstract class Document extends File
     /**
      * Create a new remote document using the document at the given URL.
      */
-    public static function fromUrl(string $url): RemoteDocument
+    public static function fromUrl(string $url, ?string $mimeType = null): RemoteDocument
     {
-        return new RemoteDocument($url);
+        return new RemoteDocument($url, $mimeType);
     }
 
     /**

--- a/src/Files/Image.php
+++ b/src/Files/Image.php
@@ -33,9 +33,9 @@ abstract class Image extends File
     /**
      * Create a new remote image using the image at the given URL.
      */
-    public static function fromUrl(string $url): RemoteImage
+    public static function fromUrl(string $url, ?string $mimeType = null): RemoteImage
     {
-        return new RemoteImage($url);
+        return new RemoteImage($url, $mimeType);
     }
 
     /**


### PR DESCRIPTION
`RemoteImage` and `RemoteDocument` constructors both accept an optional `\$mimeType`, but their static factories on `Image` and `Document` only forward the URL — so callers using the canonical entry point can't set the mime type without dropping down to `new RemoteImage(\$url, \$mimeType)` directly.

`Audio::fromUrl(string \$url, ?string \$mimeType = null)` already does this correctly, so this aligns the other two with the existing pattern.

### Before

```php
// src/Files/Image.php
public static function fromUrl(string \$url): RemoteImage
{
    return new RemoteImage(\$url);
}

// src/Files/Document.php
public static function fromUrl(string \$url): RemoteDocument
{
    return new RemoteDocument(\$url);
}
```

### After

```php
// src/Files/Image.php
public static function fromUrl(string \$url, ?string \$mimeType = null): RemoteImage
{
    return new RemoteImage(\$url, \$mimeType);
}

// src/Files/Document.php
public static function fromUrl(string \$url, ?string \$mimeType = null): RemoteDocument
{
    return new RemoteDocument(\$url, \$mimeType);
}
```

Backwards compatible: existing call sites that pass only a URL keep working unchanged.