### PR TITLE
Reject blank image size and quality

### DIFF
--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -55,6 +55,10 @@ class PendingImageGeneration
      */
     public function size(string $size): self
     {
+        if (blank($size)) {
+            throw new InvalidArgumentException('Image size cannot be blank.');
+        }
+
         $this->size = $size;
 
         return $this;
@@ -97,6 +101,10 @@ class PendingImageGeneration
      */
     public function quality(string $quality): self
     {
+        if (blank($quality)) {
+            throw new InvalidArgumentException('Image quality cannot be blank.');
+        }
+
         $this->quality = $quality;
 
         return $this;

--- a/tests/Feature/ImageFakeTest.php
+++ b/tests/Feature/ImageFakeTest.php
@@ -22,6 +22,24 @@ test('image rejects whitespace-only prompt', function () {
     Image::of('   ')->generate();
 })->throws(InvalidArgumentException::class, 'A prompt is required to generate an image.');
 
+test('image rejects blank custom size', function () {
+    Image::fake();
+
+    Image::of('A sunset')->size('')->generate();
+})->throws(InvalidArgumentException::class, 'Image size cannot be blank.');
+
+test('image rejects whitespace-only custom size', function () {
+    Image::fake();
+
+    Image::of('A sunset')->size(" \t")->generate();
+})->throws(InvalidArgumentException::class, 'Image size cannot be blank.');
+
+test('image rejects blank quality', function () {
+    Image::fake();
+
+    Image::of('A sunset')->square()->quality('')->generate();
+})->throws(InvalidArgumentException::class, 'Image quality cannot be blank.');
+
 test('images can be faked', function () {
     Image::fake([
         base64_encode('first-image'),


### PR DESCRIPTION
`PendingImageGeneration::size()` and `::quality()` now reject empty or whitespace-only values with a clear `InvalidArgumentException`, avoiding useless provider requests when misconfigured.