### PR TITLE
Document @throws RuntimeException on GeminiGateway::generateAudio

### DIFF
--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -220,6 +220,8 @@ class GeminiGateway implements Gateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @throws RuntimeException if Gemini returns no audio data or invalid base64 audio.
      */
     public function generateAudio(
         AudioProvider $provider,


### PR DESCRIPTION
## Summary

- `GeminiGateway::generateAudio()` throws `RuntimeException` in two places — when Gemini's response contains no audio data, and when the returned base64 audio is invalid — but the docblock did not advertise that contract.
- Adds the missing `@throws RuntimeException` annotation. Mirrors the pattern from #585 and #601.

No behavior change — docblock only.

## Test plan

- [x] \`vendor/bin/pint src/Gateway/Gemini/GeminiGateway.php\`
- [x] \`vendor/bin/pest tests/Feature/Providers/Gemini/\` (all 132 tests pass)