### PR TITLE
Reject blank model or column in SimilaritySearch::usingModel

### DIFF
--- a/src/Tools/SimilaritySearch.php
+++ b/src/Tools/SimilaritySearch.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Tool;
 
 class SimilaritySearch implements Tool
@@ -32,6 +33,14 @@ class SimilaritySearch implements Tool
         int $limit = 15,
         ?Closure $query = null): self
     {
+        if (blank($model)) {
+            throw new InvalidArgumentException('A model class name is required for similarity search.');
+        }
+
+        if (blank($column)) {
+            throw new InvalidArgumentException('A vector column name is required for similarity search.');
+        }
+
         return new self(function (string $queryString) use ($model, $column, $minSimilarity, $limit, $query) {
             $pendingQuery = $model::query()->whereVectorSimilarTo($column, $queryString, $minSimilarity);
 

--- a/tests/Feature/SimilaritySearchTest.php
+++ b/tests/Feature/SimilaritySearchTest.php
@@ -27,6 +27,14 @@ test('search results are returned', function () {
     expect(str_contains($results, json_encode($data, JSON_PRETTY_PRINT)))->toBeTrue();
 });
 
+test('using model rejects blank model class', function () {
+    SimilaritySearch::usingModel('', 'embedding');
+})->throws(InvalidArgumentException::class, 'A model class name is required for similarity search.');
+
+test('using model rejects blank column name', function () {
+    SimilaritySearch::usingModel(FakeVectorModel::class, '  ');
+})->throws(InvalidArgumentException::class, 'A vector column name is required for similarity search.');
+
 test('using model creates similarity search', function () {
     $search = SimilaritySearch::usingModel(
         FakeVectorModel::class,


### PR DESCRIPTION
`SimilaritySearch::usingModel()` now validates that the model class name and vector column are non-blank before building the query, avoiding opaque failures when either is accidentally empty or whitespace-only.