### PR TITLE
Persist tool result status (successful/error) in conversation history

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -423,8 +423,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -337,8 +337,8 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                 yield (new ToolResultEvent(
                     (string) Str::uuid(),
                     $toolResult,
-                    true,
-                    null,
+                    $toolResult->successful,
+                    $toolResult->error,
                     $timestamp,
                 ))->withInvocationId($invocationId);
             }
@@ -768,18 +768,24 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
                     $toolCall->name,
                     $toolCall->arguments,
                     'Error: Tool "'.$toolCall->name.'" not found.',
+                    null,
+                    false,
+                    'Tool "'.$toolCall->name.'" not found.',
                 );
 
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            ['result' => $result, 'successful' => $successful, 'error' => $error] = $this->executeToolSafely($tool, $toolCall->arguments);
 
             $results[] = new ToolResult(
                 $toolCall->id,
                 $toolCall->name,
                 $toolCall->arguments,
                 $result,
+                null,
+                $successful,
+                $error,
             );
         }
 

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -49,6 +49,20 @@ trait InvokesTools
     }
 
     /**
+     * Execute the given tool, returning result status alongside the output.
+     *
+     * @return array{result: string, successful: bool, error: ?string}
+     */
+    protected function executeToolSafely(Tool $tool, array $arguments): array
+    {
+        try {
+            return ['result' => $this->executeTool($tool, $arguments), 'successful' => true, 'error' => null];
+        } catch (\Throwable $e) {
+            return ['result' => $e->getMessage(), 'successful' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
      * Find a tool by its name from the given tools array.
      */
     protected function findTool(string $name, array $tools): ?Tool

--- a/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
@@ -273,8 +273,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -261,8 +261,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -229,8 +229,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -228,8 +228,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
@@ -255,8 +255,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -355,8 +355,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -250,8 +250,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -344,8 +344,8 @@ trait HandlesTextStreaming
             yield (new ToolResultEvent(
                 $this->generateEventId(),
                 $toolResult,
-                true,
-                null,
+                $toolResult->successful,
+                $toolResult->error,
                 time(),
             ))->withInvocationId($invocationId);
         }

--- a/src/Responses/Data/ToolResult.php
+++ b/src/Responses/Data/ToolResult.php
@@ -13,6 +13,8 @@ class ToolResult implements Arrayable, JsonSerializable
         public array $arguments,
         public mixed $result,
         public ?string $resultId = null,
+        public bool $successful = true,
+        public ?string $error = null,
     ) {}
 
     /**
@@ -26,6 +28,8 @@ class ToolResult implements Arrayable, JsonSerializable
             'arguments' => $this->arguments,
             'result' => $this->result,
             'result_id' => $this->resultId,
+            'successful' => $this->successful,
+            'error' => $this->error,
         ];
     }
 

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -169,6 +169,8 @@ class DatabaseConversationStore implements ConversationStore
                                 arguments: $toolResult['arguments'],
                                 result: $toolResult['result'],
                                 resultId: $toolResult['result_id'] ?? null,
+                                successful: $toolResult['successful'] ?? true,
+                                error: $toolResult['error'] ?? null,
                             ))
                         );
                     }

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -12,6 +12,7 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 
 describe('text streaming', function () {
@@ -157,6 +158,43 @@ describe('thinking blocks', function () {
 
         $reasoningDelta = array_values(array_filter($events, fn ($e) => $e instanceof ReasoningDelta))[0];
         expect($reasoningDelta->delta)->toBe('Let me think...');
+    });
+});
+
+describe('tool result status', function () {
+    test('successful tool result event has successful true and null error', function () {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([[
+                            'functionCall' => [
+                                'id' => 'call_1',
+                                'name' => 'FixedNumberGenerator',
+                                'args' => (object) [],
+                            ],
+                        ]], 10, 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([['text' => 'The number is 72019']], 20, 10),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
+
+        expect($toolResultEvents)->not->toBeEmpty()
+            ->and($toolResultEvents[0]->successful)->toBeTrue()
+            ->and($toolResultEvents[0]->error)->toBeNull();
     });
 });
 

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -137,6 +137,64 @@ test('it stores sparse keyed tool calls and results as JSON arrays', function ()
         ->and(array_is_list(json_decode($record->tool_results, true)))->toBeTrue();
 });
 
+test('it persists and rehydrates tool result successful status', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Status conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new AgentResponse('invocation-id', 'Done.', new Usage, new Meta);
+    $response->toolCalls = collect([new ToolCall('call-1', 'lookup', [])]);
+    $response->toolResults = collect([
+        new ToolResult('call-1', 'lookup', [], 'not found', null, false, 'Tool lookup failed.'),
+    ]);
+
+    $store->storeAssistantMessage($conversationId, 1, $prompt, $response);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->first()->successful)->toBeFalse()
+        ->and($messages[1]->toolResults->first()->error)->toBe('Tool lookup failed.');
+});
+
+test('it defaults successful to true when loading legacy tool results without the field', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Legacy conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Done.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup', 'arguments' => []],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup', 'arguments' => [], 'result' => 'ok'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->first()->successful)->toBeTrue()
+        ->and($messages[1]->toolResults->first()->error)->toBeNull();
+});
+
 test('it reloads legacy sparse keyed tool calls and results as lists', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Tool conversation');

--- a/tests/Unit/Responses/Data/ToolResultTest.php
+++ b/tests/Unit/Responses/Data/ToolResultTest.php
@@ -29,6 +29,8 @@ test('tool result to array returns all properties', function () {
         'arguments' => [],
         'result' => 'raw result',
         'result_id' => null,
+        'successful' => true,
+        'error' => null,
     ]);
 });
 


### PR DESCRIPTION
## Summary

Closes #334

- Adds `successful: bool` and `error: ?string` fields to `Data\ToolResult` (defaulting to `true`/`null` for backward compatibility)
- Serializes these fields to JSON when storing assistant messages, and rehydrates them when loading conversation history
- All 9 streaming gateways now derive `successful`/`error` for the `ToolResultEvent` from the `ToolResult` object rather than hardcoding `true, null`
- Adds `executeToolSafely()` to `InvokesTools` for callers that want to surface tool failures as failed results instead of propagating exceptions
- Bedrock's existing "tool not found" case now correctly sets `successful: false` on the result

## Test plan

- [ ] `it persists and rehydrates tool result successful status` — round-trips a failed result through the DB store
- [ ] `it defaults successful to true when loading legacy tool results without the field` — backward-compatible rehydration for records written before this change
- [ ] `successful tool result event has successful true and null error` — streaming event reflects the ToolResult object's status
- [ ] Existing 1031 tests continue to pass