### PR TITLE
fix: preserve all OpenAI text parts in tool loops

### DIFF
--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -307,13 +307,21 @@ trait ParsesTextResponses
      */
     protected function extractText(array $output): string
     {
-        $lastOutput = last($output);
+        $textParts = [];
 
-        if (is_array($lastOutput)) {
-            return $lastOutput['content'][0]['text'] ?? '';
+        foreach ($output as $item) {
+            if (($item['type'] ?? '') !== 'message') {
+                continue;
+            }
+
+            foreach ($item['content'] ?? [] as $content) {
+                if (($content['type'] ?? '') === 'output_text' && isset($content['text'])) {
+                    $textParts[] = $content['text'];
+                }
+            }
         }
 
-        return '';
+        return implode('', $textParts);
     }
 
     /**

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -79,6 +79,50 @@ test('tool result follow up uses previous response id', function () {
     expect($hasFunctionCallOutput)->toBeTrue();
 });
 
+test('tool loop steps retain all assistant text parts from a message', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'resp_tool_parts_123',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [
+                    [
+                        'type' => 'message',
+                        'status' => 'completed',
+                        'role' => 'assistant',
+                        'content' => [
+                            ['type' => 'output_text', 'text' => 'Looking up the number. '],
+                            ['type' => 'output_text', 'text' => 'Calling the tool now.'],
+                        ],
+                    ],
+                    [
+                        'type' => 'function_call',
+                        'id' => 'fc_123',
+                        'call_id' => 'call_123',
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                        'status' => 'completed',
+                    ],
+                ],
+                'usage' => [
+                    'input_tokens' => 10,
+                    'output_tokens' => 5,
+                ],
+            ]),
+            fakeOpenAiResponse('The number is 72019'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'openai',
+    );
+
+    expect($response->steps)->toHaveCount(2)
+        ->and($response->steps->first()->text)->toBe('Looking up the number. Calling the tool now.');
+});
+
 test('base64 pdf document maps to input file', function () {
     Http::fake([
         'api.openai.com/*' => fakeOpenAiResponse('I see a PDF'),


### PR DESCRIPTION
## Summary
- preserve all `output_text` parts in OpenAI tool-loop assistant responses instead of only keeping one segment
- add regression coverage for multiple text parts within a single assistant message

## Test plan
- Not run in this environment (`php` and `composer` are not installed on the agent host)

Closes #503
