### PR TITLE
Capture missing usage details across OpenAI-shaped providers

### DIFF
--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -66,10 +66,7 @@ trait HandlesTextStreaming
 
             if (! $choice) {
                 if (isset($data['usage'])) {
-                    $usage = new Usage(
-                        $data['usage']['prompt_tokens'] ?? 0,
-                        $data['usage']['completion_tokens'] ?? 0,
-                    );
+                    $usage = $this->extractUsage($data);
                 }
 
                 continue;
@@ -132,10 +129,7 @@ trait HandlesTextStreaming
             }
 
             if (isset($data['usage'])) {
-                $usage = new Usage(
-                    $data['usage']['prompt_tokens'] ?? 0,
-                    $data['usage']['completion_tokens'] ?? 0,
-                );
+                $usage = $this->extractUsage($data);
             }
         }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -323,12 +323,14 @@ trait ParsesTextResponses
     protected function extractUsage(array $data): Usage
     {
         $usage = $data['usage'] ?? [];
-        $details = $usage['completion_tokens_details'] ?? [];
+        $promptDetails = $usage['prompt_tokens_details'] ?? [];
+        $completionDetails = $usage['completion_tokens_details'] ?? [];
 
         return new Usage(
             promptTokens: $usage['prompt_tokens'] ?? 0,
             completionTokens: $usage['completion_tokens'] ?? 0,
-            reasoningTokens: $details['reasoning_tokens'] ?? 0,
+            cacheReadInputTokens: $promptDetails['cached_tokens'] ?? 0,
+            reasoningTokens: $completionDetails['reasoning_tokens'] ?? 0,
         );
     }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -323,10 +323,12 @@ trait ParsesTextResponses
     protected function extractUsage(array $data): Usage
     {
         $usage = $data['usage'] ?? [];
+        $details = $usage['completion_tokens_details'] ?? [];
 
         return new Usage(
-            $usage['prompt_tokens'] ?? 0,
-            $usage['completion_tokens'] ?? 0,
+            promptTokens: $usage['prompt_tokens'] ?? 0,
+            completionTokens: $usage['completion_tokens'] ?? 0,
+            reasoningTokens: $details['reasoning_tokens'] ?? 0,
         );
     }
 

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -65,10 +65,7 @@ trait HandlesTextStreaming
 
             if (! $choice) {
                 if (isset($data['usage'])) {
-                    $usage = new Usage(
-                        $data['usage']['prompt_tokens'] ?? 0,
-                        $data['usage']['completion_tokens'] ?? 0,
-                    );
+                    $usage = $this->extractUsage($data);
                 }
 
                 continue;
@@ -131,10 +128,7 @@ trait HandlesTextStreaming
             }
 
             if (isset($data['usage'])) {
-                $usage = new Usage(
-                    $data['usage']['prompt_tokens'] ?? 0,
-                    $data['usage']['completion_tokens'] ?? 0,
-                );
+                $usage = $this->extractUsage($data);
             }
         }
 

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -66,13 +66,7 @@ trait HandlesTextStreaming
 
             if (! $choice) {
                 if (isset($data['usage'])) {
-                    $usage = new Usage(
-                        $data['usage']['prompt_tokens'] ?? 0,
-                        $data['usage']['completion_tokens'] ?? 0,
-                        cacheWriteInputTokens: $data['usage']['prompt_tokens_details']['cache_write_tokens'] ?? 0,
-                        cacheReadInputTokens: $data['usage']['prompt_tokens_details']['cached_tokens'] ?? 0,
-                        reasoningTokens: $data['usage']['completion_tokens_details']['reasoning_tokens'] ?? 0,
-                    );
+                    $usage = $this->extractUsage($data);
                 }
 
                 continue;
@@ -150,13 +144,7 @@ trait HandlesTextStreaming
             }
 
             if (isset($data['usage'])) {
-                $usage = new Usage(
-                    $data['usage']['prompt_tokens'] ?? 0,
-                    $data['usage']['completion_tokens'] ?? 0,
-                    cacheWriteInputTokens: $data['usage']['prompt_tokens_details']['cache_write_tokens'] ?? 0,
-                    cacheReadInputTokens: $data['usage']['prompt_tokens_details']['cached_tokens'] ?? 0,
-                    reasoningTokens: $data['usage']['completion_tokens_details']['reasoning_tokens'] ?? 0,
-                );
+                $usage = $this->extractUsage($data);
             }
         }
 

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -203,6 +203,33 @@ test('response usage is correctly parsed', function () {
         ->and($response->usage->completionTokens)->toBe(5);
 });
 
+test('response usage includes reasoning tokens', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-r1-1',
+        'object' => 'chat.completion',
+        'model' => 'deepseek-r1-distill-llama-70b',
+        'choices' => [[
+            'index' => 0,
+            'message' => ['role' => 'assistant', 'content' => 'The answer is 4.'],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+            'total_tokens' => 150,
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 20,
+            ],
+        ],
+    ])]);
+
+    $response = agent()->prompt('What is 2+2?', provider: 'groq', model: 'deepseek-r1-distill-llama-70b');
+
+    expect($response->usage->promptTokens)->toBe(100)
+        ->and($response->usage->completionTokens)->toBe(50)
+        ->and($response->usage->reasoningTokens)->toBe(20);
+});
+
 test('structured response is correctly parsed', function () {
     Http::fake(['*' => fakeGroqResponse('{"symbol": "Au"}')]);
 

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -230,6 +230,33 @@ test('response usage includes reasoning tokens', function () {
         ->and($response->usage->reasoningTokens)->toBe(20);
 });
 
+test('response usage includes cached prompt tokens', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-cache-1',
+        'object' => 'chat.completion',
+        'model' => 'llama-3.3-70b-versatile',
+        'choices' => [[
+            'index' => 0,
+            'message' => ['role' => 'assistant', 'content' => 'Hello.'],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 4641,
+            'completion_tokens' => 1817,
+            'total_tokens' => 6458,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 4608,
+            ],
+        ],
+    ])]);
+
+    $response = agent()->prompt('Hello', provider: 'groq');
+
+    expect($response->usage->promptTokens)->toBe(4641)
+        ->and($response->usage->completionTokens)->toBe(1817)
+        ->and($response->usage->cacheReadInputTokens)->toBe(4608);
+});
+
 test('structured response is correctly parsed', function () {
     Http::fake(['*' => fakeGroqResponse('{"symbol": "Au"}')]);
 

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -116,6 +116,35 @@ test('streaming captures usage from final chunk', function () {
         ->and($streamEnd->usage->completionTokens)->toBe(10);
 });
 
+test('streaming captures reasoning tokens', function () {
+    Http::fake([
+        'api.groq.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->chatChunk(['role' => 'assistant', 'content' => 'The answer is 4.']),
+                $this->chatChunkFinish('stop', [
+                    'prompt_tokens' => 100,
+                    'completion_tokens' => 50,
+                    'total_tokens' => 150,
+                    'completion_tokens_details' => [
+                        'reasoning_tokens' => 20,
+                    ],
+                ]),
+                '[DONE]',
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+    expect($streamEnd->usage->promptTokens)->toBe(100)
+        ->and($streamEnd->usage->completionTokens)->toBe(50)
+        ->and($streamEnd->usage->reasoningTokens)->toBe(20);
+});
+
 test('streaming finish reason maps correctly', function (string $apiReason, $expected) {
     Http::fake([
         'api.groq.com/*' => Http::response(


### PR DESCRIPTION
## Problem

Several OpenAI-compatible gateways were silently discarding nested fields from the `usage` object, causing `Usage` to underreport tokens for reasoning models and prompt-caching workloads. The same anti-pattern (streaming handlers inlining `new Usage(...)` instead of delegating to `extractUsage()`) had already caused this bug class for DeepSeek (#435).

## Fix

Extended the original Groq-only fix to every affected gateway so this bug class doesn't get re-shipped piecemeal in follow-up PRs.

**Groq** (`src/Gateway/Groq/Concerns/`)
- `ParsesTextResponses::extractUsage()` — read `completion_tokens_details.reasoning_tokens` (as `reasoningTokens`) and `prompt_tokens_details.cached_tokens` (as `cacheReadInputTokens`).
- `HandlesTextStreaming` — both inline `new Usage(...)` constructions replaced with `\$this->extractUsage(\$data)`.

**OpenRouter** (`src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php`)
- Both inline `new Usage(...)` constructions (which redundantly inlined the four-field cache/reasoning parsing) replaced with `\$this->extractUsage(\$data)`. No behaviour change today; prevents future field additions from being dropped on the streaming path.

**Mistral** (`src/Gateway/Mistral/Concerns/HandlesTextStreaming.php`)
- Both inline `new Usage(...)` constructions replaced with `\$this->extractUsage(\$data)`. Same preventative cleanup.



## Field-name verification

All field names verified against authoritative provider sources:

| Field | Source |
|---|---|
| Groq `completion_tokens_details` / `prompt_tokens_details` | Groq Chat Completions API reference — both documented as nested objects on the `usage` schema |
| Groq `prompt_tokens_details.cached_tokens` | Groq prompt-caching docs (explicit JSON example: `{"prompt_tokens": 4641, ..., "prompt_tokens_details": {"cached_tokens": 4608}}`) |
| Groq `completion_tokens_details.reasoning_tokens` | OpenAI-compatible naming Groq mirrors; same field name as DeepSeek (#435) and OpenRouter |
| OpenRouter `prompt_tokens_details.{cached_tokens,cache_write_tokens}`, `completion_tokens_details.reasoning_tokens` | OpenRouter OpenAPI spec (`ChatUsage` schema) |
| Mistral usage fields | Mistral official Python SDK `UsageInfo` model — confirms only basic fields exist; no speculative additions |