### PR TITLE
Add JSON_UNESCAPED_UNICODE to schema instruction encoding

### DIFF
--- a/src/Gateway/Concerns/ComposesSchemaInstructions.php
+++ b/src/Gateway/Concerns/ComposesSchemaInstructions.php
@@ -12,7 +12,7 @@ trait ComposesSchemaInstructions
             return $instructions;
         }
 
-        $schemaJson = json_encode((new ObjectSchema($schema))->toSchema(), JSON_PRETTY_PRINT);
+        $schemaJson = json_encode((new ObjectSchema($schema))->toSchema(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 
         $schemaInstruction = sprintf(
             "You MUST respond EXCLUSIVELY with a JSON object that strictly adheres to the following schema. Do NOT explain or add other content. Validate your response against this schema:\n%s",

--- a/tests/Unit/Gateway/Concerns/ComposesSchemaInstructionsTest.php
+++ b/tests/Unit/Gateway/Concerns/ComposesSchemaInstructionsTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
-use Laravel\Ai\ObjectSchema;
 
 beforeEach(function () {
     $this->trait = new class

--- a/tests/Unit/Gateway/Concerns/ComposesSchemaInstructionsTest.php
+++ b/tests/Unit/Gateway/Concerns/ComposesSchemaInstructionsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
+use Laravel\Ai\ObjectSchema;
+
+beforeEach(function () {
+    $this->trait = new class
+    {
+        use ComposesSchemaInstructions {
+            composeInstructions as public;
+        }
+    };
+
+    $this->factory = new JsonSchemaTypeFactory;
+});
+
+test('returns instructions unchanged when schema is blank', function () {
+    expect($this->trait->composeInstructions('Be helpful.', null))
+        ->toBe('Be helpful.');
+});
+
+test('returns null when both instructions and schema are blank', function () {
+    expect($this->trait->composeInstructions(null, null))
+        ->toBeNull();
+});
+
+test('appends schema instruction when instructions are blank', function () {
+    $schema = ['name' => $this->factory->string()->description('The name')];
+
+    $result = $this->trait->composeInstructions(null, $schema);
+
+    expect($result)->toContain('JSON object');
+});
+
+test('prepends instructions before schema instruction', function () {
+    $schema = ['name' => $this->factory->string()->description('The name')];
+
+    $result = $this->trait->composeInstructions('Be concise.', $schema);
+
+    expect($result)->toStartWith('Be concise.');
+    expect($result)->toContain('JSON object');
+});
+
+test('non-ascii characters in schema descriptions are not unicode-escaped', function () {
+    $schema = ['name' => $this->factory->string()->description('名前を入力してください')];
+
+    $result = $this->trait->composeInstructions(null, $schema);
+
+    expect($result)->toContain('名前を入力してください');
+    expect($result)->not->toContain('\u');
+});


### PR DESCRIPTION
Fixes #643.

When using structured output with providers that fall back to inline schema instructions (Groq, DeepSeek), non-ASCII characters in field descriptions were serialized as `\uXXXX` escape sequences. This inflates the token count significantly — the issue reporter saw 17k tokens reduced to 6k after adding the flag.

## Change

`ComposesSchemaInstructions::composeInstructions()` now passes `JSON_UNESCAPED_UNICODE` alongside `JSON_PRETTY_PRINT` when encoding the schema into the system prompt.

```php
// Before
$schemaJson = json_encode((new ObjectSchema($schema))->toSchema(), JSON_PRETTY_PRINT);

// After
$schemaJson = json_encode((new ObjectSchema($schema))->toSchema(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
```

## Tests

Added `ComposesSchemaInstructionsTest` covering:
- blank schema passthrough
- null passthrough
- schema appended when instructions are blank
- instructions prepended when both are present
- non-ASCII characters in descriptions are not unicode-escaped