### PR TITLE
Throw InsufficientCreditsException for Mistral billing errors

### DIFF
--- a/src/Gateway/Concerns/HandlesFailoverErrors.php
+++ b/src/Gateway/Concerns/HandlesFailoverErrors.php
@@ -39,7 +39,7 @@ trait HandlesFailoverErrors
                 }
 
                 if ($patterns = $this->insufficientCreditPatterns()) {
-                    $message = strtolower($e->response->json('error.message', ''));
+                    $message = strtolower($e->response->json($this->insufficientCreditMessagePath(), ''));
 
                     foreach ($patterns as $pattern) {
                         if (str_contains($message, $pattern)) {
@@ -73,5 +73,13 @@ trait HandlesFailoverErrors
     protected function insufficientCreditPatterns(): array
     {
         return [];
+    }
+
+    /**
+     * The JSON path used to extract the error message for credit pattern matching.
+     */
+    protected function insufficientCreditMessagePath(): string
+    {
+        return 'error.message';
     }
 }

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -205,6 +205,29 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Mistral errors use a flat format: {"object":"error","message":"...","type":"..."},
+     * so the message lives at the root "message" key, not nested under "error".
+     */
+    protected function insufficientCreditMessagePath(): string
+    {
+        return 'message';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function insufficientCreditPatterns(): array
+    {
+        return [
+            'insufficient credits',
+            'credit balance',
+            'billing',
+        ];
+    }
+
+    /**
      * Determine the appropriate filename for the audio file based on its MIME type.
      */
     protected function audioFilename(TranscribableAudio $audio): string

--- a/tests/Feature/Providers/Mistral/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Mistral/ErrorHandlingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
@@ -49,6 +50,22 @@ test('overloaded response throws provider overloaded exception', function () {
 
     (new AssistantAgent)->prompt('Hi', provider: 'mistral');
 })->throws(ProviderOverloadedException::class);
+
+test('insufficient credit response throws insufficient credits exception', function (string $message) {
+    Http::fake([
+        'api.mistral.ai/*' => Http::response([
+            'object' => 'error',
+            'message' => $message,
+            'type' => 'billing_error',
+        ], 402),
+    ]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'mistral');
+})->with([
+    'insufficient credits' => ['You have insufficient credits to process this request.'],
+    'credit balance' => ['Your credit balance has been exhausted.'],
+    'billing' => ['There is a billing issue with your account.'],
+])->throws(InsufficientCreditsException::class);
 
 test('error in 200 response throws ai exception', function () {
     Http::fake([


### PR DESCRIPTION
## Summary

- Mistral uses a flat error envelope (`{"object":"error","message":"...","type":"..."}`) rather than the nested `{"error":{"message":"..."}}` format used by all other OpenAI-compatible providers
- `HandlesFailoverErrors::withErrorHandling` was reading `error.message` via dot-notation, which returns an empty string for Mistral's flat format — so adding `insufficientCreditPatterns()` to `MistralGateway` alone would have silently never matched
- Adds `insufficientCreditMessagePath(): string` hook to `HandlesFailoverErrors` (defaults to `'error.message'`, preserving existing behavior for all other gateways)
- `MistralGateway` overrides it to `'message'` and adds `insufficientCreditPatterns()` so billing errors now surface as `InsufficientCreditsException` instead of a generic `RequestException`

## Test plan

- [x] `tests/Feature/Providers/Mistral/ErrorHandlingTest.php` — all 7 tests pass including 3 dataset cases for insufficient credits
- [x] `tests/Feature/Providers/Anthropic/ErrorHandlingTest.php` — all 9 tests still pass (default path unchanged)