### PR TITLE
Reject blank audio voice and instructions

### DIFF
--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -39,7 +39,13 @@ class PendingAudioGeneration
      */
     public function voice(BackedEnum|string $voice): self
     {
-        $this->voice = $voice instanceof BackedEnum ? (string) $voice->value : $voice;
+        $resolved = $voice instanceof BackedEnum ? (string) $voice->value : $voice;
+
+        if (blank($resolved)) {
+            throw new InvalidArgumentException('Audio voice cannot be blank.');
+        }
+
+        $this->voice = $resolved;
 
         return $this;
     }
@@ -69,6 +75,10 @@ class PendingAudioGeneration
      */
     public function instructions(string $instructions): self
     {
+        if (blank($instructions)) {
+            throw new InvalidArgumentException('Audio instructions cannot be blank.');
+        }
+
         $this->instructions = $instructions;
 
         return $this;

--- a/tests/Feature/AudioFakeTest.php
+++ b/tests/Feature/AudioFakeTest.php
@@ -21,6 +21,30 @@ test('audio rejects whitespace-only text', function () {
     Audio::of(" \t\n")->generate();
 })->throws(InvalidArgumentException::class, 'Text content is required to generate audio.');
 
+test('audio voice rejects blank value', function () {
+    Audio::fake();
+
+    Audio::of('Hello world')->voice('');
+})->throws(InvalidArgumentException::class, 'Audio voice cannot be blank.');
+
+test('audio voice rejects whitespace-only value', function () {
+    Audio::fake();
+
+    Audio::of('Hello world')->voice(" \t\n");
+})->throws(InvalidArgumentException::class, 'Audio voice cannot be blank.');
+
+test('audio instructions rejects blank value', function () {
+    Audio::fake();
+
+    Audio::of('Hello world')->instructions('');
+})->throws(InvalidArgumentException::class, 'Audio instructions cannot be blank.');
+
+test('audio instructions rejects whitespace-only value', function () {
+    Audio::fake();
+
+    Audio::of('Hello world')->instructions(" \t\n");
+})->throws(InvalidArgumentException::class, 'Audio instructions cannot be blank.');
+
 test('audio can be faked', function () {
     Audio::fake([
         base64_encode('first-audio'),


### PR DESCRIPTION
`PendingAudioGeneration::voice()` and `PendingAudioGeneration::instructions()` previously accepted empty or whitespace-only strings, which would silently land in the request payload and produce confusing provider errors (or, for `instructions`, attach an empty system-style hint). They now reject blank values with a clear `InvalidArgumentException` at the chain site, matching the validation pattern landed for image size/quality (#593) and transcription language (#594).

For `voice()`, the validation runs after the BackedEnum unwrap so an enum case backed by an empty string is rejected the same way as a literal `''`.

### Coverage added in `tests/Feature/AudioFakeTest.php`

- `voice('')` / `voice(" \t\n")` → `Audio voice cannot be blank.`
- `instructions('')` / `instructions(" \t\n")` → `Audio instructions cannot be blank.`