### PR TITLE
Document @throws RuntimeException on file content() methods

### DIFF
--- a/src/Files/LocalAudio.php
+++ b/src/Files/LocalAudio.php
@@ -28,6 +28,8 @@ class LocalAudio extends Audio implements Arrayable, JsonSerializable, StorableF
 
     /**
      * Get the raw representation of the file.
+     *
+     * @throws RuntimeException if the file does not exist at the configured path.
      */
     public function content(): string
     {

--- a/src/Files/LocalDocument.php
+++ b/src/Files/LocalDocument.php
@@ -20,6 +20,8 @@ class LocalDocument extends Document implements Arrayable, JsonSerializable, Sto
 
     /**
      * Get the raw representation of the file.
+     *
+     * @throws RuntimeException if the file does not exist at the configured path.
      */
     public function content(): string
     {

--- a/src/Files/LocalImage.php
+++ b/src/Files/LocalImage.php
@@ -25,6 +25,8 @@ class LocalImage extends Image implements Arrayable, JsonSerializable, StorableF
 
     /**
      * Get the raw representation of the file.
+     *
+     * @throws RuntimeException if the file does not exist at the configured path.
      */
     public function content(): string
     {

--- a/src/Files/StoredAudio.php
+++ b/src/Files/StoredAudio.php
@@ -26,6 +26,8 @@ class StoredAudio extends Audio implements Arrayable, JsonSerializable, Storable
 
     /**
      * Get the raw representation of the file.
+     *
+     * @throws RuntimeException if the file does not exist on the configured disk.
      */
     public function content(): string
     {

--- a/src/Files/StoredDocument.php
+++ b/src/Files/StoredDocument.php
@@ -17,6 +17,8 @@ class StoredDocument extends Document implements Arrayable, JsonSerializable, St
 
     /**
      * Get the raw representation of the file.
+     *
+     * @throws RuntimeException if the file does not exist on the configured disk.
      */
     public function content(): string
     {

--- a/src/Files/StoredImage.php
+++ b/src/Files/StoredImage.php
@@ -23,6 +23,8 @@ class StoredImage extends Image implements Arrayable, JsonSerializable, Storable
 
     /**
      * Get the raw representation of the file.
+     *
+     * @throws RuntimeException if the file does not exist on the configured disk.
      */
     public function content(): string
     {


### PR DESCRIPTION
The `content()` methods on the six concrete file classes (`LocalAudio`, `StoredAudio`, `LocalImage`, `StoredImage`, `LocalDocument`, `StoredDocument`) all raise `RuntimeException` when the underlying path can't be read, but none of them documented the exception in their docblock. Static analyzers and IDE intellisense miss the failure mode at the call site.

Pure docblock change; no behavior change.

### Files

- `src/Files/LocalAudio.php`
- `src/Files/StoredAudio.php`
- `src/Files/LocalImage.php`
- `src/Files/StoredImage.php`
- `src/Files/LocalDocument.php`
- `src/Files/StoredDocument.php`

Each gains a single `@throws RuntimeException if the file does not exist...` line that matches the actual `throw` site (path-based wording for `Local*`, disk-based wording for `Stored*`). `RuntimeException` was already imported in every file.