### PR TITLE
Inline OpenAI conversation instead of chaining via previous_response_id

### DIFF
--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -84,7 +84,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $body, $timeout);
     }
 
     /**
@@ -128,6 +128,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, TextGateway
             $schema,
             $options,
             $response->getBody(),
+            $body,
             0,
             null,
             $timeout,

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -50,7 +50,30 @@ trait BuildsTextRequests
             $body = array_merge($body, $providerOptions);
         }
 
+        if ($this->isReasoningModel($model)) {
+            $body['include'] = array_values(array_unique([
+                ...($body['include'] ?? []),
+                'reasoning.encrypted_content',
+            ]));
+        }
+
         return $body;
+    }
+
+    /**
+     * Reasoning models return encrypted_content blobs that must round-trip
+     * across tool follow-ups so the model retains chain-of-thought.
+     * gpt-5-chat* is the non-reasoning chat variant.
+     *
+     * Keep this allowlist in sync with the Vercel AI SDK:
+     * https://github.com/vercel/ai/blob/main/packages/openai/src/openai-language-model-capabilities.ts
+     */
+    protected function isReasoningModel(string $model): bool
+    {
+        return (str_starts_with($model, 'gpt-5') && ! str_starts_with($model, 'gpt-5-chat'))
+            || str_starts_with($model, 'o4-mini')
+            || str_starts_with($model, 'o3')
+            || str_starts_with($model, 'o1');
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -3,10 +3,10 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
@@ -37,6 +37,7 @@ trait HandlesTextStreaming
         ?array $schema,
         ?TextGenerationOptions $options,
         $streamBody,
+        array $requestBody = [],
         int $depth = 0,
         ?int $maxSteps = null,
         ?int $timeout = null,
@@ -44,7 +45,6 @@ trait HandlesTextStreaming
         $maxSteps ??= $options?->maxSteps;
 
         $messageId = $this->generateEventId();
-        $responseId = '';
         $reasoningId = '';
         $streamStartEmitted = false;
         $textStartEmitted = false;
@@ -71,7 +71,6 @@ trait HandlesTextStreaming
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
                 $streamStartEmitted = true;
-                $responseId = $data['response']['id'] ?? '';
 
                 yield (new StreamStart(
                     $this->generateEventId(),
@@ -149,6 +148,7 @@ trait HandlesTextStreaming
                 $reasoningItems[] = [
                     'id' => $data['item']['id'] ?? null,
                     'summary' => $data['item']['summary'] ?? [],
+                    'encrypted_content' => $data['item']['encrypted_content'] ?? null,
                 ];
 
                 if ($reasoningId !== '') {
@@ -213,6 +213,7 @@ trait HandlesTextStreaming
 
                     $toolCall['reasoning_id'] = $latestReasoning['id'];
                     $toolCall['reasoning_summary'] = $latestReasoning['summary'] ?? [];
+                    $toolCall['reasoning_encrypted_content'] = $latestReasoning['encrypted_content'] ?? null;
                 }
 
                 $pendingToolCalls[$index] = $toolCall;
@@ -253,6 +254,7 @@ trait HandlesTextStreaming
                                 $call['call_id'] ?? null,
                                 $call['reasoning_id'] ?? null,
                                 $call['reasoning_summary'] ?? null,
+                                $call['reasoning_encrypted_content'] ?? null,
                             ),
                             time(),
                         ))->withInvocationId($invocationId);
@@ -269,7 +271,6 @@ trait HandlesTextStreaming
             if ($type === 'response.completed') {
                 $response = $data['response'] ?? [];
                 $responseData = $response;
-                $responseId = $response['id'] ?? $responseId;
                 $responseUsage = $response['usage'] ?? [];
 
                 $usage = new Usage(
@@ -285,15 +286,14 @@ trait HandlesTextStreaming
         if (filled($pendingToolCalls)) {
             yield from $this->handleStreamingToolCalls(
                 $invocationId,
-                $responseId,
                 $provider,
                 $model,
                 $tools,
                 $schema,
                 $options,
+                $requestBody,
                 $pendingToolCalls,
                 $currentText,
-                $reasoningItems,
                 $depth,
                 $maxSteps,
                 $timeout,
@@ -310,20 +310,16 @@ trait HandlesTextStreaming
         ))->withInvocationId($invocationId);
     }
 
-    /**
-     * Handle tool calls detected during streaming.
-     */
     protected function handleStreamingToolCalls(
         string $invocationId,
-        string $responseId,
         Provider $provider,
         string $model,
         array $tools,
         ?array $schema,
         ?TextGenerationOptions $options,
+        array $requestBody,
         array $pendingToolCalls,
         string $currentText,
-        array $reasoningItems,
         int $depth,
         ?int $maxSteps,
         ?int $timeout = null,
@@ -361,38 +357,20 @@ trait HandlesTextStreaming
         }
 
         if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-                'stream' => true,
-            ];
-
-            if (filled($tools)) {
-                $body['tools'] = $this->mapTools($tools, $provider);
-            }
-
-            if (filled($schema)) {
-                $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-                'max_output_tokens' => $options?->maxTokens,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
+            $this->mapAssistantMessage(
+                new AssistantMessage($currentText, collect($mappedToolCalls)),
+                $requestBody['input'],
+            );
+            $this->mapToolResultMessage(
+                new ToolResultMessage(collect($toolResults)),
+                $requestBody['input'],
+            );
 
             $response = $this->withErrorHandling(
                 $provider->name(),
                 fn () => $this->client($provider, $timeout)
                     ->withOptions(['stream' => true])
-                    ->post('responses', $body),
+                    ->post('responses', $requestBody),
             );
 
             yield from $this->processTextStream(
@@ -403,6 +381,7 @@ trait HandlesTextStreaming
                 $schema,
                 $options,
                 $response->getBody(),
+                $requestBody,
                 $depth + 1,
                 $maxSteps,
                 $timeout,
@@ -431,6 +410,7 @@ trait HandlesTextStreaming
             $tc['call_id'] ?? null,
             $tc['reasoning_id'] ?? null,
             $tc['reasoning_summary'] ?? null,
+            $tc['reasoning_encrypted_content'] ?? null,
         ), array_values($toolCalls));
     }
 

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
+use Illuminate\Support\Arr;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\MessageRole;
@@ -65,11 +66,12 @@ trait MapsMessages
             $reasoningBlocks = $message->toolCalls
                 ->whereNotNull('reasoningId')
                 ->unique('reasoningId')
-                ->map(fn ($toolCall) => [
+                ->map(fn ($toolCall) => Arr::whereNotNull([
                     'type' => 'reasoning',
                     'id' => $toolCall->reasoningId,
                     'summary' => $toolCall->reasoningSummary ?? [],
-                ])
+                    'encrypted_content' => $toolCall->reasoningEncryptedContent,
+                ]))
                 ->values()
                 ->all();
 

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -59,6 +57,7 @@ trait ParsesTextResponses
         array $tools = [],
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
+        array $requestBody = [],
         ?int $timeout = null,
     ): TextResponse {
         return $this->processResponse(
@@ -69,15 +68,13 @@ trait ParsesTextResponses
             $schema,
             new Collection,
             new Collection,
+            $requestBody,
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
         );
     }
 
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
     protected function processResponse(
         array $data,
         Provider $provider,
@@ -86,12 +83,12 @@ trait ParsesTextResponses
         ?array $schema,
         Collection $steps,
         Collection $messages,
+        array $requestBody,
         int $depth = 0,
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): TextResponse {
-        $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
         $model = $data['model'] ?? '';
 
@@ -100,7 +97,6 @@ trait ParsesTextResponses
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data);
 
-        // Associate reasoning with tool calls...
         $mappedToolCalls = $this->mapToolCallsWithReasoning($output);
 
         $step = new Step(
@@ -114,18 +110,15 @@ trait ParsesTextResponses
 
         $steps->push($step);
 
-        // Build assistant message for conversation context...
         $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
 
         $messages->push($assistantMessage);
 
-        // Execute tool calls...
         if ($finishReason === FinishReason::ToolCalls &&
             filled($mappedToolCalls) &&
             $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
             $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
 
-            // Update step with tool results...
             $steps->pop();
 
             $steps->push(new Step(
@@ -142,15 +135,15 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $responseId,
-                $model,
                 $provider,
                 $structured,
                 $tools,
                 $schema,
                 $steps,
                 $messages,
-                $toolResults,
+                $requestBody,
+                $assistantMessage,
+                $toolResultMessage,
                 $depth + 1,
                 $maxSteps,
                 $options,
@@ -183,8 +176,6 @@ trait ParsesTextResponses
     }
 
     /**
-     * Execute tool calls and return tool results.
-     *
      * @param  array<ToolCall>  $toolCalls
      * @param  array<Tool>  $tools
      * @return array<ToolResult>
@@ -214,80 +205,47 @@ trait ParsesTextResponses
         return $results;
     }
 
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
     protected function continueWithToolResults(
-        string $responseId,
-        string $model,
         Provider $provider,
         bool $structured,
         array $tools,
         ?array $schema,
         Collection $steps,
         Collection $messages,
-        array $toolResults,
+        array $requestBody,
+        AssistantMessage $assistantMessage,
+        ToolResultMessage $toolResultMessage,
         int $depth,
         ?int $maxSteps,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
     ): TextResponse {
-        $body = [
-            'model' => $model,
-            'previous_response_id' => $responseId,
-            'input' => $this->buildToolResultsInput($toolResults),
-        ];
-
-        if (filled($tools)) {
-            $body['tools'] = $this->mapTools($tools, $provider);
-        }
-
-        if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-            'max_output_tokens' => $options?->maxTokens,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
+        $this->mapAssistantMessage($assistantMessage, $requestBody['input']);
+        $this->mapToolResultMessage($toolResultMessage, $requestBody['input']);
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('responses', $body),
+            fn () => $this->client($provider, $timeout)->post('responses', $requestBody),
         );
 
         $data = $response->json();
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
-    }
-
-    /**
-     * Build the input array containing only tool results for a follow-up request.
-     *
-     * @param  array<ToolResult>  $toolResults
-     */
-    protected function buildToolResultsInput(array $toolResults): array
-    {
-        $input = [];
-
-        foreach ($toolResults as $result) {
-            $input[] = [
-                'type' => 'function_call_output',
-                'call_id' => $result->resultId,
-                'output' => $this->serializeToolResultOutput($result->result),
-            ];
-        }
-
-        return $input;
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $requestBody,
+            $depth,
+            $maxSteps,
+            $options,
+            $timeout,
+        );
     }
 
     /**
@@ -411,6 +369,7 @@ trait ParsesTextResponses
                     $item['call_id'] ?? null,
                     $latestReasoning ? ($latestReasoning['id'] ?? null) : null,
                     $latestReasoning ? ($latestReasoning['summary'] ?? null) : null,
+                    $latestReasoning ? ($latestReasoning['encrypted_content'] ?? null) : null,
                 );
             }
         }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -78,7 +78,7 @@ class OpenAiGateway implements Gateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $body, $timeout);
     }
 
     /**
@@ -116,6 +116,7 @@ class OpenAiGateway implements Gateway
             $schema,
             $options,
             $response->getBody(),
+            $body,
             0,
             null,
             $timeout,

--- a/src/Responses/Data/ToolCall.php
+++ b/src/Responses/Data/ToolCall.php
@@ -14,7 +14,24 @@ class ToolCall implements Arrayable, JsonSerializable
         public ?string $resultId = null,
         public ?string $reasoningId = null,
         public ?array $reasoningSummary = null,
+        public ?string $reasoningEncryptedContent = null,
     ) {}
+
+    /**
+     * Reconstruct an instance from a previously serialized toArray() payload.
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            arguments: $data['arguments'],
+            resultId: $data['result_id'] ?? null,
+            reasoningId: $data['reasoning_id'] ?? null,
+            reasoningSummary: $data['reasoning_summary'] ?? null,
+            reasoningEncryptedContent: $data['reasoning_encrypted_content'] ?? null,
+        );
+    }
 
     /**
      * Get the instance as an array.
@@ -28,6 +45,7 @@ class ToolCall implements Arrayable, JsonSerializable
             'result_id' => $this->resultId,
             'reasoning_id' => $this->reasoningId,
             'reasoning_summary' => $this->reasoningSummary,
+            'reasoning_encrypted_content' => $this->reasoningEncryptedContent,
         ];
     }
 

--- a/src/Responses/Data/ToolResult.php
+++ b/src/Responses/Data/ToolResult.php
@@ -16,6 +16,20 @@ class ToolResult implements Arrayable, JsonSerializable
     ) {}
 
     /**
+     * Reconstruct an instance from a previously serialized toArray() payload.
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            arguments: $data['arguments'],
+            result: $data['result'],
+            resultId: $data['result_id'] ?? null,
+        );
+    }
+
+    /**
      * Get the instance as an array.
      */
     public function toArray(): array

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -156,29 +156,16 @@ class DatabaseConversationStore implements ConversationStore
                 }
 
                 if ($toolCalls->isNotEmpty()) {
-                    $messages = [];
-
-                    $messages[] = new AssistantMessage(
-                        $record->content ?: '',
-                        $toolCalls->map(fn ($toolCall) => new ToolCall(
-                            id: $toolCall['id'],
-                            name: $toolCall['name'],
-                            arguments: $toolCall['arguments'],
-                            resultId: $toolCall['result_id'] ?? null,
-                            reasoningId: $toolCall['reasoning_id'] ?? null,
-                            reasoningSummary: $toolCall['reasoning_summary'] ?? null,
-                        ))
-                    );
+                    $messages = [
+                        new AssistantMessage(
+                            $record->content ?: '',
+                            $toolCalls->map(ToolCall::fromArray(...)),
+                        ),
+                    ];
 
                     if ($toolResults->isNotEmpty()) {
                         $messages[] = new ToolResultMessage(
-                            $toolResults->map(fn ($toolResult) => new ToolResult(
-                                id: $toolResult['id'],
-                                name: $toolResult['name'],
-                                arguments: $toolResult['arguments'],
-                                result: $toolResult['result'],
-                                resultId: $toolResult['result_id'] ?? null,
-                            ))
+                            $toolResults->map(ToolResult::fromArray(...)),
                         );
                     }
 

--- a/tests/Feature/Providers/AzureOpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/MessageMappingTest.php
@@ -39,39 +39,29 @@ test('user message maps to azure format', function () {
     });
 });
 
-test('tool result follow up uses previous response id', function () {
+test('tool result follow up inlines the full conversation without previous_response_id', function () {
     Http::fake([
         'my-resource.cognitiveservices.azure.com/*' => Http::sequence([
-            fakeAzureToolCallResponse(),
+            fakeOpenAiToolCallResponse('resp_azure_tool_123', 'gpt-4o'),
             fakeAzureResponse('The number is 72019'),
         ]),
     ]);
 
-    (new ToolUsingAgent(fixed: true))->prompt(
-        'Generate a number',
-        provider: 'azure',
-    );
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'azure');
 
-    $recorded = Http::recorded();
+    $followUpBody = json_decode(Http::recorded()[1][0]->body(), true);
 
-    expect($recorded)->toHaveCount(2);
-
-    $followUpBody = json_decode($recorded[1][0]->body(), true);
-
-    expect($followUpBody)->toHaveKey('previous_response_id')
-        ->and($followUpBody['previous_response_id'])->toBe('resp_azure_tool_123');
-
-    $hasFunctionCallOutput = false;
-
-    foreach ($followUpBody['input'] as $item) {
-        if (($item['type'] ?? '') === 'function_call_output') {
-            $hasFunctionCallOutput = true;
-            expect($item['call_id'])->toBe('call_123')
-                ->and($item['output'])->not->toBeEmpty();
-        }
-    }
-
-    expect($hasFunctionCallOutput)->toBeTrue();
+    expect($followUpBody)->not->toHaveKey('previous_response_id')
+        ->and($followUpBody['input'])->sequence(
+            fn ($item) => $item->role->toBe('system'),
+            fn ($item) => $item->toMatchArray([
+                'role' => 'user',
+                'content' => [['type' => 'input_text', 'text' => 'Generate a number']],
+            ]),
+            fn ($item) => $item->toMatchArray(['type' => 'function_call', 'call_id' => 'call_123']),
+            fn ($item) => $item->toMatchArray(['type' => 'function_call_output', 'call_id' => 'call_123'])
+                ->output->not->toBeEmpty(),
+        );
 });
 
 test('image attachment maps to input_image content block', function () {
@@ -124,24 +114,3 @@ test('document attachment maps to input_file content block', function () {
             && str_contains($fileBlock['file_data'], 'application/pdf');
     });
 });
-
-function fakeAzureToolCallResponse()
-{
-    return Http::response([
-        'id' => 'resp_azure_tool_123',
-        'status' => 'completed',
-        'model' => 'gpt-4o',
-        'output' => [[
-            'type' => 'function_call',
-            'id' => 'fc_123',
-            'call_id' => 'call_123',
-            'name' => 'FixedNumberGenerator',
-            'arguments' => '{}',
-            'status' => 'completed',
-        ]],
-        'usage' => [
-            'input_tokens' => 10,
-            'output_tokens' => 5,
-        ],
-    ]);
-}

--- a/tests/Feature/Providers/AzureOpenAi/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ToolCallLoopTest.php
@@ -32,7 +32,7 @@ test('tool calls trigger follow up request', function () {
 
     $followUpBody = json_decode($recorded[1][0]->body(), true);
 
-    expect($followUpBody)->toHaveKey('previous_response_id');
+    expect($followUpBody)->not->toHaveKey('previous_response_id');
 
     $hasFunctionCallOutput = false;
 

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -44,7 +44,7 @@ test('user message maps to openai format', function () {
     });
 });
 
-test('tool result follow up uses previous response id', function () {
+test('tool result follow up inlines the full conversation without previous_response_id', function () {
     Http::fake([
         'api.openai.com/*' => Http::sequence([
             fakeOpenAiToolCallResponse(),
@@ -52,31 +52,21 @@ test('tool result follow up uses previous response id', function () {
         ]),
     ]);
 
-    (new ToolUsingAgent(fixed: true))->prompt(
-        'Generate a number',
-        provider: 'openai',
-    );
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'openai');
 
-    $recorded = Http::recorded();
+    $followUpBody = json_decode(Http::recorded()[1][0]->body(), true);
 
-    expect($recorded)->toHaveCount(2);
-
-    $followUpBody = json_decode($recorded[1][0]->body(), true);
-
-    expect($followUpBody)->toHaveKey('previous_response_id')
-        ->and($followUpBody['previous_response_id'])->toBe('resp_tool_123');
-
-    $hasFunctionCallOutput = false;
-
-    foreach ($followUpBody['input'] as $item) {
-        if (($item['type'] ?? '') === 'function_call_output') {
-            $hasFunctionCallOutput = true;
-            expect($item['call_id'])->toBe('call_123')
-                ->and($item['output'])->not->toBeEmpty();
-        }
-    }
-
-    expect($hasFunctionCallOutput)->toBeTrue();
+    expect($followUpBody)->not->toHaveKey('previous_response_id')
+        ->and($followUpBody['input'])->sequence(
+            fn ($item) => $item->role->toBe('system'),
+            fn ($item) => $item->toMatchArray([
+                'role' => 'user',
+                'content' => [['type' => 'input_text', 'text' => 'Generate a number']],
+            ]),
+            fn ($item) => $item->toMatchArray(['type' => 'function_call', 'call_id' => 'call_123']),
+            fn ($item) => $item->toMatchArray(['type' => 'function_call_output', 'call_id' => 'call_123'])
+                ->output->not->toBeEmpty(),
+        );
 });
 
 test('base64 pdf document maps to input file', function () {
@@ -337,4 +327,74 @@ test('system instructions are in input array as system role', function () {
         return $systemMsg !== null
             && str_contains($systemMsg['content'], 'helpful assistant');
     });
+});
+
+test('reasoning model requests auto-include reasoning.encrypted_content', function () {
+    Http::fake(['api.openai.com/*' => fakeOpenAiResponse()]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'openai');
+
+    Http::assertSent(fn (Request $request) => expect(json_decode($request->body(), true))
+        ->include->toContain('reasoning.encrypted_content')
+    );
+});
+
+test('non-reasoning model requests omit reasoning.encrypted_content include', function (string $model) {
+    Http::fake(['api.openai.com/*' => fakeOpenAiResponse()]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'openai', model: $model);
+
+    Http::assertSent(fn (Request $request) => expect(json_decode($request->body(), true)['include'] ?? [])
+        ->not->toContain('reasoning.encrypted_content')
+    );
+})->with([
+    'gpt-4.1',
+    'gpt-4o',
+    'gpt-5-chat-latest',
+]);
+
+test('store is not set so OpenAI defaults to its server-side behavior', function () {
+    Http::fake(['api.openai.com/*' => fakeOpenAiResponse()]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'openai');
+
+    Http::assertSent(fn (Request $request) => expect(json_decode($request->body(), true))
+        ->not->toHaveKey('store')
+    );
+});
+
+test('encrypted reasoning blobs round-trip through tool follow-up', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'resp_rs',
+                'status' => 'completed',
+                'model' => 'gpt-5.4',
+                'output' => [
+                    ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => [], 'encrypted_content' => 'enc-blob-1'],
+                    [
+                        'type' => 'function_call',
+                        'id' => 'fc_1',
+                        'call_id' => 'call_1',
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                        'status' => 'completed',
+                    ],
+                ],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            fakeOpenAiResponse('Done'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate a number', provider: 'openai');
+
+    $followUpBody = json_decode(Http::recorded()[1][0]->body(), true);
+    $reasoningBlock = collect($followUpBody['input'])->firstWhere('type', 'reasoning');
+
+    expect($reasoningBlock)->toMatchArray([
+        'type' => 'reasoning',
+        'id' => 'rs_1',
+        'encrypted_content' => 'enc-blob-1',
+    ]);
 });

--- a/tests/Feature/Providers/OpenAi/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/OpenAi/ProviderOptionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
@@ -65,26 +64,5 @@ test('provider options are persisted in tool call follow up requests', function 
 
     expect(data_get($followUpBody, 'reasoning.effort'))->toBe('high')
         ->and(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5)
-        ->and($followUpBody)->toHaveKey('previous_response_id');
+        ->and($followUpBody)->not->toHaveKey('previous_response_id');
 });
-
-function fakeOpenAiToolCallResponse(): PromiseInterface
-{
-    return Http::response([
-        'id' => 'resp_tool_123',
-        'status' => 'completed',
-        'model' => 'gpt-5.4',
-        'output' => [[
-            'type' => 'function_call',
-            'id' => 'fc_123',
-            'call_id' => 'call_123',
-            'name' => 'FixedNumberGenerator',
-            'arguments' => '{}',
-            'status' => 'completed',
-        ]],
-        'usage' => [
-            'input_tokens' => 10,
-            'output_tokens' => 5,
-        ],
-    ]);
-}

--- a/tests/Feature/Providers/OpenAi/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolCallLoopTest.php
@@ -30,7 +30,7 @@ test('tool calls trigger follow up request', function () {
 
     $followUpBody = json_decode($recorded[1][0]->body(), true);
 
-    expect($followUpBody)->toHaveKey('previous_response_id');
+    expect($followUpBody)->not->toHaveKey('previous_response_id');
 
     $hasFunctionCallOutput = false;
 

--- a/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
+++ b/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
@@ -131,7 +131,7 @@ test('openai temperature and max tokens are preserved in tool call follow up', f
             && $request['max_output_tokens'] === 1024,
         fn (Request $request) => $request['temperature'] === 0.2
             && $request['max_output_tokens'] === 1024
-            && isset($request['previous_response_id']),
+            && ! isset($request['previous_response_id']),
     ]);
 });
 

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -176,6 +176,76 @@ test('it reloads legacy sparse keyed tool calls and results as lists', function 
         ->and($messages[1]->toolResults->keys()->all())->toBe([0, 1]);
 });
 
+test('it rehydrates reasoning encrypted content on stored tool calls', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Reasoning conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Looking that up.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            [
+                'id' => 'call-1',
+                'name' => 'lookup_order',
+                'arguments' => ['id' => 1],
+                'reasoning_id' => 'rs_1',
+                'reasoning_summary' => [],
+                'reasoning_encrypted_content' => 'enc-blob-1',
+            ],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped']],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[0]->toolCalls->first())
+        ->reasoningId->toBe('rs_1')
+        ->reasoningEncryptedContent->toBe('enc-blob-1');
+});
+
+test('it rehydrates legacy tool calls that predate reasoning encrypted content', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Legacy conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Looking that up.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1]],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped']],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages[0]->toolCalls->first())
+        ->reasoningId->toBeNull()
+        ->reasoningSummary->toBeNull()
+        ->reasoningEncryptedContent->toBeNull();
+});
+
 test('user messages with stored attachments are rehydrated as UserMessage', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Attachment conversation');

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -90,6 +90,27 @@ function fakeOpenAiResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
+function fakeOpenAiToolCallResponse(string $id = 'resp_tool_123', string $model = 'gpt-5.4'): PromiseInterface
+{
+    return Http::response([
+        'id' => $id,
+        'status' => 'completed',
+        'model' => $model,
+        'output' => [[
+            'type' => 'function_call',
+            'id' => 'fc_123',
+            'call_id' => 'call_123',
+            'name' => 'FixedNumberGenerator',
+            'arguments' => '{}',
+            'status' => 'completed',
+        ]],
+        'usage' => [
+            'input_tokens' => 10,
+            'output_tokens' => 5,
+        ],
+    ]);
+}
+
 function fakeDeepSeekResponse(string $text = 'Hello'): PromiseInterface
 {
     return Http::response([

--- a/tests/Unit/Responses/Data/ToolCallTest.php
+++ b/tests/Unit/Responses/Data/ToolCallTest.php
@@ -9,7 +9,8 @@ test('tool call stores all properties', function () {
         arguments: ['city' => 'San Francisco'],
         resultId: 'res_456',
         reasoningId: 'reason_789',
-        reasoningSummary: ['thought' => 'I should check the weather']
+        reasoningSummary: ['thought' => 'I should check the weather'],
+        reasoningEncryptedContent: 'enc-blob-1',
     );
 
     expect($toolCall->id)->toBe('call_123')
@@ -17,7 +18,8 @@ test('tool call stores all properties', function () {
         ->and($toolCall->arguments)->toBe(['city' => 'San Francisco'])
         ->and($toolCall->resultId)->toBe('res_456')
         ->and($toolCall->reasoningId)->toBe('reason_789')
-        ->and($toolCall->reasoningSummary)->toBe(['thought' => 'I should check the weather']);
+        ->and($toolCall->reasoningSummary)->toBe(['thought' => 'I should check the weather'])
+        ->and($toolCall->reasoningEncryptedContent)->toBe('enc-blob-1');
 });
 
 test('tool call to array returns all properties', function () {
@@ -32,6 +34,7 @@ test('tool call to array returns all properties', function () {
         'result_id' => null,
         'reasoning_id' => null,
         'reasoning_summary' => null,
+        'reasoning_encrypted_content' => null,
     ]);
 });
 


### PR DESCRIPTION
Currently, every OpenAI tool-call follow-up sends `previous_response_id` to chain off the prior assistant turn. Organizations with Zero Data Retention (ZDR) enabled reject these requests with `Previous response cannot be used for this organization due to Zero Data Retention`, so any agent that uses tools is broken on ZDR accounts after the first hop.

This PR flips the OpenAI gateway to inline-by-default:

```php
// before — every follow-up POST
['model' => $m, 'previous_response_id' => $id, 'input' => [/* just tool result */]]

// after — every follow-up POST
['model' => $m, 'input' => [/* full conversation, encrypted reasoning included */]]
```

ZDR just works with no config. Non-ZDR users see no retention change because `store` stays at OpenAI's default (`true`). For reasoning models (`o1*`, `o3*`, `o4-mini`, `gpt-5*` except `gpt-5-chat`) we auto-add `include: ['reasoning.encrypted_content']` and round-trip the blob via a new `ToolCall::$reasoningEncryptedContent` field so chain-of-thought survives tool steps.

Trade-off: input tokens billed roughly ~1.3x for long tool loops, half paid by OpenAI's automatic prompt cache on the repeating prefix. Output tokens unchanged. Verified live on `gpt-5.4-nano` with the reasoning replay path and DB round-trip integration tests.

No opt-in flag for the old `previous_response_id` behavior. Adding one re-introduces the two-path branching this PR set out to remove, and there's no public API surface to preserve. If anyone has a concrete need to chain off a stored response (cost optimization, manual resume, etc.), the right shape is to expose `providerOptions.openai.previous_response_id` as a per-request value.

Credits to @Junveloper — the encrypted-reasoning pars