### PR TITLE
Add tests for HandlesFailoverErrors status-code precedence ordering

### DIFF
--- a/tests/Unit/Gateway/Concerns/HandlesFailoverErrorsTest.php
+++ b/tests/Unit/Gateway/Concerns/HandlesFailoverErrorsTest.php
@@ -79,3 +79,50 @@ test('non-matching message is rethrown as the original RequestException', functi
         ]),
     ))->toThrow(RequestException::class);
 });
+
+test('402 takes precedence over an overloaded status code', function () {
+    $gateway = new class
+    {
+        use HandlesFailoverErrors {
+            withErrorHandling as public;
+        }
+
+        protected function overloadedStatusCodes(): array
+        {
+            return [402, 503];
+        }
+    };
+
+    expect(fn () => $gateway->withErrorHandling(
+        'custom',
+        fn () => throw failoverableException(402, [
+            'error' => ['message' => 'Insufficient Balance'],
+        ]),
+    ))->toThrow(InsufficientCreditsException::class);
+});
+
+test('402 takes precedence over a matching insufficient credit pattern', function () {
+    expect(function () {
+        try {
+            $this->gateway->withErrorHandling(
+                'anthropic',
+                fn () => throw failoverableException(402, [
+                    'error' => ['message' => 'Your credit balance is too low.'],
+                ]),
+            );
+        } catch (InsufficientCreditsException $e) {
+            expect($e->getCode())->toBe(402);
+
+            throw $e;
+        }
+    })->toThrow(InsufficientCreditsException::class);
+});
+
+test('overloaded status takes precedence over a matching insufficient credit pattern', function () {
+    expect(fn () => $this->gateway->withErrorHandling(
+        'anthropic',
+        fn () => throw failoverableException(529, [
+            'error' => ['message' => 'Your credit balance is too low.'],
+        ]),
+    ))->toThrow(ProviderOverloadedException::class);
+});


### PR DESCRIPTION
## Summary

\`HandlesFailoverErrors::withErrorHandling()\` evaluates four conditions in a specific order:

\`\`\`
429 → 402 → overloadedStatusCodes → insufficientCreditPatterns
\`\`\`

The merged tests from #572 pinned the \`429 over patterns\` precedence and the \`overloadedStatusCodes override\` behavior, but the three remaining ordering edges were not exercised. This PR adds tests that pin:

- 402 over an overloaded status code (when both are configured)
- 402 over a matching insufficient credit pattern
- An overloaded status over a matching insufficient credit pattern

A refactor that reorders the branches in \`withErrorHandling\` will fail these tests; copying the single-if shape will not — so these are weight-pulling regression guards, not scenario coverage.

## Test plan

- [x] \`vendor/bin/pint tests/Unit/Gateway/Concerns/HandlesFailoverErrorsTest.php\`
- [x] \`vendor/bin/pest tests/Unit/Gateway/Concerns/HandlesFailoverErrorsTest.php\` (7 passed)