### PR TITLE
Add generic types to conversation model relationships

### DIFF
--- a/src/Concerns/HasConversations.php
+++ b/src/Concerns/HasConversations.php
@@ -9,6 +9,8 @@ trait HasConversations
 {
     /**
      * Get the conversations for the model.
+     *
+     * @return HasMany<Conversation, $this>
      */
     public function conversations(): HasMany
     {

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -38,6 +38,8 @@ class Conversation extends Model
 
     /**
      * Get the messages for the conversation.
+     *
+     * @return HasMany<ConversationMessage, $this>
      */
     public function messages(): HasMany
     {

--- a/src/Models/ConversationMessage.php
+++ b/src/Models/ConversationMessage.php
@@ -51,6 +51,8 @@ class ConversationMessage extends Model
 
     /**
      * Get the conversation that owns the message.
+     *
+     * @return BelongsTo<Conversation, $this>
      */
     public function conversation(): BelongsTo
     {


### PR DESCRIPTION
The `HasConversations` trait and the new `Conversation` / `ConversationMessage` Eloquent models added in #236 declare relationships with the bare `HasMany` / `BelongsTo` return types. Larastan / Eloquent's own generics expect `@return HasMany<RelatedModel, \$this>` and `@return BelongsTo<RelatedModel, \$this>` to know what model the relationship resolves to.

Without these, calling `\$user->conversations` returns `HasMany` instead of `Collection<int, Conversation>`, and `\$message->conversation->messages` static analysis fails. Adding the generics is a pure docblock change.

### Files

- `src/Concerns/HasConversations.php` — `conversations()` → `@return HasMany<Conversation, \$this>`
- `src/Models/Conversation.php` — `messages()` → `@return HasMany<ConversationMessage, \$this>`
- `src/Models/ConversationMessage.php` — `conversation()` → `@return BelongsTo<Conversation, \$this>`

### Verified

- `vendor/bin/pest tests/Feature/ConversationRelationshipTest.php` — passes
- `vendor/bin/phpstan` — clean
- `vendor/bin/pint` — clean

No runtime change.