### PR TITLE
Support OpenAI Zero Data Retention via encrypted reasoning

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -64,6 +64,7 @@ return [
             'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
             'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
             'image_deployment' => env('AZURE_OPENAI_IMAGE_DEPLOYMENT', 'gpt-image-1'),
+            'store' => env('AZURE_OPENAI_STORE', true),
         ],
 
         'bedrock' => [
@@ -122,7 +123,7 @@ return [
             'driver' => 'openai',
             'key' => env('OPENAI_API_KEY'),
             'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
-            'encrypted_reasoning' => env('OPENAI_ENCRYPTED_REASONING', false),
+            'store' => env('OPENAI_STORE', true),
         ],
 
         'openrouter' => [

--- a/config/ai.php
+++ b/config/ai.php
@@ -122,6 +122,7 @@ return [
             'driver' => 'openai',
             'key' => env('OPENAI_API_KEY'),
             'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+            'encrypted_reasoning' => env('OPENAI_ENCRYPTED_REASONING', false),
         ],
 
         'openrouter' => [

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -84,7 +84,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $body, $timeout);
     }
 
     /**
@@ -128,6 +128,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
             $schema,
             $options,
             $response->getBody(),
+            $body,
             0,
             null,
             $timeout,

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -50,15 +50,35 @@ trait BuildsTextRequests
             $body = array_merge($body, $providerOptions);
         }
 
-        if ($provider->additionalConfiguration()['encrypted_reasoning'] ?? false) {
+        if ($this->isStateless($provider)) {
             $body['store'] = false;
-            $body['include'] = array_values(array_unique([
-                ...($body['include'] ?? []),
-                'reasoning.encrypted_content',
-            ]));
+
+            if ($this->isReasoningModel($model)) {
+                $body['include'] = array_values(array_unique([
+                    ...($body['include'] ?? []),
+                    'reasoning.encrypted_content',
+                ]));
+            }
         }
 
         return $body;
+    }
+
+    protected function isStateless(Provider $provider): bool
+    {
+        return filter_var(
+            $provider->additionalConfiguration()['store'] ?? true,
+            FILTER_VALIDATE_BOOL,
+            FILTER_NULL_ON_FAILURE,
+        ) === false;
+    }
+
+    protected function isReasoningModel(string $model): bool
+    {
+        return (str_starts_with($model, 'gpt-5') && ! str_starts_with($model, 'gpt-5-chat'))
+            || str_starts_with($model, 'o4-mini')
+            || str_starts_with($model, 'o3')
+            || str_starts_with($model, 'o1');
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -50,6 +50,14 @@ trait BuildsTextRequests
             $body = array_merge($body, $providerOptions);
         }
 
+        if ($provider->additionalConfiguration()['encrypted_reasoning'] ?? false) {
+            $body['store'] = false;
+            $body['include'] = array_values(array_unique([
+                ...($body['include'] ?? []),
+                'reasoning.encrypted_content',
+            ]));
+        }
+
         return $body;
     }
 

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -4,9 +4,12 @@ namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Generator;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
@@ -40,6 +43,8 @@ trait HandlesTextStreaming
         int $depth = 0,
         ?int $maxSteps = null,
         ?int $timeout = null,
+        ?string $instructions = null,
+        Collection $messages = new Collection,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -149,6 +154,7 @@ trait HandlesTextStreaming
                 $reasoningItems[] = [
                     'id' => $data['item']['id'] ?? null,
                     'summary' => $data['item']['summary'] ?? [],
+                    'encrypted_content' => $data['item']['encrypted_content'] ?? null,
                 ];
 
                 if ($reasoningId !== '') {
@@ -213,6 +219,7 @@ trait HandlesTextStreaming
 
                     $toolCall['reasoning_id'] = $latestReasoning['id'];
                     $toolCall['reasoning_summary'] = $latestReasoning['summary'] ?? [];
+                    $toolCall['reasoning_encrypted_content'] = $latestReasoning['encrypted_content'] ?? null;
                 }
 
                 $pendingToolCalls[$index] = $toolCall;
@@ -253,6 +260,7 @@ trait HandlesTextStreaming
                                 $call['call_id'] ?? null,
                                 $call['reasoning_id'] ?? null,
                                 $call['reasoning_summary'] ?? null,
+                                $call['reasoning_encrypted_content'] ?? null,
                             ),
                             time(),
                         ))->withInvocationId($invocationId);
@@ -297,6 +305,8 @@ trait HandlesTextStreaming
                 $depth,
                 $maxSteps,
                 $timeout,
+                $instructions,
+                $messages,
             );
 
             return;
@@ -327,6 +337,8 @@ trait HandlesTextStreaming
         int $depth,
         ?int $maxSteps,
         ?int $timeout = null,
+        ?string $instructions = null,
+        Collection $messages = new Collection,
     ): Generator {
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -361,12 +373,27 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-                'stream' => true,
-            ];
+            $encryptedReasoning = $provider->additionalConfiguration()['encrypted_reasoning'] ?? false;
+
+            if ($encryptedReasoning) {
+                $messages->push(new AssistantMessage($currentText, collect($mappedToolCalls)));
+                $messages->push(new ToolResultMessage(collect($toolResults)));
+
+                $body = [
+                    'model' => $model,
+                    'input' => $this->mapMessagesToInput($messages->all(), $instructions),
+                    'store' => false,
+                    'include' => ['reasoning.encrypted_content'],
+                    'stream' => true,
+                ];
+            } else {
+                $body = [
+                    'model' => $model,
+                    'previous_response_id' => $responseId,
+                    'input' => $this->buildToolResultsInput($toolResults),
+                    'stream' => true,
+                ];
+            }
 
             if (filled($tools)) {
                 $body['tools'] = $this->mapTools($tools, $provider);
@@ -406,6 +433,8 @@ trait HandlesTextStreaming
                 $depth + 1,
                 $maxSteps,
                 $timeout,
+                $instructions,
+                $messages,
             );
         } else {
             yield (new StreamEnd(
@@ -431,6 +460,7 @@ trait HandlesTextStreaming
             $tc['call_id'] ?? null,
             $tc['reasoning_id'] ?? null,
             $tc['reasoning_summary'] ?? null,
+            $tc['reasoning_encrypted_content'] ?? null,
         ), array_values($toolCalls));
     }
 

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -3,10 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -29,9 +26,6 @@ use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
-    /**
-     * Process an OpenAI streaming response and yield Laravel stream events.
-     */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
@@ -40,11 +34,10 @@ trait HandlesTextStreaming
         ?array $schema,
         ?TextGenerationOptions $options,
         $streamBody,
+        array $requestBody = [],
         int $depth = 0,
         ?int $maxSteps = null,
         ?int $timeout = null,
-        ?string $instructions = null,
-        Collection $messages = new Collection,
     ): Generator {
         $maxSteps ??= $options?->maxSteps;
 
@@ -299,14 +292,12 @@ trait HandlesTextStreaming
                 $tools,
                 $schema,
                 $options,
+                $requestBody,
                 $pendingToolCalls,
                 $currentText,
-                $reasoningItems,
                 $depth,
                 $maxSteps,
                 $timeout,
-                $instructions,
-                $messages,
             );
 
             return;
@@ -331,14 +322,12 @@ trait HandlesTextStreaming
         array $tools,
         ?array $schema,
         ?TextGenerationOptions $options,
+        array $requestBody,
         array $pendingToolCalls,
         string $currentText,
-        array $reasoningItems,
         int $depth,
         ?int $maxSteps,
         ?int $timeout = null,
-        ?string $instructions = null,
-        Collection $messages = new Collection,
     ): Generator {
         $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
@@ -373,53 +362,25 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $encryptedReasoning = $provider->additionalConfiguration()['encrypted_reasoning'] ?? false;
-
-            if ($encryptedReasoning) {
-                $messages->push(new AssistantMessage($currentText, collect($mappedToolCalls)));
-                $messages->push(new ToolResultMessage(collect($toolResults)));
-
-                $body = [
-                    'model' => $model,
-                    'input' => $this->mapMessagesToInput($messages->all(), $instructions),
-                    'store' => false,
-                    'include' => ['reasoning.encrypted_content'],
-                    'stream' => true,
-                ];
+            if ($this->isStateless($provider)) {
+                $this->mapAssistantMessage(
+                    new AssistantMessage($currentText, collect($mappedToolCalls)),
+                    $requestBody['input'],
+                );
+                $this->mapToolResultMessage(
+                    new ToolResultMessage(collect($toolResults)),
+                    $requestBody['input'],
+                );
             } else {
-                $body = [
-                    'model' => $model,
-                    'previous_response_id' => $responseId,
-                    'input' => $this->buildToolResultsInput($toolResults),
-                    'stream' => true,
-                ];
-            }
-
-            if (filled($tools)) {
-                $body['tools'] = $this->mapTools($tools, $provider);
-            }
-
-            if (filled($schema)) {
-                $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-                'max_output_tokens' => $options?->maxTokens,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
+                $requestBody['previous_response_id'] = $responseId;
+                $requestBody['input'] = $this->buildToolResultsInput($toolResults);
             }
 
             $response = $this->withErrorHandling(
                 $provider->name(),
                 fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
-                    ->post('responses', $body),
+                    ->post('responses', $requestBody),
             );
 
             yield from $this->processTextStream(
@@ -430,11 +391,10 @@ trait HandlesTextStreaming
                 $schema,
                 $options,
                 $response->getBody(),
+                $requestBody,
                 $depth + 1,
                 $maxSteps,
                 $timeout,
-                $instructions,
-                $messages,
             );
         } else {
             yield (new StreamEnd(

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -65,11 +65,19 @@ trait MapsMessages
             $reasoningBlocks = $message->toolCalls
                 ->whereNotNull('reasoningId')
                 ->unique('reasoningId')
-                ->map(fn ($toolCall) => [
-                    'type' => 'reasoning',
-                    'id' => $toolCall->reasoningId,
-                    'summary' => $toolCall->reasoningSummary ?? [],
-                ])
+                ->map(function ($toolCall) {
+                    $block = [
+                        'type' => 'reasoning',
+                        'id' => $toolCall->reasoningId,
+                        'summary' => $toolCall->reasoningSummary ?? [],
+                    ];
+
+                    if ($toolCall->reasoningEncryptedContent !== null) {
+                        $block['encrypted_content'] = $toolCall->reasoningEncryptedContent;
+                    }
+
+                    return $block;
+                })
                 ->values()
                 ->all();
 

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
+use Illuminate\Support\Arr;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\MessageRole;
@@ -65,19 +66,12 @@ trait MapsMessages
             $reasoningBlocks = $message->toolCalls
                 ->whereNotNull('reasoningId')
                 ->unique('reasoningId')
-                ->map(function ($toolCall) {
-                    $block = [
-                        'type' => 'reasoning',
-                        'id' => $toolCall->reasoningId,
-                        'summary' => $toolCall->reasoningSummary ?? [],
-                    ];
-
-                    if ($toolCall->reasoningEncryptedContent !== null) {
-                        $block['encrypted_content'] = $toolCall->reasoningEncryptedContent;
-                    }
-
-                    return $block;
-                })
+                ->map(fn ($toolCall) => Arr::whereNotNull([
+                    'type' => 'reasoning',
+                    'id' => $toolCall->reasoningId,
+                    'summary' => $toolCall->reasoningSummary ?? [],
+                    'encrypted_content' => $toolCall->reasoningEncryptedContent,
+                ]))
                 ->values()
                 ->all();
 

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -60,6 +60,8 @@ trait ParsesTextResponses
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $instructions = null,
+        Collection $messages = new Collection,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -68,10 +70,11 @@ trait ParsesTextResponses
             $tools,
             $schema,
             new Collection,
-            new Collection,
+            $messages,
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            instructions: $instructions,
         );
     }
 
@@ -90,6 +93,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $instructions = null,
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
@@ -155,6 +159,7 @@ trait ParsesTextResponses
                 $maxSteps,
                 $options,
                 $timeout,
+                $instructions,
             );
         }
 
@@ -231,12 +236,24 @@ trait ParsesTextResponses
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $instructions = null,
     ): TextResponse {
-        $body = [
-            'model' => $model,
-            'previous_response_id' => $responseId,
-            'input' => $this->buildToolResultsInput($toolResults),
-        ];
+        $encryptedReasoning = $provider->additionalConfiguration()['encrypted_reasoning'] ?? false;
+
+        if ($encryptedReasoning) {
+            $body = [
+                'model' => $model,
+                'input' => $this->mapMessagesToInput($messages->all(), $instructions),
+                'store' => false,
+                'include' => ['reasoning.encrypted_content'],
+            ];
+        } else {
+            $body = [
+                'model' => $model,
+                'previous_response_id' => $responseId,
+                'input' => $this->buildToolResultsInput($toolResults),
+            ];
+        }
 
         if (filled($tools)) {
             $body['tools'] = $this->mapTools($tools, $provider);
@@ -267,7 +284,7 @@ trait ParsesTextResponses
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout, $instructions);
     }
 
     /**
@@ -411,6 +428,7 @@ trait ParsesTextResponses
                     $item['call_id'] ?? null,
                     $latestReasoning ? ($latestReasoning['id'] ?? null) : null,
                     $latestReasoning ? ($latestReasoning['summary'] ?? null) : null,
+                    $latestReasoning ? ($latestReasoning['encrypted_content'] ?? null) : null,
                 );
             }
         }

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -59,9 +57,8 @@ trait ParsesTextResponses
         array $tools = [],
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
+        array $requestBody = [],
         ?int $timeout = null,
-        ?string $instructions = null,
-        Collection $messages = new Collection,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -70,17 +67,14 @@ trait ParsesTextResponses
             $tools,
             $schema,
             new Collection,
-            $messages,
+            new Collection,
+            $requestBody,
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
-            instructions: $instructions,
         );
     }
 
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
     protected function processResponse(
         array $data,
         Provider $provider,
@@ -89,11 +83,11 @@ trait ParsesTextResponses
         ?array $schema,
         Collection $steps,
         Collection $messages,
+        array $requestBody,
         int $depth = 0,
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-        ?string $instructions = null,
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
@@ -104,7 +98,6 @@ trait ParsesTextResponses
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data);
 
-        // Associate reasoning with tool calls...
         $mappedToolCalls = $this->mapToolCallsWithReasoning($output);
 
         $step = new Step(
@@ -118,18 +111,15 @@ trait ParsesTextResponses
 
         $steps->push($step);
 
-        // Build assistant message for conversation context...
         $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
 
         $messages->push($assistantMessage);
 
-        // Execute tool calls...
         if ($finishReason === FinishReason::ToolCalls &&
             filled($mappedToolCalls) &&
             $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
 
-            // Update step with tool results...
             $steps->pop();
 
             $steps->push(new Step(
@@ -146,20 +136,21 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $responseId,
-                $model,
                 $provider,
                 $structured,
                 $tools,
                 $schema,
                 $steps,
                 $messages,
+                $requestBody,
+                $responseId,
+                $assistantMessage,
+                $toolResultMessage,
                 $toolResults,
                 $depth + 1,
                 $maxSteps,
                 $options,
                 $timeout,
-                $instructions,
             );
         }
 
@@ -188,8 +179,6 @@ trait ParsesTextResponses
     }
 
     /**
-     * Execute tool calls and return tool results.
-     *
      * @param  array<ToolCall>  $toolCalls
      * @param  array<Tool>  $tools
      * @return array<ToolResult>
@@ -220,76 +209,66 @@ trait ParsesTextResponses
     }
 
     /**
-     * Continue the conversation with tool results by making a follow-up request.
+     * The stateful path keeps the original body, swaps input for just the new
+     * tool-result items, and adds previous_response_id so OpenAI loads prior
+     * state server-side. The stateless path appends the prior turn's items to
+     * the running input so OpenAI sees the full conversation each turn. Both
+     * paths inherit tools, schema, temperature, top_p, max_output_tokens, and
+     * providerOptions from the initial body.
+     *
+     * @param  array<ToolResult>  $toolResults
      */
     protected function continueWithToolResults(
-        string $responseId,
-        string $model,
         Provider $provider,
         bool $structured,
         array $tools,
         ?array $schema,
         Collection $steps,
         Collection $messages,
+        array $requestBody,
+        string $responseId,
+        AssistantMessage $assistantMessage,
+        ToolResultMessage $toolResultMessage,
         array $toolResults,
         int $depth,
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
-        ?string $instructions = null,
     ): TextResponse {
-        $encryptedReasoning = $provider->additionalConfiguration()['encrypted_reasoning'] ?? false;
-
-        if ($encryptedReasoning) {
-            $body = [
-                'model' => $model,
-                'input' => $this->mapMessagesToInput($messages->all(), $instructions),
-                'store' => false,
-                'include' => ['reasoning.encrypted_content'],
-            ];
+        if ($this->isStateless($provider)) {
+            $this->mapAssistantMessage($assistantMessage, $requestBody['input']);
+            $this->mapToolResultMessage($toolResultMessage, $requestBody['input']);
         } else {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-            ];
-        }
-
-        if (filled($tools)) {
-            $body['tools'] = $this->mapTools($tools, $provider);
-        }
-
-        if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-            'max_output_tokens' => $options?->maxTokens,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
+            $requestBody['previous_response_id'] = $responseId;
+            $requestBody['input'] = $this->buildToolResultsInput($toolResults);
         }
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('responses', $body),
+            fn () => $this->client($provider, $timeout)->post('responses', $requestBody),
         );
 
         $data = $response->json();
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout, $instructions);
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $requestBody,
+            $depth,
+            $maxSteps,
+            $options,
+            $timeout,
+        );
     }
 
     /**
-     * Build the input array containing only tool results for a follow-up request.
-     *
      * @param  array<ToolResult>  $toolResults
      */
     protected function buildToolResultsInput(array $toolResults): array

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -85,9 +85,8 @@ class OpenAiGateway implements Gateway
             $tools,
             $schema,
             $options,
+            $body,
             $timeout,
-            $instructions,
-            collect($messages),
         );
     }
 
@@ -126,11 +125,10 @@ class OpenAiGateway implements Gateway
             $schema,
             $options,
             $response->getBody(),
+            $body,
             0,
             null,
             $timeout,
-            $instructions,
-            collect($messages),
         );
     }
 

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -78,7 +78,17 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $timeout,
+            $instructions,
+            collect($messages),
+        );
     }
 
     /**
@@ -119,6 +129,8 @@ class OpenAiGateway implements Gateway
             0,
             null,
             $timeout,
+            $instructions,
+            collect($messages),
         );
     }
 

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -141,9 +141,10 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, ImagePr
      */
     public function additionalConfiguration(): array
     {
-        return array_filter([
+        return [
             'url' => rtrim($this->config['url'] ?? '', '/'),
             'api_version' => $this->config['api_version'] ?? '2025-04-01-preview',
-        ]);
+            'store' => $this->config['store'] ?? true,
+        ];
     }
 }

--- a/src/Responses/Data/ToolCall.php
+++ b/src/Responses/Data/ToolCall.php
@@ -18,6 +18,22 @@ class ToolCall implements Arrayable, JsonSerializable
     ) {}
 
     /**
+     * Reconstruct an instance from a previously serialized toArray() payload.
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            arguments: $data['arguments'],
+            resultId: $data['result_id'] ?? null,
+            reasoningId: $data['reasoning_id'] ?? null,
+            reasoningSummary: $data['reasoning_summary'] ?? null,
+            reasoningEncryptedContent: $data['reasoning_encrypted_content'] ?? null,
+        );
+    }
+
+    /**
      * Get the instance as an array.
      */
     public function toArray(): array

--- a/src/Responses/Data/ToolCall.php
+++ b/src/Responses/Data/ToolCall.php
@@ -14,6 +14,7 @@ class ToolCall implements Arrayable, JsonSerializable
         public ?string $resultId = null,
         public ?string $reasoningId = null,
         public ?array $reasoningSummary = null,
+        public ?string $reasoningEncryptedContent = null,
     ) {}
 
     /**
@@ -28,6 +29,7 @@ class ToolCall implements Arrayable, JsonSerializable
             'result_id' => $this->resultId,
             'reasoning_id' => $this->reasoningId,
             'reasoning_summary' => $this->reasoningSummary,
+            'reasoning_encrypted_content' => $this->reasoningEncryptedContent,
         ];
     }
 

--- a/src/Responses/Data/ToolResult.php
+++ b/src/Responses/Data/ToolResult.php
@@ -16,6 +16,20 @@ class ToolResult implements Arrayable, JsonSerializable
     ) {}
 
     /**
+     * Reconstruct an instance from a previously serialized toArray() payload.
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            arguments: $data['arguments'],
+            result: $data['result'],
+            resultId: $data['result_id'] ?? null,
+        );
+    }
+
+    /**
      * Get the instance as an array.
      */
     public function toArray(): array

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -156,29 +156,16 @@ class DatabaseConversationStore implements ConversationStore
                 }
 
                 if ($toolCalls->isNotEmpty()) {
-                    $messages = [];
-
-                    $messages[] = new AssistantMessage(
-                        $record->content ?: '',
-                        $toolCalls->map(fn ($toolCall) => new ToolCall(
-                            id: $toolCall['id'],
-                            name: $toolCall['name'],
-                            arguments: $toolCall['arguments'],
-                            resultId: $toolCall['result_id'] ?? null,
-                            reasoningId: $toolCall['reasoning_id'] ?? null,
-                            reasoningSummary: $toolCall['reasoning_summary'] ?? null,
-                        ))
-                    );
+                    $messages = [
+                        new AssistantMessage(
+                            $record->content ?: '',
+                            $toolCalls->map(ToolCall::fromArray(...)),
+                        ),
+                    ];
 
                     if ($toolResults->isNotEmpty()) {
                         $messages[] = new ToolResultMessage(
-                            $toolResults->map(fn ($toolResult) => new ToolResult(
-                                id: $toolResult['id'],
-                                name: $toolResult['name'],
-                                arguments: $toolResult['arguments'],
-                                result: $toolResult['result'],
-                                resultId: $toolResult['result_id'] ?? null,
-                            ))
+                            $toolResults->map(ToolResult::fromArray(...)),
                         );
                     }
 

--- a/tests/Feature/Providers/AzureOpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/MessageMappingTest.php
@@ -42,7 +42,7 @@ test('user message maps to azure format', function () {
 test('tool result follow up uses previous response id', function () {
     Http::fake([
         'my-resource.cognitiveservices.azure.com/*' => Http::sequence([
-            fakeAzureToolCallResponse(),
+            fakeOpenAiToolCallResponse('resp_azure_tool_123', 'gpt-4o'),
             fakeAzureResponse('The number is 72019'),
         ]),
     ]);
@@ -72,6 +72,30 @@ test('tool result follow up uses previous response id', function () {
     }
 
     expect($hasFunctionCallOutput)->toBeTrue();
+});
+
+test('azure store false enables stateless inline conversation', function () {
+    config(['ai.providers.azure' => [
+        ...config('ai.providers.azure'),
+        'store' => false,
+    ]]);
+
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => Http::sequence([
+            fakeOpenAiToolCallResponse('resp_azure_tool_123', 'gpt-4o'),
+            fakeAzureResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'azure');
+
+    $recorded = Http::recorded();
+    $initialBody = json_decode($recorded[0][0]->body(), true);
+    $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+    expect($initialBody['store'] ?? null)->toBeFalse()
+        ->and($followUpBody)->not->toHaveKey('previous_response_id')
+        ->and($followUpBody['store'] ?? null)->toBeFalse();
 });
 
 test('image attachment maps to input_image content block', function () {
@@ -124,24 +148,3 @@ test('document attachment maps to input_file content block', function () {
             && str_contains($fileBlock['file_data'], 'application/pdf');
     });
 });
-
-function fakeAzureToolCallResponse()
-{
-    return Http::response([
-        'id' => 'resp_azure_tool_123',
-        'status' => 'completed',
-        'model' => 'gpt-4o',
-        'output' => [[
-            'type' => 'function_call',
-            'id' => 'fc_123',
-            'call_id' => 'call_123',
-            'name' => 'FixedNumberGenerator',
-            'arguments' => '{}',
-            'status' => 'completed',
-        ]],
-        'usage' => [
-            'input_tokens' => 10,
-            'output_tokens' => 5,
-        ],
-    ]);
-}

--- a/tests/Feature/Providers/OpenAi/EncryptedReasoningTest.php
+++ b/tests/Feature/Providers/OpenAi/EncryptedReasoningTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
     config(['ai.providers.openai' => [
         ...config('ai.providers.openai'),
         'key' => 'test-key',
-        'encrypted_reasoning' => true,
+        'store' => false,
     ]]);
 });
 
@@ -160,10 +160,53 @@ test('streaming tool follow up echoes encrypted reasoning back inline', function
         ->toBeTrue('streamed tool result included');
 });
 
-test('default encrypted reasoning off preserves previous response id behaviour', function () {
+test('non-reasoning model omits reasoning.encrypted_content include even with store false', function (string $model) {
+    Http::fake(['api.openai.com/*' => fakeOpenAiResponse()]);
+
+    (new OpenAiAgent)->prompt('Hi', model: $model);
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['store'] ?? null) === false
+            && ! in_array('reasoning.encrypted_content', $body['include'] ?? [], true);
+    });
+})->with([
+    'gpt-4.1',
+    'gpt-4o',
+    'gpt-5-chat-latest',
+]);
+
+test('store accepts env-style string values', function (mixed $storeValue, bool $shouldBeStateless) {
     config(['ai.providers.openai' => [
         ...config('ai.providers.openai'),
-        'encrypted_reasoning' => false,
+        'store' => $storeValue,
+    ]]);
+
+    Http::fake(['api.openai.com/*' => fakeOpenAiResponse()]);
+
+    (new OpenAiAgent)->prompt('Hi');
+
+    Http::assertSent(function ($request) use ($shouldBeStateless) {
+        $body = json_decode($request->body(), true);
+        $isStateless = ($body['store'] ?? null) === false;
+
+        return $isStateless === $shouldBeStateless;
+    });
+})->with([
+    'bool false' => [false, true],
+    'string "false"' => ['false', true],
+    'string "0"' => ['0', true],
+    'string "no"' => ['no', true],
+    'bool true' => [true, false],
+    'string "true"' => ['true', false],
+    'unrecognized string' => ['maybe', false],
+]);
+
+test('default store true preserves previous response id behaviour', function () {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'store' => true,
     ]]);
 
     Http::fake([

--- a/tests/Feature/Providers/OpenAi/EncryptedReasoningTest.php
+++ b/tests/Feature/Providers/OpenAi/EncryptedReasoningTest.php
@@ -182,6 +182,14 @@ test('default encrypted reasoning off preserves previous response id behaviour',
         ->and($followUp['previous_response_id'])->toBe('resp_tool_1')
         ->and($followUp)->not->toHaveKey('store')
         ->and($followUp)->not->toHaveKey('include');
+
+    $input = collect($followUp['input']);
+
+    expect($input)->toHaveCount(1)
+        ->and($input->first()['type'] ?? null)->toBe('function_call_output')
+        ->and($input->first()['call_id'] ?? null)->toBe('call_1')
+        ->and($input->contains(fn ($i) => ($i['role'] ?? null) === 'user'))->toBeFalse()
+        ->and($input->contains(fn ($i) => ($i['type'] ?? null) === 'reasoning'))->toBeFalse();
 });
 
 function fakeOpenAiToolCallResponseWithEncryptedReasoning(string $reasoningId, string $encryptedContent, string $functionCallId, string $callId): PromiseInterface

--- a/tests/Feature/Providers/OpenAi/EncryptedReasoningTest.php
+++ b/tests/Feature/Providers/OpenAi/EncryptedReasoningTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
+use Tests\Fixtures\Agents\OpenAiAgent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Agents\ToolUsingAgent;
+
+beforeEach(function () {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'key' => 'test-key',
+        'encrypted_reasoning' => true,
+    ]]);
+});
+
+test('initial request includes store false and reasoning encrypted content in include', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('Hello'),
+    ]);
+
+    (new OpenAiAgent)->prompt('Hello');
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['store'] ?? null) === false
+            && in_array('reasoning.encrypted_content', $body['include'] ?? [], true);
+    });
+});
+
+test('tool follow up omits previous response id and echoes encrypted reasoning back inline', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            fakeOpenAiToolCallResponseWithEncryptedReasoning('rs_1', 'enc-blob-1', 'fc_1', 'call_1'),
+            fakeOpenAiResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'openai');
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp)->not->toHaveKey('previous_response_id')
+        ->and($followUp['store'] ?? null)->toBeFalse()
+        ->and($followUp['include'] ?? [])->toContain('reasoning.encrypted_content');
+
+    $input = collect($followUp['input']);
+
+    expect($input->contains(fn ($i) => ($i['role'] ?? null) === 'user'
+        && collect($i['content'] ?? [])->contains(fn ($c) => ($c['text'] ?? '') === 'Generate a number')))
+        ->toBeTrue('original user message resent inline')
+        ->and($input->contains(fn ($i) => ($i['type'] ?? null) === 'reasoning'
+            && ($i['id'] ?? null) === 'rs_1'
+            && ($i['encrypted_content'] ?? null) === 'enc-blob-1'))
+        ->toBeTrue('reasoning block with encrypted_content round-tripped')
+        ->and($input->contains(fn ($i) => ($i['type'] ?? null) === 'function_call'
+            && ($i['call_id'] ?? null) === 'call_1'))
+        ->toBeTrue('assistant function call resent')
+        ->and($input->contains(fn ($i) => ($i['type'] ?? null) === 'function_call_output'
+            && ($i['call_id'] ?? null) === 'call_1'))
+        ->toBeTrue('tool result included');
+});
+
+test('multi step tool loop accumulates encrypted reasoning across steps', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            fakeOpenAiToolCallResponseWithEncryptedReasoning('rs_1', 'enc-blob-1', 'fc_1', 'call_1'),
+            fakeOpenAiToolCallResponseWithEncryptedReasoning('rs_2', 'enc-blob-2', 'fc_2', 'call_2'),
+            fakeOpenAiResponse('Done'),
+        ]),
+    ]);
+
+    (new MultiStepToolAgent)->prompt('Generate a number', provider: 'openai');
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(3);
+
+    $finalFollowUp = json_decode($recorded[2][0]->body(), true);
+
+    expect($finalFollowUp)->not->toHaveKey('previous_response_id');
+
+    $input = collect($finalFollowUp['input']);
+
+    expect($input->where(fn ($i) => ($i['type'] ?? null) === 'reasoning'
+        && ($i['encrypted_content'] ?? null) === 'enc-blob-1')->count())->toBe(1)
+        ->and($input->where(fn ($i) => ($i['type'] ?? null) === 'reasoning'
+            && ($i['encrypted_content'] ?? null) === 'enc-blob-2')->count())->toBe(1)
+        ->and($input->where(fn ($i) => ($i['type'] ?? null) === 'function_call_output')->count())->toBe(2);
+});
+
+test('streaming tool follow up echoes encrypted reasoning back inline', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    [
+                        'type' => 'response.output_item.done',
+                        'item' => [
+                            'type' => 'reasoning',
+                            'id' => 'rs_1',
+                            'summary' => [],
+                            'encrypted_content' => 'enc-blob-1',
+                        ],
+                    ],
+                    $this->outputItemAdded('fc_1', 'call_1', 'FixedNumberGenerator'),
+                    $this->functionCallArgumentsDelta('fc_1', '{}'),
+                    $this->functionCallArgumentsDone('fc_1', '{}'),
+                    $this->responseCompleted(10, 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+            Http::response(
+                body: $this->ssePayload([
+                    [
+                        'type' => 'response.created',
+                        'response' => ['id' => 'resp_2', 'model' => 'gpt-5.4', 'status' => 'in_progress', 'output' => []],
+                    ],
+                    $this->outputTextDelta('Done'),
+                    $this->outputTextDone('Done'),
+                    $this->responseCompleted(20, 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]),
+    ]);
+
+    $events = [];
+    foreach ((new ProviderOptionsWithToolsAgent)->stream('Generate a number', provider: 'openai') as $event) {
+        $events[] = $event;
+    }
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp)->not->toHaveKey('previous_response_id')
+        ->and($followUp['store'] ?? null)->toBeFalse()
+        ->and($followUp['include'] ?? [])->toContain('reasoning.encrypted_content');
+
+    $input = collect($followUp['input']);
+
+    expect($input->contains(fn ($i) => ($i['type'] ?? null) === 'reasoning'
+        && ($i['id'] ?? null) === 'rs_1'
+        && ($i['encrypted_content'] ?? null) === 'enc-blob-1'))
+        ->toBeTrue('streamed reasoning block with encrypted_content round-tripped')
+        ->and($input->contains(fn ($i) => ($i['type'] ?? null) === 'function_call'
+            && ($i['call_id'] ?? null) === 'call_1'))
+        ->toBeTrue('streamed function call resent')
+        ->and($input->contains(fn ($i) => ($i['type'] ?? null) === 'function_call_output'
+            && ($i['call_id'] ?? null) === 'call_1'))
+        ->toBeTrue('streamed tool result included');
+});
+
+test('default encrypted reasoning off preserves previous response id behaviour', function () {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'encrypted_reasoning' => false,
+    ]]);
+
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            fakeOpenAiToolCallResponseWithEncryptedReasoning('rs_1', 'enc-blob-1', 'fc_1', 'call_1'),
+            fakeOpenAiResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'openai');
+
+    $recorded = Http::recorded();
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp)->toHaveKey('previous_response_id')
+        ->and($followUp['previous_response_id'])->toBe('resp_tool_1')
+        ->and($followUp)->not->toHaveKey('store')
+        ->and($followUp)->not->toHaveKey('include');
+});
+
+function fakeOpenAiToolCallResponseWithEncryptedReasoning(string $reasoningId, string $encryptedContent, string $functionCallId, string $callId): PromiseInterface
+{
+    return Http::response([
+        'id' => 'resp_tool_1',
+        'status' => 'completed',
+        'model' => 'gpt-5.4',
+        'output' => [
+            [
+                'type' => 'reasoning',
+                'id' => $reasoningId,
+                'summary' => [],
+                'encrypted_content' => $encryptedContent,
+            ],
+            [
+                'type' => 'function_call',
+                'id' => $functionCallId,
+                'call_id' => $callId,
+                'name' => 'FixedNumberGenerator',
+                'arguments' => '{}',
+                'status' => 'completed',
+            ],
+        ],
+        'usage' => [
+            'input_tokens' => 10,
+            'output_tokens' => 5,
+        ],
+    ]);
+}

--- a/tests/Feature/Providers/OpenAi/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenAi/ProviderOptionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
@@ -67,24 +66,3 @@ test('provider options are persisted in tool call follow up requests', function 
         ->and(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5)
         ->and($followUpBody)->toHaveKey('previous_response_id');
 });
-
-function fakeOpenAiToolCallResponse(): PromiseInterface
-{
-    return Http::response([
-        'id' => 'resp_tool_123',
-        'status' => 'completed',
-        'model' => 'gpt-5.4',
-        'output' => [[
-            'type' => 'function_call',
-            'id' => 'fc_123',
-            'call_id' => 'call_123',
-            'name' => 'FixedNumberGenerator',
-            'arguments' => '{}',
-            'status' => 'completed',
-        ]],
-        'usage' => [
-            'input_tokens' => 10,
-            'output_tokens' => 5,
-        ],
-    ]);
-}

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -176,6 +176,76 @@ test('it reloads legacy sparse keyed tool calls and results as lists', function 
         ->and($messages[1]->toolResults->keys()->all())->toBe([0, 1]);
 });
 
+test('it rehydrates reasoning encrypted content on stored tool calls', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Reasoning conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Looking that up.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            [
+                'id' => 'call-1',
+                'name' => 'lookup_order',
+                'arguments' => ['id' => 1],
+                'reasoning_id' => 'rs_1',
+                'reasoning_summary' => [],
+                'reasoning_encrypted_content' => 'enc-blob-1',
+            ],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped']],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[0]->toolCalls->first())
+        ->reasoningId->toBe('rs_1')
+        ->reasoningEncryptedContent->toBe('enc-blob-1');
+});
+
+test('it rehydrates legacy tool calls that predate reasoning encrypted content', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Legacy conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Looking that up.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1]],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped']],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[0]->toolCalls->first())
+        ->reasoningId->toBeNull()
+        ->reasoningSummary->toBeNull()
+        ->reasoningEncryptedContent->toBeNull();
+});
+
 test('user messages with stored attachments are rehydrated as UserMessage', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Attachment conversation');

--- a/tests/Fixtures/Agents/MultiStepToolAgent.php
+++ b/tests/Fixtures/Agents/MultiStepToolAgent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+#[MaxSteps(10)]
+class MultiStepToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that generates numbers.';
+    }
+
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator];
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -90,6 +90,27 @@ function fakeOpenAiResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
+function fakeOpenAiToolCallResponse(string $id = 'resp_tool_123', string $model = 'gpt-5.4'): PromiseInterface
+{
+    return Http::response([
+        'id' => $id,
+        'status' => 'completed',
+        'model' => $model,
+        'output' => [[
+            'type' => 'function_call',
+            'id' => 'fc_123',
+            'call_id' => 'call_123',
+            'name' => 'FixedNumberGenerator',
+            'arguments' => '{}',
+            'status' => 'completed',
+        ]],
+        'usage' => [
+            'input_tokens' => 10,
+            'output_tokens' => 5,
+        ],
+    ]);
+}
+
 function fakeDeepSeekResponse(string $text = 'Hello'): PromiseInterface
 {
     return Http::response([

--- a/tests/Unit/Responses/Data/ToolCallTest.php
+++ b/tests/Unit/Responses/Data/ToolCallTest.php
@@ -32,6 +32,7 @@ test('tool call to array returns all properties', function () {
         'result_id' => null,
         'reasoning_id' => null,
         'reasoning_summary' => null,
+        'reasoning_encrypted_content' => null,
     ]);
 });
 

--- a/tests/Unit/Responses/Data/ToolCallTest.php
+++ b/tests/Unit/Responses/Data/ToolCallTest.php
@@ -9,7 +9,8 @@ test('tool call stores all properties', function () {
         arguments: ['city' => 'San Francisco'],
         resultId: 'res_456',
         reasoningId: 'reason_789',
-        reasoningSummary: ['thought' => 'I should check the weather']
+        reasoningSummary: ['thought' => 'I should check the weather'],
+        reasoningEncryptedContent: 'enc-blob-1',
     );
 
     expect($toolCall->id)->toBe('call_123')
@@ -17,7 +18,8 @@ test('tool call stores all properties', function () {
         ->and($toolCall->arguments)->toBe(['city' => 'San Francisco'])
         ->and($toolCall->resultId)->toBe('res_456')
         ->and($toolCall->reasoningId)->toBe('reason_789')
-        ->and($toolCall->reasoningSummary)->toBe(['thought' => 'I should check the weather']);
+        ->and($toolCall->reasoningSummary)->toBe(['thought' => 'I should check the weather'])
+        ->and($toolCall->reasoningEncryptedContent)->toBe('enc-blob-1');
 });
 
 test('tool call to array returns all properties', function () {


### PR DESCRIPTION
Currently, every OpenAI tool-call follow-up — both streaming (`handleStreamingToolCalls`) and non-streaming (`continueWithToolResults`) — POSTs to `/responses` with `previous_response_id` pointing at the prior assistant turn, relying on OpenAI to load that turn's state server-side.

Organizations with Zero Data Retention enabled reject any request containing `previous_response_id` with:

> Previous response cannot be used for this organization due to Zero Data Retention

Because ZDR forbids OpenAI from storing the prior response that the ID would reference. As a result, any agent that uses tools is unusable on a ZDR account: the first response succeeds, the tool runs, then the follow-up is rejected with a 400.

This PR introduces an `encrypted_reasoning` provider config, driven by `OPENAI_ENCRYPTED_REASONING` and defaulting to `false`, that wires up [OpenAI's recommended stateless-with-reasoning path](https://developers.openai.com/api/docs/guides/migrate-to-responses#4-decide-when-to-use-statefulness):

- Every request gets `store: false`
- Every request gets `include: ['reasoning.encrypted_content']`
- Tool follow-ups omit `previous_response_id` entirely

Instead, the follow-up sends the full conversation inline through `mapMessagesToInput`, including:

- System instructions
- Prior user messages
- The assistant tool calls produced this turn
- Reasoning blocks carrying `encrypted_content`
- Tool results

This gives OpenAI the same context that server-side chaining would have provided. OpenAI decrypts the blob in memory, uses it to reconstitute reasoning, and discards it, so reasoning context is preserved across tool steps without anything being stored.

The `encrypted_content` blob is parsed off reasoning items in both `mapToolCallsWithReasoning` for non-streaming and `processTextStream` for streaming. It is carried on `ToolCall` via a new `reasoningEncryptedContent` field and re-emitted by `mapAssistantMessage` on replay.

As a result, the existing reasoning-block round-trip plumbing handles multi-step tool chains without any new threading helpers. Both paths now thread `$instructions` and the prior `$messages` collection through the recursive tool loop, so the inline conversation rebuilds the same system message and history that the initial request had.

The flag is per-provider in `config/ai.php`, so accounts with mixed ZDR settings can be modeled by registering separate provider entries.