### PR TITLE
Add support for Vercel AI Gateway provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -129,6 +129,12 @@ return [
             'key' => env('OPENROUTER_API_KEY'),
         ],
 
+        'vercel' => [
+            'driver' => 'vercel',
+            'key' => env('AI_GATEWAY_API_KEY'),
+            'url' => env('VERCEL_AI_GATEWAY_URL', 'https://ai-gateway.vercel.sh/v1'),
+        ],
+
         'voyageai' => [
             'driver' => 'voyageai',
             'key' => env('VOYAGEAI_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -32,6 +32,7 @@ use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\OpenRouterProvider;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\VercelProvider;
 use Laravel\Ai\Providers\VoyageAiProvider;
 use Laravel\Ai\Providers\XaiProvider;
 use LogicException;
@@ -419,6 +420,17 @@ class AiManager extends MultipleInstanceManager
     public function createOpenrouterDriver(array $config): OpenRouterProvider
     {
         return new OpenRouterProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a Vercel AI Gateway powered instance.
+     */
+    public function createVercelDriver(array $config): VercelProvider
+    {
+        return new VercelProvider(
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -17,6 +17,7 @@ enum Lab: string
     case Ollama = 'ollama';
     case OpenAI = 'openai';
     case OpenRouter = 'openrouter';
+    case Vercel = 'vercel';
     case VoyageAI = 'voyageai';
     case xAI = 'xai';
 }

--- a/src/Gateway/Vercel/VercelGateway.php
+++ b/src/Gateway/Vercel/VercelGateway.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Vercel;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
+use Laravel\Ai\Providers\Provider;
+
+class VercelGateway extends OpenRouterGateway
+{
+    /**
+     * Get an HTTP client for the Vercel AI Gateway API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the Vercel AI Gateway API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://ai-gateway.vercel.sh/v1', '/');
+    }
+}

--- a/src/Providers/VercelProvider.php
+++ b/src/Providers/VercelProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\ImageGateway;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Vercel\VercelGateway;
+
+class VercelProvider extends Provider implements EmbeddingProvider, ImageProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesImages;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasImageGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    public function __construct(protected array $config, protected Dispatcher $events)
+    {
+        //
+    }
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new VercelGateway($this->events);
+    }
+
+    /**
+     * Get the provider's embedding gateway.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ??= new VercelGateway($this->events);
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['text']['default'] ?? 'anthropic/claude-sonnet-4.6';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['text']['cheapest'] ?? 'anthropic/claude-haiku-4.5';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['text']['smartest'] ?? 'anthropic/claude-opus-4.6';
+    }
+
+    /**
+     * Get the provider's image gateway.
+     */
+    public function imageGateway(): ImageGateway
+    {
+        return $this->imageGateway ??= new VercelGateway($this->events);
+    }
+
+    /**
+     * Get the name of the default image model.
+     */
+    public function defaultImageModel(): string
+    {
+        return $this->config['models']['image']['default'] ?? 'google/gemini-3.1-flash-image-preview';
+    }
+
+    /**
+     * Get the default / normalized image options for the provider.
+     *
+     * aspect_ratio and image_size map to the OpenAI Chat Completions image
+     * generation parameters supported by the Vercel AI Gateway.
+     */
+    public function defaultImageOptions(?string $size = null, ?string $quality = null): array
+    {
+        return array_filter([
+            'aspect_ratio' => $size,
+            'image_size' => match ($quality) {
+                'low' => '1K',
+                'medium' => '2K',
+                'high' => '4K',
+                default => null,
+            },
+        ]);
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['models']['embeddings']['default'] ?? 'openai/text-embedding-3-small';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return $this->config['models']['embeddings']['dimensions'] ?? 1536;
+    }
+}

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -17,6 +17,7 @@ dataset('providers-with-urls', [
 
 dataset('embedding-providers', [
     'openai' => ['openai', 'OPENAI_API_KEY', 1536],
+    'vercel' => ['vercel', 'AI_GATEWAY_API_KEY', 1536],
     'voyageai' => ['voyageai', 'VOYAGEAI_API_KEY', 1024],
 ]);
 
@@ -51,6 +52,7 @@ dataset('agent-providers', [
     'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
     'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'anthropic/claude-haiku-4.5'],
+    'vercel' => ['vercel', 'AI_GATEWAY_API_KEY', 'anthropic/claude-haiku-4.5'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
 ]);
 

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -5,9 +5,14 @@ use Illuminate\Support\Facades\Facade;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Providers\OpenAiProvider;
+use Laravel\Ai\Providers\VercelProvider;
 
 test('can get an openai provider instance', function () {
     expect(Ai::textProvider('openai'))->toBeInstanceOf(OpenAiProvider::class);
+});
+
+test('can get a vercel provider instance', function () {
+    expect(Ai::textProvider('vercel'))->toBeInstanceOf(VercelProvider::class);
 });
 
 test('provider type is ensured', function () {

--- a/tests/Feature/Providers/Vercel/AgentFakeTest.php
+++ b/tests/Feature/Providers/Vercel/AgentFakeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Tests\Fixtures\Agents\VercelAgent;
+
+test('vercel agent can be faked', function () {
+    VercelAgent::fake(['Test response']);
+
+    $response = (new VercelAgent)->prompt('Hello');
+
+    expect($response->text)->toBe('Test response');
+});
+
+test('vercel agent fake with closure', function () {
+    VercelAgent::fake(fn (string $prompt) => "Echo: {$prompt}");
+
+    $response = (new VercelAgent)->prompt('Hello world');
+
+    expect($response->text)->toBe('Echo: Hello world');
+});
+
+test('vercel agent fake records prompts', function () {
+    VercelAgent::fake();
+
+    (new VercelAgent)->prompt('Hello');
+
+    VercelAgent::assertPrompted('Hello');
+    VercelAgent::assertNotPrompted('Goodbye');
+});
+
+test('vercel agent stream can be faked', function () {
+    VercelAgent::fake(['Streamed response']);
+
+    $response = (new VercelAgent)->stream('Hello');
+    $response->each(fn () => true);
+
+    expect($response->text)->toBe('Streamed response');
+});

--- a/tests/Feature/Providers/Vercel/BaseUrlTest.php
+++ b/tests/Feature/Providers/Vercel/BaseUrlTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    $this->customUrl = 'http://localhost:1234/v1';
+});
+
+test('vercel text requests use the configured base url', function () {
+    configureVercelProvider($this->customUrl);
+
+    Http::fake(['*' => fakeOpenRouterResponse('Hello from local model')]);
+
+    $response = agent()->prompt('Hello', provider: 'vercel');
+
+    expect($response->text)->toBe('Hello from local model');
+
+    Http::assertSentCount(1);
+    vercelAssertRequestSent('POST', "{$this->customUrl}/chat/completions");
+});
+
+test('vercel requests fall back to the default base url', function () {
+    configureVercelProvider();
+
+    Http::fake(['*' => fakeOpenRouterResponse('Hello from Vercel')]);
+
+    $response = agent()->prompt('Hello', provider: 'vercel');
+
+    expect($response->text)->toBe('Hello from Vercel');
+
+    Http::assertSentCount(1);
+    vercelAssertRequestSent('POST', 'https://ai-gateway.vercel.sh/v1/chat/completions');
+});
+
+test('vercel provider does not support audio generation', function () {
+    configureVercelProvider();
+
+    expect(fn () => \Laravel\Ai\Ai::audioProvider('vercel'))
+        ->toThrow(LogicException::class);
+});
+
+function configureVercelProvider(?string $url = null): void
+{
+    config(['ai.providers.vercel' => array_filter([
+        ...config('ai.providers.vercel'),
+        'key' => 'test-key',
+        'url' => $url,
+    ])]);
+}
+
+function vercelAssertRequestSent(string $method, string $url): void
+{
+    Http::assertSent(fn (Request $request) => $request->method() === $method
+        && $request->url() === $url);
+}

--- a/tests/Fixtures/Agents/VercelAgent.php
+++ b/tests/Fixtures/Agents/VercelAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider('vercel')]
+class VercelAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for the Vercel AI Gateway as a new provider in Laravel AI.

## Added

### Gateway
- Added `VercelGateway` extending Chat Completions logic
- Default base URL:
  - `https://ai-gateway.vercel.sh/v1`

### Provider
- Added `VercelProvider` with support for:
  - Text generation
  - Streaming
  - Tool calling
  - Structured outputs
  - Embeddings
  - Image generation via Chat Completions

### Enum
- Added:
  - `Lab::Vercel`

### Configuration
- Added `vercel` provider configuration to `config/ai.php`

### Manager
- Added:
  - `createVercelDriver()` to `AiManager`

## Environment Variables

```env
AI_GATEWAY_API_KEY=your_vercel_api_key

# Optional
VERCEL_AI_GATEWAY_URL=https://ai-gateway.vercel.sh/v1
```

## Usage

### Attribute Provider

```php
use Laravel\Ai\Attributes\Provider;

#[Provider('vercel')]
class MyAgent implements Agent
{
    //
}
```

### Runtime Provider

```php
agent()->prompt(
    'Hello',
    provider: 'vercel',
    model: 'anthropic/claude-sonnet-4.6'
);
```

## Supported Features

- Text generation
- Streaming responses
- Tool calling
- Structured outputs
- Embeddings
- Image generation

## Not Included

The Vercel AI Gateway currently does not expose audio endpoints in the same format, therefore:

- TTS is not supported
- Speech transcription is not supported

## Models

Models follow the `provider/model` format:

```text
openai/gpt-5.5
anthropic/claude-sonnet-4.6
```

See the full list at:
- https://vercel.com/ai-gateway/models

## Tests

Feature tests added under:

```text
tests/Feature/Providers/Vercel/
```

All tests are passing.