### PR TITLE
Fail loudly on invalid stored conversation JSON

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use JsonException;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -73,7 +74,7 @@ class DatabaseConversationStore implements ConversationStore
             'agent' => $prompt->agent::class,
             'role' => 'user',
             'content' => $prompt->prompt,
-            'attachments' => $prompt->attachments->toJson(),
+            'attachments' => $this->encodeJson($prompt->attachments->values()),
             'tool_calls' => '[]',
             'tool_results' => '[]',
             'usage' => '[]',
@@ -104,10 +105,10 @@ class DatabaseConversationStore implements ConversationStore
             'role' => 'assistant',
             'content' => $response->text,
             'attachments' => '[]',
-            'tool_calls' => json_encode($response->toolCalls->values()),
-            'tool_results' => json_encode($response->toolResults->values()),
-            'usage' => json_encode($response->usage),
-            'meta' => json_encode($response->meta),
+            'tool_calls' => $this->encodeJson($response->toolCalls->values()),
+            'tool_results' => $this->encodeJson($response->toolResults->values()),
+            'usage' => $this->encodeJson($response->usage),
+            'meta' => $this->encodeJson($response->meta),
             'created_at' => $now,
             'updated_at' => $now,
         ]);
@@ -142,8 +143,8 @@ class DatabaseConversationStore implements ConversationStore
             ->reverse()
             ->values()
             ->flatMap(function ($record) {
-                $toolCalls = collect(json_decode($record->tool_calls, true))->values();
-                $toolResults = collect(json_decode($record->tool_results, true))->values();
+                $toolCalls = collect($this->decodeJsonArray($record->tool_calls, 'tool calls', allowSparseNumericKeys: true))->values();
+                $toolResults = collect($this->decodeJsonArray($record->tool_results, 'tool results', allowSparseNumericKeys: true))->values();
 
                 if ($record->role === 'user') {
                     $attachments = $this->rehydrateAttachments($record->attachments);
@@ -191,11 +192,7 @@ class DatabaseConversationStore implements ConversationStore
 
     protected function rehydrateAttachments(string $attachments): Collection
     {
-        $decoded = json_decode($attachments, true);
-
-        if (! is_array($decoded) || ! array_is_list($decoded)) {
-            throw new InvalidArgumentException('Stored conversation attachments must be a JSON array.');
-        }
+        $decoded = $this->decodeJsonArray($attachments, 'attachments');
 
         if ($decoded === []) {
             return collect();
@@ -211,6 +208,41 @@ class DatabaseConversationStore implements ConversationStore
             })
             ->filter()
             ->values();
+    }
+
+    protected function encodeJson(mixed $value): string
+    {
+        return json_encode($value, JSON_THROW_ON_ERROR);
+    }
+
+    protected function decodeJsonArray(string $json, string $name, bool $allowSparseNumericKeys = false): array
+    {
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidArgumentException("Stored conversation {$name} must be valid JSON.", previous: $exception);
+        }
+
+        if (! is_array($decoded)) {
+            throw new InvalidArgumentException("Stored conversation {$name} must be a JSON array.");
+        }
+
+        if (! array_is_list($decoded) && (! $allowSparseNumericKeys || ! $this->hasOnlyNumericKeys($decoded))) {
+            throw new InvalidArgumentException("Stored conversation {$name} must be a JSON array.");
+        }
+
+        return $decoded;
+    }
+
+    protected function hasOnlyNumericKeys(array $array): bool
+    {
+        foreach (array_keys($array) as $key) {
+            if (! is_int($key) && ! ctype_digit((string) $key)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -141,6 +141,27 @@ test('it stores sparse keyed tool calls and results as JSON arrays', function ()
         ->and(array_is_list(json_decode($record->tool_results, true)))->toBeTrue();
 });
 
+test('assistant message JSON serialization fails loudly', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new AgentResponse('invocation-id', 'The order has shipped.', new Usage, new Meta);
+    $response->toolResults = collect([
+        new ToolResult('call-1', 'lookup_order', ['id' => 1], ["Invalid \xB1 UTF-8"]),
+    ]);
+
+    expect(fn () => $store->storeAssistantMessage($conversationId, 1, $prompt, $response))
+        ->toThrow(JsonException::class);
+});
+
 test('it reloads legacy sparse keyed tool calls and results as lists', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Tool conversation');
@@ -288,6 +309,80 @@ test('malformed stored attachment JSON fails loudly', function () {
 
     expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
         ->toThrow(InvalidArgumentException::class, 'Stored conversation attachments must be a JSON array.');
+});
+
+test('invalid stored tool call JSON fails loudly', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Malformed tool call conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => '[{"id":"call-1","name":"lookup_order","arguments":{"id":1}}',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
+        ->toThrow(InvalidArgumentException::class, 'Stored conversation tool calls must be valid JSON.');
+});
+
+test('invalid stored tool result JSON fails loudly', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Malformed tool result conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1]],
+        ]),
+        'tool_results' => '[{"id":"call-1","name":"lookup_order","arguments":{"id":1},"result":{"status":"shipped"}}',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
+        ->toThrow(InvalidArgumentException::class, 'Stored conversation tool results must be valid JSON.');
+});
+
+test('stored tool call JSON must be an array', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Malformed tool call conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode(['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1]]),
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    expect(fn () => $store->getLatestConversationMessages($conversationId, 10))
+        ->toThrow(InvalidArgumentException::class, 'Stored conversation tool calls must be a JSON array.');
 });
 
 test('malformed known stored attachments fail loudly', function () {


### PR DESCRIPTION
## Summary

This updates database conversation storage to fail loudly when stored conversation JSON is invalid instead of silently treating it as empty data.

The database conversation store now uses `JSON_THROW_ON_ERROR` when encoding conversation payloads and when decoding stored attachment, tool call, and tool result JSON.

## Motivation

Stored conversation payloads can contain tool calls, tool results, attachment metadata, usage, and provider metadata. If one of these stored JSON payloads is truncated or otherwise invalid, `json_decode` previously returned `null`, which was then collected as an empty collection. In practice, this could silently drop stored tool calls or tool results during conversation replay.

Failing loudly makes corrupted or truncated stored JSON visible immediately instead of replaying incomplete conversation state.

## Notes

Sparse numeric-keyed legacy tool call and tool result payloads are still accepted and normalized with `values()`, preserving the existing compatibility behavior.

## Tests

- `composer test -- tests/Feature/Storage/DatabaseConversationStoreTest.php`
- `composer test:lint`
- `vendor/bin/phpstan --memory-limit=-1`
- `composer test`