### PR TITLE
Reject blank or non-string embeddings inputs

### DIFF
--- a/src/Embeddings.php
+++ b/src/Embeddings.php
@@ -14,7 +14,7 @@ class Embeddings
      *
      * @param  string[]  $inputs
      *
-     * @throws InvalidArgumentException if the given inputs are not a list or are empty.
+     * @throws InvalidArgumentException if the given inputs are not a list, are empty, are not strings, or contain only blank strings.
      */
     public static function for(array $inputs): PendingEmbeddingsGeneration
     {

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -37,6 +37,8 @@ class PendingEmbeddingsGeneration
      * Create a new pending embeddings generation instance.
      *
      * @param  string[]  $inputs
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(protected array $inputs)
     {
@@ -50,7 +52,7 @@ class PendingEmbeddingsGeneration
 
         foreach ($inputs as $index => $input) {
             if (! is_string($input) || blank($input)) {
-                throw new InvalidArgumentException("Each input to embed must be a non-blank string (index {$index}).");
+                throw new InvalidArgumentException("The input at index {$index} must be a non-blank string.");
             }
         }
     }

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -47,6 +47,12 @@ class PendingEmbeddingsGeneration
         if (blank($inputs)) {
             throw new InvalidArgumentException('At least one input is required to generate embeddings.');
         }
+
+        foreach ($inputs as $index => $input) {
+            if (! is_string($input) || blank($input)) {
+                throw new InvalidArgumentException("Each input to embed must be a non-blank string (index {$index}).");
+            }
+        }
     }
 
     /**

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -21,19 +21,25 @@ test('embeddings reject blank string inputs', function () {
     Embeddings::fake();
 
     Embeddings::for([''])->generate();
-})->throws(InvalidArgumentException::class, 'Each input to embed must be a non-blank string (index 0).');
+})->throws(InvalidArgumentException::class, 'The input at index 0 must be a non-blank string.');
 
 test('embeddings reject whitespace-only string inputs', function () {
     Embeddings::fake();
 
     Embeddings::for([" \t\n"])->generate();
-})->throws(InvalidArgumentException::class, 'Each input to embed must be a non-blank string (index 0).');
+})->throws(InvalidArgumentException::class, 'The input at index 0 must be a non-blank string.');
 
 test('embeddings reject non-string inputs', function () {
     Embeddings::fake();
 
     Embeddings::for([123])->generate();
-})->throws(InvalidArgumentException::class, 'Each input to embed must be a non-blank string (index 0).');
+})->throws(InvalidArgumentException::class, 'The input at index 0 must be a non-blank string.');
+
+test('embeddings report the offending index for blank inputs', function () {
+    Embeddings::fake();
+
+    Embeddings::for(['valid', 'also valid', ''])->generate();
+})->throws(InvalidArgumentException::class, 'The input at index 2 must be a non-blank string.');
 
 describe('generating embeddings', function () {
     test('can fake embeddings', function () {

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -17,6 +17,24 @@ test('embeddings reject associative input array', function () {
     Embeddings::for(['first' => 'Hello world'])->generate();
 })->throws(InvalidArgumentException::class, 'Inputs to embed must be a list, not an associative array.');
 
+test('embeddings reject blank string inputs', function () {
+    Embeddings::fake();
+
+    Embeddings::for([''])->generate();
+})->throws(InvalidArgumentException::class, 'Each input to embed must be a non-blank string (index 0).');
+
+test('embeddings reject whitespace-only string inputs', function () {
+    Embeddings::fake();
+
+    Embeddings::for([" \t\n"])->generate();
+})->throws(InvalidArgumentException::class, 'Each input to embed must be a non-blank string (index 0).');
+
+test('embeddings reject non-string inputs', function () {
+    Embeddings::fake();
+
+    Embeddings::for([123])->generate();
+})->throws(InvalidArgumentException::class, 'Each input to embed must be a non-blank string (index 0).');
+
 describe('generating embeddings', function () {
     test('can fake embeddings', function () {
         Embeddings::fake();


### PR DESCRIPTION
Extends `PendingEmbeddingsGeneration` validation so each list element must be a non-blank string (after `blank()`), preventing useless provider calls for `['']`, whitespace-only strings, or non-strings. Updates `Embeddings::for()` `@throws` documentation accordingly.