### PR TITLE
Add cache directive to Bedrock system prompt via providerOptions

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -673,6 +673,16 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
 
         $providerOptions = $options?->providerOptions(Lab::Bedrock);
 
+        if (! empty($providerOptions['cache'])) {
+            foreach ($providerOptions['cache'] as $entry) {
+                if (($entry['target'] ?? null) === 'system' && ! empty($parameters['system'])) {
+                    $parameters['system'][] = ['cachePoint' => ['type' => 'default']];
+                }
+            }
+
+            unset($providerOptions['cache']);
+        }
+
         if (! empty($providerOptions)) {
             $parameters = array_merge($parameters, $providerOptions);
         }

--- a/tests/Feature/Providers/Bedrock/BedrockHelpers.php
+++ b/tests/Feature/Providers/Bedrock/BedrockHelpers.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Providers\Bedrock;
 
 use Aws\BedrockRuntime\BedrockRuntimeClient;
+use Aws\CommandInterface;
 use Aws\MockHandler;
 use Aws\Result;
+use GuzzleHttp\Promise\FulfilledPromise;
 use Laravel\Ai\Gateway\Bedrock\BedrockTextGateway;
 use Laravel\Ai\Providers\BedrockProvider;
 use Laravel\Ai\Providers\Provider;
@@ -46,6 +48,24 @@ trait BedrockHelpers
             'version' => '2023-09-30',
             'credentials' => false,
             'handler' => $mock,
+        ]);
+    }
+
+    protected function capturingBedrockClient(?array &$captured): BedrockRuntimeClient
+    {
+        return new BedrockRuntimeClient([
+            'region' => 'us-east-1',
+            'version' => '2023-09-30',
+            'credentials' => false,
+            'handler' => function (CommandInterface $command) use (&$captured) {
+                $captured = $command->toArray();
+
+                return new FulfilledPromise(new Result([
+                    'output' => ['message' => ['content' => [['text' => 'Hi']]]],
+                    'usage' => ['inputTokens' => 1, 'outputTokens' => 1],
+                    'stopReason' => 'end_turn',
+                ]));
+            },
         ]);
     }
 

--- a/tests/Feature/Providers/Bedrock/CacheControlTest.php
+++ b/tests/Feature/Providers/Bedrock/CacheControlTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\BedrockCachingAgent;
+
+beforeEach(function () {
+    $this->captured = null;
+    $this->run = function (object $agent) {
+        $this->gatewayWithClient($this->capturingBedrockClient($this->captured))->generateText(
+            $this->bedrockProvider(),
+            'anthropic.claude-haiku-4-5-20251001-v1:0',
+            'You are a helpful assistant.',
+            [],
+            [],
+            null,
+            TextGenerationOptions::forAgent($agent),
+        );
+    };
+});
+
+test('cachePoint marker is appended to system blocks', function () {
+    ($this->run)(new BedrockCachingAgent);
+
+    expect($this->captured['system'])->toHaveCount(2)
+        ->and($this->captured['system'][1])->toMatchArray(['cachePoint' => ['type' => 'default']]);
+});
+
+test('cache directive does not leak into converse parameters', function () {
+    ($this->run)(new BedrockCachingAgent);
+
+    expect($this->captured)->not->toHaveKey('cache');
+});
+
+test('system stays a single block without a cache directive', function () {
+    ($this->run)(new AssistantAgent);
+
+    expect($this->captured['system'])->toHaveCount(1);
+});

--- a/tests/Fixtures/Agents/BedrockCachingAgent.php
+++ b/tests/Fixtures/Agents/BedrockCachingAgent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+class BedrockCachingAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return $provider === Lab::Bedrock
+            ? ['cache' => [['target' => 'system']]]
+            : [];
+    }
+}


### PR DESCRIPTION
Follow-up to #634, which was closed because it overlapped with how Anthropic already works.

Bedrock is the part that's actually missing. The Converse API doesn't accept `cache_control` on the system string; it wants an extra `cachePoint` block appended to the `system` list, which isn't something a generic passthrough can do. So there's no clean way to enable Bedrock prompt caching from an agent today.

This PR adds a `cache` directive that `BedrockTextGateway` recognises and turns into the `cachePoint` block. From the agent side it looks like this:

```php
public function providerOptions(Lab|string \$provider): array
{
    return \$provider === Lab::Bedrock
        ? ['cache' => [['target' => 'system']]]
        : [];
}
```

The directive is consumed by the gateway and stripped before the rest of `providerOptions` is merged into the Converse parameters, so AWS never sees the `cache` key.

The new test (\`tests/Feature/Providers/Bedrock/CacheControlTest.php\`) checks three things: the marker shows up when the directive is set, it doesn't leak through to AWS, and the system block stays untouched when no directive is set. There's also a small \`capturingBedrockClient\` helper in \`BedrockHelpers\` so the test can read the exact Converse payload.