### PR TITLE
Document @throws FailoverableException across PendingResponses generate methods

### DIFF
--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -86,6 +86,8 @@ class PendingAudioGeneration
 
     /**
      * Generate the audio.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the audio.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): AudioResponse
     {

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -121,6 +121,8 @@ class PendingEmbeddingsGeneration
 
     /**
      * Generate the embeddings.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the embeddings.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): EmbeddingsResponse
     {

--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -114,6 +114,8 @@ class PendingImageGeneration
 
     /**
      * Generate the image.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the image.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): ImageResponse
     {

--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -52,6 +52,8 @@ class PendingReranking
 
     /**
      * Rerank the documents based on their relevance to the query.
+     *
+     * @throws FailoverableException if every configured provider fails to rerank the documents.
      */
     public function rerank(string $query, Lab|array|string|null $provider = null, ?string $model = null): RerankingResponse
     {

--- a/src/PendingResponses/PendingTranscriptionGeneration.php
+++ b/src/PendingResponses/PendingTranscriptionGeneration.php
@@ -97,6 +97,8 @@ class PendingTranscriptionGeneration
 
     /**
      * Generate the transcription.
+     *
+     * @throws FailoverableException if every configured provider fails to generate the transcription.
      */
     public function generate(Lab|array|string|null $provider = null, ?string $model = null): TranscriptionResponse
     {


### PR DESCRIPTION
## Summary

Five sibling methods in \`src/PendingResponses\` walk a list of configured providers and, if every one fails, rethrow the last \`FailoverableException\`:

- \`PendingImageGeneration::generate()\`
- \`PendingEmbeddingsGeneration::generate()\`
- \`PendingAudioGeneration::generate()\`
- \`PendingTranscriptionGeneration::generate()\`
- \`PendingReranking::rerank()\`

None of these docblocks advertised that contract. This PR adds the matching \`@throws FailoverableException\` annotation to each. Bundled together because they share the same failover pattern, similar to #601 ("Document @throws RuntimeException on file content() methods") which bundled the sibling \`Base64File\`/\`LocalFile\`/\`RemoteFile\`/\`StoredFile\` \`content()\` methods.

No behavior change — docblocks only.

## Test plan

- [x] \`vendor/bin/pint src/PendingResponses/\`
- [x] \`vendor/bin/pest --filter="ImageFake|EmbeddingsFake|AudioFake|TranscriptionFake|RerankingFake"\` (95 passed)