### PR TITLE
Add Audio::fromUpload static factory for sibling consistency

### DIFF
--- a/src/Files/Audio.php
+++ b/src/Files/Audio.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Ai\Files;
 
+use Illuminate\Http\UploadedFile;
+
 abstract class Audio extends File
 {
     /**
@@ -34,5 +36,16 @@ abstract class Audio extends File
     public static function fromStorage(string $path, ?string $disk = null): StoredAudio
     {
         return new StoredAudio($path, $disk);
+    }
+
+    /**
+     * Create a new Base64 audio using the given file upload.
+     */
+    public static function fromUpload(UploadedFile $file, ?string $mimeType = null): Base64Audio
+    {
+        return (new Base64Audio(
+            base64_encode($file->getContent()),
+            $mimeType ?? $file->getClientMimeType(),
+        ))->as($file->getClientOriginalName());
     }
 }


### PR DESCRIPTION
The abstract `Files\Image` and `Files\Document` classes both expose a `fromUpload(UploadedFile \$file, ?string \$mimeType = null)` static factory that wraps an `UploadedFile` into the corresponding base64-encoded subclass and preserves the original filename via `->as(\$file->getClientOriginalName())`. The abstract `Files\Audio` class does not, even though `Base64Audio::fromUpload(UploadedFile)` exists at the concrete-subclass level.

This means callers building a transcription pipeline today have to choose between the inconsistent entry point `Base64Audio::fromUpload(\$request->file('audio'))` (which doesn't preserve the original filename) and the more consistent `Files\Audio::fromUpload(\$request->file('audio'))` (which currently doesn't exist).

This PR adds the missing factory using the exact pattern from `Image::fromUpload` and `Document::fromUpload`.

### Added

```php
// src/Files/Audio.php
public static function fromUpload(UploadedFile \$file, ?string \$mimeType = null): Base64Audio
{
    return (new Base64Audio(
        base64_encode(\$file->getContent()),
        \$mimeType ?? \$file->getClientMimeType(),
    ))->as(\$file->getClientOriginalName());
}
```

Backwards compatible — `Base64Audio::fromUpload()` is left in place since it has slightly different semantics (no filename preservation) and is a public static method on a concrete class.