### PR TITLE
Reject blank description in SimilaritySearch::withDescription()

### DIFF
--- a/src/Tools/SimilaritySearch.php
+++ b/src/Tools/SimilaritySearch.php
@@ -100,6 +100,10 @@ class SimilaritySearch implements Tool
      */
     public function withDescription(string $description): self
     {
+        if (blank($description)) {
+            throw new InvalidArgumentException('A description is required for similarity search.');
+        }
+
         $this->description = $description;
 
         return $this;

--- a/tests/Feature/SimilaritySearchTest.php
+++ b/tests/Feature/SimilaritySearchTest.php
@@ -35,6 +35,14 @@ test('using model rejects blank column name', function () {
     SimilaritySearch::usingModel(FakeVectorModel::class, '  ');
 })->throws(InvalidArgumentException::class, 'A vector column name is required for similarity search.');
 
+test('with description rejects blank value', function () {
+    SimilaritySearch::usingModel(FakeVectorModel::class, 'embedding')->withDescription('');
+})->throws(InvalidArgumentException::class, 'A description is required for similarity search.');
+
+test('with description rejects whitespace-only value', function () {
+    SimilaritySearch::usingModel(FakeVectorModel::class, 'embedding')->withDescription("  \t\n");
+})->throws(InvalidArgumentException::class, 'A description is required for similarity search.');
+
 test('using model creates similarity search', function () {
     $search = SimilaritySearch::usingModel(
         FakeVectorModel::class,


### PR DESCRIPTION
`SimilaritySearch::withDescription()` previously accepted empty or whitespace-only strings, which then surface as a blank description on the rendered tool — agents would receive a tool with no description and have no idea when to call it.

Mirrors #592, which rejected blank model and column names on the same class, and matches the broader "reject blank X" pattern recently landed across `PendingImageGeneration`, `PendingEmbeddingsGeneration`, `PendingReranking`, and `PendingTranscriptionGeneration`.

### Coverage added in `tests/Feature/SimilaritySearchTest.php`

- `withDescription('')` → `A description is required for similarity search.`
- `withDescription("  \t\n")` → same message.