### PR TITLE
feat(bedrock): opt-in Converse prompt caching via cachePoints provider option

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -655,7 +655,43 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
         $providerOptions = $options?->providerOptions(Lab::Bedrock);
 
         if (! empty($providerOptions)) {
+            $parameters = $this->applyCachePoints($parameters, Arr::pull($providerOptions, 'cachePoints'));
+
             return array_merge($parameters, $providerOptions);
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Insert Bedrock Converse prompt-caching markers at the requested locations.
+     *
+     * Bedrock caching is opt-in per request: a `{cachePoint: {type: 'default'}}`
+     * marker appended to the system block and/or the tools list tells Bedrock to
+     * cache everything up to that point, so a stable system prompt and tool set are
+     * billed at the cache-read rate on subsequent calls. Request it via the reserved
+     * `cachePoints` provider option, e.g. `['cachePoints' => ['system', 'tools']]`.
+     *
+     * @param  array<string, mixed>  $parameters
+     * @param  array<int, string>|string|null  $locations
+     * @return array<string, mixed>
+     */
+    protected function applyCachePoints(array $parameters, array|string|null $locations): array
+    {
+        $locations = array_filter((array) $locations);
+
+        if ($locations === []) {
+            return $parameters;
+        }
+
+        $cachePoint = ['cachePoint' => ['type' => 'default']];
+
+        if (in_array('system', $locations, true) && ! empty($parameters['system'])) {
+            $parameters['system'][] = $cachePoint;
+        }
+
+        if (in_array('tools', $locations, true) && ! empty($parameters['toolConfig']['tools'])) {
+            $parameters['toolConfig']['tools'][] = $cachePoint;
         }
 
         return $parameters;

--- a/tests/Fixtures/Agents/CachePointsAgent.php
+++ b/tests/Fixtures/Agents/CachePointsAgent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+class CachePointsAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Bedrock => ['cachePoints' => ['system', 'tools']],
+            default => [],
+        };
+    }
+}

--- a/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
@@ -21,6 +21,7 @@ use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Tools\Request;
+use Tests\Fixtures\Agents\CachePointsAgent;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
 use Tests\Fixtures\Tools\NamedTool;
 
@@ -88,6 +89,11 @@ function textGateway(): object
                 $options,
                 $isFinalStep,
             );
+        }
+
+        public function callApplyCachePoints(array $parameters, array|string|null $locations): array
+        {
+            return $this->applyCachePoints($parameters, $locations);
         }
 
         public function callResolveMaxSteps(array $tools, ?TextGenerationOptions $options): int
@@ -619,4 +625,67 @@ test('build converse parameters omits provider options when agent has none', fun
 
     expect($params)->not->toHaveKey('additionalModelRequestFields')
         ->and($params)->not->toHaveKey('guardrailConfig');
+});
+
+test('apply cache points appends markers to the requested locations', function () {
+    $parameters = [
+        'system' => [['text' => 'you are helpful']],
+        'toolConfig' => ['tools' => [['toolSpec' => ['name' => 'X']]]],
+    ];
+
+    $result = textGateway()->callApplyCachePoints($parameters, ['system', 'tools']);
+
+    expect($result['system'])->toEqual([
+        ['text' => 'you are helpful'],
+        ['cachePoint' => ['type' => 'default']],
+    ])->and($result['toolConfig']['tools'])->toEqual([
+        ['toolSpec' => ['name' => 'X']],
+        ['cachePoint' => ['type' => 'default']],
+    ]);
+});
+
+test('apply cache points only touches the locations asked for', function () {
+    $parameters = [
+        'system' => [['text' => 'you are helpful']],
+        'toolConfig' => ['tools' => [['toolSpec' => ['name' => 'X']]]],
+    ];
+
+    $result = textGateway()->callApplyCachePoints($parameters, 'system');
+
+    expect($result['system'])->toEqual([
+        ['text' => 'you are helpful'],
+        ['cachePoint' => ['type' => 'default']],
+    ])->and($result['toolConfig']['tools'])->toEqual([['toolSpec' => ['name' => 'X']]]);
+});
+
+test('apply cache points is a no-op when nothing is requested or the target is absent', function () {
+    $parameters = ['system' => [['text' => 'hi']]];
+
+    expect(textGateway()->callApplyCachePoints($parameters, null))->toEqual($parameters)
+        ->and(textGateway()->callApplyCachePoints($parameters, []))->toEqual($parameters)
+        ->and(textGateway()->callApplyCachePoints(['messages' => []], ['system', 'tools']))
+        ->toEqual(['messages' => []]);
+});
+
+test('build converse parameters applies cache points without flat-merging the directive', function () {
+    $options = TextGenerationOptions::forAgent(new CachePointsAgent);
+
+    $params = textGateway()->callBuildConverseParameters(
+        'claude-sonnet',
+        'you are helpful',
+        [['role' => 'user', 'content' => [['text' => 'hi']]]],
+        null,
+        [['toolSpec' => ['name' => 'X']]],
+        false,
+        $options,
+        false,
+    );
+
+    expect($params['system'])->toEqual([
+        ['text' => 'you are helpful'],
+        ['cachePoint' => ['type' => 'default']],
+    ])->and($params['toolConfig']['tools'])->toEqual([
+        ['toolSpec' => ['name' => 'X']],
+        ['cachePoint' => ['type' => 'default']],
+    ])->and($params)->not->toHaveKey('cachePoints');
 });


### PR DESCRIPTION
## What

Adds opt-in [Bedrock Converse prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) to `BedrockTextGateway` via a reserved `cachePoints` provider option.

## Why

The gateway already reads `cacheReadInputTokens` / `cacheWriteInputTokens` back from the Converse response, but it never emits the `{cachePoint: {type: 'default'}}` markers the API requires — so those counters are always `0` and a stable system prompt + tool set are re-billed at the full input rate on every call. There was no way to request caching: `providerOptions` flat-merges at the top level of the request and can't reach the nested `system` / `toolConfig` blocks where the marker has to live.

## How

Agents name where to cache via the Bedrock provider option:

```php
public function providerOptions(Lab|string $provider): array
{
    return match ($provider) {
        Lab::Bedrock => ['cachePoints' => ['system', 'tools']],
        default => [],
    };
}
```

`buildConverseParameters` pulls the directive out **before** the existing flat-merge (so it never leaks into the request body) and appends a cachePoint block to the `system` array and/or `toolConfig.tools`. Locations with no content (no instructions / no tools) are skipped.

Scoped to the static prefix — `system` + `tools` — which is the biggest, most stable cache target. Message-prefix caching can be a follow-up.

## Tests

- `applyCachePoints` unit tests: system-only, tools-only, both, no-op when unrequested or target absent.
- `buildConverseParameters` integration test: directive drives insertion and does **not** flat-merge into the body.
- Full `BedrockTextGatewayTest` suite green (45 passed); Pint + PHPStan clean on the touched files.