### PR TITLE
Respect configured database connection in Conversation and ConversationMessage models

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -29,6 +29,14 @@ class Conversation extends Model
     protected $guarded = [];
 
     /**
+     * Get the database connection for the model.
+     */
+    public function getConnectionName(): ?string
+    {
+        return config('ai.conversations.connection');
+    }
+
+    /**
      * Get the table associated with the model.
      */
     public function getTable(): string

--- a/src/Models/ConversationMessage.php
+++ b/src/Models/ConversationMessage.php
@@ -42,6 +42,14 @@ class ConversationMessage extends Model
     ];
 
     /**
+     * Get the database connection for the model.
+     */
+    public function getConnectionName(): ?string
+    {
+        return config('ai.conversations.connection');
+    }
+
+    /**
      * Get the table associated with the model.
      */
     public function getTable(): string

--- a/tests/Feature/ConversationRelationshipTest.php
+++ b/tests/Feature/ConversationRelationshipTest.php
@@ -88,6 +88,40 @@ test('conversation can retrieve messages using relationship', function () {
         ->and($conversation->messages->first()->attachments)->toBeArray();
 });
 
+test('conversation model uses configured database connection', function () {
+    config(['database.connections.secondary' => [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]]);
+
+    Schema::connection('secondary')->create('agent_conversations', function (Blueprint $table) {
+        $table->string('id', 36)->primary();
+        $table->foreignId('user_id')->nullable();
+        $table->string('title');
+        $table->timestamps();
+    });
+
+    config(['ai.conversations.connection' => 'secondary']);
+
+    DB::connection('secondary')->table('agent_conversations')->insert([
+        'id' => 'secondary-conversation-1',
+        'user_id' => 1,
+        'title' => 'On Secondary DB',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $conversation = Conversation::find('secondary-conversation-1');
+
+    expect($conversation)->not->toBeNull()
+        ->and($conversation->title)->toBe('On Secondary DB')
+        ->and(DB::table('agent_conversations')->where('id', 'secondary-conversation-1')->exists())->toBeFalse();
+})->after(function () {
+    config(['ai.conversations.connection' => null]);
+});
+
 class ConversationRelationshipUser extends Model
 {
     use HasConversations;


### PR DESCRIPTION
## Problem

When `ai.conversations.connection` is configured to a secondary database, `DatabaseConversationStore`, `AiMigration`, and `AiServiceProvider` all correctly read that config — but the `Conversation` and `ConversationMessage` Eloquent models do not override `getConnectionName()`, so they always query the default database.

This means `$user->conversations()` (via `HasConversations`), `Conversation::find()`, and `$conversation->messages` silently ignore the configured connection and hit the wrong database.

## Fix

Add `getConnectionName()` to both models, returning `config('ai.conversations.connection')`. When the config is not set, `null` is returned, which causes Eloquent to fall back to the default connection — preserving existing behavior.

## Test

Added a test to `ConversationRelationshipTest` that configures a secondary in-memory SQLite connection, inserts a conversation only on that connection, then asserts `Conversation::find()` retrieves it from secondary and that the record does not exist on the default connection.