### PR TITLE
Reject blank path in LocalDocument and StoredDocument constructors

### DIFF
--- a/src/Files/LocalDocument.php
+++ b/src/Files/LocalDocument.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -15,6 +16,10 @@ class LocalDocument extends Document implements Arrayable, JsonSerializable, Sto
 
     public function __construct(public string $path, ?string $mimeType = null)
     {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Document file path cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/StoredDocument.php
+++ b/src/Files/StoredDocument.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -13,7 +14,12 @@ class StoredDocument extends Document implements Arrayable, JsonSerializable, St
 {
     use CanBeUploadedToProvider;
 
-    public function __construct(public string $path, public ?string $disk = null) {}
+    public function __construct(public string $path, public ?string $disk = null)
+    {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Document file path cannot be empty.');
+        }
+    }
 
     /**
      * Get the raw representation of the file.

--- a/tests/Unit/Files/DocumentPathTest.php
+++ b/tests/Unit/Files/DocumentPathTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\Ai\Files\LocalDocument;
+use Laravel\Ai\Files\StoredDocument;
+
+test('local document rejects empty path', function () {
+    new LocalDocument('');
+})->throws(InvalidArgumentException::class, 'Document file path cannot be empty.');
+
+test('local document rejects whitespace-only path', function () {
+    new LocalDocument("  \t\n");
+})->throws(InvalidArgumentException::class, 'Document file path cannot be empty.');
+
+test('stored document rejects empty path', function () {
+    new StoredDocument('');
+})->throws(InvalidArgumentException::class, 'Document file path cannot be empty.');
+
+test('stored document rejects whitespace-only path', function () {
+    new StoredDocument("  \t\n");
+})->throws(InvalidArgumentException::class, 'Document file path cannot be empty.');


### PR DESCRIPTION
The empty-input validation landed in #564 covered `LocalAudio`, `StoredAudio`, `LocalImage`, and `StoredImage` — each rejects a blank `path` in its constructor with a clear `InvalidArgumentException`. The two `Document` siblings (`LocalDocument`, `StoredDocument`) were missed by that PR and currently accept an empty path, which then fails downstream with a much less helpful "file does not exist" error.

This PR closes that gap so all six file path constructors validate consistently.

### Changes

- `LocalDocument::__construct()` — reject blank `\$path` with `Document file path cannot be empty.`
- `StoredDocument::__construct()` — same.
- New `tests/Unit/Files/DocumentPathTest.php` covers empty + whitespace-only for both classes.