### PR TITLE
Set invocation id on fake stream events

### DIFF
--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -132,8 +132,8 @@ class FakeTextGateway implements TextGateway
         $messageId = ulid();
 
         // Fake the stream and text starting...
-        yield new StreamStart(ulid(), $provider->name(), $model, time());
-        yield new TextStart(ulid(), $messageId, time());
+        yield (new StreamStart(ulid(), $provider->name(), $model, time()))->withInvocationId($invocationId);
+        yield (new TextStart(ulid(), $messageId, time()))->withInvocationId($invocationId);
 
         $message = (new Collection($messages))->last(function ($message) {
             return $message instanceof UserMessage;
@@ -150,7 +150,7 @@ class FakeTextGateway implements TextGateway
                 $messageId,
                 $index > 0 ? ' '.$word : $word,
                 time(),
-            ))->all();
+            )->withInvocationId($invocationId))->all();
 
         // Fake the text delta events...
         foreach ($events as $event) {
@@ -158,8 +158,8 @@ class FakeTextGateway implements TextGateway
         }
 
         // Fake the stream and text ending...
-        yield new TextEnd(ulid(), $messageId, time());
-        yield new StreamEnd(ulid(), 'stop', new Usage, time());
+        yield (new TextEnd(ulid(), $messageId, time()))->withInvocationId($invocationId);
+        yield (new StreamEnd(ulid(), 'stop', new Usage, time()))->withInvocationId($invocationId);
     }
 
     /**

--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -145,12 +145,12 @@ class FakeTextGateway implements TextGateway
 
         $events = Str::of($fakeResponse->text)
             ->explode(' ')
-            ->map(fn ($word, $index) => new TextDelta(
+            ->map(fn ($word, $index) => (new TextDelta(
                 ulid(),
                 $messageId,
                 $index > 0 ? ' '.$word : $word,
                 time(),
-            )->withInvocationId($invocationId))->all();
+            ))->withInvocationId($invocationId))->all();
 
         // Fake the text delta events...
         foreach ($events as $event) {

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -149,6 +149,17 @@ describe('stream responses', function () {
         expect($response->text)->toEqual('Third response')
             ->and($response->events)->toHaveCount(6);
     });
+
+    test('faked stream events share the response invocation id', function () {
+        AssistantAgent::fake(['Hello world']);
+
+        $response = (new AssistantAgent)->stream('First prompt');
+
+        $response->each(fn () => true);
+
+        expect($response->events)
+            ->each(fn ($event) => $event->invocationId->toBe($response->invocationId));
+    });
 });
 
 describe('queue responses', function () {


### PR DESCRIPTION
## Summary
- Attach the generated stream invocation id to events emitted by `FakeTextGateway`
- Align fake streamed events with real gateway streamed events
- Add coverage that faked stream events share the `StreamableAgentResponse` invocation id

## Test plan
- `vendor/bin/pint --dirty`
- `vendor/bin/pest tests/Feature/AgentFakeTest.php tests/Feature/BroadcastAgentTest.php`