### PR TITLE
Add Qianfan text provider

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -129,6 +129,12 @@ return [
             'key' => env('OPENROUTER_API_KEY'),
         ],
 
+        'qianfan' => [
+            'driver' => 'qianfan',
+            'key' => env('QIANFAN_API_KEY'),
+            'url' => env('QIANFAN_URL', 'https://api.baiduqianfan.ai/v1'),
+        ],
+
         'voyageai' => [
             'driver' => 'voyageai',
             'key' => env('VOYAGEAI_API_KEY'),

--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-sdk-development
-description: TRIGGER when working with ai-sdk which is Laravel official first-party AI SDK. Activate when building, editing AI agents, chatbots, text generation, image generation, audio/TTS, transcription/STT, embeddings, RAG, vector stores, reranking, structured output, streaming, conversation memory, tools, queueing, broadcasting, and provider failover across OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama, ElevenLabs, Cohere, Jina, and VoyageAI. Invoke when the user references ai-sdk, the `Laravel\Ai\` namespace, or this project's AI features — not for other AI packages used directly.
+description: TRIGGER when working with ai-sdk which is Laravel official first-party AI SDK. Activate when building, editing AI agents, chatbots, text generation, image generation, audio/TTS, transcription/STT, embeddings, RAG, vector stores, reranking, structured output, streaming, conversation memory, tools, queueing, broadcasting, and provider failover across OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Qianfan, Mistral, Ollama, ElevenLabs, Cohere, Jina, and VoyageAI. Invoke when the user references ai-sdk, the `Laravel\Ai\` namespace, or this project's AI features — not for other AI packages used directly.
 license: MIT
 metadata:
   author: laravel
@@ -416,7 +416,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 
 | Feature    | Providers                                                       |
 | ---------- | --------------------------------------------------------------- |
-| Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama |
+| Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Qianfan, Mistral, Ollama |
 | Images     | OpenAI, Gemini, xAI                                            |
 | TTS        | OpenAI, ElevenLabs                                              |
 | STT        | OpenAI, ElevenLabs, Mistral                                     |
@@ -432,5 +432,6 @@ use Laravel\Ai\Enums\Lab;
 Lab::Anthropic;
 Lab::OpenAI;
 Lab::Gemini;
+Lab::Qianfan;
 // ...
 ```

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -32,6 +32,7 @@ use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\OpenRouterProvider;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\QianfanProvider;
 use Laravel\Ai\Providers\VoyageAiProvider;
 use Laravel\Ai\Providers\XaiProvider;
 use LogicException;
@@ -419,6 +420,17 @@ class AiManager extends MultipleInstanceManager
     public function createOpenrouterDriver(array $config): OpenRouterProvider
     {
         return new OpenRouterProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a Qianfan powered instance.
+     */
+    public function createQianfanDriver(array $config): QianfanProvider
+    {
+        return new QianfanProvider(
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -17,6 +17,7 @@ enum Lab: string
     case Ollama = 'ollama';
     case OpenAI = 'openai';
     case OpenRouter = 'openrouter';
+    case Qianfan = 'qianfan';
     case VoyageAI = 'voyageai';
     case xAI = 'xai';
 }

--- a/src/Gateway/Qianfan/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Qianfan/Concerns/BuildsTextRequests.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+
+trait BuildsTextRequests
+{
+    use ComposesSchemaInstructions;
+
+    /**
+     * Build the request body for the Chat Completions API.
+     */
+    protected function buildTextRequestBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessagesToChat(
+                $messages,
+                $this->composeInstructions($instructions, $schema),
+            ),
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat();
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        $body = array_merge($body, Arr::whereNotNull([
+            'temperature' => $options?->temperature,
+            'top_p' => $options?->topP,
+        ]));
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        return $body;
+    }
+
+    /**
+     * Build the response format options for structured output.
+     */
+    protected function buildResponseFormat(): array
+    {
+        return ['type' => 'json_object'];
+    }
+}

--- a/src/Gateway/Qianfan/Concerns/CreatesQianfanClient.php
+++ b/src/Gateway/Qianfan/Concerns/CreatesQianfanClient.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+
+trait CreatesQianfanClient
+{
+    /**
+     * Get an HTTP client for the Qianfan API.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withToken($provider->providerCredentials()['key'])
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Get the base URL for the Qianfan API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.baiduqianfan.ai/v1', '/');
+    }
+}

--- a/src/Gateway/Qianfan/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Qianfan/Concerns/HandlesTextStreaming.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Generator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+trait HandlesTextStreaming
+{
+    /**
+     * Process a Chat Completions streaming response and yield Laravel stream events.
+     */
+    protected function processTextStream(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        $streamBody,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        array $priorChatMessages = [],
+        ?int $timeout = null,
+    ): Generator {
+        $maxSteps ??= $options?->maxSteps;
+
+        $messageId = $this->generateEventId();
+        $streamStartEmitted = false;
+        $textStartEmitted = false;
+        $currentText = '';
+        $pendingToolCalls = [];
+        $usage = null;
+        $finishReason = null;
+
+        foreach ($this->parseServerSentEvents($streamBody) as $data) {
+            if (isset($data['error'])) {
+                yield (new Error(
+                    $this->generateEventId(),
+                    $data['error']['code'] ?? 'unknown_error',
+                    $data['error']['message'] ?? 'Unknown error',
+                    false,
+                    time(),
+                ))->withInvocationId($invocationId);
+
+                return;
+            }
+
+            $choice = $data['choices'][0] ?? null;
+
+            if (! $choice) {
+                if (isset($data['usage'])) {
+                    $usage = $this->extractUsage($data);
+                }
+
+                continue;
+            }
+
+            $delta = $choice['delta'] ?? [];
+
+            if (! $streamStartEmitted) {
+                $streamStartEmitted = true;
+
+                yield (new StreamStart(
+                    $this->generateEventId(),
+                    $provider->name(),
+                    $data['model'] ?? $model,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['content']) && $delta['content'] !== '') {
+                if (! $textStartEmitted) {
+                    $textStartEmitted = true;
+
+                    yield (new TextStart(
+                        $this->generateEventId(),
+                        $messageId,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                $currentText .= $delta['content'];
+
+                yield (new TextDelta(
+                    $this->generateEventId(),
+                    $messageId,
+                    $delta['content'],
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            if (isset($delta['tool_calls'])) {
+                foreach ($delta['tool_calls'] as $toolCallDelta) {
+                    $index = $toolCallDelta['index'];
+
+                    if (! isset($pendingToolCalls[$index])) {
+                        $pendingToolCalls[$index] = [
+                            'id' => $toolCallDelta['id'] ?? '',
+                            'name' => $toolCallDelta['function']['name'] ?? '',
+                            'arguments' => '',
+                        ];
+                    }
+
+                    if (isset($toolCallDelta['function']['arguments'])) {
+                        $pendingToolCalls[$index]['arguments'] .= $toolCallDelta['function']['arguments'];
+                    }
+                }
+            }
+
+            if (isset($choice['finish_reason']) && $choice['finish_reason'] !== null) {
+                $finishReason = $choice['finish_reason'];
+            }
+
+            if (isset($data['usage'])) {
+                $usage = $this->extractUsage($data);
+            }
+        }
+
+        if ($textStartEmitted) {
+            yield (new TextEnd(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
+            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+
+            foreach ($mappedToolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield from $this->handleStreamingToolCalls(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $mappedToolCalls,
+                $currentText,
+                $instructions,
+                $originalMessages,
+                $depth,
+                $maxSteps,
+                $priorChatMessages,
+                $timeout,
+            );
+
+            return;
+        }
+
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            $this->extractFinishReason(['finish_reason' => $finishReason ?? ''])->value,
+            $usage ?? new Usage(0, 0),
+            time(),
+        ))->withInvocationId($invocationId);
+    }
+
+    /**
+     * Handle tool calls detected during streaming.
+     */
+    protected function handleStreamingToolCalls(
+        string $invocationId,
+        Provider $provider,
+        string $model,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        array $mappedToolCalls,
+        string $currentText,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        array $priorChatMessages,
+        ?int $timeout = null,
+    ): Generator {
+        $toolResults = [];
+
+        foreach ($mappedToolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $toolResult = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+
+            $toolResults[] = $toolResult;
+
+            yield (new ToolResultEvent(
+                $this->generateEventId(),
+                $toolResult,
+                true,
+                null,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
+        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $assistantMessage = ['role' => 'assistant'];
+
+            if (filled($currentText)) {
+                $assistantMessage['content'] = $currentText;
+            }
+
+            $assistantMessage['tool_calls'] = array_map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
+            );
+
+            $toolResultMessages = [];
+
+            foreach ($toolResults as $toolResult) {
+                $toolResultMessages[] = [
+                    'role' => 'tool',
+                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                    'content' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+
+            $updatedPriorMessages = [...$priorChatMessages, $assistantMessage, ...$toolResultMessages];
+
+            $chatMessages = [
+                ...$this->mapMessagesToChat(
+                    $originalMessages,
+                    $this->composeInstructions($instructions, $schema),
+                ),
+                ...$updatedPriorMessages,
+            ];
+
+            $body = [
+                'model' => $model,
+                'messages' => $chatMessages,
+                'stream' => true,
+                'stream_options' => ['include_usage' => true],
+            ];
+
+            if (filled($tools)) {
+                $mappedTools = $this->mapTools($tools);
+
+                if (filled($mappedTools)) {
+                    $body['tool_choice'] = 'auto';
+                    $body['tools'] = $mappedTools;
+                }
+            }
+
+            if (filled($schema)) {
+                $body['response_format'] = $this->buildResponseFormat();
+            }
+
+            if (! is_null($options?->maxTokens)) {
+                $body['max_completion_tokens'] = $options->maxTokens;
+            }
+
+            $body = array_merge($body, Arr::whereNotNull([
+                'temperature' => $options?->temperature,
+                'top_p' => $options?->topP,
+            ]));
+
+            $providerOptions = $options?->providerOptions($provider->driver());
+
+            if (filled($providerOptions)) {
+                $body = array_merge($body, $providerOptions);
+            }
+
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)
+                    ->withOptions(['stream' => true])
+                    ->post('chat/completions', $body),
+            );
+
+            yield from $this->processTextStream(
+                $invocationId,
+                $provider,
+                $model,
+                $tools,
+                $schema,
+                $options,
+                $response->getBody(),
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $updatedPriorMessages,
+                $timeout,
+            );
+        } else {
+            yield (new StreamEnd(
+                $this->generateEventId(),
+                'stop',
+                new Usage(0, 0),
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+    }
+
+    /**
+     * Map raw streaming tool call data to ToolCall DTOs.
+     *
+     * @return array<ToolCall>
+     */
+    protected function mapStreamToolCalls(array $toolCalls): array
+    {
+        return array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['name'] ?? '',
+            json_decode($toolCall['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), array_values($toolCalls));
+    }
+
+    /**
+     * Generate a lowercase UUID v7 for use as a stream event ID.
+     */
+    protected function generateEventId(): string
+    {
+        return strtolower((string) Str::uuid7());
+    }
+}

--- a/src/Gateway/Qianfan/Concerns/MapsAttachments.php
+++ b/src/Gateway/Qianfan/Concerns/MapsAttachments.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\File;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredImage;
+
+trait MapsAttachments
+{
+    /**
+     * Map the given Laravel attachments to Chat Completions content parts.
+     */
+    protected function mapAttachments(Collection $attachments): array
+    {
+        return $attachments->map(function ($attachment) {
+            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+                throw new InvalidArgumentException(
+                    'Unsupported attachment type ['.get_class($attachment).']'
+                );
+            }
+
+            return match (true) {
+                $attachment instanceof Base64Image => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->mime.';base64,'.$attachment->base64],
+                ],
+                $attachment instanceof RemoteImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => $attachment->url],
+                ],
+                $attachment instanceof LocalImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(file_get_contents($attachment->path))],
+                ],
+                $attachment instanceof StoredImage => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.($attachment->mimeType() ?? 'image/png').';base64,'.base64_encode(
+                        Storage::disk($attachment->disk)->get($attachment->path)
+                    )],
+                ],
+                $attachment instanceof UploadedFile && $this->isImage($attachment) => [
+                    'type' => 'image_url',
+                    'image_url' => ['url' => 'data:'.$attachment->getClientMimeType().';base64,'.base64_encode($attachment->get())],
+                ],
+                default => throw new InvalidArgumentException('Qianfan does not support document attachments. Only image attachments are supported.'),
+            };
+        })->all();
+    }
+
+    /**
+     * Determine if the given uploaded file is an image.
+     */
+    protected function isImage(UploadedFile $attachment): bool
+    {
+        return in_array($attachment->getClientMimeType(), [
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'image/webp',
+        ]);
+    }
+}

--- a/src/Gateway/Qianfan/Concerns/MapsMessages.php
+++ b/src/Gateway/Qianfan/Concerns/MapsMessages.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+
+trait MapsMessages
+{
+    /**
+     * Map the given Laravel messages to Chat Completions messages format.
+     */
+    protected function mapMessagesToChat(array $messages, ?string $instructions = null): array
+    {
+        $chatMessages = [];
+
+        if (filled($instructions)) {
+            $chatMessages[] = [
+                'role' => 'system',
+                'content' => $instructions,
+            ];
+        }
+
+        foreach ($messages as $message) {
+            $message = Message::tryFrom($message);
+
+            match ($message->role) {
+                MessageRole::User => $this->mapUserMessage($message, $chatMessages),
+                MessageRole::Assistant => $this->mapAssistantMessage($message, $chatMessages),
+                MessageRole::ToolResult => $this->mapToolResultMessage($message, $chatMessages),
+            };
+        }
+
+        return $chatMessages;
+    }
+
+    /**
+     * Map a user message to Chat Completions format.
+     */
+    protected function mapUserMessage(UserMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof UserMessage || $message->attachments->isEmpty()) {
+            $chatMessages[] = [
+                'role' => 'user',
+                'content' => $message->content,
+            ];
+
+            return;
+        }
+
+        $chatMessages[] = [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => $message->content],
+                ...$this->mapAttachments($message->attachments),
+            ],
+        ];
+    }
+
+    /**
+     * Map an assistant message to Chat Completions format.
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$chatMessages): void
+    {
+        $msg = ['role' => 'assistant'];
+
+        if (filled($message->content)) {
+            $msg['content'] = $message->content;
+        }
+
+        if (! $message instanceof AssistantMessage) {
+            $chatMessages[] = $msg;
+
+            return;
+        }
+
+        if ($message->toolCalls->isNotEmpty()) {
+            $msg['tool_calls'] = $message->toolCalls->map(
+                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
+            )->all();
+        }
+
+        $chatMessages[] = $msg;
+    }
+
+    /**
+     * Map a tool result message to Chat Completions format.
+     */
+    protected function mapToolResultMessage(ToolResultMessage|Message $message, array &$chatMessages): void
+    {
+        if (! $message instanceof ToolResultMessage) {
+            return;
+        }
+
+        foreach ($message->toolResults as $toolResult) {
+            $chatMessages[] = [
+                'role' => 'tool',
+                'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
+                'content' => $this->serializeToolResultOutput($toolResult->result),
+            ];
+        }
+    }
+
+    /**
+     * Serialize a tool call DTO to Chat Completions array format.
+     */
+    protected function serializeToolCallToChat(ToolCall $toolCall): array
+    {
+        return [
+            'id' => $toolCall->resultId ?? $toolCall->id,
+            'type' => 'function',
+            'function' => [
+                'name' => $toolCall->name,
+                'arguments' => json_encode($toolCall->arguments ?: (object) []),
+            ],
+        ];
+    }
+
+    /**
+     * Serialize a tool result output value to a string.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
+}

--- a/src/Gateway/Qianfan/Concerns/MapsTools.php
+++ b/src/Gateway/Qianfan/Concerns/MapsTools.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Tools\ToolNameResolver;
+use RuntimeException;
+
+trait MapsTools
+{
+    /**
+     * Map the given tools to Chat Completions function definitions.
+     */
+    protected function mapTools(array $tools): array
+    {
+        $mapped = [];
+
+        foreach ($tools as $tool) {
+            if ($tool instanceof ProviderTool) {
+                throw new RuntimeException('Qianfan does not support ['.class_basename($tool).'] provider tools.');
+            }
+
+            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapTool($tool);
+            }
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * Map a regular tool to a Chat Completions function definition.
+     */
+    protected function mapTool(Tool $tool): array
+    {
+        $schema = $tool->schema(new JsonSchemaTypeFactory);
+
+        $schemaArray = filled($schema)
+            ? (new ObjectSchema($schema))->toSchema()
+            : [];
+
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => ToolNameResolver::resolve($tool),
+                'description' => (string) $tool->description(),
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => $schemaArray['properties'] ?? (object) [],
+                    'required' => $schemaArray['required'] ?? [],
+                    'additionalProperties' => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Gateway/Qianfan/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Qianfan/Concerns/ParsesTextResponses.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan\Concerns;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+
+trait ParsesTextResponses
+{
+    /**
+     * Validate the Qianfan response data.
+     *
+     * @throws AiException
+     */
+    protected function validateTextResponse(array $data): void
+    {
+        if (! $data || isset($data['error'])) {
+            throw new AiException(sprintf(
+                'Qianfan Error: [%s] %s',
+                $data['error']['type'] ?? $data['error']['code'] ?? 'unknown',
+                $data['error']['message'] ?? 'Unknown Qianfan error.',
+            ));
+        }
+    }
+
+    /**
+     * Parse the Qianfan response data into a TextResponse.
+     */
+    protected function parseTextResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        ?int $timeout = null,
+    ): TextResponse {
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            new Collection,
+            new Collection,
+            instructions: $instructions,
+            originalMessages: $originalMessages,
+            maxSteps: $options?->maxSteps,
+            options: $options,
+            timeout: $timeout,
+        );
+    }
+
+    /**
+     * Process a single response, handling tool loops recursively.
+     */
+    protected function processResponse(
+        array $data,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions = null,
+        array $originalMessages = [],
+        int $depth = 0,
+        ?int $maxSteps = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $choice = $data['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+        $model = $data['model'] ?? '';
+
+        $text = $message['content'] ?? '';
+        $rawToolCalls = $message['tool_calls'] ?? [];
+        $usage = $this->extractUsage($data);
+        $finishReason = $this->extractFinishReason($choice);
+
+        $mappedToolCalls = array_map(fn (array $toolCall) => new ToolCall(
+            $toolCall['id'] ?? '',
+            $toolCall['function']['name'] ?? '',
+            json_decode($toolCall['function']['arguments'] ?? '{}', true) ?? [],
+            $toolCall['id'] ?? null,
+        ), $rawToolCalls);
+
+        $step = new Step(
+            $text,
+            $mappedToolCalls,
+            [],
+            $finishReason,
+            $usage,
+            new Meta($provider->name(), $model),
+        );
+
+        $steps->push($step);
+
+        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
+
+        $messages->push($assistantMessage);
+
+        if ($finishReason === FinishReason::ToolCalls &&
+            filled($mappedToolCalls) &&
+            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+
+            $steps->pop();
+
+            $steps->push(new Step(
+                $text,
+                $mappedToolCalls,
+                $toolResults,
+                $finishReason,
+                $usage,
+                new Meta($provider->name(), $model),
+            ));
+
+            $toolResultMessage = new ToolResultMessage(collect($toolResults));
+
+            $messages->push($toolResultMessage);
+
+            return $this->continueWithToolResults(
+                $model,
+                $provider,
+                $structured,
+                $tools,
+                $schema,
+                $steps,
+                $messages,
+                $instructions,
+                $originalMessages,
+                $depth + 1,
+                $maxSteps,
+                $options,
+                $timeout,
+            );
+        }
+
+        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
+        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
+
+        if ($structured) {
+            $structuredData = json_decode($text, true) ?? [];
+
+            return (new StructuredTextResponse(
+                $structuredData,
+                $text,
+                $this->combineUsage($steps),
+                new Meta($provider->name(), $model),
+            ))->withToolCallsAndResults(
+                toolCalls: $allToolCalls,
+                toolResults: $allToolResults,
+            )->withSteps($steps);
+        }
+
+        return (new TextResponse(
+            $text,
+            $this->combineUsage($steps),
+            new Meta($provider->name(), $model),
+        ))->withMessages($messages)->withSteps($steps);
+    }
+
+    /**
+     * Execute tool calls and return tool results.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @param  array<Tool>  $tools
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $toolCalls, array $tools): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                continue;
+            }
+
+            $result = $this->executeTool($tool, $toolCall->arguments);
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+                $toolCall->resultId,
+            );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Continue the conversation with tool results by making a follow-up request.
+     */
+    protected function continueWithToolResults(
+        string $model,
+        Provider $provider,
+        bool $structured,
+        array $tools,
+        ?array $schema,
+        Collection $steps,
+        Collection $messages,
+        ?string $instructions,
+        array $originalMessages,
+        int $depth,
+        ?int $maxSteps,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $chatMessages = $this->mapMessagesToChat(
+            $originalMessages,
+            $this->composeInstructions($instructions, $schema),
+        );
+
+        foreach ($messages as $msg) {
+            match (true) {
+                $msg instanceof AssistantMessage => $this->mapAssistantMessage($msg, $chatMessages),
+                $msg instanceof ToolResultMessage => $this->mapToolResultMessage($msg, $chatMessages),
+                default => null,
+            };
+        }
+
+        $body = [
+            'model' => $model,
+            'messages' => $chatMessages,
+        ];
+
+        if (filled($tools)) {
+            $mappedTools = $this->mapTools($tools);
+
+            if (filled($mappedTools)) {
+                $body['tool_choice'] = 'auto';
+                $body['tools'] = $mappedTools;
+            }
+        }
+
+        if (filled($schema)) {
+            $body['response_format'] = $this->buildResponseFormat();
+        }
+
+        if (! is_null($options?->maxTokens)) {
+            $body['max_completion_tokens'] = $options->maxTokens;
+        }
+
+        $body = array_merge($body, Arr::whereNotNull([
+            'temperature' => $options?->temperature,
+            'top_p' => $options?->topP,
+        ]));
+
+        $providerOptions = $options?->providerOptions($provider->driver());
+
+        if (filled($providerOptions)) {
+            $body = array_merge($body, $providerOptions);
+        }
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->processResponse(
+            $data,
+            $provider,
+            $structured,
+            $tools,
+            $schema,
+            $steps,
+            $messages,
+            $instructions,
+            $originalMessages,
+            $depth,
+            $maxSteps,
+            $options,
+            $timeout,
+        );
+    }
+
+    /**
+     * Extract usage data from the response.
+     */
+    protected function extractUsage(array $data): Usage
+    {
+        $usage = $data['usage'] ?? [];
+        $details = $usage['completion_tokens_details'] ?? [];
+
+        return new Usage(
+            promptTokens: $usage['prompt_tokens'] ?? 0,
+            completionTokens: $usage['completion_tokens'] ?? 0,
+            cacheReadInputTokens: $usage['prompt_cache_hit_tokens'] ?? 0,
+            reasoningTokens: $details['reasoning_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract and map the finish reason from the response.
+     */
+    protected function extractFinishReason(array $choice): FinishReason
+    {
+        return match ($choice['finish_reason'] ?? '') {
+            'stop' => FinishReason::Stop,
+            'tool_calls' => FinishReason::ToolCalls,
+            'length' => FinishReason::Length,
+            'content_filter' => FinishReason::ContentFilter,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Combine usage across all steps.
+     */
+    protected function combineUsage(Collection $steps): Usage
+    {
+        return $steps->reduce(
+            fn (Usage $carry, Step $step) => $carry->add($step->usage),
+            new Usage(0, 0)
+        );
+    }
+}

--- a/src/Gateway/Qianfan/QianfanGateway.php
+++ b/src/Gateway/Qianfan/QianfanGateway.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Qianfan;
+
+use Generator;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\TextResponse;
+
+class QianfanGateway implements TextGateway
+{
+    use Concerns\BuildsTextRequests;
+    use Concerns\CreatesQianfanClient;
+    use Concerns\HandlesTextStreaming;
+    use Concerns\MapsAttachments;
+    use Concerns\MapsMessages;
+    use Concerns\MapsTools;
+    use Concerns\ParsesTextResponses;
+    use HandlesFailoverErrors;
+    use InvokesTools;
+    use ParsesServerSentEvents;
+
+    public function __construct(protected Dispatcher $events)
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse(
+            $data,
+            $provider,
+            filled($schema),
+            $tools,
+            $schema,
+            $options,
+            $instructions,
+            $messages,
+            $timeout,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $body = $this->buildTextRequestBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+            $options,
+        );
+
+        $body['stream'] = true;
+        $body['stream_options'] = ['include_usage' => true];
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post('chat/completions', $body),
+        );
+
+        yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
+            $tools,
+            $schema,
+            $options,
+            $response->getBody(),
+            $instructions,
+            $messages,
+            0,
+            null,
+            [],
+            $timeout,
+        );
+    }
+}

--- a/src/Providers/QianfanProvider.php
+++ b/src/Providers/QianfanProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Qianfan\QianfanGateway;
+
+class QianfanProvider extends Provider implements TextProvider
+{
+    use Concerns\GeneratesText;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    public function __construct(protected array $config, protected Dispatcher $events)
+    {
+        //
+    }
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new QianfanGateway($this->events);
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['text']['default'] ?? 'ernie-4.5-turbo-128k';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['text']['cheapest'] ?? 'ernie-speed-128k';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['text']['smartest'] ?? 'ernie-4.5-turbo-128k';
+    }
+}

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -238,6 +238,24 @@ describe('provider enum support', function () {
             return $prompt->prompt === 'Enum stream';
         });
     });
+
+    test('prompt accepts qianfan ai provider enum', function () {
+        config(['ai.providers.qianfan' => [
+            'driver' => 'qianfan',
+            'key' => 'test-key',
+        ]]);
+
+        AssistantAgent::fake(['Laravel']);
+
+        $response = (new AssistantAgent)->prompt('Enum prompt', provider: Lab::Qianfan);
+
+        expect($response->text)->toBe('Laravel');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->prompt === 'Enum prompt'
+                && $prompt->provider()->name() === 'qianfan';
+        });
+    });
 });
 
 describe('timeout handling', function () {

--- a/tests/Feature/AiManagerTest.php
+++ b/tests/Feature/AiManagerTest.php
@@ -5,9 +5,19 @@ use Illuminate\Support\Facades\Facade;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Providers\OpenAiProvider;
+use Laravel\Ai\Providers\QianfanProvider;
 
 test('can get an openai provider instance', function () {
     expect(Ai::textProvider('openai'))->toBeInstanceOf(OpenAiProvider::class);
+});
+
+test('can get a qianfan provider instance', function () {
+    config(['ai.providers.qianfan' => [
+        'driver' => 'qianfan',
+        'key' => 'test-key',
+    ]]);
+
+    expect(Ai::textProvider('qianfan'))->toBeInstanceOf(QianfanProvider::class);
 });
 
 test('provider type is ensured', function () {

--- a/tests/Feature/Providers/Qianfan/BaseUrlTest.php
+++ b/tests/Feature/Providers/Qianfan/BaseUrlTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    $this->customUrl = 'http://localhost:1234/v1';
+});
+
+test('qianfan text requests use the configured base url', function () {
+    configureQianfanProvider($this->customUrl);
+
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello from local model')]);
+
+    $response = agent()->prompt('Hello', provider: 'qianfan');
+
+    expect($response->text)->toBe('Hello from local model');
+
+    Http::assertSentCount(1);
+    qianfanAssertRequestSent('POST', "{$this->customUrl}/chat/completions");
+});
+
+test('qianfan requests fall back to the default base url', function () {
+    configureQianfanProvider();
+
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello from Qianfan')]);
+
+    $response = agent()->prompt('Hello', provider: 'qianfan');
+
+    expect($response->text)->toBe('Hello from Qianfan');
+
+    Http::assertSentCount(1);
+    qianfanAssertRequestSent('POST', 'https://api.baiduqianfan.ai/v1/chat/completions');
+});
+
+test('qianfan trims trailing slash from configured base url', function () {
+    configureQianfanProvider('https://example.test/v1/');
+
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'qianfan');
+
+    Http::assertSentCount(1);
+    qianfanAssertRequestSent('POST', 'https://example.test/v1/chat/completions');
+});
+
+function configureQianfanProvider(?string $url = null): void
+{
+    config(['ai.providers.qianfan' => array_filter([
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+        'url' => $url,
+    ])]);
+}
+
+function qianfanAssertRequestSent(string $method, string $url): void
+{
+    Http::assertSent(fn (Request $request) => $request->method() === $method
+        && $request->url() === $url);
+}

--- a/tests/Feature/Providers/Qianfan/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Qianfan/ErrorHandlingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+beforeEach(function () {
+    config(['ai.providers.qianfan' => [
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('http error response throws request exception', function () {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'max_tokens: must be at least 1',
+        ],
+    ], 400)]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'qianfan');
+})->throws(RequestException::class);
+
+test('rate limit response throws rate limited exception', function () {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'type' => 'rate_limit_error',
+            'message' => 'Rate limit exceeded',
+        ],
+    ], 429)]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'qianfan');
+})->throws(RateLimitedException::class);
+
+test('overloaded response throws provider overloaded exception', function () {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'type' => 'server_error',
+            'message' => 'The server is currently overloaded. Please try again later.',
+        ],
+    ], 503)]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'qianfan');
+})->throws(ProviderOverloadedException::class);
+
+test('402 response throws insufficient credits exception', function () {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'message' => 'Insufficient Balance',
+            'type' => 'insufficient_balance_error',
+            'param' => null,
+            'code' => 'insufficient_balance',
+        ],
+    ], 402)]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'qianfan');
+})->throws(InsufficientCreditsException::class);
+
+test('error in 200 response throws ai exception', function () {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'type' => 'api_error',
+            'message' => 'Internal server error',
+        ],
+    ], 200)]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'qianfan');
+})->throws(AiException::class, 'Qianfan Error');

--- a/tests/Feature/Providers/Qianfan/MessageMappingTest.php
+++ b/tests/Feature/Providers/Qianfan/MessageMappingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Image;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.qianfan' => [
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('image attachment maps to image url content block', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('I see an image')]);
+
+    $image = new Base64Image(base64_encode('fake-image-data'), 'image/png');
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [$image],
+        provider: 'qianfan',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['messages'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'image_url');
+
+        return $imageBlock !== null
+            && str_contains($imageBlock['image_url']['url'], 'image/png')
+            && str_contains($imageBlock['image_url']['url'], base64_encode('fake-image-data'));
+    });
+});
+
+test('document attachments throw exception', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse()]);
+
+    $pdf = new Base64Document(base64_encode('fake-pdf'), 'application/pdf');
+
+    agent('You are helpful.')->prompt(
+        'What is in this PDF?',
+        attachments: [$pdf],
+        provider: 'qianfan',
+    );
+})->throws(InvalidArgumentException::class);

--- a/tests/Feature/Providers/Qianfan/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Qianfan/ProviderOptionsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\ProviderOptionsAgent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.qianfan' => [
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('provider options are included in qianfan request body', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    (new ProviderOptionsAgent)->prompt('Hello', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'frequency_penalty') === 0.5
+            && data_get($body, 'presence_penalty') === 0.3;
+    });
+});
+
+test('request body does not contain provider options when agent does not implement interface', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ! array_key_exists('frequency_penalty', $body)
+            && ! array_key_exists('presence_penalty', $body);
+    });
+});
+
+test('provider options are persisted in tool call follow up requests', function () {
+    Http::fake(['*' => $this->fakeQianfanToolCallResponse()]);
+
+    (new ProviderOptionsWithToolsAgent)->prompt('Give me a number', provider: 'qianfan');
+
+    $requests = Http::recorded(fn (Request $request) => true);
+
+    expect($requests)->toHaveCount(2);
+
+    $followUpBody = json_decode($requests[1][0]->body(), true);
+
+    expect(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5);
+});

--- a/tests/Feature/Providers/Qianfan/QianfanHelpers.php
+++ b/tests/Feature/Providers/Qianfan/QianfanHelpers.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature\Providers\Qianfan;
+
+use Illuminate\Http\Client\ResponseSequence;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+trait QianfanHelpers
+{
+    protected function collectStreamEvents(?object $agent = null): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $response = $agent->stream(
+            'Hello',
+            provider: 'qianfan',
+        );
+
+        $events = [];
+
+        foreach ($response as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            if ($event === '[DONE]') {
+                $lines[] = 'data: [DONE]';
+            } else {
+                $lines[] = 'data: '.json_encode($event);
+            }
+        }
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+
+    protected function chatChunk(array $delta, ?string $finishReason = null): array
+    {
+        return [
+            'id' => 'chatcmpl-qianfan-1',
+            'object' => 'chat.completion.chunk',
+            'model' => 'ernie-4.5-turbo-128k',
+            'choices' => [[
+                'index' => 0,
+                'delta' => $delta,
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+    }
+
+    protected function chatChunkFinish(string $finishReason, ?array $usage = null): array
+    {
+        $chunk = [
+            'id' => 'chatcmpl-qianfan-1',
+            'object' => 'chat.completion.chunk',
+            'model' => 'ernie-4.5-turbo-128k',
+            'choices' => [[
+                'index' => 0,
+                'delta' => (object) [],
+                'finish_reason' => $finishReason,
+            ]],
+        ];
+
+        if ($usage) {
+            $chunk['usage'] = $usage;
+        }
+
+        return $chunk;
+    }
+
+    protected function chatChunkToolCallStart(int $index, string $id, string $name): array
+    {
+        return [
+            'id' => 'chatcmpl-qianfan-1',
+            'object' => 'chat.completion.chunk',
+            'model' => 'ernie-4.5-turbo-128k',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'id' => $id,
+                        'type' => 'function',
+                        'function' => ['name' => $name, 'arguments' => ''],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+
+    protected function chatChunkToolCallDelta(int $index, string $arguments): array
+    {
+        return [
+            'id' => 'chatcmpl-qianfan-1',
+            'object' => 'chat.completion.chunk',
+            'model' => 'ernie-4.5-turbo-128k',
+            'choices' => [[
+                'index' => 0,
+                'delta' => [
+                    'tool_calls' => [[
+                        'index' => $index,
+                        'function' => ['arguments' => $arguments],
+                    ]],
+                ],
+                'finish_reason' => null,
+            ]],
+        ];
+    }
+
+    protected function fakeQianfanResponse(string $content = 'Hello', string $model = 'ernie-4.5-turbo-128k')
+    {
+        return Http::response([
+            'id' => 'chatcmpl-qianfan-1',
+            'object' => 'chat.completion',
+            'model' => $model,
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => $content,
+                ],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]);
+    }
+
+    protected function fakeQianfanToolCallResponse(): ResponseSequence
+    {
+        return Http::sequence([
+            Http::response([
+                'id' => 'chatcmpl-qianfan-tool-1',
+                'object' => 'chat.completion',
+                'model' => 'ernie-4.5-turbo-128k',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => '',
+                        'tool_calls' => [[
+                            'id' => 'call_qianfan_1',
+                            'type' => 'function',
+                            'function' => [
+                                'name' => 'FixedNumberGenerator',
+                                'arguments' => '{}',
+                            ],
+                        ]],
+                    ],
+                    'finish_reason' => 'tool_calls',
+                ]],
+                'usage' => [
+                    'prompt_tokens' => 12,
+                    'completion_tokens' => 3,
+                ],
+            ]),
+            $this->fakeQianfanResponse('The number is 72019'),
+        ]);
+    }
+}

--- a/tests/Feature/Providers/Qianfan/RequestMappingTest.php
+++ b/tests/Feature/Providers/Qianfan/RequestMappingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\StructuredAgent;
+use Tests\Fixtures\Tools\RandomNumberGenerator;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.qianfan' => [
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('request includes model and messages', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    agent()->prompt('Hi there', provider: 'qianfan', model: 'ernie-4.5-turbo-128k');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'ernie-4.5-turbo-128k'
+            && count($body['messages']) >= 1
+            && collect($body['messages'])->contains(fn ($message) => $message['role'] === 'user' && $message['content'] === 'Hi there');
+    });
+});
+
+test('system instructions are sent as system message', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    (new AssistantAgent)->prompt('Hello', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $systemMessage = collect($body['messages'])->firstWhere('role', 'system');
+
+        return $systemMessage !== null
+            && str_contains($systemMessage['content'], 'helpful assistant');
+    });
+});
+
+test('temperature and max tokens are included when set via attributes', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    (new AttributeAgent)->prompt('Hello', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'temperature') === 0.7
+            && data_get($body, 'max_completion_tokens') === 4096;
+    });
+});
+
+test('tools include tool choice auto', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('42')]);
+
+    agent(tools: [new RandomNumberGenerator])->prompt('Give me a number', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['tool_choice'] === 'auto'
+            && is_array($body['tools'])
+            && count($body['tools']) > 0;
+    });
+});
+
+test('structured output uses json object response format', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('{"symbol": "Au"}')]);
+
+    (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'response_format') === ['type' => 'json_object'];
+    });
+});
+
+test('request sends bearer token authorization', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'qianfan');
+
+    Http::assertSent(function (Request $request) {
+        return $request->hasHeader('Authorization', 'Bearer test-key');
+    });
+});
+
+test('response text is correctly parsed', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Laravel is great')]);
+
+    $response = agent()->prompt('Tell me about Laravel', provider: 'qianfan');
+
+    expect($response->text)->toBe('Laravel is great')
+        ->and($response->meta->provider)->toBe('qianfan');
+});
+
+test('response usage is correctly parsed', function () {
+    Http::fake(['*' => $this->fakeQianfanResponse('Hello')]);
+
+    $response = agent()->prompt('Hello', provider: 'qianfan');
+
+    expect($response->usage->promptTokens)->toBe(10)
+        ->and($response->usage->completionTokens)->toBe(5);
+});

--- a/tests/Feature/Providers/Qianfan/StreamingTest.php
+++ b/tests/Feature/Providers/Qianfan/StreamingTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.qianfan' => [
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('streaming request includes stream options', function () {
+    Http::fake(['*' => Http::response(
+        body: $this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+            $this->chatChunkFinish('stop', ['prompt_tokens' => 1, 'completion_tokens' => 1]),
+            '[DONE]',
+        ]),
+        status: 200,
+        headers: ['Content-Type' => 'text/event-stream'],
+    )]);
+
+    $stream = agent()->stream('Hello', provider: 'qianfan');
+
+    foreach ($stream as $event) {
+        //
+    }
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['stream'] === true
+            && data_get($body, 'stream_options.include_usage') === true;
+    });
+});
+
+test('streaming emits text events', function () {
+    Http::fake(['*' => Http::response(
+        body: $this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+            $this->chatChunk(['content' => ' world']),
+            $this->chatChunkFinish('stop', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+            '[DONE]',
+        ]),
+        status: 200,
+        headers: ['Content-Type' => 'text/event-stream'],
+    )]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events[0])->toBeInstanceOf(StreamStart::class)
+        ->and($events[1])->toBeInstanceOf(TextStart::class)
+        ->and($events[2])->toBeInstanceOf(TextDelta::class)->delta->toBe('Hello')
+        ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
+        ->and($events[count($events) - 2])->toBeInstanceOf(TextEnd::class)
+        ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming handles tool calls', function () {
+    Http::fake(['*' => Http::sequence([
+        Http::response(
+            body: $this->ssePayload([
+                $this->chatChunkToolCallStart(0, 'call_1', 'FixedNumberGenerator'),
+                $this->chatChunkToolCallDelta(0, '{}'),
+                $this->chatChunkFinish('tool_calls', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+                '[DONE]',
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+        Http::response(
+            body: $this->ssePayload([
+                $this->chatChunk(['role' => 'assistant', 'content' => 'The number is 72019']),
+                $this->chatChunkFinish('stop', ['prompt_tokens' => 20, 'completion_tokens' => 10]),
+                '[DONE]',
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ])]);
+
+    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+    $toolCallEvents = array_values(array_filter($events, fn ($event) => $event instanceof ToolCallEvent));
+
+    expect($toolCallEvents)->not->toBeEmpty()
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->id)->toBe('call_1');
+});
+
+test('streaming error event stops stream', function () {
+    Http::fake(['*' => Http::response(
+        body: $this->ssePayload([
+            ['error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit exceeded']],
+        ]),
+        status: 200,
+        headers: ['Content-Type' => 'text/event-stream'],
+    )]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(Error::class)
+        ->and($events[0]->type)->toBe('rate_limit_exceeded')
+        ->and($events[0]->message)->toBe('Rate limit exceeded');
+});
+
+test('streaming captures usage from final chunk', function () {
+    Http::fake(['*' => Http::response(
+        body: $this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+            $this->chatChunkFinish('stop', ['prompt_tokens' => 42, 'completion_tokens' => 10]),
+            '[DONE]',
+        ]),
+        status: 200,
+        headers: ['Content-Type' => 'text/event-stream'],
+    )]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($event) => $event instanceof StreamEnd))[0];
+
+    expect($streamEnd->usage->promptTokens)->toBe(42)
+        ->and($streamEnd->usage->completionTokens)->toBe(10);
+});
+
+test('streaming finish reason maps correctly', function (string $apiReason, FinishReason $expected) {
+    Http::fake(['*' => Http::response(
+        body: $this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Hello']),
+            $this->chatChunkFinish($apiReason, ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+            '[DONE]',
+        ]),
+        status: 200,
+        headers: ['Content-Type' => 'text/event-stream'],
+    )]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($event) => $event instanceof StreamEnd))[0];
+
+    expect($streamEnd->reason)->toBe($expected->value);
+})->with([
+    'stop maps to Stop' => ['stop', FinishReason::Stop],
+    'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
+    'length maps to Length' => ['length', FinishReason::Length],
+    'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
+    'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
+]);

--- a/tests/Feature/Providers/Qianfan/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Qianfan/ToolCallLoopTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\ToolUsingAgent;
+
+beforeEach(function () {
+    config(['ai.providers.qianfan' => [
+        ...config('ai.providers.qianfan'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('tool calls trigger follow up request', function () {
+    Http::fake(['*' => Http::sequence([
+        fakeUniqueQianfanToolCallResponse(),
+        $this->fakeQianfanResponse('The number is 72019'),
+    ])]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a random number',
+        provider: 'qianfan',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUpBody = json_decode($recorded[1][0]->body(), true);
+
+    $hasAssistantWithToolCalls = collect($followUpBody['messages'])
+        ->contains(fn (array $message) => $message['role'] === 'assistant' && isset($message['tool_calls']));
+
+    $hasToolResult = collect($followUpBody['messages'])
+        ->contains(fn (array $message) => $message['role'] === 'tool');
+
+    expect($hasAssistantWithToolCalls)->toBeTrue()
+        ->and($hasToolResult)->toBeTrue();
+});
+
+test('max steps limits tool call depth', function () {
+    Http::fake(['*' => Http::sequence([
+        fakeUniqueQianfanToolCallResponse(),
+        fakeUniqueQianfanToolCallResponse(),
+        fakeUniqueQianfanToolCallResponse(),
+        $this->fakeQianfanResponse('Done'),
+    ])]);
+
+    (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate numbers',
+        provider: 'qianfan',
+    );
+
+    $recorded = Http::recorded();
+
+    expect(count($recorded))->toBeLessThanOrEqual(3);
+});
+
+function fakeUniqueQianfanToolCallResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-qianfan-tool-'.uniqid(),
+        'object' => 'chat.completion',
+        'model' => 'ernie-4.5-turbo-128k',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_'.uniqid(),
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ]);
+}

--- a/tests/Fixtures/Agents/ProviderOptionsAgent.php
+++ b/tests/Fixtures/Agents/ProviderOptionsAgent.php
@@ -67,6 +67,10 @@ class ProviderOptionsAgent implements Agent, HasProviderOptions
                 'frequency_penalty' => 0.5,
                 'presence_penalty' => 0.3,
             ],
+            Lab::Qianfan => [
+                'frequency_penalty' => 0.5,
+                'presence_penalty' => 0.3,
+            ],
             Lab::Bedrock => [
                 'additionalModelRequestFields' => [
                     'thinking' => [

--- a/tests/Fixtures/Agents/ProviderOptionsWithToolsAgent.php
+++ b/tests/Fixtures/Agents/ProviderOptionsWithToolsAgent.php
@@ -68,6 +68,9 @@ class ProviderOptionsWithToolsAgent implements Agent, HasProviderOptions, HasToo
             Lab::DeepSeek => [
                 'frequency_penalty' => 0.5,
             ],
+            Lab::Qianfan => [
+                'frequency_penalty' => 0.5,
+            ],
             default => [],
         };
     }

--- a/tests/Integration/AiProviderEnumTest.php
+++ b/tests/Integration/AiProviderEnumTest.php
@@ -14,9 +14,9 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Transcription;
 use Tests\Fixtures\Agents\AssistantAgent;
 
-beforeEach(fn () => requiresApiKey('GROQ_API_KEY', 'OPENAI_API_KEY'));
-
 test('agent prompt accepts ai provider enum', function () {
+    requiresApiKey('GROQ_API_KEY');
+
     Event::fake();
 
     $response = (new AssistantAgent)->prompt(
@@ -32,6 +32,8 @@ test('agent prompt accepts ai provider enum', function () {
 });
 
 test('agent stream accepts ai provider enum', function () {
+    requiresApiKey('GROQ_API_KEY');
+
     Event::fake();
 
     $response = (new AssistantAgent)->stream(
@@ -53,6 +55,8 @@ test('agent stream accepts ai provider enum', function () {
 });
 
 test('agent queue accepts ai provider enum', function () {
+    requiresApiKey('GROQ_API_KEY');
+
     (new AssistantAgent)->queue(
         'What is the name of the PHP framework created by Taylor Otwell?',
         provider: Lab::Groq,
@@ -69,6 +73,8 @@ test('agent queue accepts ai provider enum', function () {
 });
 
 test('agent prompt accepts array of ai provider enum values for failover', function () {
+    requiresApiKey('GROQ_API_KEY');
+
     $response = (new AssistantAgent)->prompt(
         'What is the name of the PHP framework created by Taylor Otwell?',
         provider: [Lab::Groq],
@@ -79,7 +85,27 @@ test('agent prompt accepts array of ai provider enum values for failover', funct
         ->and($response->meta->provider)->toEqual('groq');
 });
 
+test('agent prompt accepts qianfan ai provider enum with fake gateway', function () {
+    config(['ai.providers.qianfan' => [
+        'driver' => 'qianfan',
+        'key' => 'test-key',
+    ]]);
+
+    AssistantAgent::fake(['Laravel']);
+
+    $response = (new AssistantAgent)->prompt(
+        'What is the name of the PHP framework created by Taylor Otwell?',
+        provider: Lab::Qianfan,
+        model: 'ernie-4.5-turbo-128k',
+    );
+
+    expect($response->text)->toBe('Laravel')
+        ->and($response->meta->provider)->toEqual('qianfan');
+});
+
 test('embeddings generate accepts ai provider enum', function () {
+    requiresApiKey('OPENAI_API_KEY');
+
     Event::fake();
 
     $response = Embeddings::for(['I love to watch Star Trek.'])
@@ -94,6 +120,8 @@ test('embeddings generate accepts ai provider enum', function () {
 });
 
 test('audio generate accepts ai provider enum', function () {
+    requiresApiKey('OPENAI_API_KEY');
+
     $response = Audio::of('Hello there! How are you today?')
         ->generate(provider: Lab::OpenAI);
 
@@ -101,6 +129,8 @@ test('audio generate accepts ai provider enum', function () {
 });
 
 test('transcription generate accepts ai provider enum', function () {
+    requiresApiKey('OPENAI_API_KEY');
+
     $audio = Audio::of('Hello there! How are you today?')->generate();
 
     $transcription = Transcription::of($audio->audio)

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,6 +9,7 @@ use Tests\Feature\Providers\Mistral\MistralHelpers;
 use Tests\Feature\Providers\Ollama\OllamaHelpers;
 use Tests\Feature\Providers\OpenAi\OpenAiHelpers;
 use Tests\Feature\Providers\OpenRouter\OpenRouterHelpers;
+use Tests\Feature\Providers\Qianfan\QianfanHelpers;
 use Tests\Feature\Providers\Xai\XaiHelpers;
 use Tests\TestCase;
 
@@ -26,6 +27,7 @@ pest()->use(GroqHelpers::class)->group('provider-groq')->in('Feature/Providers/G
 pest()->use(MistralHelpers::class)->group('provider-mistral')->in('Feature/Providers/Mistral');
 pest()->use(OllamaHelpers::class)->group('provider-ollama')->in('Feature/Providers/Ollama');
 pest()->use(OpenAiHelpers::class)->group('provider-openai')->in('Feature/Providers/OpenAi');
+pest()->use(QianfanHelpers::class)->group('provider-qianfan')->in('Feature/Providers/Qianfan');
 pest()->use(XaiHelpers::class)->group('provider-xai')->in('Feature/Providers/Xai');
 
 pest()->use(OpenRouterHelpers::class)->group('provider-openrouter')->in('Feature/Providers/OpenRouter');


### PR DESCRIPTION
## Summary

This PR adds first-party Qianfan text generation support to Laravel AI.

It includes:
- Qianfan provider registration, config, and `Lab::Qianfan` enum support
- Chat Completions request mapping for prompts, system instructions, tools, structured output, attachments, and provider options
- Non-streaming and streaming response parsing, including usage, finish reasons, tool calls, and tool loop follow-up requests
- Focused offline test coverage for request mapping, streaming, tool loops, provider options, errors, base URL handling, message mapping, and enum support

## Notes

Qianfan is added as a text-only provider in this PR. Embeddings, reranking, image generation, and Baidu AI Search provider tools are left for follow-up work.

This PR does not add Qianfan to the live integration provider datasets, so CI does not require `QIANFAN_API_KEY`.

## Test Plan

- `PATH=./vendor/bin:$PATH composer test:lint`
- `PATH=./vendor/bin:$PATH composer test:types`
- `PATH=./vendor/bin:$PATH composer test`

Results:
- Pint passed
- PHPStan passed with no errors
- Test suite passed: 1441 passed, 184 skipped, 2738 assertions

I also ran a local live smoke test with a real Qianfan API key:
- Qianfan prompt smoke: passed
- Qianfan stream smoke: passed