### PR TITLE
Add tests for Promptable provider and model resolution precedence

### DIFF
--- a/tests/Feature/AgentProviderModelResolutionTest.php
+++ b/tests/Feature/AgentProviderModelResolutionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+function resolveProvidersAndModels(Agent $agent, mixed $provider = null, ?string $model = null): array
+{
+    $method = new ReflectionMethod($agent, 'getProvidersAndModels');
+    $method->setAccessible(true);
+
+    return $method->invoke($agent, $provider, $model);
+}
+
+#[Provider('anthropic')]
+#[Model('attribute-model')]
+class ProviderAttributesAgentFixture implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'test';
+    }
+}
+
+#[Provider('anthropic')]
+#[Model('attribute-model')]
+class ProviderMethodsAgentFixture implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'test';
+    }
+
+    public function provider(): string
+    {
+        return 'openai';
+    }
+
+    public function model(): string
+    {
+        return 'method-model';
+    }
+}
+
+#[Provider('anthropic')]
+#[Model('attribute-model')]
+class ProviderMethodReturnsNullAgentFixture implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'test';
+    }
+
+    public function provider(): ?string
+    {
+        return null;
+    }
+
+    public function model(): ?string
+    {
+        return null;
+    }
+}
+
+class NoProviderConfigAgentFixture implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'test';
+    }
+}
+
+test('explicit provider and model arguments override both method and attribute', function () {
+    expect(resolveProvidersAndModels(new ProviderMethodsAgentFixture, 'cohere', 'explicit-model'))
+        ->toBe(['cohere' => 'explicit-model']);
+});
+
+test('provider attribute is used when no explicit argument and no method', function () {
+    expect(resolveProvidersAndModels(new ProviderAttributesAgentFixture))
+        ->toBe(['anthropic' => 'attribute-model']);
+});
+
+test('provider and model methods take precedence over attributes', function () {
+    expect(resolveProvidersAndModels(new ProviderMethodsAgentFixture))
+        ->toBe(['openai' => 'method-model']);
+});
+
+test('a provider method returning null short-circuits the attribute lookup and falls back to config', function () {
+    config(['ai.default' => 'gemini']);
+
+    expect(resolveProvidersAndModels(new ProviderMethodReturnsNullAgentFixture))
+        ->toBe(['gemini' => null]);
+});
+
+test('config ai.default is used when neither method nor attribute provides a provider', function () {
+    config(['ai.default' => 'openai']);
+
+    expect(resolveProvidersAndModels(new NoProviderConfigAgentFixture))
+        ->toBe(['openai' => null]);
+});
+
+test('array failover provider skips model resolution from method or attribute', function () {
+    expect(resolveProvidersAndModels(
+        new ProviderMethodsAgentFixture,
+        ['anthropic' => 'claude-opus-4-7', 'openai' => null],
+    ))->toBe(['anthropic' => 'claude-opus-4-7', 'openai' => null]);
+});


### PR DESCRIPTION
## Summary

\`Promptable::getProvidersAndModels()\` decides which provider/model an agent prompt targets by walking a four-step chain — explicit argument → method on the agent → attribute on the class → \`config('ai.default')\`. None of those precedence edges had tests, and \`AgentAttributeTest\` only asserts that the \`#[Provider]\` attribute is _used_, not how it ranks against the other sources.

This PR adds tests that pin:

- explicit arguments win over both method and attribute
- attribute is used when no method exists
- method takes precedence over attribute when both are present
- **a method returning null short-circuits the attribute lookup and falls through to \`config('ai.default')\`** — this is a deliberate deviation from \`TextGenerationOptions::resolve()\`, which _does_ fall back to the attribute on a null method return. A refactor that unifies the two paths will fail this test.
- \`config('ai.default')\` is used when nothing else is set
- an array-form failover provider skips model resolution from method or attribute (the per-entry model is honored instead)

These are weight-pulling tests — they pin the precedence contract rather than mirror single-if branches.

## Test plan

- [x] \`vendor/bin/pint tests/Feature/AgentProviderModelResolutionTest.php\`
- [x] \`vendor/bin/pest tests/Feature/AgentProviderModelResolutionTest.php\` (6 passed)