### PR TITLE
Set claude-opus-4-8 as Anthropic's smartest text model

### DIFF
--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -74,7 +74,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['text']['smartest'] ?? 'claude-opus-4-7';
+        return $this->config['models']['text']['smartest'] ?? 'claude-opus-4-8';
     }
 
     /**


### PR DESCRIPTION
Anthropic released Claude Opus 4.8, now their most capable generally available model, so `#[UseSmartestModel]` should resolve to it instead of Opus 4.7.

The [migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) confirms there are no breaking API changes from 4.7: same features, 1M context window, 128k max output, adaptive thinking, prompt caching, etc. The default stays config-overridable via `models.text.smartest`.