### PR TITLE
Reject blank URL in RemoteDocument, RemoteImage, and RemoteAudio constructors

### DIFF
--- a/src/Files/RemoteAudio.php
+++ b/src/Files/RemoteAudio.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
@@ -17,6 +18,10 @@ class RemoteAudio extends Audio implements Arrayable, JsonSerializable, Storable
 
     public function __construct(public string $url, ?string $mimeType = null)
     {
+        if (blank($url)) {
+            throw new InvalidArgumentException('Remote audio URL cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/RemoteDocument.php
+++ b/src/Files/RemoteDocument.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -14,6 +15,10 @@ class RemoteDocument extends Document implements Arrayable, JsonSerializable, St
 
     public function __construct(public string $url, ?string $mimeType = null)
     {
+        if (blank($url)) {
+            throw new InvalidArgumentException('Remote document URL cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/RemoteImage.php
+++ b/src/Files/RemoteImage.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -14,6 +15,10 @@ class RemoteImage extends Image implements Arrayable, JsonSerializable, Storable
 
     public function __construct(public string $url, ?string $mimeType = null)
     {
+        if (blank($url)) {
+            throw new InvalidArgumentException('Remote image URL cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/tests/Unit/Files/RemoteUrlTest.php
+++ b/tests/Unit/Files/RemoteUrlTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Laravel\Ai\Files\RemoteAudio;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+
+test('remote document rejects empty url', function () {
+    new RemoteDocument('');
+})->throws(InvalidArgumentException::class, 'Remote document URL cannot be empty.');
+
+test('remote document rejects whitespace-only url', function () {
+    new RemoteDocument("  \t\n");
+})->throws(InvalidArgumentException::class, 'Remote document URL cannot be empty.');
+
+test('remote image rejects empty url', function () {
+    new RemoteImage('');
+})->throws(InvalidArgumentException::class, 'Remote image URL cannot be empty.');
+
+test('remote image rejects whitespace-only url', function () {
+    new RemoteImage("  \t\n");
+})->throws(InvalidArgumentException::class, 'Remote image URL cannot be empty.');
+
+test('remote audio rejects empty url', function () {
+    new RemoteAudio('');
+})->throws(InvalidArgumentException::class, 'Remote audio URL cannot be empty.');
+
+test('remote audio rejects whitespace-only url', function () {
+    new RemoteAudio("  \t\n");
+})->throws(InvalidArgumentException::class, 'Remote audio URL cannot be empty.');


### PR DESCRIPTION
## Summary

- `RemoteDocument`, `RemoteImage`, and `RemoteAudio` constructors now throw `InvalidArgumentException` when given an empty or whitespace-only URL
- Follows the same pattern established by #600 and #604 for `Local*` and `Stored*` file classes
- Adds 6 unit tests in `tests/Unit/Files/RemoteUrlTest.php` covering both empty and whitespace-only inputs for all three classes

## Test plan

- [x] `tests/Unit/Files/RemoteUrlTest.php` — 6 assertions, all passing
- [x] No regressions in `tests/Unit/Files/` (19 total pass)