### PR TITLE
Fail loudly when stored conversation attachments cannot be reconstructed

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -207,9 +207,16 @@ class DatabaseConversationStore implements ConversationStore
                     throw new InvalidArgumentException('Stored conversation attachment entries must be objects.');
                 }
 
-                return File::fromArray($attachment);
+                $file = File::fromArray($attachment);
+
+                if ($file === null) {
+                    $type = $attachment['type'] ?? 'unknown';
+
+                    throw new InvalidArgumentException("Cannot reconstruct stored conversation attachment because [{$type}] is unknown or invalid.");
+                }
+
+                return $file;
             })
-            ->filter()
             ->values();
     }
 

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -290,6 +290,32 @@ test('malformed stored attachment JSON fails loudly', function () {
         ->toThrow(InvalidArgumentException::class, 'Stored conversation attachments must be a JSON array.');
 });
 
+test('unknown stored attachment type fails loudly', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Unknown attachment conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => 'Describe this video.',
+        'attachments' => json_encode([
+            ['type' => 'video', 'url' => 'https://example.com/clip.mp4'],
+        ]),
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
+        ->toThrow(InvalidArgumentException::class, 'Cannot reconstruct stored conversation attachment because [video] is unknown or invalid.');
+});
+
 test('malformed known stored attachments fail loudly', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Malformed attachment conversation');


### PR DESCRIPTION
When reloading remembered conversations, unknown or invalid attachment types were silently dropped via `filter()` after `File::fromArray()` returned null. That could make user messages lose attachments without any error.

This throws an `InvalidArgumentException` instead, consistent with existing loud failures for malformed attachment JSON and missing required fields.