### PR TITLE
Reject blank transcription language

### DIFF
--- a/src/PendingResponses/PendingTranscriptionGeneration.php
+++ b/src/PendingResponses/PendingTranscriptionGeneration.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\PendingResponses;
 
 use Closure;
 use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Enums\Lab;
@@ -42,6 +43,10 @@ class PendingTranscriptionGeneration
      */
     public function language(string $language): self
     {
+        if (blank($language)) {
+            throw new InvalidArgumentException('Transcription language cannot be blank.');
+        }
+
         $this->language = $language;
 
         return $this;

--- a/tests/Feature/TranscriptionFakeTest.php
+++ b/tests/Feature/TranscriptionFakeTest.php
@@ -22,6 +22,18 @@ test('transcription rejects empty base64 audio', function () {
     Transcription::fromBase64('')->generate();
 })->throws(InvalidArgumentException::class, 'Base64 audio content cannot be empty.');
 
+test('transcription rejects blank language', function () {
+    Transcription::fake();
+
+    Transcription::of(base64_encode('fake-audio'))->language('')->generate();
+})->throws(InvalidArgumentException::class, 'Transcription language cannot be blank.');
+
+test('transcription rejects whitespace-only language', function () {
+    Transcription::fake();
+
+    Transcription::of(base64_encode('fake-audio'))->language(" \t")->generate();
+})->throws(InvalidArgumentException::class, 'Transcription language cannot be blank.');
+
 test('transcriptions can be faked', function () {
     Transcription::fake([
         'First transcription',


### PR DESCRIPTION
`PendingTranscriptionGeneration::language()` now rejects empty or whitespace-only values so misconfigured ISO language hints fail fast instead of being sent to providers.