### PR TITLE
Document @throws InvalidArgumentException on PendingReranking::__construct

### DIFF
--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -21,6 +21,8 @@ class PendingReranking
      * Create a new pending reranking instance.
      *
      * @param  array<int, string>  $documents
+     *
+     * @throws InvalidArgumentException if the documents are not a list, are empty, or contain non-string or blank entries.
      */
     public function __construct(
         protected array $documents,


### PR DESCRIPTION
## Summary

- `PendingReranking::__construct()` validates that the documents argument is a list and that each entry is a non-blank string (introduced in #591), throwing `InvalidArgumentException` otherwise, but the docblock did not advertise that contract.
- Adds the missing `@throws InvalidArgumentException` annotation. Mirrors the existing docblock on `PendingEmbeddingsGeneration::__construct`, which documents the same validation pattern.

No behavior change — docblock only.

## Test plan

- [x] \`vendor/bin/pint src/PendingResponses/PendingReranking.php\`
- [x] \`vendor/bin/pest --filter=Reranking\` (55 passed)