### PR TITLE
Update deprecated Gemini default to gemini-3.5-flash

### DIFF
--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -92,7 +92,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['text']['default'] ?? 'gemini-3-flash-preview';
+        return $this->config['models']['text']['default'] ?? 'gemini-3.5-flash';
     }
 
     /**
@@ -154,7 +154,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTranscriptionModel(): string
     {
-        return $this->config['models']['transcription']['default'] ?? 'gemini-3-flash-preview';
+        return $this->config['models']['transcription']['default'] ?? 'gemini-3.5-flash';
     }
 
     /**

--- a/tests/Feature/Providers/Gemini/GeminiHelpers.php
+++ b/tests/Feature/Providers/Gemini/GeminiHelpers.php
@@ -23,7 +23,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3-flash-preview',
+            'modelVersion' => 'gemini-3.5-flash',
         ]);
     }
 
@@ -48,7 +48,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3-flash-preview',
+            'modelVersion' => 'gemini-3.5-flash',
         ]);
     }
 
@@ -67,7 +67,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3-flash-preview',
+            'modelVersion' => 'gemini-3.5-flash',
         ]);
     }
 
@@ -92,7 +92,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3-flash-preview',
+            'modelVersion' => 'gemini-3.5-flash',
         ]);
     }
 
@@ -140,7 +140,7 @@ trait GeminiHelpers
 
         return [
             'candidates' => [$candidate],
-            'modelVersion' => $modelVersion ?? 'gemini-3-flash-preview',
+            'modelVersion' => $modelVersion ?? 'gemini-3.5-flash',
         ];
     }
 

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -17,11 +17,11 @@ describe('request structure', function () {
         (new AssistantAgent)->prompt(
             'What is Laravel?',
             provider: 'gemini',
-            model: 'gemini-3-flash-preview',
+            model: 'gemini-3.5-flash',
         );
 
         Http::assertSent(function ($request) {
-            return str_contains($request->url(), 'models/gemini-3-flash-preview:generateContent')
+            return str_contains($request->url(), 'models/gemini-3.5-flash:generateContent')
                 && $request->data()['contents'][0]['role'] === 'user'
                 && $request->data()['contents'][0]['parts'][0]['text'] === 'What is Laravel?';
         });

--- a/tests/Feature/Providers/Gemini/TranscriptionTest.php
+++ b/tests/Feature/Providers/Gemini/TranscriptionTest.php
@@ -18,13 +18,13 @@ test('transcription request sends audio as inline data with correct mime type', 
     ]);
 
     Transcription::of(base64_encode('fake-audio'), 'audio/mp3')
-        ->generate(provider: 'gemini', model: 'gemini-3-flash-preview');
+        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
 
     Http::assertSent(function (Request $request) {
         $body = $request->data();
         $parts = $body['contents'][0]['parts'];
 
-        return str_contains($request->url(), 'models/gemini-3-flash-preview:generateContent')
+        return str_contains($request->url(), 'models/gemini-3.5-flash:generateContent')
             && $parts[1]['inlineData']['mimeType'] === 'audio/mp3'
             && $parts[1]['inlineData']['data'] === base64_encode('fake-audio');
     });
@@ -37,7 +37,7 @@ test('transcription request includes language in prompt when specified', functio
 
     Transcription::of(base64_encode('fake-audio'), 'audio/mp3')
         ->language('fr')
-        ->generate(provider: 'gemini', model: 'gemini-3-flash-preview');
+        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
 
     Http::assertSent(fn (Request $request) => str_contains(
         $request->data()['contents'][0]['parts'][0]['text'],
@@ -51,12 +51,12 @@ test('transcription response returns text with correct meta', function () {
     ]);
 
     $response = Transcription::of(base64_encode('fake-audio'), 'audio/mp3')
-        ->generate(provider: 'gemini', model: 'gemini-3-flash-preview');
+        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
 
     expect($response->text)->toBe('Hello world')
         ->and($response->segments)->toHaveCount(0)
         ->and($response->meta->provider)->toBe('gemini')
-        ->and($response->meta->model)->toBe('gemini-3-flash-preview')
+        ->and($response->meta->model)->toBe('gemini-3.5-flash')
         ->and($response->usage->promptTokens)->toBe(10)
         ->and($response->usage->completionTokens)->toBe(5);
 });
@@ -68,7 +68,7 @@ test('transcription uses default model when none specified', function () {
 
     Transcription::of(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'gemini');
 
-    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-3-flash-preview:generateContent'));
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-3.5-flash:generateContent'));
 });
 
 test('diarized transcription request sends json schema in generation config', function () {
@@ -78,7 +78,7 @@ test('diarized transcription request sends json schema in generation config', fu
 
     Transcription::of(base64_encode('fake-audio'), 'audio/mp3')
         ->diarize()
-        ->generate(provider: 'gemini', model: 'gemini-3-flash-preview');
+        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
 
     Http::assertSent(function (Request $request) {
         $body = $request->data();
@@ -97,7 +97,7 @@ test('diarized transcription response returns text and segments', function () {
 
     $response = Transcription::of(base64_encode('fake-audio'), 'audio/mp3')
         ->diarize()
-        ->generate(provider: 'gemini', model: 'gemini-3-flash-preview');
+        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
 
     expect($response->text)->toBe('Hello world')
         ->and($response->segments)->toHaveCount(2)
@@ -121,7 +121,7 @@ test('diarized transcription parses srt and hour timestamp formats', function ()
 
     $response = Transcription::of(base64_encode('fake-audio'), 'audio/mp3')
         ->diarize()
-        ->generate(provider: 'gemini', model: 'gemini-3-flash-preview');
+        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
 
     expect($response->segments[0]->startSeconds)->toBe(1.5)
         ->and($response->segments[0]->endSeconds)->toBe(62.25)

--- a/tests/Feature/Providers/TimeoutInToolLoopTest.php
+++ b/tests/Feature/Providers/TimeoutInToolLoopTest.php
@@ -210,7 +210,7 @@ function timeoutFakeGeminiToolCallResponse(): PromiseInterface
             'candidatesTokenCount' => 5,
             'totalTokenCount' => 15,
         ],
-        'modelVersion' => 'gemini-3-flash-preview',
+        'modelVersion' => 'gemini-3.5-flash',
     ]);
 }
 
@@ -229,7 +229,7 @@ function timeoutFakeGeminiTextResponse(string $text): PromiseInterface
             'candidatesTokenCount' => 5,
             'totalTokenCount' => 15,
         ],
-        'modelVersion' => 'gemini-3-flash-preview',
+        'modelVersion' => 'gemini-3.5-flash',
     ]);
 }
 

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -78,7 +78,7 @@ test('it persists tool calls and results from a remembered agent prompt', functi
                     'finishReason' => 'STOP',
                 ]],
                 'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5, 'totalTokenCount' => 15],
-                'modelVersion' => 'gemini-3-flash-preview',
+                'modelVersion' => 'gemini-3.5-flash',
             ]),
             Http::response([
                 'candidates' => [[
@@ -89,7 +89,7 @@ test('it persists tool calls and results from a remembered agent prompt', functi
                     'finishReason' => 'STOP',
                 ]],
                 'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5, 'totalTokenCount' => 15],
-                'modelVersion' => 'gemini-3-flash-preview',
+                'modelVersion' => 'gemini-3.5-flash',
             ]),
         ]),
     ]);


### PR DESCRIPTION
Currently the Gemini provider's default text and transcription models point at `gemini-3-flash-preview`, which Google has shut down per their [deprecations table](https://ai.google.dev/gemini-api/docs/deprecations). Any agent using `#[Provider([Lab::Gemini])]` or `#[UseCheapestModel]` 404s out of the box. #657 fixed the cheapest fallback but missed the default.

This PR points both defaults at `gemini-3.5-flash`, which is exactly the replacement Google lists for `gemini-3-flash-preview`.

Fixes #659.