### PR TITLE
Fix Mistral transcription requests

### DIFF
--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -178,10 +178,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
 
         if ($diarize) {
             $params['diarize'] = true;
-            $params[] = [
-                'name' => 'timestamp_granularities',
-                'contents' => 'segment',
-            ];
+            $params['timestamp_granularities'] = ['segment'];
         } elseif ($language) {
             $params['language'] = $language;
         }
@@ -190,7 +187,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
             $provider->name(),
             fn () => $this->client($provider, $timeout)
                 ->attach('file', $audio->content(), $this->audioFilename($audio), ['Content-Type' => $audio->mimeType()])
-                ->post('audio/transcriptions', array_merge($providerOptions, $params)),
+                ->post('audio/transcriptions', $this->multipartParams(array_merge($providerOptions, $params))),
         );
 
         $data = $response->json();
@@ -209,6 +206,25 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
             ),
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Convert request parameters into multipart parts, expanding array values.
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<int, array{name: string, contents: scalar}>
+     */
+    protected function multipartParams(array $params): array
+    {
+        $parts = [];
+
+        foreach ($params as $name => $value) {
+            foreach (is_array($value) ? array_values($value) : [$value] as $item) {
+                $parts[] = ['name' => $name, 'contents' => $item];
+            }
+        }
+
+        return $parts;
     }
 
     /**

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -174,16 +174,23 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
         int $timeout = 30,
         array $providerOptions = [],
     ): TranscriptionResponse {
+        $params = ['model' => $model];
+
+        if ($diarize) {
+            $params['diarize'] = true;
+            $params[] = [
+                'name' => 'timestamp_granularities',
+                'contents' => 'segment',
+            ];
+        } elseif ($language) {
+            $params['language'] = $language;
+        }
+
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)
                 ->attach('file', $audio->content(), $this->audioFilename($audio), ['Content-Type' => $audio->mimeType()])
-                ->post('audio/transcriptions', array_merge($providerOptions, array_filter([
-                    'model' => $model,
-                    'language' => $diarize ? null : $language,
-                    'diarize' => $diarize,
-                    'timestamp_granularities' => $diarize ? ['segment'] : null,
-                ]))),
+                ->post('audio/transcriptions', array_merge($providerOptions, $params)),
         );
 
         $data = $response->json();

--- a/tests/Feature/Providers/Mistral/TranscriptionTest.php
+++ b/tests/Feature/Providers/Mistral/TranscriptionTest.php
@@ -71,6 +71,23 @@ test('transcription sends context bias from provider options', function () {
     });
 });
 
+test('transcription sends context bias array as repeated parts', function () {
+    Http::fake(['*' => fakeTranscriptionResponse()]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->providerOptions(['context_bias' => ['Laravel', 'Forge', 'Vapor']])
+        ->generate(provider: 'mistral');
+
+    Http::assertSent(function (Request $request) {
+        $body = $request->body();
+
+        return substr_count($body, 'name="context_bias"') === 3
+            && str_contains($body, 'Laravel')
+            && str_contains($body, 'Forge')
+            && str_contains($body, 'Vapor');
+    });
+});
+
 test('transcription sends bearer token', function () {
     Http::fake(['*' => fakeTranscriptionResponse()]);
 
@@ -107,9 +124,13 @@ test('transcription omits language and sends diarize flag when diarizing', funct
         ->generate(provider: 'mistral');
 
     Http::assertSent(function (Request $request) {
-        return str_contains($request->body(), 'diarize')
-            && str_contains($request->body(), 'segment')
-            && ! str_contains($request->body(), 'language');
+        $body = $request->body();
+
+        return str_contains($body, 'diarize')
+            && str_contains($body, 'name="timestamp_granularities"')
+            && ! str_contains($body, 'timestamp_granularities[')
+            && str_contains($body, 'segment')
+            && ! str_contains($body, 'language');
     });
 });
 


### PR DESCRIPTION
I recently upgraded my laravel/framework version, and I started getting errors from Mistral's transcription API. In particular, I got the following:

```json
{
  "object": "error",
  "message": {
    "detail": [
      {
        "type": "assertion_error",
        "loc": [],
        "msg": "Assertion failed, When diarize is set to True and streaming is disabled, the timestamp granularity must be set to ['segment'], got []",
        "input": {
          "model": "voxtral-mini-latest",
          "audio": "--audio-bytes--",
          "language": null,
          "temperature": null,
          "max_tokens": null,
          "stream": false,
          "return_language": false,
          "streaming": "disabled",
          "timestamp_granularities": [],
          "diarize": true,
          "context_bias": [],
          "target_streaming_delay_ms": null,
          "metadata": null
        },
        "ctx": {
          "error": {}
        }
      }
    ]
  },
  "type": "invalid_request_error",
  "param": null,
  "code": null,
  "raw_status_code": 422
}
```

Looking at the code, I was confused because the `timestamp_granularities` seems to be set to "segments" in the code... but after some digging, I could trace back the regression to a recent PR in laravel/framework: laravel/framework#59984

This was released in `v13.9.0`, and I'm not sure how many things are broken because of that. At the very least, this PR fixes Mistral's transcriptions.

I have reported this issue to laravel/framework in case you want to take a look at a more general fix: https://github.com/laravel/framework/issues/60319