### PR TITLE
Fix Gemini image generation when text part precedes image data

### DIFF
--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -173,6 +173,7 @@ class GeminiGateway implements Gateway
 
         $images = (new Collection($data['candidates'][0]['content']['parts'] ?? []))
             ->filter(fn ($part) => isset($part['inlineData']))
+            ->values()
             ->map(fn ($part) => new GeneratedImage(
                 $part['inlineData']['data'],
                 $part['inlineData']['mimeType'],

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -35,6 +35,7 @@ dataset('image-providers', [
     'openai-dall-e-3' => ['openai', 'OPENAI_API_KEY', 'dall-e-3'],
     'openai-gpt-image-2' => ['openai', 'OPENAI_API_KEY', 'gpt-image-2'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-imagine-image'],
+    'gemini-2.5-flash-image' => ['gemini', 'GEMINI_API_KEY', 'gemini-2.5-flash-image'],
 ]);
 
 dataset('reranking-providers', [

--- a/tests/Feature/Providers/Gemini/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Gemini/ImageGenerationTest.php
@@ -165,6 +165,32 @@ test('only inlineData parts are returned when response contains mixed text and i
         ->and($response->images->first()->mime)->toBe('image/png');
 });
 
+test('firstImage works when response leads with a text part before the inlineData', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'candidates' => [[
+                'content' => [
+                    'parts' => [
+                        ['text' => 'Here is your image:'],
+                        [
+                            'inlineData' => [
+                                'mimeType' => 'image/png',
+                                'data' => base64_encode('fake-image'),
+                            ],
+                        ],
+                    ],
+                ],
+            ]],
+        ]),
+    ]);
+
+    $response = Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+
+    expect($response->firstImage()->mime)->toBe('image/png')
+        ->and($response->firstImage()->image)->toBe(base64_encode('fake-image'))
+        ->and((string) $response)->toBe('fake-image');
+});
+
 test('image response is correctly parsed', function () {
     Http::fake([
         'generativelanguage.googleapis.com/*' => fakeGeminiImageResponse('image/png'),


### PR DESCRIPTION
Currently `firstImage()` (and `store()` / `(string) $response`) on a Gemini image response throws `Undefined array key 0` when Gemini returns its parts as `[text, inlineData]`, which `gemini-2.5-flash-image` regularly does.

Re-key the filtered parts collection so the inline image lands at index 0.

Fixes #656