### PR TITLE
Reject blank content in Base64Image and Base64Document constructors

### DIFF
--- a/src/Files/Base64Document.php
+++ b/src/Files/Base64Document.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\UploadedFile;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -14,6 +15,10 @@ class Base64Document extends Document implements Arrayable, JsonSerializable, St
 
     public function __construct(public string $base64, ?string $mimeType = null)
     {
+        if (blank($base64)) {
+            throw new InvalidArgumentException('Base64 document content cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/Base64Image.php
+++ b/src/Files/Base64Image.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -13,6 +14,10 @@ class Base64Image extends Image implements Arrayable, JsonSerializable, Storable
 
     public function __construct(public string $base64, ?string $mimeType = null)
     {
+        if (blank($base64)) {
+            throw new InvalidArgumentException('Base64 image content cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/tests/Unit/Files/Base64ContentTest.php
+++ b/tests/Unit/Files/Base64ContentTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+
+test('base64 image rejects empty content', function () {
+    new Base64Image('');
+})->throws(InvalidArgumentException::class, 'Base64 image content cannot be empty.');
+
+test('base64 image rejects whitespace-only content', function () {
+    new Base64Image("  \t\n");
+})->throws(InvalidArgumentException::class, 'Base64 image content cannot be empty.');
+
+test('base64 document rejects empty content', function () {
+    new Base64Document('');
+})->throws(InvalidArgumentException::class, 'Base64 document content cannot be empty.');
+
+test('base64 document rejects whitespace-only content', function () {
+    new Base64Document("  \t\n");
+})->throws(InvalidArgumentException::class, 'Base64 document content cannot be empty.');


### PR DESCRIPTION
`Base64Audio::__construct()` already rejects blank base64 content with a clear `InvalidArgumentException`, but the two sibling base64 file types (`Base64Image`, `Base64Document`) accept any string. An empty base64 attachment then ships to the provider as a zero-byte file, which surfaces as a confusing 4xx error from each provider.

This PR closes the gap so all three `Base64*` constructors validate consistently. Mirrors the path-validation pattern landed for `LocalAudio`/`StoredAudio`/`LocalImage`/`StoredImage` in #564 and the recent "reject blank X" wave (#590, #591, #593, #594).

### Changes

- `Base64Image::__construct()` — reject blank `\$base64` with `Base64 image content cannot be empty.`
- `Base64Document::__construct()` — reject blank `\$base64` with `Base64 document content cannot be empty.`
- New `tests/Unit/Files/Base64ContentTest.php` covers empty + whitespace-only for both classes.