### PR TITLE
Use long text columns for conversation payloads

### DIFF
--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -29,12 +29,12 @@ return new class extends AiMigration
             $table->foreignId('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
-            $table->text('content');
-            $table->text('attachments');
-            $table->text('tool_calls');
-            $table->text('tool_results');
-            $table->text('usage');
-            $table->text('meta');
+            $table->longText('content');
+            $table->longText('attachments');
+            $table->longText('tool_calls');
+            $table->longText('tool_results');
+            $table->longText('usage');
+            $table->longText('meta');
             $table->timestamps();
 
             $table->index(['conversation_id', 'user_id', 'updated_at'], 'conversation_index');

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -336,12 +336,12 @@ function createConversationSchema(?string $connection = null): void
         $table->foreignId('user_id')->nullable();
         $table->string('agent');
         $table->string('role', 25);
-        $table->text('content');
-        $table->text('attachments');
-        $table->text('tool_calls');
-        $table->text('tool_results');
-        $table->text('usage');
-        $table->text('meta');
+        $table->longText('content');
+        $table->longText('attachments');
+        $table->longText('tool_calls');
+        $table->longText('tool_results');
+        $table->longText('usage');
+        $table->longText('meta');
         $table->timestamps();
     });
 }


### PR DESCRIPTION
## Summary

This updates the default database conversation storage schema to use `longText` columns for conversation message payloads.

The following `agent_conversation_messages` columns now use `longText`:

- `content`
- `attachments`
- `tool_calls`
- `tool_results`
- `usage`
- `meta`

## Motivation

Agent conversation messages may contain large payloads, including long assistant responses, attachment metadata, tool calls, tool results, usage information, and provider metadata.

On MySQL-compatible databases, regular `text` columns can be too small for these payloads. Using `longText` gives the default conversation storage schema more room for larger AI conversation data without changing the public API.

## Upgrade note

New installations will receive `longText` payload columns from the default conversation migration.

Applications that have already published and run the previous conversation migration should update their published migration or add an application-level migration to alter the existing `agent_conversation_messages` payload columns from `text` to `longText`.

## Tests

- `composer test -- tests/Feature/Storage/DatabaseConversationStoreTest.php`
- `composer test:lint`
- `vendor/bin/phpstan --memory-limit=-1`
- `composer test`