### PR TITLE
Document @throws LogicException on OpenAiGateway::generateTranscription

### DIFF
--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -220,6 +220,8 @@ class GeminiGateway implements Gateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @throws RuntimeException if Gemini returns no audio data or invalid base64 audio.
      */
     public function generateAudio(
         AudioProvider $provider,

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -264,6 +264,8 @@ class OpenAiGateway implements Gateway
      * Generate text from the given audio.
      *
      * @param  array<string, mixed>  $providerOptions
+     *
+     * @throws LogicException if diarization is requested together with the `prompt` provider option.
      */
     public function generateTranscription(
         TranscriptionProvider $provider,

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -86,6 +86,8 @@ class PendingAudioGeneration
 
     /**
      * Generate the audio.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the audio.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): AudioResponse
     {

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -121,6 +121,8 @@ class PendingEmbeddingsGeneration
 
     /**
      * Generate the embeddings.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the embeddings.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): EmbeddingsResponse
     {

--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -114,6 +114,8 @@ class PendingImageGeneration
 
     /**
      * Generate the image.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the image.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): ImageResponse
     {
@@ -146,6 +148,8 @@ class PendingImageGeneration
 
     /**
      * Queue the generation of an image.
+     *
+     * @throws LogicException if any attachment is not a local image or an image stored on a filesystem disk.
      */
     public function queue(Lab|array|string|null $provider = null, ?string $model = null): QueuedImageResponse
     {

--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -21,6 +21,8 @@ class PendingReranking
      * Create a new pending reranking instance.
      *
      * @param  array<int, string>  $documents
+     *
+     * @throws InvalidArgumentException if the documents are not a list, are empty, or contain non-string or blank entries.
      */
     public function __construct(
         protected array $documents,
@@ -52,6 +54,8 @@ class PendingReranking
 
     /**
      * Rerank the documents based on their relevance to the query.
+     *
+     * @throws FailoverableException if every configured provider fails to rerank the documents.
      */
     public function rerank(string $query, Lab|array|string|null $provider = null, ?string $model = null): RerankingResponse
     {

--- a/src/PendingResponses/PendingTranscriptionGeneration.php
+++ b/src/PendingResponses/PendingTranscriptionGeneration.php
@@ -97,6 +97,8 @@ class PendingTranscriptionGeneration
 
     /**
      * Generate the transcription.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the transcription.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): TranscriptionResponse
     {
@@ -129,6 +131,8 @@ class PendingTranscriptionGeneration
 
     /**
      * Queue the generation of the transcription.
+     *
+     * @throws LogicException if the audio attachment is not a local audio or an audio file stored on a filesystem disk.
      */
     public function queue(Lab|array|string|null $provider = null, ?string $model = null): QueuedTranscriptionResponse
     {

--- a/src/Tools/SimilaritySearch.php
+++ b/src/Tools/SimilaritySearch.php
@@ -25,6 +25,8 @@ class SimilaritySearch implements Tool
 
     /**
      * Create a new similarity search tool instance.
+     *
+     * @throws InvalidArgumentException if the given model class name or vector column name is blank.
      */
     public static function usingModel(
         string $model,


### PR DESCRIPTION
## Summary

Combines #626, #627, #628, #629, #630, and #631 into a single commit to keep the GitHub history clean. All six PRs add missing `@throws` annotations to methods whose runtime contracts were not advertised in their docblocks. No behavior change — docblocks only.

- `OpenAiGateway::generateTranscription` — `@throws LogicException` (#626)
- `GeminiGateway::generateAudio` — `@throws RuntimeException` (#627)
- `SimilaritySearch::usingModel` — `@throws InvalidArgumentException` (#628)
- `PendingReranking::__construct` — `@throws InvalidArgumentException` (#629)
- `PendingResponses` generate methods — `@throws FailoverableException` (#630)
- `PendingResponses` queue methods — `@throws LogicException` (#631)

Once this lands, #627–#631 can be closed as superseded.
