### PR TITLE
Migrate OpenAI web_search_preview to web_search with provider options

### DIFF
--- a/src/Gateway/OpenAi/Concerns/MapsTools.php
+++ b/src/Gateway/OpenAi/Concerns/MapsTools.php
@@ -99,7 +99,7 @@ trait MapsTools
         }
 
         return [
-            'type' => 'web_search_preview',
+            'type' => 'web_search',
             ...$provider->webSearchToolOptions($tool),
         ];
     }

--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -7,6 +7,7 @@ use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Anthropic\AnthropicFileGateway;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
@@ -50,7 +51,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
                     'country' => $search->country,
                 ])
                 : null,
-        ]);
+        ]) + $search->providerOptions(Lab::Anthropic);
     }
 
     /**

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\OpenAi\OpenAiFileGateway;
 use Laravel\Ai\Gateway\OpenAi\OpenAiStoreGateway;
 use Laravel\Ai\Providers\Tools\FileSearch;
@@ -62,15 +63,14 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function webSearchToolOptions(WebSearch $search): array
     {
-        $filters = [];
+        $options = $search->providerOptions(Lab::OpenAI);
 
-        if (filled($search->allowedDomains)) {
-            $filters['allowed_domains'] = collect($search->allowedDomains)->take(100);
-        }
+        $filters = array_merge(
+            filled($search->allowedDomains) ? ['allowed_domains' => $search->allowedDomains] : [],
+            $options['filters'] ?? [],
+        );
 
-        if (filled($search->blockedDomains)) {
-            $filters['blocked_domains'] = collect($search->blockedDomains)->take(100);
-        }
+        unset($options['filters']);
 
         return array_filter([
             'filters' => filled($filters) ? $filters : null,
@@ -82,9 +82,7 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
                     'country' => $search->country,
                 ])
                 : null,
-        ]) + [
-            'external_web_access' => ! $search->offlineMode,
-        ];
+        ]) + $options;
     }
 
     /**

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -62,10 +62,18 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function webSearchToolOptions(WebSearch $search): array
     {
+        $filters = [];
+
+        if (filled($search->allowedDomains)) {
+            $filters['allowed_domains'] = collect($search->allowedDomains)->take(100);
+        }
+
+        if (filled($search->blockedDomains)) {
+            $filters['blocked_domains'] = collect($search->blockedDomains)->take(100);
+        }
+
         return array_filter([
-            'filters' => filled($search->allowedDomains)
-                ? ['allowed_domains' => $search->allowedDomains]
-                : null,
+            'filters' => filled($filters) ? $filters : null,
             'user_location' => $search->hasLocation()
                 ? array_filter([
                     'type' => 'approximate',
@@ -74,7 +82,9 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
                     'country' => $search->country,
                 ])
                 : null,
-        ]);
+        ]) + [
+            'external_web_access' => ! $search->offlineMode,
+        ];
     }
 
     /**

--- a/src/Providers/Tools/ProviderTool.php
+++ b/src/Providers/Tools/ProviderTool.php
@@ -2,7 +2,40 @@
 
 namespace Laravel\Ai\Providers\Tools;
 
-abstract class ProviderTool
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+
+abstract class ProviderTool implements HasProviderOptions
 {
-    //
+    /**
+     * Provider-specific options keyed by lab name (e.g. 'openai', 'anthropic').
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $providerOptions = [];
+
+    /**
+     * Attach provider-specific options that the matching gateway will merge into the tool payload.
+     */
+    public function withProviderOptions(Lab|string $provider, array $options): static
+    {
+        $this->providerOptions[$this->normalizeProvider($provider)] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Get the provider-specific options for the given provider.
+     *
+     * @return array<string, mixed>
+     */
+    public function providerOptions(Lab|string $provider): array
+    {
+        return $this->providerOptions[$this->normalizeProvider($provider)] ?? [];
+    }
+
+    protected function normalizeProvider(Lab|string $provider): string
+    {
+        return $provider instanceof Lab ? $provider->value : $provider;
+    }
 }

--- a/src/Providers/Tools/ProviderTool.php
+++ b/src/Providers/Tools/ProviderTool.php
@@ -15,7 +15,7 @@ abstract class ProviderTool implements HasProviderOptions
     protected array $providerOptions = [];
 
     /**
-     * Attach provider-specific options that the matching gateway will merge into the tool payload.
+     * Attach provider-specific options to the tool payload.
      */
     public function withProviderOptions(Lab|string $provider, array $options): static
     {
@@ -34,6 +34,9 @@ abstract class ProviderTool implements HasProviderOptions
         return $this->providerOptions[$this->normalizeProvider($provider)] ?? [];
     }
 
+    /**
+     * Normalize the provider / lab value to a string.
+     */
     protected function normalizeProvider(Lab|string $provider): string
     {
         return $provider instanceof Lab ? $provider->value : $provider;

--- a/src/Providers/Tools/WebSearch.php
+++ b/src/Providers/Tools/WebSearch.php
@@ -13,6 +13,8 @@ class WebSearch extends ProviderTool
     public function __construct(
         public ?int $maxSearches = null,
         public array $allowedDomains = [],
+        public array $blockedDomains = [],
+        public bool $offlineMode = false,
     ) {}
 
     /**
@@ -31,6 +33,23 @@ class WebSearch extends ProviderTool
     public function allow(array $domains): self
     {
         $this->allowedDomains = $domains;
+
+        return $this;
+    }
+
+    /**
+     * Set the allowed domains.
+     */
+    public function block(array $domains): self
+    {
+        $this->blockedDomains = $domains;
+
+        return $this;
+    }
+
+    public function offline(bool $offline = true): self
+    {
+        $this->offlineMode = $offline;
 
         return $this;
     }

--- a/src/Providers/Tools/WebSearch.php
+++ b/src/Providers/Tools/WebSearch.php
@@ -13,8 +13,6 @@ class WebSearch extends ProviderTool
     public function __construct(
         public ?int $maxSearches = null,
         public array $allowedDomains = [],
-        public array $blockedDomains = [],
-        public bool $offlineMode = false,
     ) {}
 
     /**
@@ -33,23 +31,6 @@ class WebSearch extends ProviderTool
     public function allow(array $domains): self
     {
         $this->allowedDomains = $domains;
-
-        return $this;
-    }
-
-    /**
-     * Set the allowed domains.
-     */
-    public function block(array $domains): self
-    {
-        $this->blockedDomains = $domains;
-
-        return $this;
-    }
-
-    public function offline(bool $offline = true): self
-    {
-        $this->offlineMode = $offline;
 
         return $this;
     }

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Providers\Tools\FileSearch;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Agents\NamedToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -58,6 +59,37 @@ test('tool with a name() method emits the declared name', function () {
         $names = collect($request->data()['tools'] ?? [])->pluck('name')->all();
 
         return in_array('aliased_tool', $names, true);
+    });
+});
+
+test('web search tool sends allowed_domains', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [(new WebSearch)->allow(['laravel.com', 'php.net'])])
+        ->prompt('Search', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_search');
+
+        return data_get($tool, 'allowed_domains') === ['laravel.com', 'php.net'];
+    });
+});
+
+test('web search tool forwards anthropic provider options into the tool payload', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [
+        (new WebSearch)->withProviderOptions('anthropic', ['blocked_domains' => ['spam.com']]),
+    ])->prompt('Search', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_search');
+
+        return data_get($tool, 'blocked_domains') === ['spam.com'];
     });
 });
 

--- a/tests/Feature/Providers/OpenAi/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
 use Tests\Fixtures\Tools\NonStrictTool;
@@ -101,5 +102,147 @@ test('tool with empty schema includes strict compliant parameters', function () 
             && $tool['parameters']['properties'] === []
             && $tool['parameters']['required'] === []
             && $tool['parameters']['additionalProperties'] === false;
+    });
+});
+
+test('web search tool sends type web_search', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [new WebSearch])->prompt('Search the web', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return $tool !== null;
+    });
+});
+
+test('web search tool sends external_web_access true by default', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [new WebSearch])->prompt('Search the web', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'external_web_access') === true;
+    });
+});
+
+test('web search tool in offline mode sends external_web_access false', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [(new WebSearch)->offline()])->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'external_web_access') === false;
+    });
+});
+
+test('web search tool sends allowed_domains filter', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [(new WebSearch)->allow(['example.com', 'docs.example.com'])])
+        ->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'filters.allowed_domains') === ['example.com', 'docs.example.com'];
+    });
+});
+
+test('web search tool sends blocked_domains filter', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [(new WebSearch)->block(['spam.com', 'ads.example.com'])])
+        ->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'filters.blocked_domains') === ['spam.com', 'ads.example.com'];
+    });
+});
+
+test('web search tool sends both allowed and blocked domains', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [(new WebSearch)->allow(['good.com'])->block(['bad.com'])])
+        ->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'filters.allowed_domains') === ['good.com']
+            && data_get($tool, 'filters.blocked_domains') === ['bad.com'];
+    });
+});
+
+test('web search tool omits filters when no domains configured', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [new WebSearch])->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return ! array_key_exists('filters', $tool);
+    });
+});
+
+test('web search tool sends user_location when location is set', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [(new WebSearch)->location(city: 'Warsaw', country: 'PL')])
+        ->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'user_location.type') === 'approximate'
+            && data_get($tool, 'user_location.city') === 'Warsaw'
+            && data_get($tool, 'user_location.country') === 'PL';
+    });
+});
+
+test('web search tool omits user_location when no location set', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [new WebSearch])->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return ! array_key_exists('user_location', $tool);
     });
 });

--- a/tests/Feature/Providers/OpenAi/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolMappingTest.php
@@ -120,7 +120,7 @@ test('web search tool sends type web_search', function () {
     });
 });
 
-test('web search tool sends external_web_access true by default', function () {
+test('web search tool omits openai-specific options by default', function () {
     Http::fake([
         '*' => fakeOpenAiResponse('result'),
     ]);
@@ -131,22 +131,45 @@ test('web search tool sends external_web_access true by default', function () {
         $body = json_decode($request->body(), true);
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
 
-        return data_get($tool, 'external_web_access') === true;
+        return ! array_key_exists('external_web_access', $tool);
     });
 });
 
-test('web search tool in offline mode sends external_web_access false', function () {
+test('web search tool forwards openai provider options into the tool payload', function () {
     Http::fake([
         '*' => fakeOpenAiResponse('result'),
     ]);
 
-    agent(tools: [(new WebSearch)->offline()])->prompt('Search', provider: 'openai');
+    agent(tools: [
+        (new WebSearch)->withProviderOptions('openai', [
+            'external_web_access' => false,
+            'search_context_size' => 'high',
+        ]),
+    ])->prompt('Search', provider: 'openai');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
 
-        return data_get($tool, 'external_web_access') === false;
+        return data_get($tool, 'external_web_access') === false
+            && data_get($tool, 'search_context_size') === 'high';
+    });
+});
+
+test('web search tool ignores provider options keyed to another provider', function () {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [
+        (new WebSearch)->withProviderOptions('anthropic', ['external_web_access' => false]),
+    ])->prompt('Search', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return ! array_key_exists('external_web_access', $tool);
     });
 });
 
@@ -166,13 +189,16 @@ test('web search tool sends allowed_domains filter', function () {
     });
 });
 
-test('web search tool sends blocked_domains filter', function () {
+test('web search tool sends blocked_domains via provider options', function () {
     Http::fake([
         '*' => fakeOpenAiResponse('result'),
     ]);
 
-    agent(tools: [(new WebSearch)->block(['spam.com', 'ads.example.com'])])
-        ->prompt('Search', provider: 'openai');
+    agent(tools: [
+        (new WebSearch)->withProviderOptions('openai', [
+            'filters' => ['blocked_domains' => ['spam.com', 'ads.example.com']],
+        ]),
+    ])->prompt('Search', provider: 'openai');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
@@ -182,13 +208,16 @@ test('web search tool sends blocked_domains filter', function () {
     });
 });
 
-test('web search tool sends both allowed and blocked domains', function () {
+test('web search tool merges allow() with blocked_domains provider option', function () {
     Http::fake([
         '*' => fakeOpenAiResponse('result'),
     ]);
 
-    agent(tools: [(new WebSearch)->allow(['good.com'])->block(['bad.com'])])
-        ->prompt('Search', provider: 'openai');
+    agent(tools: [
+        (new WebSearch)
+            ->allow(['good.com'])
+            ->withProviderOptions('openai', ['filters' => ['blocked_domains' => ['bad.com']]]),
+    ])->prompt('Search', provider: 'openai');
 
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);


### PR DESCRIPTION
Currently, calling `(new WebSearch)->allow([...])` against OpenAI returns HTTP 400 because the legacy `web_search_preview` tool doesn't accept `filters`. There's also no clean way to pass OpenAI-only knobs (`blocked_domains`, `external_web_access`, `search_context_size`) without adding methods to the shared `WebSearch` tool, which would leak OpenAI semantics into Anthropic and Gemini.

This PR switches OpenAI to the non-legacy `web_search` type and adds a `withProviderOptions()` channel on the abstract `ProviderTool` base class. Each provider gateway reads its own slice when building the tool payload, so the shared `WebSearch` API stays vendor-neutral.

```php
// Before: 400 on OpenAI
(new WebSearch)->allow(['laravel.com']);

// After: works, plus a passthrough for provider-specific knobs
(new WebSearch)
    ->allow(['laravel.com'])
    ->withProviderOptions(Lab::OpenAI, [
        'external_web_access' => false,
        'search_context_size' => 'high',
        'filters' => ['blocked_domains' => ['spam.com']],
    ])
    ->withProviderOptions(Lab::Anthropic, [
        'blocked_domains' => ['spam.com'],
    ]);
```

`ProviderTool` now implements the existing `HasProviderOptions` contract, so the same channel is available to every provider tool. Verified end-to-end against the live OpenAI API during development.