### PR TITLE
Support Inline Conversation on OpenAI tool follow-ups for Zero Data Retention

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -122,6 +122,7 @@ return [
             'driver' => 'openai',
             'key' => env('OPENAI_API_KEY'),
             'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+            'zero_data_retention' => env('OPENAI_ZERO_DATA_RETENTION', false),
         ],
 
         'openrouter' => [

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -54,6 +54,34 @@ trait BuildsTextRequests
     }
 
     /**
+     * Build the request body for a tool-result follow-up request.
+     *
+     * Zero Data Retention accounts reject `previous_response_id`, so the
+     * full conversation is sent inline instead of relying on server-side chaining.
+     */
+    protected function buildToolFollowUpBody(
+        string $model,
+        string $responseId,
+        bool $zeroDataRetention,
+        array $toolResults,
+        array $messages = [],
+        ?string $instructions = null,
+    ): array {
+        if ($zeroDataRetention) {
+            return [
+                'model' => $model,
+                'input' => $this->mapMessagesToInput($messages, $instructions),
+            ];
+        }
+
+        return [
+            'model' => $model,
+            'previous_response_id' => $responseId,
+            'input' => $this->buildToolResultsInput($toolResults),
+        ];
+    }
+
+    /**
      * Build the text format options for structured output.
      */
     protected function buildSchemaFormat(array $schema, bool $strict): array

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
@@ -40,6 +42,8 @@ trait HandlesTextStreaming
         int $depth = 0,
         ?int $maxSteps = null,
         ?int $timeout = null,
+        ?string $instructions = null,
+        array $priorMessages = [],
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -297,6 +301,8 @@ trait HandlesTextStreaming
                 $depth,
                 $maxSteps,
                 $timeout,
+                $instructions,
+                $priorMessages,
             );
 
             return;
@@ -327,6 +333,8 @@ trait HandlesTextStreaming
         int $depth,
         ?int $maxSteps,
         ?int $timeout = null,
+        ?string $instructions = null,
+        array $priorMessages = [],
     ): Generator {
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -361,12 +369,30 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-                'stream' => true,
-            ];
+            $zeroDataRetention = $provider->additionalConfiguration()['zero_data_retention'] ?? false;
+
+            $nextPriorMessages = $priorMessages;
+
+            if ($zeroDataRetention) {
+                $nextPriorMessages = [
+                    ...$priorMessages,
+                    new AssistantMessage($currentText, collect($mappedToolCalls)),
+                    new ToolResultMessage(collect($toolResults)),
+                ];
+
+                $body = [
+                    'model' => $model,
+                    'input' => $this->mapMessagesToInput($nextPriorMessages, $instructions),
+                    'stream' => true,
+                ];
+            } else {
+                $body = [
+                    'model' => $model,
+                    'previous_response_id' => $responseId,
+                    'input' => $this->buildToolResultsInput($toolResults),
+                    'stream' => true,
+                ];
+            }
 
             if (filled($tools)) {
                 $body['tools'] = $this->mapTools($tools, $provider);
@@ -406,6 +432,8 @@ trait HandlesTextStreaming
                 $depth + 1,
                 $maxSteps,
                 $timeout,
+                $instructions,
+                $nextPriorMessages,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -379,20 +379,17 @@ trait HandlesTextStreaming
                     new AssistantMessage($currentText, collect($mappedToolCalls)),
                     new ToolResultMessage(collect($toolResults)),
                 ];
-
-                $body = [
-                    'model' => $model,
-                    'input' => $this->mapMessagesToInput($nextPriorMessages, $instructions),
-                    'stream' => true,
-                ];
-            } else {
-                $body = [
-                    'model' => $model,
-                    'previous_response_id' => $responseId,
-                    'input' => $this->buildToolResultsInput($toolResults),
-                    'stream' => true,
-                ];
             }
+
+            $body = $this->buildToolFollowUpBody(
+                $model,
+                $responseId,
+                $zeroDataRetention,
+                $toolResults,
+                is_array($nextPriorMessages) ? $nextPriorMessages : [],
+                $instructions,
+            );
+            $body['stream'] = true;
 
             if (filled($tools)) {
                 $body['tools'] = $this->mapTools($tools, $provider);

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -43,7 +43,7 @@ trait HandlesTextStreaming
         ?int $maxSteps = null,
         ?int $timeout = null,
         ?string $instructions = null,
-        array $priorMessages = [],
+        ?array $priorMessages = null,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -334,7 +334,7 @@ trait HandlesTextStreaming
         ?int $maxSteps,
         ?int $timeout = null,
         ?string $instructions = null,
-        array $priorMessages = [],
+        ?array $priorMessages = null,
     ): Generator {
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -375,7 +375,7 @@ trait HandlesTextStreaming
 
             if ($zeroDataRetention) {
                 $nextPriorMessages = [
-                    ...$priorMessages,
+                    ...(is_array($priorMessages) ? $priorMessages : []),
                     new AssistantMessage($currentText, collect($mappedToolCalls)),
                     new ToolResultMessage(collect($toolResults)),
                 ];

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -61,7 +61,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
         ?string $instructions = null,
-        array $priorMessages = [],
+        ?array $priorMessages = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -95,7 +95,7 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
         ?string $instructions = null,
-        array $priorMessages = [],
+        ?array $priorMessages = null,
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
@@ -240,14 +240,14 @@ trait ParsesTextResponses
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
         ?string $instructions = null,
-        array $priorMessages = [],
+        ?array $priorMessages = null,
     ): TextResponse {
         $zeroDataRetention = $provider->additionalConfiguration()['zero_data_retention'] ?? false;
 
         $body = $zeroDataRetention
             ? [
                 'model' => $model,
-                'input' => $this->mapMessagesToInput([...$priorMessages, ...$messages->all()], $instructions),
+                'input' => $this->mapMessagesToInput([...(is_array($priorMessages) ? $priorMessages : []), ...$messages->all()], $instructions),
             ]
             : [
                 'model' => $model,

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -60,6 +60,8 @@ trait ParsesTextResponses
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $instructions = null,
+        array $priorMessages = [],
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -72,6 +74,8 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            instructions: $instructions,
+            priorMessages: $priorMessages,
         );
     }
 
@@ -90,6 +94,8 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $instructions = null,
+        array $priorMessages = [],
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
@@ -155,6 +161,8 @@ trait ParsesTextResponses
                 $maxSteps,
                 $options,
                 $timeout,
+                $instructions,
+                $priorMessages,
             );
         }
 
@@ -231,12 +239,21 @@ trait ParsesTextResponses
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $instructions = null,
+        array $priorMessages = [],
     ): TextResponse {
-        $body = [
-            'model' => $model,
-            'previous_response_id' => $responseId,
-            'input' => $this->buildToolResultsInput($toolResults),
-        ];
+        $zeroDataRetention = $provider->additionalConfiguration()['zero_data_retention'] ?? false;
+
+        $body = $zeroDataRetention
+            ? [
+                'model' => $model,
+                'input' => $this->mapMessagesToInput([...$priorMessages, ...$messages->all()], $instructions),
+            ]
+            : [
+                'model' => $model,
+                'previous_response_id' => $responseId,
+                'input' => $this->buildToolResultsInput($toolResults),
+            ];
 
         if (filled($tools)) {
             $body['tools'] = $this->mapTools($tools, $provider);
@@ -267,7 +284,7 @@ trait ParsesTextResponses
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout, $instructions, $priorMessages);
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -244,16 +244,14 @@ trait ParsesTextResponses
     ): TextResponse {
         $zeroDataRetention = $provider->additionalConfiguration()['zero_data_retention'] ?? false;
 
-        $body = $zeroDataRetention
-            ? [
-                'model' => $model,
-                'input' => $this->mapMessagesToInput([...(is_array($priorMessages) ? $priorMessages : []), ...$messages->all()], $instructions),
-            ]
-            : [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-            ];
+        $body = $this->buildToolFollowUpBody(
+            $model,
+            $responseId,
+            $zeroDataRetention,
+            $toolResults,
+            [...(is_array($priorMessages) ? $priorMessages : []), ...$messages->all()],
+            $instructions,
+        );
 
         if (filled($tools)) {
             $body['tools'] = $this->mapTools($tools, $provider);

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -78,7 +78,7 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout, $instructions, $messages);
     }
 
     /**
@@ -119,6 +119,8 @@ class OpenAiGateway implements Gateway
             0,
             null,
             $timeout,
+            $instructions,
+            $messages,
         );
     }
 

--- a/tests/Feature/Providers/OpenAi/ZeroDataRetentionTest.php
+++ b/tests/Feature/Providers/OpenAi/ZeroDataRetentionTest.php
@@ -1,0 +1,252 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Agents\ToolUsingAgent;
+
+beforeEach(function () {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'key' => 'test-key',
+        'zero_data_retention' => true,
+    ]]);
+});
+
+test('zero data retention rebuilds tool follow up without previous_response_id', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'resp_tool_1',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [[
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'call_id' => 'call_1',
+                    'name' => 'FixedNumberGenerator',
+                    'arguments' => '{}',
+                    'status' => 'completed',
+                ]],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            fakeOpenAiResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a random number',
+        provider: 'openai',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp)->not->toHaveKey('previous_response_id');
+
+    $input = collect($followUp['input']);
+
+    expect($input->contains(fn ($input) => ($input['role'] ?? null) === 'system'))->toBeTrue('system instructions resent')
+        ->and($input->contains(fn ($input) => ($input['role'] ?? null) === 'user'
+            && collect($input['content'] ?? [])->contains(fn ($c) => ($c['text'] ?? '') === 'Generate a random number')))->toBeTrue('user message resent')
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call'
+            && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue('assistant tool call resent')
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call_output'
+            && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue('tool result included');
+});
+
+test('zero data retention accumulates context across multiple tool steps', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'resp_tool_1',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [[
+                    'type' => 'function_call',
+                    'id' => 'fc_1',
+                    'call_id' => 'call_1',
+                    'name' => 'FixedNumberGenerator',
+                    'arguments' => '{}',
+                    'status' => 'completed',
+                ]],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            Http::response([
+                'id' => 'resp_tool_2',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [[
+                    'type' => 'function_call',
+                    'id' => 'fc_2',
+                    'call_id' => 'call_2',
+                    'name' => 'FixedNumberGenerator',
+                    'arguments' => '{}',
+                    'status' => 'completed',
+                ]],
+                'usage' => ['input_tokens' => 12, 'output_tokens' => 5],
+            ]),
+            fakeOpenAiResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new MultiStepToolAgent)->prompt(
+        'Generate a random number',
+        provider: 'openai',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(3);
+
+    $secondFollowUp = json_decode($recorded[2][0]->body(), true);
+
+    expect($secondFollowUp)->not->toHaveKey('previous_response_id');
+
+    $input = collect($secondFollowUp['input']);
+
+    expect($input->where(fn ($input) => ($input['role'] ?? null) === 'user'
+        && collect($input['content'] ?? [])->contains(fn ($c) => ($c['text'] ?? '') === 'Generate a random number'))->count())
+        ->toBe(1, 'original user message present exactly once')
+        ->and($input->where(fn ($input) => ($input['type'] ?? null) === 'function_call')->count())
+        ->toBe(2, 'both assistant tool calls included')
+        ->and($input->where(fn ($input) => ($input['type'] ?? null) === 'function_call_output')->count())
+        ->toBe(2, 'both tool results included')
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call' && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue()
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call' && ($input['call_id'] ?? null) === 'call_2'))->toBeTrue()
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call_output' && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue()
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call_output' && ($input['call_id'] ?? null) === 'call_2'))->toBeTrue();
+});
+
+test('zero data retention rebuilds streaming tool follow up without previous_response_id', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputItemAdded('fc_1', 'call_1', 'FixedNumberGenerator'),
+                    $this->functionCallArgumentsDelta('fc_1', '{}'),
+                    $this->functionCallArgumentsDone('fc_1', '{}'),
+                    $this->responseCompleted(10, 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+            Http::response(
+                body: $this->ssePayload([
+                    [
+                        'type' => 'response.created',
+                        'response' => ['id' => 'resp_2', 'model' => 'gpt-5.4', 'status' => 'in_progress', 'output' => []],
+                    ],
+                    $this->outputTextDelta('Done'),
+                    $this->outputTextDone('Done'),
+                    $this->responseCompleted(20, 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]),
+    ]);
+
+    $agent = new ProviderOptionsWithToolsAgent;
+
+    $events = [];
+
+    foreach ($agent->stream('Generate a random number', provider: 'openai') as $event) {
+        $events[] = $event;
+    }
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp)->not->toHaveKey('previous_response_id');
+
+    $input = collect($followUp['input']);
+
+    expect($input->contains(fn ($input) => ($input['role'] ?? null) === 'system'))->toBeTrue('system instructions resent')
+        ->and($input->contains(fn ($input) => ($input['role'] ?? null) === 'user'
+            && collect($input['content'] ?? [])->contains(fn ($c) => ($c['text'] ?? '') === 'Generate a random number')))->toBeTrue('user message resent')
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call'
+            && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue('assistant tool call resent')
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call_output'
+            && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue('tool result included');
+});
+
+test('zero data retention accumulates streaming context across multiple tool steps', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputItemAdded('fc_1', 'call_1', 'FixedNumberGenerator'),
+                    $this->functionCallArgumentsDelta('fc_1', '{}'),
+                    $this->functionCallArgumentsDone('fc_1', '{}'),
+                    $this->responseCompleted(10, 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+            Http::response(
+                body: $this->ssePayload([
+                    [
+                        'type' => 'response.created',
+                        'response' => ['id' => 'resp_2', 'model' => 'gpt-5.4', 'status' => 'in_progress', 'output' => []],
+                    ],
+                    $this->outputItemAdded('fc_2', 'call_2', 'FixedNumberGenerator'),
+                    $this->functionCallArgumentsDelta('fc_2', '{}'),
+                    $this->functionCallArgumentsDone('fc_2', '{}'),
+                    $this->responseCompleted(12, 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+            Http::response(
+                body: $this->ssePayload([
+                    [
+                        'type' => 'response.created',
+                        'response' => ['id' => 'resp_3', 'model' => 'gpt-5.4', 'status' => 'in_progress', 'output' => []],
+                    ],
+                    $this->outputTextDelta('Done'),
+                    $this->outputTextDone('Done'),
+                    $this->responseCompleted(20, 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]),
+    ]);
+
+    $agent = new MultiStepToolAgent;
+
+    foreach ($agent->stream('Generate a random number', provider: 'openai') as $event) {
+        // drain the stream
+    }
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(3);
+
+    $secondFollowUp = json_decode($recorded[2][0]->body(), true);
+
+    expect($secondFollowUp)->not->toHaveKey('previous_response_id');
+
+    $input = collect($secondFollowUp['input']);
+
+    expect($input->where(fn ($input) => ($input['role'] ?? null) === 'user'
+        && collect($input['content'] ?? [])->contains(fn ($c) => ($c['text'] ?? '') === 'Generate a random number'))->count())
+        ->toBe(1, 'original user message present exactly once')
+        ->and($input->where(fn ($input) => ($input['type'] ?? null) === 'function_call')->count())
+        ->toBe(2, 'both assistant tool calls included')
+        ->and($input->where(fn ($input) => ($input['type'] ?? null) === 'function_call_output')->count())
+        ->toBe(2, 'both tool results included')
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call' && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue()
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call' && ($input['call_id'] ?? null) === 'call_2'))->toBeTrue()
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call_output' && ($input['call_id'] ?? null) === 'call_1'))->toBeTrue()
+        ->and($input->contains(fn ($input) => ($input['type'] ?? null) === 'function_call_output' && ($input['call_id'] ?? null) === 'call_2'))->toBeTrue();
+});

--- a/tests/Fixtures/Agents/MultiStepToolAgent.php
+++ b/tests/Fixtures/Agents/MultiStepToolAgent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+#[MaxSteps(5)]
+class MultiStepToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that uses tools.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new FixedNumberGenerator,
+        ];
+    }
+}


### PR DESCRIPTION
Currently, every OpenAI tool-call follow-up - both streaming (`handleStreamingToolCalls`) and non-streaming (`continueWithToolResults`) - POSTs to `/responses` with `previous_response_id` pointing at the prior assistant turn, relying on OpenAI to load that turn's state server-side. 

Organizations with Zero Data Retention enabled reject any request containing `previous_response_id` with `Previous response cannot be used for this organization due to Zero Data Retention`, because ZDR forbids OpenAI from storing the prior response that the ID would reference. As a result, any agent that uses tools is unusable on a ZDR account: the first response succeeds, the tool runs, then the follow-up is rejected with a 400.

This PR introduces a `zero_data_retention` provider config (driven by `OPENAI_ZERO_DATA_RETENTION`, default `false`) and a new `buildToolFollowUpBody` helper in `BuildsTextRequests` that picks between the two body shapes. When the flag is on, the follow-up omits `previous_response_id` and sends the full conversation inline - system instructions, prior user messages, the assistant tool calls produced this turn (with their reasoning blocks), and the tool results - through `mapMessagesToInput`, so OpenAI has the same context server-side chaining would have given it.

Both paths now thread a `priorMessages` array through the recursive tool loop, so the inline conversation accumulates correctly across multi-step tool chains. The streaming path reuses `mapAssistantMessage` via an `AssistantMessage` constructed from the streamed `ToolCall` DTOs - rather than re-implementing the OpenAI input shape inline - keeping a single source of truth for how an assistant turn with tool calls and reasoning gets serialized.

The flag is per-provider in `config/ai.php`, so accounts with mixed ZDR settings can be modeled by registering separate provider entries.