### PR TITLE
Bump PHPStan to level 1 and fix type errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,4 +4,4 @@ parameters:
     - src
     - database
 
-  level: 0
+  level: 1

--- a/src/Ai.php
+++ b/src/Ai.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @see AiManager
+ *
  * @mixin AiManager
  */
 class Ai extends Facade

--- a/src/Ai.php
+++ b/src/Ai.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @see AiManager
+ * @mixin AiManager
  */
 class Ai extends Facade
 {

--- a/src/Responses/TranscriptionResponse.php
+++ b/src/Responses/TranscriptionResponse.php
@@ -23,7 +23,7 @@ class TranscriptionResponse
         Meta $meta,
     ) {
         $this->text = $text;
-        $this->segments = $segments ?? new Collection;
+        $this->segments = $segments;
         $this->usage = $usage;
         $this->meta = $meta;
     }


### PR DESCRIPTION
PHPStan was sitting at level 0 with no enforcement. This bumps it to level 1 and fixes the two errors that surface.

`@mixin AiManager` is added to the `Ai` facade so PHPStan can resolve the static methods delegated through `__callStatic`. The null coalesce on `TranscriptionResponse::$segments` is removed since the parameter is typed as non-nullable `Collection`, making `?? new Collection` unreachable dead code.