### PR TITLE
Allow agents to exclude stream events from broadcast

### DIFF
--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Streaming\BroadcastStreamEventFilter;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Throwable;
@@ -45,6 +46,10 @@ class BroadcastAgent implements ShouldQueue
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
             ->each(function (StreamEvent $event) {
+                if (! BroadcastStreamEventFilter::shouldBroadcast($this->agent, $event)) {
+                    return;
+                }
+
                 $event->withInvocationId($this->invocationId)->broadcastNow($this->channels);
             })
             ->then(function ($response) use (&$streamedResponse) {

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -26,6 +26,7 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\QueuedAgentResponse;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
+use Laravel\Ai\Streaming\BroadcastStreamEventFilter;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use ReflectionClass;
 use RuntimeException;
@@ -149,12 +150,26 @@ trait Promptable
     }
 
     /**
+     * The stream event classes that should not be broadcast.
+     *
+     * @return list<class-string<StreamEvent>>
+     */
+    public function exceptBroadcastStreamEvents(): array
+    {
+        return [];
+    }
+
+    /**
      * Invoke the agent with a given prompt and broadcast the streamed events.
      */
     public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         return $this->stream($prompt, $attachments, $provider, $model)
             ->each(function (StreamEvent $event) use ($channels, $now) {
+                if (! BroadcastStreamEventFilter::shouldBroadcast($this, $event)) {
+                    return;
+                }
+
                 $event->{$now ? 'broadcastNow' : 'broadcast'}($channels);
             });
     }

--- a/src/Streaming/BroadcastStreamEventFilter.php
+++ b/src/Streaming/BroadcastStreamEventFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Ai\Streaming;
+
+use Laravel\Ai\Streaming\Events\StreamEvent;
+
+final class BroadcastStreamEventFilter
+{
+    /**
+     * Determine if the given stream event should be broadcast for the agent.
+     */
+    public static function shouldBroadcast(object $agent, StreamEvent $event): bool
+    {
+        if (! method_exists($agent, 'exceptBroadcastStreamEvents')) {
+            return true;
+        }
+
+        $except = $agent->exceptBroadcastStreamEvents();
+
+        return $except === [] || ! in_array($event::class, $except, true);
+    }
+}

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -5,7 +5,12 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Responses\StreamedAgentResponse;
+use Laravel\Ai\Streaming\BroadcastStreamEventFilter;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextStart;
 use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\BroadcastFilteringAgent;
 
 test('then callback receives streamed agent response', function () {
     Event::fake();
@@ -126,6 +131,47 @@ test('failed event shares the invocation id with broadcasts from handle', functi
     });
 
     expect(array_values(array_unique($broadcastIds)))->toBe([$invocationId]);
+});
+
+test('broadcast agent skips excluded stream event classes', function () {
+    Event::fake();
+    BroadcastFilteringAgent::fake(['Hello world']);
+
+    $job = new BroadcastAgent(
+        agent: new BroadcastFilteringAgent,
+        prompt: 'Say hello',
+        channels: new Channel('test-channel'),
+    );
+
+    $job->handle();
+
+    Event::assertDispatched(AnonymousEvent::class, fn (AnonymousEvent $event) => $event->broadcastAs() === 'stream_start');
+    Event::assertDispatched(AnonymousEvent::class, fn (AnonymousEvent $event) => $event->broadcastAs() === 'stream_end');
+    Event::assertNotDispatched(AnonymousEvent::class, fn (AnonymousEvent $event) => $event->broadcastAs() === 'text_delta');
+});
+
+test('broadcast skips excluded stream event classes when streaming synchronously', function () {
+    Event::fake();
+    BroadcastFilteringAgent::fake(['Hello world']);
+
+    (new BroadcastFilteringAgent)->broadcastNow('Say hello', new Channel('test-channel'));
+
+    Event::assertDispatched(AnonymousEvent::class, fn (AnonymousEvent $event) => $event->broadcastAs() === 'stream_end');
+    Event::assertNotDispatched(AnonymousEvent::class, fn (AnonymousEvent $event) => $event->broadcastAs() === 'text_delta');
+});
+
+test('broadcast stream event filter allows all events by default', function () {
+    $agent = new AssistantAgent;
+
+    expect(BroadcastStreamEventFilter::shouldBroadcast($agent, new StreamStart('id', 'openai', 'gpt-4', time())))->toBeTrue()
+        ->and(BroadcastStreamEventFilter::shouldBroadcast($agent, new TextDelta('id', 'msg', 'Hi', time())))->toBeTrue();
+});
+
+test('broadcast stream event filter respects excluded classes', function () {
+    $agent = new BroadcastFilteringAgent;
+
+    expect(BroadcastStreamEventFilter::shouldBroadcast($agent, new TextStart('id', 'msg', time())))->toBeTrue()
+        ->and(BroadcastStreamEventFilter::shouldBroadcast($agent, new TextDelta('id', 'msg', 'Hi', time())))->toBeFalse();
 });
 
 test('streamed response passed to then is fully resolved', function () {

--- a/tests/Fixtures/Agents/BroadcastFilteringAgent.php
+++ b/tests/Fixtures/Agents/BroadcastFilteringAgent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+
+class BroadcastFilteringAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    /**
+     * @return list<class-string<StreamEvent>>
+     */
+    public function exceptBroadcastStreamEvents(): array
+    {
+        return [TextDelta::class, ToolCall::class, ToolResult::class];
+    }
+}


### PR DESCRIPTION
Fixes #174 (partial — event filtering; complements payload-size / exception-handling work)
Add exceptBroadcastStreamEvents() on Promptable agents
Apply filtering in sync broadcast() and BroadcastAgent queued streams
Regression tests for excluded TextDelta / tool events