### PR TITLE
Document @throws on AzureOpenAiGateway::generateImage()

### DIFF
--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -169,6 +169,8 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
      * @param  array<Image>  $attachments
      * @param  '3:2'|'2:3'|'1:1'|null  $size
      * @param  'low'|'medium'|'high'|null  $quality
+     *
+     * @throws LogicException if attachments are passed; Azure OpenAI does not support image edits.
      */
     public function generateImage(
         ImageProvider $provider,


### PR DESCRIPTION
`AzureOpenAiGateway::generateImage()` throws `LogicException` when the caller passes attachments (`The Azure OpenAI provider does not support image edits.`), but the docblock didn't declare it. The four corresponding methods on `AnthropicGateway` that throw `LogicException` for "not supported" cases all do declare `@throws LogicException`, so this aligns the Azure gateway with the existing convention.

Pure docblock change; no behavior change.

### Before

```php
/**
 * Generate an image.
 *
 * @param  array<Image>  \$attachments
 * @param  '3:2'|'2:3'|'1:1'|null  \$size
 * @param  'low'|'medium'|'high'|null  \$quality
 */
public function generateImage(...)
```

### After

```php
/**
 * Generate an image.
 *
 * @param  array<Image>  \$attachments
 * @param  '3:2'|'2:3'|'1:1'|null  \$size
 * @param  'low'|'medium'|'high'|null  \$quality
 *
 * @throws LogicException if attachments are passed; Azure OpenAI does not support image edits.
 */
public function generateImage(...)
```

`LogicException` was already imported at the top of the file (used by the `throw` on line 183).