### PR TITLE
Reject blank MIME type in File::withMimeType()

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -79,6 +79,10 @@ abstract class File implements HasName
      */
     public function withMimeType(string $mimeType): static
     {
+        if (blank($mimeType)) {
+            throw new InvalidArgumentException('MIME type cannot be blank.');
+        }
+
         $this->mime = $mimeType;
 
         return $this;

--- a/tests/Unit/Files/FileTest.php
+++ b/tests/Unit/Files/FileTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Laravel\Ai\Files\Base64Image;
+
+test('with mime type rejects blank value', function () {
+    (new Base64Image(base64_encode('image-bytes')))->withMimeType('');
+})->throws(InvalidArgumentException::class, 'MIME type cannot be blank.');
+
+test('with mime type rejects whitespace-only value', function () {
+    (new Base64Image(base64_encode('image-bytes')))->withMimeType("  \t\n");
+})->throws(InvalidArgumentException::class, 'MIME type cannot be blank.');


### PR DESCRIPTION
`File::withMimeType()` previously accepted empty or whitespace-only strings. Setting a blank MIME type silently corrupts the attachment payload — providers either reject the request with a confusing error or, worse, treat the file as `application/octet-stream` and skip vision/audio processing.

Mirrors the validation pattern that recently landed for `PendingImageGeneration::size()` and `::quality()` (#593), `PendingTranscriptionGeneration::language()` (#594), and `SimilaritySearch` (#592). Applies at the abstract `File` base, so all 12 file subclasses inherit the same guard.

### Coverage added in `tests/Unit/Files/FileTest.php`

- `withMimeType('')` → `MIME type cannot be blank.`
- `withMimeType("  \t\n")` → same message.