### PR TITLE
Remove image+text restriction on openrouter image generation

### DIFF
--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -169,7 +169,7 @@ class OpenRouterGateway implements Gateway
                 ->post('chat/completions', array_filter([
                     'model' => $model,
                     'messages' => $this->buildImageMessages($prompt, $attachments),
-                    'modalities' => ['image', 'text'],
+                    'modalities' => ['image'],
                     'image_config' => $imageConfig ?: null,
                 ]))
         );

--- a/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
@@ -47,7 +47,7 @@ test('image request includes model, messages, and modalities', function () {
 
         return str_contains($request->url(), 'chat/completions')
             && $body['model'] === 'google/gemini-2.5-flash-image'
-            && $body['modalities'] === ['image', 'text']
+            && $body['modalities'] === ['image']
             && $body['messages'][0]['role'] === 'user'
             && $body['messages'][0]['content'] === 'A blue circle';
     });


### PR DESCRIPTION
The current implementation of image generation using Openrouter only works on models that also support text.

`'modalities' => ['image', 'text']`

This works for something like `google/gemini-2.5-flash-image` as it supports `Output Modalities: image, text`

However a model like `sourceful/riverflow-v2-fast` that only support `Output Modalities: image` fail.

Removing the requirement of image+text resolves this, assuming that the hard coded restriction is not there for a specific purpose.

<img width="799" height="1107" alt="image" src="https://github.com/user-attachments/assets/7b066540-7eb5-46f5-8927-2db86cd0a8f8" />
