### PR TITLE
Fix transcription usage mapping for output tokens

### DIFF
--- a/src/Gateway/Concerns/ExtractsTranscriptionUsage.php
+++ b/src/Gateway/Concerns/ExtractsTranscriptionUsage.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Laravel\Ai\Responses\Data\Usage;
+
+trait ExtractsTranscriptionUsage
+{
+    /**
+     * Build usage data from a transcription API response payload.
+     */
+    protected function transcriptionUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+        $promptTokens = $usage['input_tokens'] ?? 0;
+
+        $completionTokens = $usage['output_tokens']
+            ?? $usage['completion_tokens']
+            ?? max(0, ($usage['total_tokens'] ?? 0) - $promptTokens);
+
+        return new Usage($promptTokens, $completionTokens);
+    }
+}

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -19,6 +19,7 @@ use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Gateway\Concerns\ExtractsTranscriptionUsage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
@@ -27,7 +28,6 @@ use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
-use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -43,6 +43,7 @@ class OpenAiGateway implements Gateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use ExtractsTranscriptionUsage;
     use HandlesFailoverErrors;
     use InvokesTools;
     use ParsesServerSentEvents;
@@ -303,10 +304,7 @@ class OpenAiGateway implements Gateway
                 $segment['start'] ?? 0,
                 $segment['end'] ?? 0,
             )),
-            new Usage(
-                $data['usage']['input_tokens'] ?? 0,
-                $data['usage']['total_tokens'] ?? 0,
-            ),
+            $this->transcriptionUsage($data),
             new Meta($provider->name(), $model),
         );
     }

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
+use Laravel\Ai\Gateway\Concerns\ExtractsTranscriptionUsage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
@@ -38,6 +39,7 @@ class OpenRouterGateway implements Gateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use ExtractsTranscriptionUsage;
     use HandlesFailoverErrors;
     use InvokesTools;
     use ParsesServerSentEvents;
@@ -342,10 +344,7 @@ class OpenRouterGateway implements Gateway
         return new TranscriptionResponse(
             $data['text'] ?? '',
             collect(),
-            new Usage(
-                $data['usage']['input_tokens'] ?? 0,
-                $data['usage']['total_tokens'] ?? 0,
-            ),
+            $this->transcriptionUsage($data),
             new Meta($provider->name(), $model),
         );
     }

--- a/tests/Feature/Providers/OpenAi/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenAi/TranscriptionTest.php
@@ -95,7 +95,24 @@ test('transcription usage is correctly parsed', function () {
         ->generate(provider: 'openai');
 
     expect($response->usage->promptTokens)->toBe(100)
-        ->and($response->usage->completionTokens)->toBe(150);
+        ->and($response->usage->completionTokens)->toBe(50);
+});
+
+test('transcription usage prefers output_tokens when provided', function () {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hello',
+        'usage' => [
+            'input_tokens' => 100,
+            'output_tokens' => 40,
+            'total_tokens' => 150,
+        ],
+    ])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->generate(provider: 'openai');
+
+    expect($response->usage->promptTokens)->toBe(100)
+        ->and($response->usage->completionTokens)->toBe(40);
 });
 
 test('transcription sends language when provided', function () {

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -177,7 +177,7 @@ test('transcription usage is correctly parsed', function () {
     $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openrouter');
 
     expect($response->usage->promptTokens)->toBe(100)
-        ->and($response->usage->completionTokens)->toBe(150);
+        ->and($response->usage->completionTokens)->toBe(50);
 });
 
 test('transcription request sends bearer token', function () {

--- a/tests/Unit/Gateway/ExtractsTranscriptionUsageTest.php
+++ b/tests/Unit/Gateway/ExtractsTranscriptionUsageTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Laravel\Ai\Gateway\Concerns\ExtractsTranscriptionUsage;
+
+test('transcription usage prefers output tokens over total tokens', function () {
+    $gateway = new class
+    {
+        use ExtractsTranscriptionUsage;
+
+        public function usage(array $data)
+        {
+            return $this->transcriptionUsage($data);
+        }
+    };
+
+    $usage = $gateway->usage([
+        'usage' => [
+            'input_tokens' => 100,
+            'output_tokens' => 40,
+            'total_tokens' => 150,
+        ],
+    ]);
+
+    expect($usage->promptTokens)->toBe(100)
+        ->and($usage->completionTokens)->toBe(40);
+});
+
+test('transcription usage derives completion tokens from total when output tokens are absent', function () {
+    $gateway = new class
+    {
+        use ExtractsTranscriptionUsage;
+
+        public function usage(array $data)
+        {
+            return $this->transcriptionUsage($data);
+        }
+    };
+
+    $usage = $gateway->usage([
+        'usage' => [
+            'input_tokens' => 100,
+            'total_tokens' => 150,
+        ],
+    ]);
+
+    expect($usage->promptTokens)->toBe(100)
+        ->and($usage->completionTokens)->toBe(50);
+});


### PR DESCRIPTION
## Summary
- Map transcription `Usage::completionTokens` from `output_tokens` (or `completion_tokens`) instead of `total_tokens`
- Fixes inflated completion token counts for OpenAI and OpenRouter when the API returns separate output/total fields
- Fall back to `total_tokens - input_tokens` when only legacy usage fields are present

## Test plan
- [x] `tests/Unit/Gateway/ExtractsTranscriptionUsageTest.php`
- [x] `tests/Feature/Providers/OpenAi/TranscriptionTest.php`
- [x] `tests/Feature/Providers/OpenRouter/TranscriptionTest.php`