### PR TITLE
Expose provider name as property on failover exceptions

### DIFF
--- a/src/Exceptions/InsufficientCreditsException.php
+++ b/src/Exceptions/InsufficientCreditsException.php
@@ -6,12 +6,22 @@ use Throwable;
 
 class InsufficientCreditsException extends AiException implements FailoverableException
 {
+    public function __construct(
+        public readonly string $provider,
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
     public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
     {
         return new self(
+            $provider,
             'AI provider ['.$provider.'] has insufficient credits or quota.',
             $code,
-            $previous
+            $previous,
         );
     }
 }

--- a/src/Exceptions/ProviderOverloadedException.php
+++ b/src/Exceptions/ProviderOverloadedException.php
@@ -6,9 +6,19 @@ use Throwable;
 
 class ProviderOverloadedException extends AiException implements FailoverableException
 {
+    public function __construct(
+        public readonly string $provider,
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
     public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
     {
         return new self(
+            $provider,
             'AI provider ['.$provider.'] is overloaded.',
             $code,
             $previous,

--- a/src/Exceptions/RateLimitedException.php
+++ b/src/Exceptions/RateLimitedException.php
@@ -6,12 +6,22 @@ use Throwable;
 
 class RateLimitedException extends AiException implements FailoverableException
 {
+    public function __construct(
+        public readonly string $provider,
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
     public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
     {
         return new self(
+            $provider,
             'Application rate limited by AI provider ['.$provider.'].',
             $code,
-            $previous
+            $previous,
         );
     }
 }

--- a/tests/Unit/Exceptions/FailoverExceptionProviderTest.php
+++ b/tests/Unit/Exceptions/FailoverExceptionProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+
+test('RateLimitedException exposes provider name as property', function () {
+    $e = RateLimitedException::forProvider('anthropic');
+
+    expect($e->provider)->toBe('anthropic');
+});
+
+test('ProviderOverloadedException exposes provider name as property', function () {
+    $e = ProviderOverloadedException::forProvider('openai');
+
+    expect($e->provider)->toBe('openai');
+});
+
+test('InsufficientCreditsException exposes provider name as property', function () {
+    $e = InsufficientCreditsException::forProvider('deepseek');
+
+    expect($e->provider)->toBe('deepseek');
+});
+
+test('exception message still contains provider name', function () {
+    expect(RateLimitedException::forProvider('groq')->getMessage())
+        ->toContain('groq');
+
+    expect(ProviderOverloadedException::forProvider('gemini')->getMessage())
+        ->toContain('gemini');
+
+    expect(InsufficientCreditsException::forProvider('openrouter')->getMessage())
+        ->toContain('openrouter');
+});


### PR DESCRIPTION
## Summary

`RateLimitedException`, `ProviderOverloadedException`, and `InsufficientCreditsException` all embed the provider name inside the exception message, but provide no way to access it programmatically. Catching code that needs to know which provider failed must parse the message string — which is fragile and couples application logic to a human-readable sentence.

This PR adds a `public readonly string $provider` property to all three failover exception classes. The `forProvider()` factory method is updated to populate it. The existing message format is unchanged.

Before:
```php
} catch (RateLimitedException $e) {
    // must parse: "Application rate limited by AI provider [anthropic]."
    preg_match('/\[(.+)\]/', $e->getMessage(), $m);
    $provider = $m[1];
}
```

After:
```php
} catch (RateLimitedException $e) {
    $provider = $e->provider; // 'anthropic'
}
```

## Changes

- `src/Exceptions/RateLimitedException.php` — add constructor + `provider` property
- `src/Exceptions/ProviderOverloadedException.php` — add constructor + `provider` property
- `src/Exceptions/InsufficientCreditsException.php` — add constructor + `provider` property
- `tests/Unit/Exceptions/FailoverExceptionProviderTest.php` — 4 assertions covering all three classes

## Test plan

- [x] All 4 new unit tests pass
- [x] All existing `HandlesFailoverErrorsTest` tests pass
- [x] All existing provider `ErrorHandlingTest` tests pass