### PR TITLE
Apply model attribute and explicit model to all providers in a failover list

### DIFF
--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -254,7 +254,7 @@ trait Promptable
             }
         }
 
-        if (! is_array($provider) && is_null($model)) {
+        if (is_null($model)) {
             if (method_exists($this, 'model')) {
                 $model = $this->model();
             } else {

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -61,9 +61,9 @@ abstract class Provider
             return [$providers => $model];
         }
 
-        return (new Collection($providers))->mapWithKeys(function ($value, $key) {
+        return (new Collection($providers))->mapWithKeys(function ($value, $key) use ($model) {
             return is_numeric($key)
-                ? [($value instanceof Lab ? $value->value : $value) => null]
+                ? [($value instanceof Lab ? $value->value : $value) => $model]
                 : [($key instanceof Lab ? $key->value : $key) => $value];
         })->all();
     }

--- a/tests/Feature/AgentStreamFailoverTest.php
+++ b/tests/Feature/AgentStreamFailoverTest.php
@@ -8,6 +8,7 @@ use Laravel\Ai\AiManager;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
@@ -49,6 +50,39 @@ test('stream fails over to next provider when primary is rate limited', function
     Event::assertDispatched(AgentFailedOver::class);
 
     Event::assertDispatched(AgentStreamed::class, fn (AgentStreamed $event) => $event->invocationId === $response->invocationId);
+});
+
+test('stream failover uses explicit model for each provider attempt', function () {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(fakeGroqStreamBodyForStreamFailover(), 200);
+
+    $response = (new AssistantAgent)->stream(
+        'Hello',
+        provider: ['primary', 'backup'],
+        model: 'llama-3.3-70b-versatile',
+    );
+
+    $response->each(fn () => true);
+
+    Event::assertDispatched(StreamingAgent::class, function (StreamingAgent $event) {
+        return $event->prompt->provider->name() === 'primary'
+            && $event->prompt->model === 'llama-3.3-70b-versatile';
+    });
+
+    Event::assertDispatched(StreamingAgent::class, function (StreamingAgent $event) {
+        return $event->prompt->provider->name() === 'backup'
+            && $event->prompt->model === 'llama-3.3-70b-versatile';
+    });
 });
 
 test('stream throws last exception when all providers fail', function () {

--- a/tests/Feature/ProviderModelListTest.php
+++ b/tests/Feature/ProviderModelListTest.php
@@ -22,4 +22,3 @@ test('Lab enum provider list uses passed model as default', function () {
     expect(Provider::formatProviderAndModelList([Lab::Anthropic, Lab::OpenAI], 'claude-3-5-sonnet'))
         ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'claude-3-5-sonnet']);
 });
-

--- a/tests/Feature/ProviderModelListTest.php
+++ b/tests/Feature/ProviderModelListTest.php
@@ -1,24 +1,63 @@
 <?php
 
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Providers\Provider;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\FailoverModelAttributeAgent;
 
 test('numeric provider list uses passed model as default for each provider', function () {
-    expect(Provider::formatProviderAndModelList(['anthropic', 'openai'], 'claude-3-5-sonnet'))
-        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'claude-3-5-sonnet']);
+    expect(Provider::formatProviderAndModelList(['primary', 'backup'], 'gpt-4.1-mini'))
+        ->toBe(['primary' => 'gpt-4.1-mini', 'backup' => 'gpt-4.1-mini']);
 });
 
 test('numeric provider list retains null model when none given', function () {
-    expect(Provider::formatProviderAndModelList(['anthropic', 'openai']))
-        ->toBe(['anthropic' => null, 'openai' => null]);
+    expect(Provider::formatProviderAndModelList(['primary', 'backup']))
+        ->toBe(['primary' => null, 'backup' => null]);
 });
 
 test('associative provider list preserves per-provider models', function () {
-    expect(Provider::formatProviderAndModelList(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'gpt-4']))
-        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'gpt-4']);
+    expect(Provider::formatProviderAndModelList(['openai' => 'gpt-4.1-mini', 'mistral' => 'mistral-large-latest']))
+        ->toBe(['openai' => 'gpt-4.1-mini', 'mistral' => 'mistral-large-latest']);
 });
 
 test('Lab enum provider list uses passed model as default', function () {
-    expect(Provider::formatProviderAndModelList([Lab::Anthropic, Lab::OpenAI], 'claude-3-5-sonnet'))
-        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'claude-3-5-sonnet']);
+    expect(Provider::formatProviderAndModelList([Lab::OpenAI, Lab::Azure], 'gpt-4.1-mini'))
+        ->toBe(['openai' => 'gpt-4.1-mini', 'azure' => 'gpt-4.1-mini']);
+});
+
+test('provider attribute list uses model attribute when prompting', function () {
+    config([
+        'ai.providers.primary' => ['driver' => 'openai', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'openai', 'key' => 'test-key'],
+    ]);
+
+    FailoverModelAttributeAgent::fake();
+
+    (new FailoverModelAttributeAgent)->prompt('Hello');
+
+    FailoverModelAttributeAgent::assertPrompted(function (AgentPrompt $prompt) {
+        return $prompt->provider->name() === 'primary'
+            && $prompt->model === 'gpt-4.1-mini';
+    });
+});
+
+test('explicit prompt model is used for provider lists', function () {
+    config([
+        'ai.providers.primary' => ['driver' => 'openai', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'openai', 'key' => 'test-key'],
+    ]);
+
+    AssistantAgent::fake();
+
+    (new AssistantAgent)->prompt(
+        'Hello',
+        provider: ['primary', 'backup'],
+        model: 'gpt-4.1-mini',
+    );
+
+    AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+        return $prompt->provider->name() === 'primary'
+            && $prompt->model === 'gpt-4.1-mini';
+    });
 });

--- a/tests/Feature/ProviderModelListTest.php
+++ b/tests/Feature/ProviderModelListTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Providers\Provider;
+
+test('numeric provider list uses passed model as default for each provider', function () {
+    expect(Provider::formatProviderAndModelList(['anthropic', 'openai'], 'claude-3-5-sonnet'))
+        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'claude-3-5-sonnet']);
+});
+
+test('numeric provider list retains null model when none given', function () {
+    expect(Provider::formatProviderAndModelList(['anthropic', 'openai']))
+        ->toBe(['anthropic' => null, 'openai' => null]);
+});
+
+test('associative provider list preserves per-provider models', function () {
+    expect(Provider::formatProviderAndModelList(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'gpt-4']))
+        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'gpt-4']);
+});
+
+test('Lab enum provider list uses passed model as default', function () {
+    expect(Provider::formatProviderAndModelList([Lab::Anthropic, Lab::OpenAI], 'claude-3-5-sonnet'))
+        ->toBe(['anthropic' => 'claude-3-5-sonnet', 'openai' => 'claude-3-5-sonnet']);
+});
+

--- a/tests/Fixtures/Agents/FailoverModelAttributeAgent.php
+++ b/tests/Fixtures/Agents/FailoverModelAttributeAgent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider(['primary', 'backup'])]
+#[Model('gpt-4.1-mini')]
+class FailoverModelAttributeAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a bug where a shared model configured for an agent failover provider list was silently ignored.

This applies to the existing failover API where providers are tried in order:

```php
$agent->prompt(
    "Hello",
    provider: ["primary", "backup"],
    model: "gpt-4.1-mini",
);
```

or via attributes:

```php
#[Provider(["primary", "backup"])]
#[Model("gpt-4.1-mini")]
class SupportAgent implements Agent
{
    use Promptable;
}
```

Before this change, array providers skipped agent-level model resolution, and numeric provider-list entries were normalized with `null` as the model. The SDK then fell back to each provider default model instead of using the explicitly configured shared model.

This is related to #182, but it does not add a new provider/model failover API. Per-provider models for unique providers continue to use the existing associative form:

```php
$agent->prompt("Hello", provider: [
    "openai" => "gpt-4.1-mini",
    "mistral" => "mistral-large-latest",
]);
```

## Current Failover Behavior

- Providers are attempted in the order provided.
- A mapped model is used when present.
- If no model is mapped, the provider default text model is used.
- Failover only happens for `FailoverableException`.
- If every provider fails, the last failover exception is thrown.
- Streaming failover only happens before any stream events have been emitted.
