### PR TITLE
Pass cache_control through to Anthropic and Bedrock system prompts

### DIFF
--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -63,7 +63,34 @@ trait BuildsTextRequests
             'top_p' => $options?->topP,
         ]));
 
+        if (! empty($providerOptions['cache'])) {
+            $body = $this->withCacheControl($body, $providerOptions['cache']);
+            unset($providerOptions['cache']);
+        }
+
         return array_merge($body, $providerOptions);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $cache
+     */
+    protected function withCacheControl(array $body, array $cache): array
+    {
+        foreach ($cache as $entry) {
+            if (($entry['target'] ?? null) !== 'system' || ! isset($body['system'])) {
+                continue;
+            }
+
+            $system = is_string($body['system'])
+                ? [['type' => 'text', 'text' => $body['system']]]
+                : $body['system'];
+
+            $system[array_key_last($system)]['cache_control'] = ['type' => 'ephemeral'];
+
+            $body['system'] = $system;
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -671,6 +671,16 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
 
         $providerOptions = $options?->providerOptions(Lab::Bedrock);
 
+        if (! empty($providerOptions['cache'])) {
+            foreach ($providerOptions['cache'] as $entry) {
+                if (($entry['target'] ?? null) === 'system' && ! empty($parameters['system'])) {
+                    $parameters['system'][] = ['cachePoint' => ['type' => 'default']];
+                }
+            }
+
+            unset($providerOptions['cache']);
+        }
+
         if (! empty($providerOptions)) {
             $parameters = array_merge($parameters, $providerOptions);
         }

--- a/tests/Feature/Providers/Anthropic/CacheControlTest.php
+++ b/tests/Feature/Providers/Anthropic/CacheControlTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\CachingAgent;
+
+test('system prompt is sent as a cached block', function () {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new CachingAgent)->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $system = $request->data()['system'];
+
+        return is_array($system)
+            && $system[0]['type'] === 'text'
+            && $system[0]['cache_control'] === ['type' => 'ephemeral'];
+    });
+});
+
+test('cache directive does not appear in the request body', function () {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new CachingAgent)->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(fn ($request) => ! array_key_exists('cache', $request->data()));
+});
+
+test('system stays a plain string without a cache directive', function () {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(fn ($request) => is_string($request->data()['system']));
+});

--- a/tests/Feature/Providers/Bedrock/BedrockHelpers.php
+++ b/tests/Feature/Providers/Bedrock/BedrockHelpers.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Providers\Bedrock;
 
 use Aws\BedrockRuntime\BedrockRuntimeClient;
+use Aws\CommandInterface;
 use Aws\MockHandler;
 use Aws\Result;
+use GuzzleHttp\Promise\FulfilledPromise;
 use Laravel\Ai\Gateway\Bedrock\BedrockTextGateway;
 use Laravel\Ai\Providers\BedrockProvider;
 use Laravel\Ai\Providers\Provider;
@@ -46,6 +48,24 @@ trait BedrockHelpers
             'version' => '2023-09-30',
             'credentials' => false,
             'handler' => $mock,
+        ]);
+    }
+
+    protected function capturingBedrockClient(?array &$captured): BedrockRuntimeClient
+    {
+        return new BedrockRuntimeClient([
+            'region' => 'us-east-1',
+            'version' => '2023-09-30',
+            'credentials' => false,
+            'handler' => function (CommandInterface $command) use (&$captured) {
+                $captured = $command->toArray();
+
+                return new FulfilledPromise(new Result([
+                    'output' => ['message' => ['content' => [['text' => 'Hi']]]],
+                    'usage' => ['inputTokens' => 1, 'outputTokens' => 1],
+                    'stopReason' => 'end_turn',
+                ]));
+            },
         ]);
     }
 

--- a/tests/Feature/Providers/Bedrock/CacheControlTest.php
+++ b/tests/Feature/Providers/Bedrock/CacheControlTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\CachingAgent;
+
+beforeEach(function () {
+    $this->captured = null;
+    $this->run = function (object $agent) {
+        $this->gatewayWithClient($this->capturingBedrockClient($this->captured))->generateText(
+            $this->bedrockProvider(),
+            'anthropic.claude-haiku-4-5-20251001-v1:0',
+            'You are a helpful assistant.',
+            [],
+            [],
+            null,
+            TextGenerationOptions::forAgent($agent),
+        );
+    };
+});
+
+test('cachePoint marker is appended to system blocks', function () {
+    ($this->run)(new CachingAgent);
+
+    expect($this->captured['system'])->toHaveCount(2)
+        ->and($this->captured['system'][1])->toMatchArray(['cachePoint' => ['type' => 'default']]);
+});
+
+test('cache directive does not leak into converse parameters', function () {
+    ($this->run)(new CachingAgent);
+
+    expect($this->captured)->not->toHaveKey('cache');
+});
+
+test('system stays a single block without a cache directive', function () {
+    ($this->run)(new AssistantAgent);
+
+    expect($this->captured['system'])->toHaveCount(1);
+});

--- a/tests/Fixtures/Agents/CachingAgent.php
+++ b/tests/Fixtures/Agents/CachingAgent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+class CachingAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Anthropic, Lab::Bedrock => ['cache' => [['target' => 'system']]],
+            default => [],
+        };
+    }
+}


### PR DESCRIPTION
Lets agents mark the system prompt for caching via providerOptions:

    return ['cache' => [['target' => 'system']]];

Anthropic gets a cache_control: ephemeral block on the system string; Bedrock gets a cachePoint marker appended to the system list. The key is stripped from providerOptions before the rest is merged so it never ends up in the API payload.