### PR TITLE
Rehydrate attachments when loading conversation history

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Files;
 
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\HasName;
 
 abstract class File implements HasName
@@ -15,29 +16,44 @@ abstract class File implements HasName
      */
     public static function fromArray(array $data): ?File
     {
-        $file = match ($data['type'] ?? null) {
-            'base64-image' => new Base64Image($data['base64'] ?? '', $data['mime'] ?? null),
-            'local-image' => new LocalImage($data['path'] ?? '', $data['mime'] ?? null),
-            'stored-image' => new StoredImage($data['path'] ?? '', $data['disk'] ?? null),
-            'remote-image' => new RemoteImage($data['url'] ?? '', $data['mime'] ?? null),
-            'provider-image' => new ProviderImage($data['id'] ?? ''),
-            'base64-document' => new Base64Document($data['base64'] ?? '', $data['mime'] ?? null),
-            'local-document' => new LocalDocument($data['path'] ?? '', $data['mime'] ?? null),
-            'stored-document' => new StoredDocument($data['path'] ?? '', $data['disk'] ?? null),
-            'remote-document' => new RemoteDocument($data['url'] ?? '', $data['mime'] ?? null),
-            'provider-document' => new ProviderDocument($data['id'] ?? ''),
-            'base64-audio' => new Base64Audio($data['base64'] ?? '', $data['mime'] ?? null),
-            'local-audio' => new LocalAudio($data['path'] ?? '', $data['mime'] ?? null),
-            'stored-audio' => new StoredAudio($data['path'] ?? '', $data['disk'] ?? null),
-            'remote-audio' => new RemoteAudio($data['url'] ?? '', $data['mime'] ?? null),
+        $type = $data['type'] ?? null;
+
+        if (! is_string($type)) {
+            return null;
+        }
+
+        $file = match ($type) {
+            'base64-image' => new Base64Image(self::value($data, 'base64', $type), $data['mime'] ?? null),
+            'local-image' => new LocalImage(self::value($data, 'path', $type), $data['mime'] ?? null),
+            'stored-image' => new StoredImage(self::value($data, 'path', $type), $data['disk'] ?? null),
+            'remote-image' => new RemoteImage(self::value($data, 'url', $type), $data['mime'] ?? null),
+            'provider-image' => new ProviderImage(self::value($data, 'id', $type)),
+            'base64-document' => new Base64Document(self::value($data, 'base64', $type), $data['mime'] ?? null),
+            'local-document' => new LocalDocument(self::value($data, 'path', $type), $data['mime'] ?? null),
+            'stored-document' => new StoredDocument(self::value($data, 'path', $type), $data['disk'] ?? null),
+            'remote-document' => new RemoteDocument(self::value($data, 'url', $type), $data['mime'] ?? null),
+            'provider-document' => new ProviderDocument(self::value($data, 'id', $type)),
+            'base64-audio' => new Base64Audio(self::value($data, 'base64', $type), $data['mime'] ?? null),
+            'local-audio' => new LocalAudio(self::value($data, 'path', $type), $data['mime'] ?? null),
+            'stored-audio' => new StoredAudio(self::value($data, 'path', $type), $data['disk'] ?? null),
+            'remote-audio' => new RemoteAudio(self::value($data, 'url', $type), $data['mime'] ?? null),
             default => null,
         };
 
-        if ($file !== null && isset($data['name'])) {
+        if ($file !== null && array_key_exists('name', $data)) {
             $file->as($data['name']);
         }
 
         return $file;
+    }
+
+    protected static function value(array $data, string $key, string $type): string
+    {
+        if (! isset($data[$key])) {
+            throw new InvalidArgumentException("Cannot reconstruct [{$type}] attachment because [{$key}] is missing or invalid.");
+        }
+
+        return $data[$key];
     }
 
     /**

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -11,6 +11,36 @@ abstract class File implements HasName
     public ?string $mime = null;
 
     /**
+     * Reconstruct a file instance from its array representation.
+     */
+    public static function fromArray(array $data): ?File
+    {
+        $file = match ($data['type'] ?? null) {
+            'base64-image' => new Base64Image($data['base64'] ?? '', $data['mime'] ?? null),
+            'local-image' => new LocalImage($data['path'] ?? '', $data['mime'] ?? null),
+            'stored-image' => new StoredImage($data['path'] ?? '', $data['disk'] ?? null),
+            'remote-image' => new RemoteImage($data['url'] ?? '', $data['mime'] ?? null),
+            'provider-image' => new ProviderImage($data['id'] ?? ''),
+            'base64-document' => new Base64Document($data['base64'] ?? '', $data['mime'] ?? null),
+            'local-document' => new LocalDocument($data['path'] ?? '', $data['mime'] ?? null),
+            'stored-document' => new StoredDocument($data['path'] ?? '', $data['disk'] ?? null),
+            'remote-document' => new RemoteDocument($data['url'] ?? '', $data['mime'] ?? null),
+            'provider-document' => new ProviderDocument($data['id'] ?? ''),
+            'base64-audio' => new Base64Audio($data['base64'] ?? '', $data['mime'] ?? null),
+            'local-audio' => new LocalAudio($data['path'] ?? '', $data['mime'] ?? null),
+            'stored-audio' => new StoredAudio($data['path'] ?? '', $data['disk'] ?? null),
+            'remote-audio' => new RemoteAudio($data['url'] ?? '', $data['mime'] ?? null),
+            default => null,
+        };
+
+        if ($file !== null && isset($data['name'])) {
+            $file->as($data['name']);
+        }
+
+        return $file;
+    }
+
+    /**
      * Get the displayable name of the file.
      */
     public function name(): ?string

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -7,9 +7,24 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Files\Base64Audio;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\LocalAudio;
+use Laravel\Ai\Files\LocalDocument;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\ProviderDocument;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteAudio;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredAudio;
+use Laravel\Ai\Files\StoredDocument;
+use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -125,6 +140,15 @@ class DatabaseConversationStore implements ConversationStore
                 $toolResults = collect(json_decode($record->tool_results, true))->values();
 
                 if ($record->role === 'user') {
+                    $attachments = collect(json_decode($record->attachments, true))
+                        ->map(fn (array $a) => $this->deserializeAttachment($a))
+                        ->filter()
+                        ->values();
+
+                    if ($attachments->isNotEmpty()) {
+                        return [new UserMessage($record->content, $attachments)];
+                    }
+
                     return [new Message('user', $record->content)];
                 }
 
@@ -160,6 +184,30 @@ class DatabaseConversationStore implements ConversationStore
 
                 return [new AssistantMessage($record->content)];
             });
+    }
+
+    /**
+     * Reconstruct an attachment object from its serialized array representation.
+     */
+    protected function deserializeAttachment(array $attachment): mixed
+    {
+        return match ($attachment['type'] ?? '') {
+            'base64-image' => new Base64Image($attachment['base64'], $attachment['mime'] ?? null),
+            'local-image' => new LocalImage($attachment['path'], $attachment['mime'] ?? null),
+            'stored-image' => new StoredImage($attachment['path'], $attachment['disk'] ?? null),
+            'remote-image' => new RemoteImage($attachment['url'], $attachment['mime'] ?? null),
+            'provider-image' => new ProviderImage($attachment['id']),
+            'base64-document' => new Base64Document($attachment['base64'], $attachment['mime'] ?? null),
+            'local-document' => new LocalDocument($attachment['path'], $attachment['mime'] ?? null),
+            'stored-document' => new StoredDocument($attachment['path'], $attachment['disk'] ?? null),
+            'remote-document' => new RemoteDocument($attachment['url'], $attachment['mime'] ?? null),
+            'provider-document' => new ProviderDocument($attachment['id']),
+            'base64-audio' => new Base64Audio($attachment['base64'], $attachment['mime'] ?? null),
+            'local-audio' => new LocalAudio($attachment['path'], $attachment['mime'] ?? null),
+            'stored-audio' => new StoredAudio($attachment['path'], $attachment['disk'] ?? null),
+            'remote-audio' => new RemoteAudio($attachment['url'], $attachment['mime'] ?? null),
+            default => null,
+        };
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -7,20 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\ConversationStore;
-use Laravel\Ai\Files\Base64Audio;
-use Laravel\Ai\Files\Base64Document;
-use Laravel\Ai\Files\Base64Image;
-use Laravel\Ai\Files\LocalAudio;
-use Laravel\Ai\Files\LocalDocument;
-use Laravel\Ai\Files\LocalImage;
-use Laravel\Ai\Files\ProviderDocument;
-use Laravel\Ai\Files\ProviderImage;
-use Laravel\Ai\Files\RemoteAudio;
-use Laravel\Ai\Files\RemoteDocument;
-use Laravel\Ai\Files\RemoteImage;
-use Laravel\Ai\Files\StoredAudio;
-use Laravel\Ai\Files\StoredDocument;
-use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Files\File;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -141,7 +128,7 @@ class DatabaseConversationStore implements ConversationStore
 
                 if ($record->role === 'user') {
                     $attachments = collect(json_decode($record->attachments, true))
-                        ->map(fn (array $a) => $this->deserializeAttachment($a))
+                        ->map(fn (array $attachment) => File::fromArray($attachment))
                         ->filter()
                         ->values();
 
@@ -184,30 +171,6 @@ class DatabaseConversationStore implements ConversationStore
 
                 return [new AssistantMessage($record->content)];
             });
-    }
-
-    /**
-     * Reconstruct an attachment object from its serialized array representation.
-     */
-    protected function deserializeAttachment(array $attachment): mixed
-    {
-        return match ($attachment['type'] ?? '') {
-            'base64-image' => new Base64Image($attachment['base64'], $attachment['mime'] ?? null),
-            'local-image' => new LocalImage($attachment['path'], $attachment['mime'] ?? null),
-            'stored-image' => new StoredImage($attachment['path'], $attachment['disk'] ?? null),
-            'remote-image' => new RemoteImage($attachment['url'], $attachment['mime'] ?? null),
-            'provider-image' => new ProviderImage($attachment['id']),
-            'base64-document' => new Base64Document($attachment['base64'], $attachment['mime'] ?? null),
-            'local-document' => new LocalDocument($attachment['path'], $attachment['mime'] ?? null),
-            'stored-document' => new StoredDocument($attachment['path'], $attachment['disk'] ?? null),
-            'remote-document' => new RemoteDocument($attachment['url'], $attachment['mime'] ?? null),
-            'provider-document' => new ProviderDocument($attachment['id']),
-            'base64-audio' => new Base64Audio($attachment['base64'], $attachment['mime'] ?? null),
-            'local-audio' => new LocalAudio($attachment['path'], $attachment['mime'] ?? null),
-            'stored-audio' => new StoredAudio($attachment['path'], $attachment['disk'] ?? null),
-            'remote-audio' => new RemoteAudio($attachment['url'], $attachment['mime'] ?? null),
-            default => null,
-        };
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -145,10 +146,7 @@ class DatabaseConversationStore implements ConversationStore
                 $toolResults = collect(json_decode($record->tool_results, true))->values();
 
                 if ($record->role === 'user') {
-                    $attachments = collect(json_decode($record->attachments, true))
-                        ->map(fn (array $attachment) => File::fromArray($attachment))
-                        ->filter()
-                        ->values();
+                    $attachments = $this->rehydrateAttachments($record->attachments);
 
                     if ($attachments->isNotEmpty()) {
                         return [new UserMessage($record->content, $attachments)];
@@ -189,6 +187,30 @@ class DatabaseConversationStore implements ConversationStore
 
                 return [new AssistantMessage($record->content)];
             });
+    }
+
+    protected function rehydrateAttachments(string $attachments): Collection
+    {
+        $decoded = json_decode($attachments, true);
+
+        if (! is_array($decoded) || ! array_is_list($decoded)) {
+            throw new InvalidArgumentException('Stored conversation attachments must be a JSON array.');
+        }
+
+        if ($decoded === []) {
+            return collect();
+        }
+
+        return collect($decoded)
+            ->map(function (mixed $attachment) {
+                if (! is_array($attachment)) {
+                    throw new InvalidArgumentException('Stored conversation attachment entries must be objects.');
+                }
+
+                return File::fromArray($attachment);
+            })
+            ->filter()
+            ->values();
     }
 
     /**

--- a/tests/Feature/FileFromArrayTest.php
+++ b/tests/Feature/FileFromArrayTest.php
@@ -33,6 +33,23 @@ dataset('attachment types', [
     'remote-audio' => [fn () => (new RemoteAudio('https://x/y.mp3', 'audio/mpeg'))->as('y.mp3'), RemoteAudio::class, ['url' => 'https://x/y.mp3', 'mime' => 'audio/mpeg']],
 ]);
 
+dataset('malformed attachment types', [
+    'base64-image' => [['type' => 'base64-image'], 'base64'],
+    'local-image' => [['type' => 'local-image'], 'path'],
+    'stored-image' => [['type' => 'stored-image'], 'path'],
+    'remote-image' => [['type' => 'remote-image'], 'url'],
+    'provider-image' => [['type' => 'provider-image'], 'id'],
+    'base64-document' => [['type' => 'base64-document'], 'base64'],
+    'local-document' => [['type' => 'local-document'], 'path'],
+    'stored-document' => [['type' => 'stored-document'], 'path'],
+    'remote-document' => [['type' => 'remote-document'], 'url'],
+    'provider-document' => [['type' => 'provider-document'], 'id'],
+    'base64-audio' => [['type' => 'base64-audio'], 'base64'],
+    'local-audio' => [['type' => 'local-audio'], 'path'],
+    'stored-audio' => [['type' => 'stored-audio'], 'path'],
+    'remote-audio' => [['type' => 'remote-audio'], 'url'],
+]);
+
 test('File::fromArray round-trips attachment types', function (Closure $factory, string $class, array $properties) {
     $original = $factory();
 
@@ -50,6 +67,11 @@ test('File::fromArray returns null for an unknown type', function () {
     expect(File::fromArray(['type' => 'video']))->toBeNull()
         ->and(File::fromArray([]))->toBeNull();
 });
+
+test('File::fromArray throws for malformed known attachment types', function (array $data, string $field) {
+    expect(fn () => File::fromArray($data))
+        ->toThrow(InvalidArgumentException::class, "[{$field}] is missing or invalid");
+})->with('malformed attachment types');
 
 test('File::fromArray restores the name even when toArray emits null', function () {
     $rehydrated = File::fromArray([

--- a/tests/Feature/FileFromArrayTest.php
+++ b/tests/Feature/FileFromArrayTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Laravel\Ai\Files\Base64Audio;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalAudio;
+use Laravel\Ai\Files\LocalDocument;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\ProviderDocument;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteAudio;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredAudio;
+use Laravel\Ai\Files\StoredDocument;
+use Laravel\Ai\Files\StoredImage;
+
+dataset('attachment types', [
+    'base64-image' => [fn () => (new Base64Image('aGVsbG8=', 'image/png'))->as('hi.png'), Base64Image::class, ['base64' => 'aGVsbG8=', 'mime' => 'image/png']],
+    'local-image' => [fn () => (new LocalImage('/tmp/a.png', 'image/png'))->as('a.png'), LocalImage::class, ['path' => '/tmp/a.png', 'mime' => 'image/png']],
+    'stored-image' => [fn () => (new StoredImage('photos/a.png', 'local'))->as('a.png'), StoredImage::class, ['path' => 'photos/a.png', 'disk' => 'local']],
+    'remote-image' => [fn () => (new RemoteImage('https://x/y.png', 'image/png'))->as('y.png'), RemoteImage::class, ['url' => 'https://x/y.png', 'mime' => 'image/png']],
+    'provider-image' => [fn () => (new ProviderImage('file_img_1'))->as('img.png'), ProviderImage::class, ['id' => 'file_img_1']],
+    'base64-document' => [fn () => (new Base64Document('aGVsbG8=', 'application/pdf'))->as('a.pdf'), Base64Document::class, ['base64' => 'aGVsbG8=', 'mime' => 'application/pdf']],
+    'local-document' => [fn () => (new LocalDocument('/tmp/a.pdf', 'application/pdf'))->as('a.pdf'), LocalDocument::class, ['path' => '/tmp/a.pdf', 'mime' => 'application/pdf']],
+    'stored-document' => [fn () => (new StoredDocument('docs/a.pdf', 'local'))->as('a.pdf'), StoredDocument::class, ['path' => 'docs/a.pdf', 'disk' => 'local']],
+    'remote-document' => [fn () => (new RemoteDocument('https://x/y.pdf', 'application/pdf'))->as('y.pdf'), RemoteDocument::class, ['url' => 'https://x/y.pdf', 'mime' => 'application/pdf']],
+    'provider-document' => [fn () => (new ProviderDocument('file_doc_1'))->as('doc.pdf'), ProviderDocument::class, ['id' => 'file_doc_1']],
+    'base64-audio' => [fn () => (new Base64Audio('aGVsbG8=', 'audio/mpeg'))->as('a.mp3'), Base64Audio::class, ['base64' => 'aGVsbG8=', 'mime' => 'audio/mpeg']],
+    'local-audio' => [fn () => (new LocalAudio('/tmp/a.mp3', 'audio/mpeg'))->as('a.mp3'), LocalAudio::class, ['path' => '/tmp/a.mp3', 'mime' => 'audio/mpeg']],
+    'stored-audio' => [fn () => (new StoredAudio('clips/a.mp3', 'local'))->as('a.mp3'), StoredAudio::class, ['path' => 'clips/a.mp3', 'disk' => 'local']],
+    'remote-audio' => [fn () => (new RemoteAudio('https://x/y.mp3', 'audio/mpeg'))->as('y.mp3'), RemoteAudio::class, ['url' => 'https://x/y.mp3', 'mime' => 'audio/mpeg']],
+]);
+
+test('File::fromArray round-trips attachment types', function (Closure $factory, string $class, array $properties) {
+    $original = $factory();
+
+    $rehydrated = File::fromArray($original->toArray());
+
+    expect($rehydrated)->toBeInstanceOf($class)
+        ->and($rehydrated->name())->toBe($original->name());
+
+    foreach ($properties as $property => $value) {
+        expect($rehydrated->{$property})->toBe($value);
+    }
+})->with('attachment types');
+
+test('File::fromArray returns null for an unknown type', function () {
+    expect(File::fromArray(['type' => 'video']))->toBeNull()
+        ->and(File::fromArray([]))->toBeNull();
+});
+
+test('File::fromArray restores the name even when toArray emits null', function () {
+    $rehydrated = File::fromArray([
+        'type' => 'remote-image',
+        'url' => 'https://example.com/x.png',
+        'mime' => 'image/png',
+        'name' => null,
+    ]);
+
+    expect($rehydrated)->toBeInstanceOf(RemoteImage::class)
+        ->and($rehydrated->name)->toBeNull();
+});

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -6,8 +6,12 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -170,6 +174,96 @@ test('it reloads legacy sparse keyed tool calls and results as lists', function 
         ->and($messages[0]->toolCalls->keys()->all())->toBe([0, 1])
         ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[1]->toolResults->keys()->all())->toBe([0, 1]);
+});
+
+test('user messages with stored attachments are rehydrated as UserMessage', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Attachment conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => 'Describe this image.',
+        'attachments' => json_encode([
+            ['type' => 'remote-image', 'url' => 'https://example.com/photo.jpg', 'mime' => 'image/jpeg', 'name' => null],
+        ]),
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0])->toBeInstanceOf(UserMessage::class)
+        ->and($messages[0]->content)->toBe('Describe this image.')
+        ->and($messages[0]->attachments)->toHaveCount(1)
+        ->and($messages[0]->attachments->first())->toBeInstanceOf(RemoteImage::class)
+        ->and($messages[0]->attachments->first()->url)->toBe('https://example.com/photo.jpg');
+});
+
+test('user messages with multiple attachment types are all rehydrated', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Multi-attachment conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => 'Analyze these files.',
+        'attachments' => json_encode([
+            ['type' => 'remote-image', 'url' => 'https://example.com/photo.jpg', 'mime' => 'image/jpeg', 'name' => null],
+            ['type' => 'stored-document', 'path' => 'docs/report.pdf', 'disk' => 'local', 'name' => 'report.pdf'],
+        ]),
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[0])->toBeInstanceOf(UserMessage::class)
+        ->and($messages[0]->attachments)->toHaveCount(2)
+        ->and($messages[0]->attachments[0])->toBeInstanceOf(RemoteImage::class)
+        ->and($messages[0]->attachments[1])->toBeInstanceOf(StoredDocument::class)
+        ->and($messages[0]->attachments[1]->path)->toBe('docs/report.pdf');
+});
+
+test('user messages with no attachments are returned as plain Message', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Plain conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => 'Hello.',
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[0])->toBeInstanceOf(Message::class)
+        ->and($messages[0])->not->toBeInstanceOf(UserMessage::class);
 });
 
 function createConversationSchema(?string $connection = null): void

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -266,6 +266,56 @@ test('user messages with no attachments are returned as plain Message', function
         ->and($messages[0])->not->toBeInstanceOf(UserMessage::class);
 });
 
+test('malformed stored attachment JSON fails loudly', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Malformed attachment conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => 'Describe this image.',
+        'attachments' => json_encode(['type' => 'remote-image', 'url' => 'https://example.com/photo.jpg']),
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
+        ->toThrow(InvalidArgumentException::class, 'Stored conversation attachments must be a JSON array.');
+});
+
+test('malformed known stored attachments fail loudly', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Malformed attachment conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => 'Describe this image.',
+        'attachments' => json_encode([
+            ['type' => 'remote-image', 'mime' => 'image/jpeg'],
+        ]),
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
+        ->toThrow(InvalidArgumentException::class, 'Cannot reconstruct [remote-image] attachment because [url] is missing or invalid.');
+});
+
 function createConversationSchema(?string $connection = null): void
 {
     $schema = Schema::connection($connection);


### PR DESCRIPTION
Conversations with attachments worked on the first turn but silently lost their images, documents, and audio on every follow-up. `DatabaseConversationStore` was writing the `attachments` JSON column on each user message but never reading it back, so historical user messages were returned as plain `Message` objects. Gateways gate attachment mapping on `instanceof UserMessage && attachments->isNotEmpty()`, so once the rehydration step was skipped the provider only ever saw text from turn two onwards.

Fixes #218

### Usage

```php
$agent = new VisionAgent;
$agent->forUser($user);

// Turn 1 — attachments live on the AgentPrompt, sent to the provider as expected.
$agent->prompt('What is in this photo?', [
    new RemoteImage('https://example.com/cat.jpg', 'image/jpeg'),
]);
// → "A tabby cat sitting on a windowsill, wearing a red collar."

// Turn 2 — history is loaded from the database.
$agent->continueLastConversation($user)->prompt('What colour was its collar?');

// Before this PR:
// The store returned a plain Message with no attachments, the gateway saw
// no image in the history, and the agent replied:
// → "I don't see an image in our conversation."
//
// After this PR:
// The store rehydrates the RemoteImage from the attachments column, returns a
// UserMessage, the gateway resends the image to the provider, and the agent replies:
// → "The cat's collar was red."
```