### PR TITLE
Reject blank or non-string reranking documents

### DIFF
--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -32,6 +32,12 @@ class PendingReranking
         if (blank($documents)) {
             throw new InvalidArgumentException('At least one document is required to rerank.');
         }
+
+        foreach ($documents as $index => $document) {
+            if (! is_string($document) || blank($document)) {
+                throw new InvalidArgumentException("Each document to rerank must be a non-blank string (index {$index}).");
+            }
+        }
     }
 
     /**

--- a/src/Reranking.php
+++ b/src/Reranking.php
@@ -15,7 +15,7 @@ class Reranking
      *
      * @param  Collection<int, string>|array<int, string>  $documents
      *
-     * @throws InvalidArgumentException if the given documents are not a list or are empty.
+     * @throws InvalidArgumentException if the given documents are not a list, are empty, are not strings, or contain only blank strings.
      */
     public static function of(Collection|array $documents): PendingReranking
     {

--- a/tests/Feature/RerankingFakeTest.php
+++ b/tests/Feature/RerankingFakeTest.php
@@ -18,6 +18,24 @@ test('rerank rejects empty collection of documents', function () {
     Reranking::of(collect([]))->rerank('What is Laravel?');
 })->throws(InvalidArgumentException::class, 'At least one document is required to rerank.');
 
+test('rerank rejects blank document strings', function () {
+    Reranking::fake();
+
+    Reranking::of([''])->rerank('What is Laravel?');
+})->throws(InvalidArgumentException::class, 'Each document to rerank must be a non-blank string (index 0).');
+
+test('rerank rejects whitespace-only document strings', function () {
+    Reranking::fake();
+
+    Reranking::of([" \t\n"])->rerank('What is Laravel?');
+})->throws(InvalidArgumentException::class, 'Each document to rerank must be a non-blank string (index 0).');
+
+test('rerank rejects non-string documents', function () {
+    Reranking::fake();
+
+    Reranking::of([123])->rerank('What is Laravel?');
+})->throws(InvalidArgumentException::class, 'Each document to rerank must be a non-blank string (index 0).');
+
 test('can fake reranking', function () {
     Reranking::fake();
 


### PR DESCRIPTION
Aligns reranking validation with embeddings: each document must be a non-blank string so `Reranking::of([''])`, whitespace-only entries, or non-strings fail fast with a clear `InvalidArgumentException` and index. Updates `Reranking::of()` `@throws` documentation.