### PR TITLE
Add tests for BedrockTextGateway cache token usage capture

### DIFF
--- a/tests/Feature/Providers/Bedrock/CacheUsageTest.php
+++ b/tests/Feature/Providers/Bedrock/CacheUsageTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+describe('bedrock cache usage capture', function () {
+    test('generateText captures cache read and write tokens from converse response usage', function () {
+        $client = $this->fakeBedrockConverse([
+            'output' => [
+                'message' => [
+                    'content' => [['text' => 'Hi']],
+                ],
+            ],
+            'usage' => [
+                'inputTokens' => 100,
+                'outputTokens' => 50,
+                'cacheReadInputTokens' => 80,
+                'cacheWriteInputTokens' => 20,
+            ],
+            'stopReason' => 'end_turn',
+        ]);
+
+        $gateway = $this->gatewayWithClient($client);
+
+        $response = $gateway->generateText(
+            $this->bedrockProvider(),
+            'anthropic.claude-opus-4-7-v1:0',
+            null,
+        );
+
+        expect($response->usage->promptTokens)->toBe(100)
+            ->and($response->usage->completionTokens)->toBe(50)
+            ->and($response->usage->cacheReadInputTokens)->toBe(80)
+            ->and($response->usage->cacheWriteInputTokens)->toBe(20);
+    });
+
+    test('generateText sums cache tokens across tool-loop steps', function () {
+        $client = $this->fakeBedrockConverseSequence([
+            [
+                'output' => [
+                    'message' => [
+                        'content' => [[
+                            'toolUse' => [
+                                'toolUseId' => 't1',
+                                'name' => 'FixedNumberGenerator',
+                                'input' => [],
+                            ],
+                        ]],
+                    ],
+                ],
+                'usage' => [
+                    'inputTokens' => 30,
+                    'outputTokens' => 15,
+                    'cacheReadInputTokens' => 25,
+                    'cacheWriteInputTokens' => 10,
+                ],
+                'stopReason' => 'tool_use',
+            ],
+            [
+                'output' => [
+                    'message' => [
+                        'content' => [['text' => 'done']],
+                    ],
+                ],
+                'usage' => [
+                    'inputTokens' => 40,
+                    'outputTokens' => 20,
+                    'cacheReadInputTokens' => 35,
+                    'cacheWriteInputTokens' => 5,
+                ],
+                'stopReason' => 'end_turn',
+            ],
+        ]);
+
+        $gateway = $this->gatewayWithClient($client);
+
+        $response = $gateway->generateText(
+            $this->bedrockProvider(),
+            'anthropic.claude-opus-4-7-v1:0',
+            null,
+            tools: [new FixedNumberGenerator],
+        );
+
+        expect($response->usage->promptTokens)->toBe(70)
+            ->and($response->usage->completionTokens)->toBe(35)
+            ->and($response->usage->cacheReadInputTokens)->toBe(60)
+            ->and($response->usage->cacheWriteInputTokens)->toBe(15);
+    });
+
+    test('streamText captures cache read and write tokens from metadata event', function () {
+        $client = $this->fakeBedrockStream([
+            $this->contentBlockStart(0),
+            $this->contentBlockDelta(0, ['text' => 'Hi']),
+            $this->contentBlockStop(0),
+            $this->messageStop('end_turn'),
+            ['metadata' => ['usage' => [
+                'inputTokens' => 200,
+                'outputTokens' => 75,
+                'cacheReadInputTokens' => 150,
+                'cacheWriteInputTokens' => 40,
+            ]]],
+        ]);
+
+        $gateway = $this->gatewayWithClient($client);
+
+        $events = iterator_to_array(
+            $gateway->streamText('inv-1', $this->bedrockProvider(), 'anthropic.claude-opus-4-7-v1:0', null),
+            preserve_keys: false,
+        );
+
+        $streamEnd = collect($events)->first(fn ($e) => $e instanceof StreamEnd);
+
+        expect($streamEnd)->not->toBeNull()
+            ->and($streamEnd->usage->promptTokens)->toBe(200)
+            ->and($streamEnd->usage->completionTokens)->toBe(75)
+            ->and($streamEnd->usage->cacheReadInputTokens)->toBe(150)
+            ->and($streamEnd->usage->cacheWriteInputTokens)->toBe(40);
+    });
+
+    test('missing cache token fields default to zero without throwing', function () {
+        $client = $this->fakeBedrockConverse([
+            'output' => [
+                'message' => [
+                    'content' => [['text' => 'Hi']],
+                ],
+            ],
+            'usage' => [
+                'inputTokens' => 10,
+                'outputTokens' => 5,
+            ],
+            'stopReason' => 'end_turn',
+        ]);
+
+        $gateway = $this->gatewayWithClient($client);
+
+        $response = $gateway->generateText(
+            $this->bedrockProvider(),
+            'anthropic.claude-opus-4-7-v1:0',
+            null,
+        );
+
+        expect($response->usage->cacheReadInputTokens)->toBe(0)
+            ->and($response->usage->cacheWriteInputTokens)->toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

#642 ("BedrockTextGateway: Add cache usage") added \`cacheReadInputTokens\` / \`cacheWriteInputTokens\` capture from the Bedrock Converse usage payload — both in the non-streaming \`generateText\` path and in the streaming \`metadata.usage\` event — but the new fields were not exercised by any test. This PR adds tests that pin:

- \`generateText\` extracts both cache token fields from the response usage.
- \`generateText\` **accumulates cache tokens across tool-loop steps via \`Usage::add\`** — a refactor that drops the per-step accumulation will fail this test.
- \`streamText\` extracts the same fields from the \`metadata.usage\` event.
- Missing cache token fields default to zero rather than throwing.

The middle test is the weight-puller: it asserts the multi-step summation, not a single-branch mirror.

## Test plan

- [x] \`vendor/bin/pint tests/Feature/Providers/Bedrock/CacheUsageTest.php\`
- [x] \`vendor/bin/pest tests/Feature/Providers/Bedrock/CacheUsageTest.php\` (4 passed)