### PR TITLE
Consistent provider key resolution in provider options 

### DIFF
--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -34,7 +34,7 @@ trait BuildsTextRequests
 
         $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
 
-        $providerOptions = $options?->providerOptions(Lab::Anthropic) ?? [];
+        $providerOptions = $options?->providerOptions($provider->driver()) ?? [];
 
         if (filled($schema) && $this->supportsNativeStructuredOutput($provider)) {
             $body['output_config'] = [

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Illuminate\Support\Arr;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;

--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Illuminate\Support\Arr;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;

--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -83,7 +83,7 @@ trait BuildsTextRequests
             'topP' => $options?->topP,
         ]));
 
-        $providerOptions = $options?->providerOptions(Lab::tryFrom($provider->driver()) ?? $provider->driver()) ?? [];
+        $providerOptions = $options?->providerOptions($provider->driver()) ?? [];
 
         // Hoist keys that need to be passed at top level, as everything else is passed in generationConfig
         $topLevelKeys = ['cachedContent'];

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -4,7 +4,6 @@ namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\Support\Arr;
 use Laravel\Ai\Attributes\Strict;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
@@ -45,9 +44,7 @@ trait BuildsTextRequests
             'top_p' => $options?->topP,
         ]));
 
-        $providerOptions = $options?->providerOptions(
-            Lab::tryFrom($provider->driver()) ?? $provider->driver()
-        );
+        $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {
             $body = array_merge($body, $providerOptions);

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -6,7 +6,6 @@ use Generator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\Ai\Attributes\Strict;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -383,9 +382,7 @@ trait HandlesTextStreaming
                 'max_output_tokens' => $options?->maxTokens,
             ]));
 
-            $providerOptions = $options?->providerOptions(
-                Lab::tryFrom($provider->driver()) ?? $provider->driver()
-            );
+            $providerOptions = $options?->providerOptions($provider->driver());
 
             if (filled($providerOptions)) {
                 $body = array_merge($body, $providerOptions);

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Tool;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -253,9 +252,7 @@ trait ParsesTextResponses
             'max_output_tokens' => $options?->maxTokens,
         ]));
 
-        $providerOptions = $options?->providerOptions(
-            Lab::tryFrom($provider->driver()) ?? $provider->driver()
-        );
+        $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {
             $body = array_merge($body, $providerOptions);

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -31,7 +31,9 @@ class TextGenerationOptions
     public function providerOptions(Lab|string $provider): ?array
     {
         if ($this->agent instanceof HasProviderOptions) {
-            return $this->agent->providerOptions($provider);
+            return $this->agent->providerOptions(
+                $provider instanceof Lab ? $provider : (Lab::tryFrom($provider) ?? $provider)
+            );
         }
 
         return null;

--- a/src/Gateway/Xai/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Xai/Concerns/BuildsTextRequests.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\Support\Arr;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
@@ -44,9 +43,7 @@ trait BuildsTextRequests
             'top_p' => $options?->topP,
         ]));
 
-        $providerOptions = $options?->providerOptions(
-            Lab::tryFrom($provider->driver()) ?? $provider->driver()
-        );
+        $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {
             $body = array_merge($body, $providerOptions);

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -5,7 +5,6 @@ namespace Laravel\Ai\Gateway\Xai\Concerns;
 use Generator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -372,9 +371,7 @@ trait HandlesTextStreaming
                 'max_output_tokens' => $options?->maxTokens,
             ]));
 
-            $providerOptions = $options?->providerOptions(
-                Lab::tryFrom($provider->driver()) ?? $provider->driver()
-            );
+            $providerOptions = $options?->providerOptions($provider->driver());
 
             if (filled($providerOptions)) {
                 $body = array_merge($body, $providerOptions);

--- a/src/Gateway/Xai/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Xai/Concerns/ParsesTextResponses.php
@@ -5,7 +5,6 @@ namespace Laravel\Ai\Gateway\Xai\Concerns;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Tool;
-use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -236,9 +235,7 @@ trait ParsesTextResponses
             'max_output_tokens' => $options?->maxTokens,
         ]));
 
-        $providerOptions = $options?->providerOptions(
-            Lab::tryFrom($provider->driver()) ?? $provider->driver()
-        );
+        $providerOptions = $options?->providerOptions($provider->driver());
 
         if (filled($providerOptions)) {
             $body = array_merge($body, $providerOptions);

--- a/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenRouter/ProviderOptionsTest.php
@@ -2,6 +2,10 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 
@@ -37,6 +41,36 @@ test('request body does not contain provider options when agent does not impleme
 
         return ! array_key_exists('frequency_penalty', $body)
             && ! array_key_exists('presence_penalty', $body);
+    });
+});
+
+test('agents using the docs idiom (no Lab::tryFrom workaround) have provider options reach the openrouter body', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    $agent = new class implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return match ($provider) {
+                Lab::OpenRouter => ['reasoning' => ['effort' => 'medium']],
+                default => [],
+            };
+        }
+    };
+
+    $agent->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'reasoning.effort') === 'medium';
     });
 });
 

--- a/tests/Unit/Gateway/TextGenerationOptionsTest.php
+++ b/tests/Unit/Gateway/TextGenerationOptionsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Promptable;
+
+class ProviderOptionsAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'test';
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        return match ($provider) {
+            Lab::OpenRouter => ['reasoning' => ['effort' => 'medium']],
+            Lab::Anthropic => ['thinking' => ['type' => 'enabled']],
+            default => [],
+        };
+    }
+}
+
+class NoProviderOptionsAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'test';
+    }
+}
+
+it('normalizes a string driver name to a Lab enum so the documented match idiom works', function () {
+    $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+    expect($options->providerOptions('openrouter'))
+        ->toBe(['reasoning' => ['effort' => 'medium']]);
+});
+
+it('accepts a Lab enum directly without re-normalizing', function () {
+    $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+    expect($options->providerOptions(Lab::Anthropic))
+        ->toBe(['thinking' => ['type' => 'enabled']]);
+});
+
+it('passes the raw string through when it does not match any Lab case', function () {
+    $agent = new class implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return ['received' => $provider];
+        }
+    };
+
+    $options = TextGenerationOptions::forAgent($agent);
+
+    expect($options->providerOptions('unknown-driver'))
+        ->toBe(['received' => 'unknown-driver']);
+});
+
+it('returns null when the agent does not implement HasProviderOptions', function () {
+    $options = TextGenerationOptions::forAgent(new NoProviderOptionsAgent);
+
+    expect($options->providerOptions('openai'))->toBeNull();
+});


### PR DESCRIPTION
### Summary

- Fixes #578 
- This mr makes resolution of provider key consistent, have moved boilerplate code into a centralized place in TextGenerationOptions
- RCA is explained well in root cause section [here](https://github.com/laravel/ai/issues/578)

