### PR TITLE
Document @throws LogicException on PendingResponses queue methods

### DIFF
--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -146,6 +146,8 @@ class PendingImageGeneration
 
     /**
      * Queue the generation of an image.
+     *
+     * @throws LogicException if any attachment is not a local image or an image stored on a filesystem disk.
      */
     public function queue(Lab|array|string|null $provider = null, ?string $model = null): QueuedImageResponse
     {

--- a/src/PendingResponses/PendingTranscriptionGeneration.php
+++ b/src/PendingResponses/PendingTranscriptionGeneration.php
@@ -129,6 +129,8 @@ class PendingTranscriptionGeneration
 
     /**
      * Queue the generation of the transcription.
+     *
+     * @throws LogicException if the audio attachment is not a local audio or an audio file stored on a filesystem disk.
      */
     public function queue(Lab|array|string|null $provider = null, ?string $model = null): QueuedTranscriptionResponse
     {


### PR DESCRIPTION
## Summary

Two \`queue()\` methods in \`src/PendingResponses\` reject non-queueable attachments by throwing \`LogicException\`, but neither docblock advertised that contract:

- \`PendingImageGeneration::queue()\` — via \`ensureAttachmentsAreQueueable()\`, rejects attachments that are not \`LocalImage\` or \`StoredImage\`.
- \`PendingTranscriptionGeneration::queue()\` — rejects audio that is not \`LocalAudio\` or \`StoredAudio\`.

This PR adds the matching \`@throws LogicException\` annotation to each. Bundled together because both \`queue()\` methods share the same "must be a queueable file source" contract.

No behavior change — docblocks only.

## Test plan

- [x] \`vendor/bin/pint src/PendingResponses/\`
- [x] \`vendor/bin/pest --filter="queued image|queued transcription"\` (7 passed)