### PR TITLE
Document @throws InvalidArgumentException on SimilaritySearch::usingModel

### DIFF
--- a/src/Tools/SimilaritySearch.php
+++ b/src/Tools/SimilaritySearch.php
@@ -25,6 +25,8 @@ class SimilaritySearch implements Tool
 
     /**
      * Create a new similarity search tool instance.
+     *
+     * @throws InvalidArgumentException if the given model class name or vector column name is blank.
      */
     public static function usingModel(
         string $model,


### PR DESCRIPTION
## Summary

- `SimilaritySearch::usingModel()` validates that both the model class name and vector column name are non-blank — throwing `InvalidArgumentException` when either is missing — but the docblock did not advertise that contract.
- Adds the missing `@throws InvalidArgumentException` annotation. Pairs with #592 which introduced the validation, and mirrors #585 / #576.

No behavior change — docblock only.

## Test plan

- [x] \`vendor/bin/pint src/Tools/SimilaritySearch.php\`
- [x] \`vendor/bin/pest tests/Feature/SimilaritySearchTest.php\` (all 6 tests pass)