### PR TITLE
Add tests for remaining BedrockException insufficient-credit patterns

### DIFF
--- a/tests/Unit/Gateway/Bedrock/BedrockExceptionTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockExceptionTest.php
@@ -118,6 +118,27 @@ test('non-bedrock exception with quota exceeded message maps to insufficient cre
     expect($aiException)->toBeInstanceOf(InsufficientCreditsException::class);
 });
 
+test('non-bedrock exception message is matched against every configured credit pattern', function (string $message) {
+    $generic = new RuntimeException($message);
+
+    $aiException = BedrockException::toAiException($generic, 'bedrock', 'claude-sonnet');
+
+    expect($aiException)->toBeInstanceOf(InsufficientCreditsException::class);
+})->with([
+    'insufficient' => ['You have insufficient funds remaining.'],
+    'quota exceeded' => ['Your monthly quota exceeded the limit.'],
+    'billing' => ['There is a billing issue on your account; please update payment method.'],
+    'service quota' => ['Service quota for this model has been reached.'],
+]);
+
+test('pattern match is case-insensitive across the entire message', function () {
+    $generic = new RuntimeException('REQUEST DENIED: INSUFFICIENT FUNDS FOR THIS OPERATION');
+
+    $aiException = BedrockException::toAiException($generic, 'bedrock', 'claude-sonnet');
+
+    expect($aiException)->toBeInstanceOf(InsufficientCreditsException::class);
+});
+
 test('non-bedrock generic exception wraps as ai exception', function () {
     $generic = new RuntimeException('Some network failure', 500);
 


### PR DESCRIPTION
## Summary

\`BedrockException\` matches incoming AWS-error messages against six credit-related patterns to surface \`InsufficientCreditsException\`:

\`\`\`
credit balance, insufficient, quota exceeded,
exceeded your current quota, billing, service quota
\`\`\`

Only two of these (\`credit balance\`, \`exceeded your current quota\`) had explicit tests. This PR adds:

1. A dataset-driven test covering the four previously-untested patterns (\`insufficient\`, \`quota exceeded\`, \`billing\`, \`service quota\`).
2. A test that pins the **case-insensitive** whole-message match, since the implementation lowercases the message before substring-checking. A refactor that drops the lowercase normalization will fail this test.

Mirrors the structure of the merged Anthropic credit-pattern tests (#575).

## Test plan

- [x] \`vendor/bin/pint tests/Unit/Gateway/Bedrock/BedrockExceptionTest.php\`
- [x] \`vendor/bin/pest tests/Unit/Gateway/Bedrock/BedrockExceptionTest.php\` (16 passed)