### PR TITLE
Updates deprecated gemini model to successor

### DIFF
--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -100,7 +100,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['text']['cheapest'] ?? 'gemini-3.1-flash-lite-preview';
+        return $this->config['models']['text']['cheapest'] ?? 'gemini-3.1-flash-lite';
     }
 
     /**

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -46,7 +46,7 @@ dataset('agent-providers', [
     'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
     'azure' => ['azure', 'AZURE_OPENAI_API_KEY', 'gpt-5.4-mini'],
     'deepseek' => ['deepseek', 'DEEPSEEK_API_KEY', 'deepseek-v4-pro'],
-    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite'],
     'groq' => ['groq', 'GROQ_API_KEY', 'openai/gpt-oss-20b'],
     'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
@@ -57,12 +57,12 @@ dataset('agent-providers', [
 dataset('agent-document-providers', [
     'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
-    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite'],
 ]);
 
 dataset('agent-image-providers', [
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
-    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite-preview'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
 ]);
 


### PR DESCRIPTION
The `gemini-3.1-flash-lite` which is used as the default cheapest text model is deprecated as of 2026-05-25.
> Source: https://ai.google.dev/gemini-api/docs/deprecations

Using the `#[UseCheapestModel]` with the `Lab::Gemini` provider will throw the following exception:

> Laravel\Ai\Exceptions\AiException: Gemini Error [404]: NOT_FOUND - This model models/gemini-3.1-flash-lite-preview is no longer available. Please update your code to use a newer model for the latest features and improvements.

---

This PR updates to the successor model `gemini-3.1-flash-lite`