### PR TITLE
Add tests for Provider::formatProviderAndModelList branch coverage

### DIFF
--- a/tests/Unit/Providers/ProviderFormatProviderAndModelListTest.php
+++ b/tests/Unit/Providers/ProviderFormatProviderAndModelListTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Providers\Provider;
+
+test('Lab enum is normalized to its string value with the given model', function () {
+    expect(Provider::formatProviderAndModelList(Lab::Anthropic, 'claude-opus-4-7-v1'))
+        ->toBe(['anthropic' => 'claude-opus-4-7-v1']);
+});
+
+test('Lab enum without a model produces a null model entry', function () {
+    expect(Provider::formatProviderAndModelList(Lab::Anthropic))
+        ->toBe(['anthropic' => null]);
+});
+
+test('string provider with a model returns a single-entry list', function () {
+    expect(Provider::formatProviderAndModelList('openai', 'gpt-4'))
+        ->toBe(['openai' => 'gpt-4']);
+});
+
+test('string provider without a model produces a null model entry', function () {
+    expect(Provider::formatProviderAndModelList('openai'))
+        ->toBe(['openai' => null]);
+});
+
+test('mixed numeric and associative keys honor each entry independently', function () {
+    expect(Provider::formatProviderAndModelList([
+        'anthropic',
+        'openai' => 'gpt-4',
+    ]))->toBe(['anthropic' => null, 'openai' => 'gpt-4']);
+});
+
+test('mixed keys apply the top-level model only to numeric entries', function () {
+    expect(Provider::formatProviderAndModelList(
+        ['anthropic', 'openai' => 'gpt-4'],
+        'default-model',
+    ))->toBe(['anthropic' => 'default-model', 'openai' => 'gpt-4']);
+});
+
+test('Lab enum value in a numeric position is normalized to its string value', function () {
+    expect(Provider::formatProviderAndModelList([
+        Lab::Anthropic,
+        Lab::OpenAI->value => 'gpt-4',
+    ]))->toBe(['anthropic' => null, 'openai' => 'gpt-4']);
+});
+
+test('Lab enum as an associative key is normalized to its string value', function () {
+    expect(Provider::formatProviderAndModelList([
+        Lab::Anthropic->value => 'claude-opus-4-7',
+    ]))->toBe(['anthropic' => 'claude-opus-4-7']);
+});


### PR DESCRIPTION
## Summary

\`Provider::formatProviderAndModelList()\` normalizes the various accepted provider/model shapes — a \`Lab\` enum, a string, or any kind of array — into a canonical \`[provider => model|null]\` map used by every \`PendingResponses::generate\` failover loop and by \`Promptable::getProvidersAndModels()\`.

After rebasing onto current 0.x, #633 has added feature-level coverage in \`tests/Feature/ProviderModelListTest.php\` for the numeric / associative / Lab-enum-array list cases. This PR keeps only the unit-level cases that are **not** covered there:

- \`Lab\` enum **passed directly** (not in an array) with and without a model.
- \`string\` provider (not in an array) with and without a model.
- **Mixed numeric + associative keys**: numeric entries inherit the top-level model, associative entries keep their per-entry value.
- \`Lab\` enum **values in a numeric array position** alongside string associative keys (verifies the per-element normalization is independent of position).
- \`Lab\` enum **as an associative key** is normalized to its string value (the symmetric case to the existing "Lab enum array values" test in #633).

These are weight-pulling tests — they pin contracts that #633's tests don't cover.

## Test plan

- [x] \`vendor/bin/pint tests/Unit/Providers/ProviderFormatProviderAndModelListTest.php\`
- [x] \`vendor/bin/pest tests/Unit/Providers/ProviderFormatProviderAndModelListTest.php tests/Feature/ProviderModelListTest.php\` (14 passed, no overlap)