### PR TITLE
Add Oracle (OCI Generative AI) provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/laravel/ai/compare/v0.7.2...0.x)
 
+### What's Changed
+
+* Add Oracle (OCI Generative AI) provider with text generation, streaming, tool calling, structured output, and embeddings (Cohere + Generic model families).
+
 ## [v0.7.2](https://github.com/laravel/ai/compare/v0.7.1...v0.7.2) - 2026-05-28
 
 ### What's Changed

--- a/config/ai.php
+++ b/config/ai.php
@@ -129,6 +129,21 @@ return [
             'key' => env('OPENROUTER_API_KEY'),
         ],
 
+        'oracle' => [
+            'driver' => 'oracle',
+            'region' => env('OCI_GENAI_REGION', 'us-chicago-1'),
+            'compartment_id' => env('OCI_COMPARTMENT_ID'),
+            'tenancy_id' => env('OCI_TENANCY_ID'),
+            'user_id' => env('OCI_USER_ID'),
+            'fingerprint' => env('OCI_KEY_FINGERPRINT'),
+            'private_key' => env('OCI_PRIVATE_KEY'),
+            'private_key_path' => env('OCI_PRIVATE_KEY_PATH'),
+            'passphrase' => env('OCI_PRIVATE_KEY_PASSPHRASE'),
+            'serving_type' => env('OCI_SERVING_TYPE', 'ON_DEMAND'),
+            'endpoint_id' => env('OCI_ENDPOINT_ID'),
+            'url' => env('OCI_GENAI_URL'),
+        ],
+
         'voyageai' => [
             'driver' => 'voyageai',
             'key' => env('VOYAGEAI_API_KEY'),

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -31,6 +31,7 @@ use Laravel\Ai\Providers\MistralProvider;
 use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiProvider;
 use Laravel\Ai\Providers\OpenRouterProvider;
+use Laravel\Ai\Providers\OracleProvider;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\VoyageAiProvider;
 use Laravel\Ai\Providers\XaiProvider;
@@ -419,6 +420,17 @@ class AiManager extends MultipleInstanceManager
     public function createOpenrouterDriver(array $config): OpenRouterProvider
     {
         return new OpenRouterProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create an Oracle (OCI Generative AI) powered instance.
+     */
+    public function createOracleDriver(array $config): OracleProvider
+    {
+        return new OracleProvider(
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -17,6 +17,7 @@ enum Lab: string
     case Ollama = 'ollama';
     case OpenAI = 'openai';
     case OpenRouter = 'openrouter';
+    case Oracle = 'oracle';
     case VoyageAI = 'voyageai';
     case xAI = 'xai';
 }

--- a/src/Gateway/Oracle/Concerns/CreatesOracleClient.php
+++ b/src/Gateway/Oracle/Concerns/CreatesOracleClient.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle\Concerns;
+
+use GuzzleHttp\Middleware;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use Laravel\Ai\Gateway\Oracle\OracleRequestSigner;
+use Laravel\Ai\Providers\Provider;
+use Psr\Http\Message\RequestInterface;
+
+trait CreatesOracleClient
+{
+    /**
+     * Create a new HTTP client for the OCI Generative AI inference API.
+     *
+     * Requests are signed per the OCI HTTP Signature scheme via a Guzzle request
+     * middleware so the signature is computed over the final serialized body.
+     */
+    protected function client(Provider $provider, ?int $timeout = null): PendingRequest
+    {
+        $signer = $this->oracleSigner($provider);
+
+        return Http::baseUrl($this->baseUrl($provider))
+            ->withHeaders(['Accept' => 'application/json'])
+            ->withMiddleware(Middleware::mapRequest(
+                fn (RequestInterface $request) => $signer->sign($request)
+            ))
+            ->timeout($timeout ?? 60)
+            ->throw();
+    }
+
+    /**
+     * Build the request signer from the provider's resolved credentials.
+     */
+    protected function oracleSigner(Provider $provider): OracleRequestSigner
+    {
+        $credentials = $provider->providerCredentials();
+
+        foreach (['tenancy_id', 'user_id', 'fingerprint'] as $required) {
+            if (empty($credentials[$required])) {
+                throw new InvalidArgumentException("The OCI [{$required}] credential is required to sign Generative AI requests.");
+            }
+        }
+
+        return new OracleRequestSigner(
+            $credentials['tenancy_id'],
+            $credentials['user_id'],
+            $credentials['fingerprint'],
+            $this->resolvePrivateKey($credentials),
+            $credentials['passphrase'] ?? null,
+        );
+    }
+
+    /**
+     * Resolve the PEM private key from its inline value or filesystem path.
+     *
+     * @param  array<string, mixed>  $credentials
+     */
+    protected function resolvePrivateKey(array $credentials): string
+    {
+        if (! empty($credentials['private_key'])) {
+            return $credentials['private_key'];
+        }
+
+        if (! empty($credentials['private_key_path']) && is_file($credentials['private_key_path'])) {
+            return (string) file_get_contents($credentials['private_key_path']);
+        }
+
+        throw new InvalidArgumentException('An OCI private key (contents or path) is required to sign Generative AI requests.');
+    }
+
+    /**
+     * Get the base URL for the OCI Generative AI inference API.
+     */
+    protected function baseUrl(Provider $provider): string
+    {
+        $config = $provider->additionalConfiguration();
+
+        $url = $config['url']
+            ?? 'https://inference.generativeai.'.($config['region'] ?? 'us-chicago-1').'.oci.oraclecloud.com';
+
+        return rtrim($url, '/');
+    }
+}

--- a/src/Gateway/Oracle/Concerns/DetectsModelFamily.php
+++ b/src/Gateway/Oracle/Concerns/DetectsModelFamily.php
@@ -22,4 +22,15 @@ trait DetectsModelFamily
     {
         return $this->isCohereModel($model) ? 'COHERE' : 'GENERIC';
     }
+
+    /**
+     * Determine whether the embedding model accepts a configurable output dimension.
+     *
+     * Cohere embed v3 models emit a fixed-size vector; only the v4 family supports the
+     * outputDimensions field, so the requested dimension is forwarded for it alone.
+     */
+    protected function supportsOutputDimensions(string $model): bool
+    {
+        return str_contains($model, 'embed-v4') || str_contains($model, 'embed-4');
+    }
 }

--- a/src/Gateway/Oracle/Concerns/DetectsModelFamily.php
+++ b/src/Gateway/Oracle/Concerns/DetectsModelFamily.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle\Concerns;
+
+trait DetectsModelFamily
+{
+    /**
+     * Determine whether the given model uses the Cohere chat request/response format.
+     *
+     * OCI exposes two API formats: COHERE for the Cohere model family and GENERIC for
+     * everything else (Meta Llama, xAI Grok, etc.). Detection is by model id prefix.
+     */
+    protected function isCohereModel(string $model): bool
+    {
+        return str_starts_with($model, 'cohere.');
+    }
+
+    /**
+     * Get the OCI chat apiFormat discriminator for the given model.
+     */
+    protected function apiFormat(string $model): string
+    {
+        return $this->isCohereModel($model) ? 'COHERE' : 'GENERIC';
+    }
+}

--- a/src/Gateway/Oracle/Concerns/MapsCohereChat.php
+++ b/src/Gateway/Oracle/Concerns/MapsCohereChat.php
@@ -129,8 +129,11 @@ trait MapsCohereChat
     /**
      * Convert a JSON schema object into Cohere parameterDefinitions.
      *
-     * TODO: nested object/array property types are flattened to their JSON type; deep schemas
-     * may need richer mapping once exercised against a live tenancy.
+     * Cohere parameter types must be Python type names (str/int/float/bool/List/Dict),
+     * not JSON-schema types, so each property type is mapped accordingly.
+     *
+     * TODO: nested object/array property types are flattened to their scalar Python type;
+     * deep schemas may need richer mapping once exercised against a live tenancy.
      *
      * @param  array<string, mixed>  $jsonSchema
      * @return array<string, array<string, mixed>>
@@ -145,12 +148,32 @@ trait MapsCohereChat
         foreach ($properties as $name => $definition) {
             $definitions[$name] = [
                 'description' => (string) ($definition['description'] ?? ''),
-                'type' => $definition['type'] ?? 'string',
+                'type' => $this->cohereParameterType($definition['type'] ?? 'string'),
                 'isRequired' => in_array($name, $required, true),
             ];
         }
 
         return $definitions;
+    }
+
+    /**
+     * Map a JSON schema type to the Cohere/Python parameter type name.
+     *
+     * @param  string|array<int, string>  $type
+     */
+    protected function cohereParameterType(string|array $type): string
+    {
+        $type = is_array($type) ? ($type[0] ?? 'string') : $type;
+
+        return match ($type) {
+            'string' => 'str',
+            'integer' => 'int',
+            'number' => 'float',
+            'boolean' => 'bool',
+            'array' => 'List',
+            'object' => 'Dict',
+            default => $type,
+        };
     }
 
     /**

--- a/src/Gateway/Oracle/Concerns/MapsCohereChat.php
+++ b/src/Gateway/Oracle/Concerns/MapsCohereChat.php
@@ -209,7 +209,7 @@ trait MapsCohereChat
             $toolCalls[] = new ToolCall(
                 $call['id'] ?? (string) Str::uuid(),
                 $call['name'] ?? '',
-                $call['parameters'] ?? [],
+                $this->decodeArguments($call['parameters'] ?? []),
             );
         }
 

--- a/src/Gateway/Oracle/Concerns/MapsCohereChat.php
+++ b/src/Gateway/Oracle/Concerns/MapsCohereChat.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Tools\ToolNameResolver;
+
+/**
+ * Maps Laravel AI messages/tools to OCI's CohereChatRequest (apiFormat = COHERE) and
+ * parses CohereChatResponse payloads. Used for the cohere.command-* model family.
+ */
+trait MapsCohereChat
+{
+    /**
+     * Build the Cohere request state (current message, chat history, preamble) from Laravel AI messages.
+     *
+     * Cohere takes the latest user turn as `message` and all prior turns as `chatHistory`; the
+     * system instructions are mapped to `preambleOverride`.
+     *
+     * @return array{message: string, chatHistory: array<int, array<string, string>>, preamble: ?string}
+     */
+    protected function buildCohereState(array $messages, ?string $instructions): array
+    {
+        $turns = [];
+
+        foreach ($messages as $message) {
+            $turn = $this->cohereTurn($message);
+
+            if ($turn !== null) {
+                $turns[] = $turn;
+            }
+        }
+
+        $message = '';
+
+        for ($i = count($turns) - 1; $i >= 0; $i--) {
+            if ($turns[$i]['role'] === 'USER') {
+                $message = $turns[$i]['message'];
+
+                array_splice($turns, $i, 1);
+
+                break;
+            }
+        }
+
+        return [
+            'message' => $message,
+            'chatHistory' => $turns,
+            'preamble' => filled($instructions) ? $instructions : null,
+        ];
+    }
+
+    /**
+     * Convert a single Laravel AI message into a Cohere chat-history turn (or null to skip).
+     *
+     * @return array{role: string, message: string}|null
+     */
+    protected function cohereTurn(mixed $message): ?array
+    {
+        return match (true) {
+            $message instanceof UserMessage => ['role' => 'USER', 'message' => $message->content],
+            $message instanceof AssistantMessage => $message->content !== ''
+                ? ['role' => 'CHATBOT', 'message' => $message->content]
+                : null,
+            $message instanceof ToolResultMessage => null,
+            $message instanceof Message => [
+                'role' => $message->role === MessageRole::Assistant ? 'CHATBOT' : 'USER',
+                'message' => $message->content,
+            ],
+            is_array($message) => [
+                'role' => ($message['role'] ?? '') === MessageRole::Assistant->value ? 'CHATBOT' : 'USER',
+                'message' => $message['content'] ?? '',
+            ],
+            default => null,
+        };
+    }
+
+    /**
+     * Format Laravel AI tools as Cohere tool definitions.
+     *
+     * @param  array<Tool>  $tools
+     * @return array<int, array<string, mixed>>
+     */
+    protected function formatCohereTools(array $tools): array
+    {
+        return (new Collection($tools))
+            ->filter(fn ($tool) => $tool instanceof Tool)
+            ->map(fn (Tool $tool) => [
+                'name' => ToolNameResolver::resolve($tool),
+                'description' => (string) $tool->description(),
+                'parameterDefinitions' => $this->schemaToParameterDefinitions(
+                    (new ObjectSchema($tool->schema(new JsonSchemaTypeFactory)))->toArray()
+                ),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Build the synthetic structured-output tool for the Cohere format.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildCohereSchemaTool(array $schema): array
+    {
+        return [
+            [
+                'name' => self::STRUCTURED_OUTPUT_TOOL,
+                'description' => 'Return the response as a structured JSON object matching the provided schema.',
+                'parameterDefinitions' => $this->schemaToParameterDefinitions($schema),
+            ],
+        ];
+    }
+
+    /**
+     * Convert a JSON schema object into Cohere parameterDefinitions.
+     *
+     * TODO: nested object/array property types are flattened to their JSON type; deep schemas
+     * may need richer mapping once exercised against a live tenancy.
+     *
+     * @param  array<string, mixed>  $jsonSchema
+     * @return array<string, array<string, mixed>>
+     */
+    protected function schemaToParameterDefinitions(array $jsonSchema): array
+    {
+        $properties = $jsonSchema['properties'] ?? [];
+        $required = $jsonSchema['required'] ?? [];
+
+        $definitions = [];
+
+        foreach ($properties as $name => $definition) {
+            $definitions[$name] = [
+                'description' => (string) ($definition['description'] ?? ''),
+                'type' => $definition['type'] ?? 'string',
+                'isRequired' => in_array($name, $required, true),
+            ];
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * Build Cohere toolResults from executed tool results paired with their originating calls.
+     *
+     * @param  array<ToolResult>  $toolResults
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildCohereToolResults(array $toolResults): array
+    {
+        return array_map(fn (ToolResult $toolResult) => [
+            'call' => [
+                'name' => $toolResult->name,
+                'parameters' => (object) $toolResult->arguments,
+            ],
+            'outputs' => [
+                is_array($toolResult->result) ? $toolResult->result : ['output' => (string) $toolResult->result],
+            ],
+        ], $toolResults);
+    }
+
+    /**
+     * Parse a CohereChatResponse into normalized text, tool calls, finish reason, and usage.
+     *
+     * @param  array<string, mixed>  $chatResponse
+     * @return array{text: string, toolCalls: array<ToolCall>, finishReason: FinishReason, usage: Usage}
+     */
+    protected function parseCohereResponse(array $chatResponse): array
+    {
+        $toolCalls = [];
+
+        foreach ($chatResponse['toolCalls'] ?? [] as $call) {
+            $toolCalls[] = new ToolCall(
+                $call['id'] ?? (string) Str::uuid(),
+                $call['name'] ?? '',
+                $call['parameters'] ?? [],
+            );
+        }
+
+        return [
+            'text' => $chatResponse['text'] ?? '',
+            'toolCalls' => $toolCalls,
+            'finishReason' => $this->cohereFinishReason($chatResponse['finishReason'] ?? ''),
+            'usage' => $this->extractUsage($chatResponse),
+        ];
+    }
+
+    /**
+     * Map an OCI Cohere finish reason to the Laravel AI finish reason enum.
+     */
+    protected function cohereFinishReason(string $reason): FinishReason
+    {
+        return match (strtoupper($reason)) {
+            'COMPLETE' => FinishReason::Stop,
+            'MAX_TOKENS' => FinishReason::Length,
+            'ERROR_TOXIC' => FinishReason::ContentFilter,
+            'ERROR', 'ERROR_LIMIT', 'USER_CANCEL' => FinishReason::Error,
+            default => FinishReason::Unknown,
+        };
+    }
+}

--- a/src/Gateway/Oracle/Concerns/MapsGenericChat.php
+++ b/src/Gateway/Oracle/Concerns/MapsGenericChat.php
@@ -220,6 +220,10 @@ trait MapsGenericChat
      */
     protected function decodeArguments(mixed $arguments): array
     {
+        if (is_object($arguments)) {
+            $arguments = json_decode((string) json_encode($arguments), true);
+        }
+
         if (is_array($arguments)) {
             return $arguments;
         }

--- a/src/Gateway/Oracle/Concerns/MapsGenericChat.php
+++ b/src/Gateway/Oracle/Concerns/MapsGenericChat.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle\Concerns;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Tools\ToolNameResolver;
+
+/**
+ * Maps Laravel AI messages/tools to OCI's GenericChatRequest (apiFormat = GENERIC) and
+ * parses GenericChatResponse payloads. Used for Meta Llama, xAI Grok, and other non-Cohere models.
+ */
+trait MapsGenericChat
+{
+    /**
+     * Build the OCI generic message list from Laravel AI messages and system instructions.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildGenericMessages(array $messages, ?string $instructions): array
+    {
+        $formatted = [];
+
+        if (filled($instructions)) {
+            $formatted[] = $this->genericMessage('SYSTEM', $instructions);
+        }
+
+        foreach ($messages as $message) {
+            $formatted = array_merge($formatted, $this->formatGenericMessage($message));
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * Format a single Laravel AI message into one or more OCI generic messages.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function formatGenericMessage(mixed $message): array
+    {
+        return match (true) {
+            $message instanceof AssistantMessage => [$this->genericAssistantMessage($message->content, $message->toolCalls->all())],
+            $message instanceof ToolResultMessage => $this->genericToolResultMessages($message->toolResults->all()),
+            $message instanceof UserMessage => [$this->genericMessage('USER', $message->content)],
+            $message instanceof Message => [$this->genericMessage(
+                $message->role === MessageRole::Assistant ? 'ASSISTANT' : 'USER',
+                $message->content,
+            )],
+            default => [$this->genericMessage(
+                ($message['role'] ?? '') === MessageRole::Assistant->value ? 'ASSISTANT' : 'USER',
+                $message['content'] ?? '',
+            )],
+        };
+    }
+
+    /**
+     * Build a simple single-text-part generic message.
+     *
+     * @return array<string, mixed>
+     */
+    protected function genericMessage(string $role, string $text): array
+    {
+        return [
+            'role' => $role,
+            'content' => [['type' => 'TEXT', 'text' => $text]],
+        ];
+    }
+
+    /**
+     * Build a generic ASSISTANT message carrying optional text and tool calls.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @return array<string, mixed>
+     */
+    protected function genericAssistantMessage(string $text, array $toolCalls): array
+    {
+        $message = ['role' => 'ASSISTANT'];
+
+        $message['content'] = $text !== '' ? [['type' => 'TEXT', 'text' => $text]] : [];
+
+        if (! empty($toolCalls)) {
+            $message['toolCalls'] = array_map(fn (ToolCall $toolCall) => [
+                'id' => $toolCall->id,
+                'type' => 'FUNCTION',
+                'name' => $toolCall->name,
+                'arguments' => json_encode($toolCall->arguments ?: (object) []),
+            ], $toolCalls);
+        }
+
+        return $message;
+    }
+
+    /**
+     * Build the TOOL-role generic messages carrying tool results.
+     *
+     * @param  array<ToolResult>  $toolResults
+     * @return array<int, array<string, mixed>>
+     */
+    protected function genericToolResultMessages(array $toolResults): array
+    {
+        return array_map(fn (ToolResult $toolResult) => [
+            'role' => 'TOOL',
+            'toolCallId' => $toolResult->id,
+            'content' => [['type' => 'TEXT', 'text' => is_string($toolResult->result) ? $toolResult->result : json_encode($toolResult->result)]],
+        ], $toolResults);
+    }
+
+    /**
+     * Format Laravel AI tools as OCI generic FUNCTION tool definitions.
+     *
+     * @param  array<Tool>  $tools
+     * @return array<int, array<string, mixed>>
+     */
+    protected function formatGenericTools(array $tools): array
+    {
+        return (new Collection($tools))
+            ->filter(fn ($tool) => $tool instanceof Tool)
+            ->map(fn (Tool $tool) => [
+                'type' => 'FUNCTION',
+                'function' => [
+                    'name' => ToolNameResolver::resolve($tool),
+                    'description' => (string) $tool->description(),
+                    'parameters' => (new ObjectSchema($tool->schema(new JsonSchemaTypeFactory)))->toArray(),
+                ],
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Build the synthetic structured-output tool plus any real tools for the generic format.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<Tool>  $tools
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildGenericSchemaTools(array $schema, array $tools): array
+    {
+        return array_merge([
+            [
+                'type' => 'FUNCTION',
+                'function' => [
+                    'name' => self::STRUCTURED_OUTPUT_TOOL,
+                    'description' => 'Return the response as a structured JSON object matching the provided schema.',
+                    'parameters' => (new ObjectSchema($schema))->toArray(),
+                ],
+            ],
+        ], $this->formatGenericTools($tools));
+    }
+
+    /**
+     * Parse a GenericChatResponse into normalized text, tool calls, finish reason, and usage.
+     *
+     * @param  array<string, mixed>  $chatResponse
+     * @return array{text: string, toolCalls: array<ToolCall>, finishReason: FinishReason, usage: Usage}
+     */
+    protected function parseGenericResponse(array $chatResponse): array
+    {
+        $choice = $chatResponse['choices'][0] ?? [];
+        $message = $choice['message'] ?? [];
+
+        $text = '';
+
+        foreach ($message['content'] ?? [] as $part) {
+            if (isset($part['text'])) {
+                $text .= $part['text'];
+            }
+        }
+
+        $toolCalls = [];
+
+        foreach ($message['toolCalls'] ?? [] as $call) {
+            $toolCalls[] = new ToolCall(
+                $call['id'] ?? (string) Str::uuid(),
+                $call['name'] ?? '',
+                $this->decodeArguments($call['arguments'] ?? null),
+            );
+        }
+
+        return [
+            'text' => $text,
+            'toolCalls' => $toolCalls,
+            'finishReason' => $this->genericFinishReason($choice['finishReason'] ?? ''),
+            'usage' => $this->extractUsage($chatResponse),
+        ];
+    }
+
+    /**
+     * Map an OCI generic finish reason to the Laravel AI finish reason enum.
+     */
+    protected function genericFinishReason(string $reason): FinishReason
+    {
+        return match (strtolower($reason)) {
+            'stop', 'complete' => FinishReason::Stop,
+            'tool_calls' => FinishReason::ToolCalls,
+            'length', 'max_tokens' => FinishReason::Length,
+            'content_filter' => FinishReason::ContentFilter,
+            '' => FinishReason::Unknown,
+            default => FinishReason::Unknown,
+        };
+    }
+
+    /**
+     * Decode tool-call arguments which OCI returns as a JSON-encoded string.
+     *
+     * @return array<string, mixed>
+     */
+    protected function decodeArguments(mixed $arguments): array
+    {
+        if (is_array($arguments)) {
+            return $arguments;
+        }
+
+        if (! is_string($arguments) || $arguments === '') {
+            return [];
+        }
+
+        $decoded = json_decode($arguments, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * Extract token usage from an OCI chat response (shared shape across families).
+     *
+     * @param  array<string, mixed>  $chatResponse
+     */
+    protected function extractUsage(array $chatResponse): Usage
+    {
+        $usage = $chatResponse['usage'] ?? [];
+
+        return new Usage(
+            promptTokens: $usage['promptTokens'] ?? 0,
+            completionTokens: $usage['completionTokens'] ?? 0,
+        );
+    }
+}

--- a/src/Gateway/Oracle/OracleException.php
+++ b/src/Gateway/Oracle/OracleException.php
@@ -46,7 +46,7 @@ class OracleException
                 ),
                 default => new AiException(
                     'OCI Generative AI error for provider ['.$provider.']: '.$e->getMessage(),
-                    code: $e->getCode(),
+                    code: $status,
                     previous: $e,
                 ),
             };

--- a/src/Gateway/Oracle/OracleException.php
+++ b/src/Gateway/Oracle/OracleException.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Str;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Throwable;
+
+class OracleException
+{
+    /**
+     * Patterns that indicate an insufficient credits or quota error.
+     *
+     * @var list<string>
+     */
+    protected static array $insufficientCreditPatterns = [
+        'quota',
+        'limit exceeded',
+        'insufficient',
+        'billing',
+    ];
+
+    /**
+     * Create a new AI exception from an OCI Generative AI request exception.
+     */
+    public static function toAiException(Throwable $e, string $provider, string $model): AiException
+    {
+        if ($e instanceof AiException) {
+            return $e;
+        }
+
+        if ($e instanceof RequestException && $e->response !== null) {
+            $status = $e->response->status();
+
+            return match (true) {
+                $status === 429 => RateLimitedException::forProvider($provider, $status, $e),
+                $status === 402 => InsufficientCreditsException::forProvider($provider, $status, $e),
+                in_array($status, [500, 502, 503, 504], true) => new ProviderOverloadedException(
+                    'AI provider ['.$provider.'] is overloaded or unavailable.',
+                    code: $status,
+                    previous: $e,
+                ),
+                default => new AiException(
+                    'OCI Generative AI error for provider ['.$provider.']: '.$e->getMessage(),
+                    code: $e->getCode(),
+                    previous: $e,
+                ),
+            };
+        }
+
+        if (static::isInsufficientCreditsError($e)) {
+            return InsufficientCreditsException::forProvider($provider, $e->getCode(), $e);
+        }
+
+        return new AiException(
+            $e->getMessage(),
+            code: $e->getCode(),
+            previous: $e,
+        );
+    }
+
+    /**
+     * Determine if the given exception indicates an insufficient credits or quota error.
+     */
+    protected static function isInsufficientCreditsError(Throwable $e): bool
+    {
+        return Str::contains(strtolower($e->getMessage()), static::$insufficientCreditPatterns);
+    }
+}

--- a/src/Gateway/Oracle/OracleException.php
+++ b/src/Gateway/Oracle/OracleException.php
@@ -44,6 +44,7 @@ class OracleException
                     code: $status,
                     previous: $e,
                 ),
+                static::indicatesInsufficientCredits($e->getMessage().' '.$e->response->body()) => InsufficientCreditsException::forProvider($provider, $status, $e),
                 default => new AiException(
                     'OCI Generative AI error for provider ['.$provider.']: '.$e->getMessage(),
                     code: $status,
@@ -68,6 +69,14 @@ class OracleException
      */
     protected static function isInsufficientCreditsError(Throwable $e): bool
     {
-        return Str::contains(strtolower($e->getMessage()), static::$insufficientCreditPatterns);
+        return static::indicatesInsufficientCredits($e->getMessage());
+    }
+
+    /**
+     * Determine if the given text contains an insufficient credits or quota signal.
+     */
+    protected static function indicatesInsufficientCredits(string $text): bool
+    {
+        return Str::contains(strtolower($text), static::$insufficientCreditPatterns);
     }
 }

--- a/src/Gateway/Oracle/OracleRequestSigner.php
+++ b/src/Gateway/Oracle/OracleRequestSigner.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle;
+
+use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use RuntimeException;
+
+/**
+ * Signs outgoing OCI requests using the OCI HTTP Signature scheme (draft-cavage-http-signatures-08).
+ *
+ * Supports API-key (config-file) authentication. The class is intentionally structured so that
+ * alternative credential sources (instance-principal / resource-principal) can produce a signer
+ * with a resolved key + keyId without changing the signing algorithm below.
+ *
+ * @see https://docs.oracle.com/en-us/iaas/Content/API/Concepts/signingrequests.htm
+ */
+class OracleRequestSigner
+{
+    /**
+     * The headers signed for requests that carry a body (POST / PUT / PATCH).
+     *
+     * @var list<string>
+     */
+    protected const BODY_HEADERS = ['(request-target)', 'host', 'date', 'x-content-sha256', 'content-type', 'content-length'];
+
+    /**
+     * The headers signed for requests without a body (GET / HEAD / DELETE).
+     *
+     * @var list<string>
+     */
+    protected const BODYLESS_HEADERS = ['(request-target)', 'host', 'date'];
+
+    public function __construct(
+        protected string $tenancyId,
+        protected string $userId,
+        protected string $fingerprint,
+        protected string $privateKey,
+        protected ?string $passphrase = null,
+    ) {}
+
+    /**
+     * Get the keyId used to identify the API signing key to OCI.
+     */
+    public function keyId(): string
+    {
+        return "{$this->tenancyId}/{$this->userId}/{$this->fingerprint}";
+    }
+
+    /**
+     * Sign the given PSR-7 request and return a new request carrying the signature headers.
+     */
+    public function sign(RequestInterface $request, ?string $date = null): RequestInterface
+    {
+        $method = strtolower($request->getMethod());
+        $date ??= gmdate('D, d M Y H:i:s').' GMT';
+        $host = $request->getUri()->getHost();
+
+        $request = $request->withHeader('date', $date);
+
+        if (! $request->hasHeader('host')) {
+            $request = $request->withHeader('host', $host);
+        }
+
+        $hasBody = in_array($method, ['post', 'put', 'patch'], true);
+
+        if ($hasBody) {
+            $body = (string) $request->getBody();
+            $request->getBody()->rewind();
+
+            $contentType = $request->getHeaderLine('content-type') ?: 'application/json';
+
+            $request = $request
+                ->withHeader('content-type', $contentType)
+                ->withHeader('content-length', (string) strlen($body))
+                ->withHeader('x-content-sha256', base64_encode(hash('sha256', $body, true)));
+        }
+
+        $headers = $hasBody ? self::BODY_HEADERS : self::BODYLESS_HEADERS;
+
+        $signingString = $this->buildSigningString($request, $headers);
+
+        $signature = $this->signString($signingString);
+
+        $authorization = sprintf(
+            'Signature version="1",keyId="%s",algorithm="rsa-sha256",headers="%s",signature="%s"',
+            $this->keyId(),
+            implode(' ', $headers),
+            $signature,
+        );
+
+        return $request->withHeader('Authorization', $authorization);
+    }
+
+    /**
+     * Build the signing string for the given request and ordered header list.
+     *
+     * @param  list<string>  $headers
+     */
+    public function buildSigningString(RequestInterface $request, array $headers): string
+    {
+        $lines = [];
+
+        foreach ($headers as $header) {
+            if ($header === '(request-target)') {
+                $target = $request->getUri()->getPath();
+
+                if ($query = $request->getUri()->getQuery()) {
+                    $target .= '?'.$query;
+                }
+
+                $lines[] = '(request-target): '.strtolower($request->getMethod()).' '.$target;
+
+                continue;
+            }
+
+            $lines[] = $header.': '.$request->getHeaderLine($header);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Sign the given string with the configured RSA private key and return the base64 signature.
+     */
+    protected function signString(string $signingString): string
+    {
+        $key = openssl_pkey_get_private($this->privateKey, $this->passphrase ?? '');
+
+        if ($key === false) {
+            throw new InvalidArgumentException('Unable to load the OCI private key. Verify the key contents and passphrase.');
+        }
+
+        $signature = '';
+
+        if (! openssl_sign($signingString, $signature, $key, OPENSSL_ALGO_SHA256)) {
+            throw new RuntimeException('Failed to sign the OCI request.');
+        }
+
+        return base64_encode($signature);
+    }
+}

--- a/src/Gateway/Oracle/OracleRequestSigner.php
+++ b/src/Gateway/Oracle/OracleRequestSigner.php
@@ -106,7 +106,7 @@ class OracleRequestSigner
 
         foreach ($headers as $header) {
             if ($header === '(request-target)') {
-                $target = $request->getUri()->getPath();
+                $target = $request->getUri()->getPath() ?: '/';
 
                 if ($query = $request->getUri()->getQuery()) {
                     $target .= '?'.$query;

--- a/src/Gateway/Oracle/OracleRequestSigner.php
+++ b/src/Gateway/Oracle/OracleRequestSigner.php
@@ -66,7 +66,10 @@ class OracleRequestSigner
 
         if ($hasBody) {
             $body = (string) $request->getBody();
-            $request->getBody()->rewind();
+
+            if ($request->getBody()->isSeekable()) {
+                $request->getBody()->rewind();
+            }
 
             $contentType = $request->getHeaderLine('content-type') ?: 'application/json';
 

--- a/src/Gateway/Oracle/OracleTextGateway.php
+++ b/src/Gateway/Oracle/OracleTextGateway.php
@@ -345,11 +345,17 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
         $embeddings = [];
         $totalTokens = 0;
 
+        // Cohere embed v3 models have a fixed output dimension, so the requested dimension is
+        // only forwarded for model families that accept the configurable outputDimensions field.
+        $dimensionPayload = $this->supportsOutputDimensions($model)
+            ? ['outputDimensions' => $dimensions]
+            : [];
+
         foreach (array_chunk(array_values($inputs), self::EMBED_BATCH_SIZE) as $batch) {
             $payload = array_merge([
                 'inputType' => 'SEARCH_DOCUMENT',
                 'truncate' => 'END',
-            ], $providerOptions, [
+            ], $dimensionPayload, $providerOptions, [
                 ...$this->servingPayload($provider, $model),
                 'inputs' => $batch,
             ]);

--- a/src/Gateway/Oracle/OracleTextGateway.php
+++ b/src/Gateway/Oracle/OracleTextGateway.php
@@ -65,6 +65,16 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
      */
     protected const EMBED_BATCH_SIZE = 96;
 
+    /**
+     * The structural chat-request keys that agent provider options may not override.
+     *
+     * @var list<string>
+     */
+    protected const RESERVED_REQUEST_KEYS = [
+        'apiFormat', 'messages', 'message', 'chatHistory', 'preambleOverride',
+        'tools', 'toolChoice', 'toolResults', 'isForceSingleStep', 'isStream', 'streamOptions',
+    ];
+
     public function __construct()
     {
         $this->initializeToolCallbacks();
@@ -516,16 +526,6 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
             'topP' => $options->topP,
         ]);
     }
-
-    /**
-     * The structural chat-request keys that agent provider options may not override.
-     *
-     * @var list<string>
-     */
-    protected const RESERVED_REQUEST_KEYS = [
-        'apiFormat', 'messages', 'message', 'chatHistory', 'preambleOverride',
-        'tools', 'toolChoice', 'toolResults', 'isForceSingleStep', 'isStream', 'streamOptions',
-    ];
 
     /**
      * Merge the agent's Oracle provider options into the chat request.

--- a/src/Gateway/Oracle/OracleTextGateway.php
+++ b/src/Gateway/Oracle/OracleTextGateway.php
@@ -1,0 +1,779 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Oracle;
+
+use Generator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Oracle\Concerns\CreatesOracleClient;
+use Laravel\Ai\Gateway\Oracle\Concerns\DetectsModelFamily;
+use Laravel\Ai\Gateway\Oracle\Concerns\MapsCohereChat;
+use Laravel\Ai\Gateway\Oracle\Concerns\MapsGenericChat;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\StructuredTextResponse;
+use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+use Throwable;
+
+class OracleTextGateway implements EmbeddingGateway, TextGateway
+{
+    use CreatesOracleClient;
+    use DetectsModelFamily;
+    use HandlesFailoverErrors;
+    use InvokesTools;
+    use MapsCohereChat;
+    use MapsGenericChat;
+    use ParsesServerSentEvents;
+
+    protected const STRUCTURED_OUTPUT_TOOL = 'structured_output';
+
+    /**
+     * The OCI Generative AI API version path segment.
+     */
+    protected const API_VERSION = '20231130';
+
+    /**
+     * The maximum number of inputs OCI accepts per embedText call.
+     */
+    protected const EMBED_BATCH_SIZE = 96;
+
+    public function __construct()
+    {
+        $this->initializeToolCallbacks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): TextResponse {
+        return $this->isCohereModel($model)
+            ? $this->generateCohereText($provider, $model, $instructions, $messages, $tools, $schema, $options, $timeout)
+            : $this->generateGenericText($provider, $model, $instructions, $messages, $tools, $schema, $options, $timeout);
+    }
+
+    /**
+     * Generate text using the GENERIC chat format (Llama, Grok, etc.).
+     */
+    protected function generateGenericText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+    ): TextResponse {
+        $conversation = $this->buildGenericMessages($messages, $instructions);
+        $maxSteps = $this->resolveMaxSteps($tools, $options);
+        $schemaTools = $schema ? $this->buildGenericSchemaTools($schema, $tools) : null;
+        $formattedTools = $schemaTools === null && ! empty($tools) ? $this->formatGenericTools($tools) : null;
+
+        $allToolCalls = [];
+        $allToolResults = [];
+        $finalOutput = '';
+        $totalUsage = new Usage;
+        $step = 0;
+        $responseMessages = new Collection;
+        $steps = new Collection;
+        $meta = new Meta($provider->name(), $model);
+
+        while ($step < $maxSteps) {
+            $chatRequest = $this->buildGenericChatRequest(
+                $conversation, $schemaTools, $formattedTools, empty($tools), $options, ($step + 1) >= $maxSteps,
+            );
+
+            $parsed = $this->parseGenericResponse($this->postChat($provider, $model, $chatRequest, $timeout));
+
+            $totalUsage = $totalUsage->add($parsed['usage']);
+
+            [$toolCalls, $structured] = $this->extractStructuredToolCall($parsed['toolCalls'], $schemaTools !== null);
+
+            if ($structured !== null) {
+                $finalOutput = $structured;
+            } elseif (! $schemaTools) {
+                $finalOutput = $parsed['text'];
+            }
+
+            $step++;
+            $finishReason = $parsed['finishReason'];
+
+            $responseMessages->push(new AssistantMessage($parsed['text'], new Collection($toolCalls)));
+
+            if (empty($toolCalls)) {
+                if ($schemaTools && $finishReason === FinishReason::ToolCalls) {
+                    $finishReason = FinishReason::Stop;
+                }
+
+                $steps->push(new Step($parsed['text'], $toolCalls, [], $finishReason, $parsed['usage'], $meta));
+
+                break;
+            }
+
+            $allToolCalls = array_merge($allToolCalls, $toolCalls);
+            $conversation[] = $this->genericAssistantMessage($parsed['text'], $toolCalls);
+
+            $toolResults = $this->executeToolCalls($tools, $toolCalls);
+            $allToolResults = array_merge($allToolResults, $toolResults);
+
+            $steps->push(new Step($parsed['text'], $toolCalls, $toolResults, $finishReason, $parsed['usage'], $meta));
+
+            if (! empty($toolResults)) {
+                $conversation = array_merge($conversation, $this->genericToolResultMessages($toolResults));
+                $responseMessages->push(new ToolResultMessage(new Collection($toolResults)));
+            }
+        }
+
+        return $this->buildTextResponse($schema, $finalOutput, $totalUsage, $meta, $responseMessages, $steps, $allToolCalls, $allToolResults);
+    }
+
+    /**
+     * Generate text using the COHERE chat format (cohere.command-* models).
+     */
+    protected function generateCohereText(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+    ): TextResponse {
+        $state = $this->buildCohereState($messages, $instructions);
+        $maxSteps = $this->resolveMaxSteps($tools, $options);
+        $schemaTool = $schema ? $this->buildCohereSchemaTool($schema) : null;
+        $formattedTools = $schemaTool === null && ! empty($tools) ? $this->formatCohereTools($tools) : null;
+
+        $allToolCalls = [];
+        $allToolResults = [];
+        $finalOutput = '';
+        $totalUsage = new Usage;
+        $step = 0;
+        $pendingToolResults = [];
+        $responseMessages = new Collection;
+        $steps = new Collection;
+        $meta = new Meta($provider->name(), $model);
+
+        while ($step < $maxSteps) {
+            $chatRequest = $this->buildCohereChatRequest(
+                $state, $formattedTools, $schemaTool, $options, $pendingToolResults,
+            );
+
+            $parsed = $this->parseCohereResponse($this->postChat($provider, $model, $chatRequest, $timeout));
+
+            $totalUsage = $totalUsage->add($parsed['usage']);
+
+            [$toolCalls, $structured] = $this->extractStructuredToolCall($parsed['toolCalls'], $schemaTool !== null);
+
+            if ($structured !== null) {
+                $finalOutput = $structured;
+            } elseif (! $schemaTool) {
+                $finalOutput = $parsed['text'];
+            }
+
+            $step++;
+            $finishReason = $parsed['finishReason'];
+
+            $responseMessages->push(new AssistantMessage($parsed['text'], new Collection($toolCalls)));
+
+            if (empty($toolCalls)) {
+                $steps->push(new Step($parsed['text'], $toolCalls, [], $finishReason, $parsed['usage'], $meta));
+
+                break;
+            }
+
+            $allToolCalls = array_merge($allToolCalls, $toolCalls);
+
+            if ($parsed['text'] !== '') {
+                $state['chatHistory'][] = ['role' => 'CHATBOT', 'message' => $parsed['text']];
+            }
+
+            $toolResults = $this->executeToolCalls($tools, $toolCalls);
+            $allToolResults = array_merge($allToolResults, $toolResults);
+            $pendingToolResults = array_merge($pendingToolResults, $this->buildCohereToolResults($toolResults));
+
+            $steps->push(new Step($parsed['text'], $toolCalls, $toolResults, $finishReason, $parsed['usage'], $meta));
+
+            if (! empty($toolResults)) {
+                $responseMessages->push(new ToolResultMessage(new Collection($toolResults)));
+            }
+        }
+
+        return $this->buildTextResponse($schema, $finalOutput, $totalUsage, $meta, $responseMessages, $steps, $allToolCalls, $allToolResults);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function streamText(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+        ?TextGenerationOptions $options = null,
+        ?int $timeout = null,
+    ): Generator {
+        $cohere = $this->isCohereModel($model);
+
+        $chatRequest = $cohere
+            ? $this->buildCohereChatRequest(
+                $this->buildCohereState($messages, $instructions),
+                empty($tools) ? null : $this->formatCohereTools($tools),
+                null, $options, [], isStream: true,
+            )
+            : $this->buildGenericChatRequest(
+                $this->buildGenericMessages($messages, $instructions),
+                null, empty($tools) ? null : $this->formatGenericTools($tools),
+                empty($tools), $options, true, isStream: true,
+            );
+
+        try {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)
+                    ->withOptions(['stream' => true])
+                    ->post(self::API_VERSION.'/actions/chat', $this->buildChatDetails($provider, $model, $chatRequest)),
+            );
+        } catch (Throwable $e) {
+            throw OracleException::toAiException($e, $provider->name(), $model);
+        }
+
+        $messageId = (string) Str::uuid();
+        $timestamp = time();
+
+        yield (new StreamStart((string) Str::uuid(), $provider->name(), $model, $timestamp))
+            ->withInvocationId($invocationId);
+
+        $textStarted = false;
+        $pendingToolCalls = [];
+        $usage = new Usage;
+        $finishReason = 'stop';
+
+        foreach ($this->parseServerSentEvents($response->getBody()) as $event) {
+            if ($delta = $this->streamTextDelta($event)) {
+                if (! $textStarted) {
+                    $textStarted = true;
+
+                    yield (new TextStart((string) Str::uuid(), $messageId, $timestamp))->withInvocationId($invocationId);
+                }
+
+                yield (new TextDelta((string) Str::uuid(), $messageId, $delta, $timestamp))->withInvocationId($invocationId);
+            }
+
+            $this->accumulateStreamToolCalls($event, $pendingToolCalls);
+
+            if ($extracted = $this->streamUsage($event)) {
+                $usage = $extracted;
+            }
+
+            if ($reason = $this->streamFinishReason($event)) {
+                $finishReason = $reason;
+            }
+        }
+
+        if ($textStarted) {
+            yield (new TextEnd((string) Str::uuid(), $messageId, $timestamp))->withInvocationId($invocationId);
+        }
+
+        $toolCalls = $this->finalizeStreamToolCalls($pendingToolCalls);
+
+        if (! empty($toolCalls)) {
+            foreach ($toolCalls as $toolCall) {
+                yield (new ToolCallEvent((string) Str::uuid(), $toolCall, $timestamp))->withInvocationId($invocationId);
+            }
+
+            foreach ($this->executeToolCalls($tools, $toolCalls) as $toolResult) {
+                yield (new ToolResultEvent((string) Str::uuid(), $toolResult, true, null, $timestamp))->withInvocationId($invocationId);
+            }
+        }
+
+        yield (new StreamEnd($messageId, $finishReason, $usage, $timestamp))->withInvocationId($invocationId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): EmbeddingsResponse {
+        $embeddings = [];
+        $totalTokens = 0;
+
+        foreach (array_chunk(array_values($inputs), self::EMBED_BATCH_SIZE) as $batch) {
+            $payload = array_merge([
+                'inputType' => 'SEARCH_DOCUMENT',
+                'truncate' => 'END',
+            ], $providerOptions, [
+                ...$this->servingPayload($provider, $model),
+                'inputs' => $batch,
+            ]);
+
+            try {
+                $response = $this->withErrorHandling(
+                    $provider->name(),
+                    fn () => $this->client($provider, $timeout)->post(self::API_VERSION.'/actions/embedText', $payload),
+                );
+
+                $data = $response->json();
+            } catch (Throwable $e) {
+                throw OracleException::toAiException($e, $provider->name(), $model);
+            }
+
+            $embeddings = array_merge($embeddings, $data['embeddings'] ?? []);
+            $totalTokens += $data['usage']['totalTokens'] ?? 0;
+        }
+
+        return new EmbeddingsResponse($embeddings, $totalTokens, new Meta($provider->name(), $model));
+    }
+
+    /**
+     * Build the GenericChatRequest body.
+     *
+     * @param  array<int, array<string, mixed>>  $messages
+     * @param  array<int, array<string, mixed>>|null  $schemaTools
+     * @param  array<int, array<string, mixed>>|null  $formattedTools
+     * @return array<string, mixed>
+     */
+    protected function buildGenericChatRequest(
+        array $messages,
+        ?array $schemaTools,
+        ?array $formattedTools,
+        bool $toolsEmpty,
+        ?TextGenerationOptions $options,
+        bool $isFinalStep,
+        bool $isStream = false,
+    ): array {
+        $request = array_merge([
+            'apiFormat' => 'GENERIC',
+            'messages' => $messages,
+        ], $this->buildInferenceFields($options));
+
+        if ($schemaTools !== null) {
+            $request['tools'] = $schemaTools;
+            $request['toolChoice'] = ($isFinalStep || $toolsEmpty)
+                ? ['type' => 'FUNCTION', 'function' => ['name' => self::STRUCTURED_OUTPUT_TOOL]]
+                : 'AUTO';
+        } elseif ($formattedTools !== null) {
+            $request['tools'] = $formattedTools;
+        }
+
+        if ($isStream) {
+            $request['isStream'] = true;
+        }
+
+        return $this->mergeProviderOptions($request, $options);
+    }
+
+    /**
+     * Build the CohereChatRequest body.
+     *
+     * @param  array{message: string, chatHistory: array<int, array<string, string>>, preamble: ?string}  $state
+     * @param  array<int, array<string, mixed>>|null  $formattedTools
+     * @param  array<int, array<string, mixed>>|null  $schemaTool
+     * @param  array<int, array<string, mixed>>  $toolResults
+     * @return array<string, mixed>
+     */
+    protected function buildCohereChatRequest(
+        array $state,
+        ?array $formattedTools,
+        ?array $schemaTool,
+        ?TextGenerationOptions $options,
+        array $toolResults = [],
+        bool $isStream = false,
+    ): array {
+        $request = array_merge([
+            'apiFormat' => 'COHERE',
+            'message' => $state['message'],
+        ], $this->buildInferenceFields($options));
+
+        if ($state['preamble'] !== null) {
+            $request['preambleOverride'] = $state['preamble'];
+        }
+
+        if (! empty($state['chatHistory'])) {
+            $request['chatHistory'] = $state['chatHistory'];
+        }
+
+        if ($schemaTool !== null) {
+            $request['tools'] = $schemaTool;
+            $request['isForceSingleStep'] = true;
+        } elseif ($formattedTools !== null) {
+            $request['tools'] = $formattedTools;
+        }
+
+        if (! empty($toolResults)) {
+            $request['toolResults'] = $toolResults;
+        }
+
+        if ($isStream) {
+            $request['isStream'] = true;
+        }
+
+        return $this->mergeProviderOptions($request, $options);
+    }
+
+    /**
+     * Wrap a chatRequest in the OCI ChatDetails envelope (compartment + serving mode).
+     *
+     * @param  array<string, mixed>  $chatRequest
+     * @return array<string, mixed>
+     */
+    protected function buildChatDetails(TextProvider $provider, string $model, array $chatRequest): array
+    {
+        return array_filter([
+            ...$this->servingPayload($provider, $model),
+            'chatRequest' => $chatRequest,
+        ], fn ($value) => $value !== null);
+    }
+
+    /**
+     * Build the shared compartmentId + servingMode payload for chat and embedding requests.
+     *
+     * @return array<string, mixed>
+     */
+    protected function servingPayload(TextProvider|EmbeddingProvider $provider, string $model): array
+    {
+        $config = $provider->additionalConfiguration();
+
+        $servingMode = ($config['serving_type'] ?? 'ON_DEMAND') === 'DEDICATED' && ! empty($config['endpoint_id'])
+            ? ['servingType' => 'DEDICATED', 'endpointId' => $config['endpoint_id']]
+            : ['servingType' => 'ON_DEMAND', 'modelId' => $model];
+
+        return [
+            'compartmentId' => $config['compartment_id'] ?? null,
+            'servingMode' => $servingMode,
+        ];
+    }
+
+    /**
+     * Build the shared inference fields (maxTokens / temperature / topP).
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildInferenceFields(?TextGenerationOptions $options): array
+    {
+        if ($options === null) {
+            return [];
+        }
+
+        return Arr::whereNotNull([
+            'maxTokens' => $options->maxTokens,
+            'temperature' => $options->temperature,
+            'topP' => $options->topP,
+        ]);
+    }
+
+    /**
+     * Merge the agent's Oracle provider options into the chat request.
+     *
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     */
+    protected function mergeProviderOptions(array $request, ?TextGenerationOptions $options): array
+    {
+        $providerOptions = $options?->providerOptions(Lab::Oracle);
+
+        return empty($providerOptions) ? $request : array_merge($request, $providerOptions);
+    }
+
+    /**
+     * Send a chat request and return the inner chatResponse payload.
+     *
+     * @param  array<string, mixed>  $chatRequest
+     * @return array<string, mixed>
+     */
+    protected function postChat(TextProvider $provider, string $model, array $chatRequest, ?int $timeout): array
+    {
+        try {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)->post(
+                    self::API_VERSION.'/actions/chat',
+                    $this->buildChatDetails($provider, $model, $chatRequest),
+                ),
+            );
+
+            return $response->json('chatResponse', []);
+        } catch (Throwable $e) {
+            throw OracleException::toAiException($e, $provider->name(), $model);
+        }
+    }
+
+    /**
+     * Split out the synthetic structured-output tool call from the real tool calls.
+     *
+     * @param  array<ToolCall>  $toolCalls
+     * @return array{0: array<ToolCall>, 1: ?string}
+     */
+    protected function extractStructuredToolCall(array $toolCalls, bool $hasSchema): array
+    {
+        if (! $hasSchema) {
+            return [$toolCalls, null];
+        }
+
+        $structured = null;
+        $remaining = [];
+
+        foreach ($toolCalls as $toolCall) {
+            if ($toolCall->name === self::STRUCTURED_OUTPUT_TOOL) {
+                $structured = json_encode($toolCall->arguments ?: []);
+
+                continue;
+            }
+
+            $remaining[] = $toolCall;
+        }
+
+        return [$remaining, $structured];
+    }
+
+    /**
+     * Build the final text or structured response.
+     *
+     * @param  array<string, mixed>|null  $schema
+     * @param  array<ToolCall>  $allToolCalls
+     * @param  array<ToolResult>  $allToolResults
+     */
+    protected function buildTextResponse(
+        ?array $schema,
+        string $finalOutput,
+        Usage $totalUsage,
+        Meta $meta,
+        Collection $responseMessages,
+        Collection $steps,
+        array $allToolCalls,
+        array $allToolResults,
+    ): TextResponse {
+        if ($schema) {
+            $structured = json_decode($finalOutput, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $structured = [];
+            }
+
+            return (new StructuredTextResponse($structured, $finalOutput, $totalUsage, $meta))
+                ->withToolCallsAndResults(new Collection($allToolCalls), new Collection($allToolResults))
+                ->withSteps($steps);
+        }
+
+        return (new TextResponse($finalOutput, $totalUsage, $meta))
+            ->withMessages($responseMessages)
+            ->withSteps($steps);
+    }
+
+    /**
+     * Resolve the maximum number of steps for the given tools and options.
+     *
+     * @param  array<Tool>  $tools
+     */
+    protected function resolveMaxSteps(array $tools, ?TextGenerationOptions $options): int
+    {
+        if (empty($tools)) {
+            return 1;
+        }
+
+        return (int) ($options?->maxSteps ?? round(count($tools) * 1.5));
+    }
+
+    /**
+     * Extract an incremental text delta from a streaming event (defensive across both families).
+     *
+     * @param  array<string, mixed>  $event
+     */
+    protected function streamTextDelta(array $event): string
+    {
+        if (isset($event['text']) && is_string($event['text'])) {
+            return $event['text'];
+        }
+
+        $delta = '';
+
+        foreach ($event['message']['content'] ?? [] as $part) {
+            if (isset($part['text'])) {
+                $delta .= $part['text'];
+            }
+        }
+
+        return $delta;
+    }
+
+    /**
+     * Accumulate streamed tool-call fragments by index across both families.
+     *
+     * @param  array<string, mixed>  $event
+     * @param  array<int, array{id: string, name: string, arguments: string}>  $pending
+     */
+    protected function accumulateStreamToolCalls(array $event, array &$pending): void
+    {
+        $calls = $event['toolCalls'] ?? $event['message']['toolCalls'] ?? [];
+
+        foreach ($calls as $index => $call) {
+            $index = $call['index'] ?? $index;
+
+            $pending[$index] ??= ['id' => '', 'name' => '', 'arguments' => ''];
+
+            if (! empty($call['id'])) {
+                $pending[$index]['id'] = $call['id'];
+            }
+
+            if (! empty($call['name'])) {
+                $pending[$index]['name'] = $call['name'];
+            }
+
+            $arguments = $call['arguments'] ?? $call['parameters'] ?? null;
+
+            if (is_array($arguments)) {
+                $pending[$index]['arguments'] = json_encode($arguments);
+            } elseif (is_string($arguments)) {
+                $pending[$index]['arguments'] .= $arguments;
+            }
+        }
+    }
+
+    /**
+     * Convert accumulated streaming tool-call fragments into ToolCall objects.
+     *
+     * @param  array<int, array{id: string, name: string, arguments: string}>  $pending
+     * @return array<ToolCall>
+     */
+    protected function finalizeStreamToolCalls(array $pending): array
+    {
+        $toolCalls = [];
+
+        foreach ($pending as $call) {
+            if ($call['name'] === '') {
+                continue;
+            }
+
+            $toolCalls[] = new ToolCall(
+                $call['id'] !== '' ? $call['id'] : (string) Str::uuid(),
+                $call['name'],
+                $this->decodeArguments($call['arguments']),
+            );
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * Extract token usage from a streaming event, if present.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    protected function streamUsage(array $event): ?Usage
+    {
+        if (! isset($event['usage'])) {
+            return null;
+        }
+
+        return new Usage(
+            promptTokens: $event['usage']['promptTokens'] ?? 0,
+            completionTokens: $event['usage']['completionTokens'] ?? 0,
+        );
+    }
+
+    /**
+     * Extract the mapped finish reason from a streaming event, if present.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    protected function streamFinishReason(array $event): ?string
+    {
+        if (empty($event['finishReason'])) {
+            return null;
+        }
+
+        $reason = $this->isCohereFinishReason($event['finishReason'])
+            ? $this->cohereFinishReason($event['finishReason'])
+            : $this->genericFinishReason($event['finishReason']);
+
+        return $reason->value;
+    }
+
+    /**
+     * Determine whether a streamed finish reason uses the Cohere (uppercase) vocabulary.
+     */
+    protected function isCohereFinishReason(string $reason): bool
+    {
+        return in_array(strtoupper($reason), ['COMPLETE', 'MAX_TOKENS', 'ERROR_TOXIC', 'ERROR_LIMIT', 'USER_CANCEL'], true);
+    }
+
+    /**
+     * Execute the tool calls against the provided tools and collect results.
+     *
+     * @param  array<Tool>  $tools
+     * @param  array<ToolCall>  $toolCalls
+     * @return array<ToolResult>
+     */
+    protected function executeToolCalls(array $tools, array $toolCalls): array
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                $results[] = new ToolResult(
+                    $toolCall->id,
+                    $toolCall->name,
+                    $toolCall->arguments,
+                    'Error: Tool "'.$toolCall->name.'" not found.',
+                );
+
+                continue;
+            }
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $this->executeTool($tool, $toolCall->arguments),
+            );
+        }
+
+        return $results;
+    }
+}

--- a/src/Gateway/Oracle/OracleTextGateway.php
+++ b/src/Gateway/Oracle/OracleTextGateway.php
@@ -58,7 +58,10 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
     protected const API_VERSION = '20231130';
 
     /**
-     * The maximum number of inputs OCI accepts per embedText call.
+     * The number of inputs sent per embedText call.
+     *
+     * The API constraint is per-input token length rather than a fixed array bound, but the
+     * OCI console caps batches at 96 inputs; we mirror that as a safe client-side batch size.
      */
     protected const EMBED_BATCH_SIZE = 96;
 
@@ -394,14 +397,15 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
         if ($schemaTools !== null) {
             $request['tools'] = $schemaTools;
             $request['toolChoice'] = ($isFinalStep || $toolsEmpty)
-                ? ['type' => 'FUNCTION', 'function' => ['name' => self::STRUCTURED_OUTPUT_TOOL]]
-                : 'AUTO';
+                ? ['type' => 'FUNCTION', 'name' => self::STRUCTURED_OUTPUT_TOOL]
+                : ['type' => 'AUTO'];
         } elseif ($formattedTools !== null) {
             $request['tools'] = $formattedTools;
         }
 
         if ($isStream) {
             $request['isStream'] = true;
+            $request['streamOptions'] = ['isIncludeUsage' => true];
         }
 
         return $this->mergeProviderOptions($request, $options);
@@ -450,6 +454,7 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
 
         if ($isStream) {
             $request['isStream'] = true;
+            $request['streamOptions'] = ['isIncludeUsage' => true];
         }
 
         return $this->mergeProviderOptions($request, $options);

--- a/src/Gateway/Oracle/OracleTextGateway.php
+++ b/src/Gateway/Oracle/OracleTextGateway.php
@@ -518,7 +518,20 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
     }
 
     /**
+     * The structural chat-request keys that agent provider options may not override.
+     *
+     * @var list<string>
+     */
+    protected const RESERVED_REQUEST_KEYS = [
+        'apiFormat', 'messages', 'message', 'chatHistory', 'preambleOverride',
+        'tools', 'toolChoice', 'toolResults', 'isForceSingleStep', 'isStream', 'streamOptions',
+    ];
+
+    /**
      * Merge the agent's Oracle provider options into the chat request.
+     *
+     * Reserved structural keys are stripped first so provider options can only tune inference
+     * parameters (penalties, seed, etc.) and never break request invariants.
      *
      * @param  array<string, mixed>  $request
      * @return array<string, mixed>
@@ -527,7 +540,13 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
     {
         $providerOptions = $options?->providerOptions(Lab::Oracle);
 
-        return empty($providerOptions) ? $request : array_merge($request, $providerOptions);
+        if (empty($providerOptions)) {
+            return $request;
+        }
+
+        $providerOptions = array_diff_key($providerOptions, array_flip(self::RESERVED_REQUEST_KEYS));
+
+        return array_merge($request, $providerOptions);
     }
 
     /**
@@ -676,8 +695,8 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
 
             $arguments = $call['arguments'] ?? $call['parameters'] ?? null;
 
-            if (is_array($arguments)) {
-                $pending[$index]['arguments'] = json_encode($arguments);
+            if (is_array($arguments) || is_object($arguments)) {
+                $pending[$index]['arguments'] = (string) json_encode($arguments);
             } elseif (is_string($arguments)) {
                 $pending[$index]['arguments'] .= $arguments;
             }

--- a/src/Gateway/Oracle/OracleTextGateway.php
+++ b/src/Gateway/Oracle/OracleTextGateway.php
@@ -289,10 +289,11 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
             throw OracleException::toAiException($e, $provider->name(), $model);
         }
 
+        $streamId = (string) Str::uuid();
         $messageId = (string) Str::uuid();
         $timestamp = time();
 
-        yield (new StreamStart((string) Str::uuid(), $provider->name(), $model, $timestamp))
+        yield (new StreamStart($streamId, $provider->name(), $model, $timestamp))
             ->withInvocationId($invocationId);
 
         $textStarted = false;
@@ -338,7 +339,7 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
             }
         }
 
-        yield (new StreamEnd($messageId, $finishReason, $usage, $timestamp))->withInvocationId($invocationId);
+        yield (new StreamEnd($streamId, $finishReason, $usage, $timestamp))->withInvocationId($invocationId);
     }
 
     /**
@@ -768,7 +769,7 @@ class OracleTextGateway implements EmbeddingGateway, TextGateway
      */
     protected function isCohereFinishReason(string $reason): bool
     {
-        return in_array(strtoupper($reason), ['COMPLETE', 'MAX_TOKENS', 'ERROR_TOXIC', 'ERROR_LIMIT', 'USER_CANCEL'], true);
+        return in_array(strtoupper($reason), ['COMPLETE', 'MAX_TOKENS', 'ERROR', 'ERROR_TOXIC', 'ERROR_LIMIT', 'USER_CANCEL'], true);
     }
 
     /**

--- a/src/Providers/OracleProvider.php
+++ b/src/Providers/OracleProvider.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Oracle\OracleTextGateway;
+
+class OracleProvider extends Provider implements EmbeddingProvider, TextProvider
+{
+    use Concerns\GeneratesEmbeddings;
+    use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
+    use Concerns\HasTextGateway;
+    use Concerns\StreamsText;
+
+    public function __construct(
+        protected array $config,
+        protected Dispatcher $events
+    ) {}
+
+    /**
+     * Get the credentials for the underlying AI provider.
+     */
+    public function providerCredentials(): array
+    {
+        return array_filter([
+            'tenancy_id' => $this->config['tenancy_id'] ?? null,
+            'user_id' => $this->config['user_id'] ?? null,
+            'fingerprint' => $this->config['fingerprint'] ?? null,
+            'private_key' => $this->config['private_key'] ?? null,
+            'private_key_path' => $this->config['private_key_path'] ?? null,
+            'passphrase' => $this->config['passphrase'] ?? null,
+        ]);
+    }
+
+    /**
+     * Get the provider connection configuration other than the driver, key, and name.
+     */
+    public function additionalConfiguration(): array
+    {
+        return array_filter([
+            'region' => $this->config['region'] ?? 'us-chicago-1',
+            'compartment_id' => $this->config['compartment_id'] ?? null,
+            'serving_type' => $this->config['serving_type'] ?? 'ON_DEMAND',
+            'endpoint_id' => $this->config['endpoint_id'] ?? null,
+            'url' => $this->config['url'] ?? null,
+        ], fn ($value) => $value !== null);
+    }
+
+    /**
+     * Get the name of the default text model.
+     */
+    public function defaultTextModel(): string
+    {
+        return $this->config['models']['text']['default'] ?? 'cohere.command-a-03-2025';
+    }
+
+    /**
+     * Get the name of the cheapest text model.
+     */
+    public function cheapestTextModel(): string
+    {
+        return $this->config['models']['text']['cheapest'] ?? 'cohere.command-r-08-2024';
+    }
+
+    /**
+     * Get the name of the smartest text model.
+     */
+    public function smartestTextModel(): string
+    {
+        return $this->config['models']['text']['smartest'] ?? 'cohere.command-a-03-2025';
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['models']['embeddings']['default'] ?? 'cohere.embed-multilingual-v3.0';
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return $this->config['models']['embeddings']['dimensions'] ?? 1024;
+    }
+
+    /**
+     * Get the provider's text gateway.
+     */
+    public function textGateway(): TextGateway
+    {
+        return $this->textGateway ??= new OracleTextGateway;
+    }
+
+    /**
+     * Get the provider's embedding gateway.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ??= new OracleTextGateway;
+    }
+}

--- a/tests/Feature/Providers/Oracle/BaseUrlTest.php
+++ b/tests/Feature/Providers/Oracle/BaseUrlTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+beforeEach(fn () => $this->configureOracle());
+
+test('oracle requests build the regional inference endpoint from the configured region', function () {
+    config(['ai.providers.oracle.region' => 'eu-frankfurt-1', 'ai.providers.oracle.url' => null]);
+
+    Http::fake([
+        'inference.generativeai.eu-frankfurt-1.oci.oraclecloud.com/*' => $this->fakeCohereTextResponse(),
+    ]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'oracle', model: 'cohere.command-a-03-2025');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'inference.generativeai.eu-frankfurt-1.oci.oraclecloud.com'));
+});
+
+test('oracle requests use an explicit url override when configured', function () {
+    config(['ai.providers.oracle.url' => 'https://custom-proxy.example.com']);
+
+    Http::fake([
+        'custom-proxy.example.com/*' => $this->fakeCohereTextResponse(),
+    ]);
+
+    (new AssistantAgent)->prompt('Hi', provider: 'oracle', model: 'cohere.command-a-03-2025');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'https://custom-proxy.example.com'));
+});

--- a/tests/Feature/Providers/Oracle/EmbeddingTest.php
+++ b/tests/Feature/Providers/Oracle/EmbeddingTest.php
@@ -29,6 +29,20 @@ test('embeddings target the embedText action and map the response vectors', func
     });
 });
 
+test('v3 embedding models omit outputDimensions but v4 models forward it', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeEmbeddingsResponse(),
+    ]);
+
+    Embeddings::for(['text'])->dimensions(1024)->generate(provider: 'oracle', model: 'cohere.embed-multilingual-v3.0');
+
+    Http::assertSent(fn ($request) => ! array_key_exists('outputDimensions', $request->data()));
+
+    Embeddings::for(['text'])->dimensions(512)->generate(provider: 'oracle', model: 'cohere.embed-v4.0');
+
+    Http::assertSent(fn ($request) => ($request->data()['outputDimensions'] ?? null) === 512);
+});
+
 test('embeddings forward provider options such as inputType', function () {
     Http::fake([
         'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeEmbeddingsResponse(),

--- a/tests/Feature/Providers/Oracle/EmbeddingTest.php
+++ b/tests/Feature/Providers/Oracle/EmbeddingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+beforeEach(fn () => $this->configureOracle());
+
+test('embeddings target the embedText action and map the response vectors', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeEmbeddingsResponse([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]),
+    ]);
+
+    $response = Embeddings::for(['first text', 'second text'])
+        ->dimensions(1024)
+        ->generate(provider: 'oracle', model: 'cohere.embed-multilingual-v3.0');
+
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->first())->toEqual([0.1, 0.2, 0.3])
+        ->and($response->tokens)->toBe(4);
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return str_contains($request->url(), '20231130/actions/embedText')
+            && $body['servingMode']['modelId'] === 'cohere.embed-multilingual-v3.0'
+            && $body['inputs'] === ['first text', 'second text']
+            && $body['inputType'] === 'SEARCH_DOCUMENT'
+            && $body['truncate'] === 'END';
+    });
+});
+
+test('embeddings forward provider options such as inputType', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeEmbeddingsResponse(),
+    ]);
+
+    Embeddings::for(['query text'])
+        ->dimensions(1024)
+        ->providerOptions(['inputType' => 'SEARCH_QUERY'])
+        ->generate(provider: 'oracle', model: 'cohere.embed-multilingual-v3.0');
+
+    Http::assertSent(fn ($request) => $request->data()['inputType'] === 'SEARCH_QUERY');
+});

--- a/tests/Feature/Providers/Oracle/OracleHelpers.php
+++ b/tests/Feature/Providers/Oracle/OracleHelpers.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\Providers\Oracle;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+trait OracleHelpers
+{
+    /**
+     * Configure the Oracle provider with a freshly generated signing key so requests can be signed.
+     */
+    protected function configureOracle(): void
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+
+        openssl_pkey_export($key, $pem);
+
+        config([
+            'ai.providers.oracle.tenancy_id' => 'ocid1.tenancy.oc1..test',
+            'ai.providers.oracle.user_id' => 'ocid1.user.oc1..test',
+            'ai.providers.oracle.fingerprint' => 'aa:bb:cc:dd',
+            'ai.providers.oracle.private_key' => $pem,
+            'ai.providers.oracle.private_key_path' => null,
+            'ai.providers.oracle.compartment_id' => 'ocid1.compartment.oc1..test',
+            'ai.providers.oracle.region' => 'us-chicago-1',
+            'ai.providers.oracle.url' => null,
+        ]);
+    }
+
+    protected function fakeCohereTextResponse(string $text = 'Hello', string $model = 'cohere.command-a-03-2025'): PromiseInterface
+    {
+        return Http::response([
+            'modelId' => $model,
+            'modelVersion' => '1.0',
+            'chatResponse' => [
+                'apiFormat' => 'COHERE',
+                'text' => $text,
+                'finishReason' => 'COMPLETE',
+                'chatHistory' => [],
+                'usage' => ['promptTokens' => 10, 'completionTokens' => 5, 'totalTokens' => 15],
+            ],
+        ]);
+    }
+
+    protected function fakeGenericTextResponse(string $text = 'Hello', string $model = 'meta.llama-3.3-70b-instruct'): PromiseInterface
+    {
+        return Http::response([
+            'modelId' => $model,
+            'modelVersion' => '1.0',
+            'chatResponse' => [
+                'apiFormat' => 'GENERIC',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'ASSISTANT',
+                        'content' => [['type' => 'TEXT', 'text' => $text]],
+                    ],
+                    'finishReason' => 'stop',
+                ]],
+                'usage' => ['promptTokens' => 10, 'completionTokens' => 5, 'totalTokens' => 15],
+            ],
+        ]);
+    }
+
+    protected function fakeCohereToolCallResponse(string $toolName = 'FixedNumberGenerator', array $parameters = []): PromiseInterface
+    {
+        return Http::response([
+            'modelId' => 'cohere.command-a-03-2025',
+            'chatResponse' => [
+                'apiFormat' => 'COHERE',
+                'text' => '',
+                'finishReason' => 'COMPLETE',
+                'toolCalls' => [['name' => $toolName, 'parameters' => (object) $parameters]],
+                'usage' => ['promptTokens' => 10, 'completionTokens' => 5],
+            ],
+        ]);
+    }
+
+    protected function fakeGenericToolCallResponse(string $toolName = 'FixedNumberGenerator', array $arguments = []): PromiseInterface
+    {
+        return Http::response([
+            'modelId' => 'meta.llama-3.3-70b-instruct',
+            'chatResponse' => [
+                'apiFormat' => 'GENERIC',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'ASSISTANT',
+                        'content' => [],
+                        'toolCalls' => [[
+                            'id' => 'call_1',
+                            'type' => 'FUNCTION',
+                            'name' => $toolName,
+                            'arguments' => json_encode($arguments ?: (object) []),
+                        ]],
+                    ],
+                    'finishReason' => 'tool_calls',
+                ]],
+                'usage' => ['promptTokens' => 10, 'completionTokens' => 5],
+            ],
+        ]);
+    }
+
+    protected function fakeEmbeddingsResponse(array $embeddings = [[0.1, 0.2, 0.3]]): PromiseInterface
+    {
+        return Http::response([
+            'embeddings' => $embeddings,
+            'modelId' => 'cohere.embed-multilingual-v3.0',
+            'modelVersion' => '3.0',
+            'usage' => ['promptTokens' => 4, 'totalTokens' => 4],
+        ]);
+    }
+
+    /**
+     * Collect the events emitted by streaming an agent against the Oracle provider.
+     */
+    protected function collectStreamEvents(?object $agent = null, string $model = 'cohere.command-a-03-2025'): array
+    {
+        $agent ??= new AssistantAgent;
+
+        $events = [];
+
+        foreach ($agent->stream('Hello', provider: 'oracle', model: $model) as $event) {
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    /**
+     * Build an SSE response body from a list of event payloads.
+     */
+    protected function ssePayload(array $events): string
+    {
+        $lines = [];
+
+        foreach ($events as $event) {
+            $lines[] = 'data: '.json_encode($event);
+        }
+
+        return implode("\n\n", $lines)."\n\n";
+    }
+}

--- a/tests/Feature/Providers/Oracle/RequestMappingTest.php
+++ b/tests/Feature/Providers/Oracle/RequestMappingTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\OracleAgent;
+
+beforeEach(fn () => $this->configureOracle());
+
+test('cohere chat requests target the chat action with the COHERE api format', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeCohereTextResponse('Laravel is great'),
+    ]);
+
+    $response = (new AssistantAgent)->prompt('What is Laravel?', provider: 'oracle', model: 'cohere.command-a-03-2025');
+
+    expect((string) $response)->toBe('Laravel is great');
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return str_contains($request->url(), '20231130/actions/chat')
+            && $body['servingMode']['modelId'] === 'cohere.command-a-03-2025'
+            && $body['servingMode']['servingType'] === 'ON_DEMAND'
+            && $body['compartmentId'] === 'ocid1.compartment.oc1..test'
+            && $body['chatRequest']['apiFormat'] === 'COHERE'
+            && $body['chatRequest']['message'] === 'What is Laravel?'
+            && $body['chatRequest']['preambleOverride'] === 'You are a helpful assistant that responds extremely concisely to all queries.';
+    });
+});
+
+test('generic chat requests use the GENERIC api format and message content parts', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeGenericTextResponse('Llama says hi'),
+    ]);
+
+    $response = (new AssistantAgent)->prompt('Hello there', provider: 'oracle', model: 'meta.llama-3.3-70b-instruct');
+
+    expect((string) $response)->toBe('Llama says hi');
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return $body['chatRequest']['apiFormat'] === 'GENERIC'
+            && $body['servingMode']['modelId'] === 'meta.llama-3.3-70b-instruct'
+            && $body['chatRequest']['messages'][0]['role'] === 'SYSTEM'
+            && $body['chatRequest']['messages'][1]['role'] === 'USER'
+            && $body['chatRequest']['messages'][1]['content'][0]['text'] === 'Hello there';
+    });
+});
+
+test('requests are signed with the OCI HTTP signature scheme', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeCohereTextResponse(),
+    ]);
+
+    (new OracleAgent)->prompt('Hi');
+
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('Authorization')
+            && str_contains($request->header('Authorization')[0], 'Signature version="1"')
+            && str_contains($request->header('Authorization')[0], 'algorithm="rsa-sha256"')
+            && $request->hasHeader('x-content-sha256')
+            && $request->hasHeader('date');
+    });
+});
+
+test('the model attribute on the agent selects the model', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeCohereTextResponse(),
+    ]);
+
+    (new OracleAgent)->prompt('Hi');
+
+    Http::assertSent(fn ($request) => $request->data()['servingMode']['modelId'] === 'cohere.command-a-03-2025');
+});
+
+test('token usage is mapped from the OCI usage block', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => $this->fakeCohereTextResponse(),
+    ]);
+
+    $response = (new AssistantAgent)->prompt('Hi', provider: 'oracle', model: 'cohere.command-a-03-2025');
+
+    expect($response->usage->promptTokens)->toBe(10)
+        ->and($response->usage->completionTokens)->toBe(5);
+});

--- a/tests/Feature/Providers/Oracle/StreamingTest.php
+++ b/tests/Feature/Providers/Oracle/StreamingTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+
+beforeEach(fn () => $this->configureOracle());
+
+test('cohere streaming emits text events', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['text' => 'Hello'],
+                ['text' => ' world'],
+                ['finishReason' => 'COMPLETE', 'usage' => ['promptTokens' => 10, 'completionTokens' => 5]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents(model: 'cohere.command-a-03-2025');
+
+    expect($events[0])->toBeInstanceOf(StreamStart::class)
+        ->and($events[1])->toBeInstanceOf(TextStart::class)
+        ->and($events[2])->toBeInstanceOf(TextDelta::class)->delta->toBe('Hello')
+        ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
+        ->and($events[count($events) - 2])->toBeInstanceOf(TextEnd::class)
+        ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
+
+    expect($events[count($events) - 1]->usage->promptTokens)->toBe(10);
+});
+
+test('generic streaming emits text events from content part deltas', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['message' => ['content' => [['type' => 'TEXT', 'text' => 'Hi']]]],
+                ['message' => ['content' => [['type' => 'TEXT', 'text' => ' there']]]],
+                ['finishReason' => 'stop', 'usage' => ['promptTokens' => 8, 'completionTokens' => 3]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents(model: 'meta.llama-3.3-70b-instruct');
+
+    $deltas = array_values(array_filter($events, fn ($e) => $e instanceof TextDelta));
+
+    expect($deltas[0]->delta)->toBe('Hi')
+        ->and($deltas[1]->delta)->toBe(' there')
+        ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming requests set isStream on the chat request', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response(
+            body: $this->ssePayload([['text' => 'Hello'], ['finishReason' => 'COMPLETE']]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $this->collectStreamEvents(model: 'cohere.command-a-03-2025');
+
+    Http::assertSent(fn ($request) => ($request->data()['chatRequest']['isStream'] ?? false) === true);
+});

--- a/tests/Feature/Providers/Oracle/StreamingTest.php
+++ b/tests/Feature/Providers/Oracle/StreamingTest.php
@@ -56,6 +56,38 @@ test('generic streaming emits text events from content part deltas', function ()
         ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
 });
 
+test('stream start and end share the same id', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response(
+            body: $this->ssePayload([['text' => 'Hi'], ['finishReason' => 'COMPLETE']]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents(model: 'cohere.command-a-03-2025');
+
+    $start = array_values(array_filter($events, fn ($e) => $e instanceof StreamStart))[0];
+    $end = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+    expect($end->id)->toBe($start->id);
+});
+
+test('cohere ERROR finish reason maps to the error reason on stream end', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response(
+            body: $this->ssePayload([['text' => 'partial'], ['finishReason' => 'ERROR']]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents(model: 'cohere.command-a-03-2025');
+
+    expect($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class)
+        ->and($events[count($events) - 1]->reason)->toBe('error');
+});
+
 test('streaming requests set isStream on the chat request', function () {
     Http::fake([
         'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response(

--- a/tests/Feature/Providers/Oracle/StructuredOutputTest.php
+++ b/tests/Feature/Providers/Oracle/StructuredOutputTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\StructuredAgent;
+
+beforeEach(fn () => $this->configureOracle());
+
+test('cohere structured output is parsed from the forced structured tool call', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response([
+            'modelId' => 'cohere.command-a-03-2025',
+            'chatResponse' => [
+                'apiFormat' => 'COHERE',
+                'text' => '',
+                'finishReason' => 'COMPLETE',
+                'toolCalls' => [['name' => 'structured_output', 'parameters' => ['symbol' => 'He']]],
+                'usage' => ['promptTokens' => 10, 'completionTokens' => 5],
+            ],
+        ]),
+    ]);
+
+    $response = (new StructuredAgent)->prompt(
+        'What is the symbol for helium?',
+        provider: 'oracle',
+        model: 'cohere.command-a-03-2025',
+    );
+
+    expect($response->structured)->toEqual(['symbol' => 'He']);
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return $body['chatRequest']['isForceSingleStep'] === true
+            && $body['chatRequest']['tools'][0]['name'] === 'structured_output';
+    });
+});
+
+test('generic structured output forces the structured tool choice', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::response([
+            'modelId' => 'meta.llama-3.3-70b-instruct',
+            'chatResponse' => [
+                'apiFormat' => 'GENERIC',
+                'choices' => [[
+                    'index' => 0,
+                    'message' => [
+                        'role' => 'ASSISTANT',
+                        'content' => [],
+                        'toolCalls' => [[
+                            'id' => 'call_1',
+                            'type' => 'FUNCTION',
+                            'name' => 'structured_output',
+                            'arguments' => '{"symbol":"He"}',
+                        ]],
+                    ],
+                    'finishReason' => 'tool_calls',
+                ]],
+                'usage' => ['promptTokens' => 10, 'completionTokens' => 5],
+            ],
+        ]),
+    ]);
+
+    $response = (new StructuredAgent)->prompt(
+        'What is the symbol for helium?',
+        provider: 'oracle',
+        model: 'meta.llama-3.3-70b-instruct',
+    );
+
+    expect($response->structured)->toEqual(['symbol' => 'He']);
+
+    Http::assertSent(fn ($request) => $request->data()['chatRequest']['toolChoice'] === [
+        'type' => 'FUNCTION',
+        'function' => ['name' => 'structured_output'],
+    ]);
+});

--- a/tests/Feature/Providers/Oracle/StructuredOutputTest.php
+++ b/tests/Feature/Providers/Oracle/StructuredOutputTest.php
@@ -70,6 +70,6 @@ test('generic structured output forces the structured tool choice', function () 
 
     Http::assertSent(fn ($request) => $request->data()['chatRequest']['toolChoice'] === [
         'type' => 'FUNCTION',
-        'function' => ['name' => 'structured_output'],
+        'name' => 'structured_output',
     ]);
 });

--- a/tests/Feature/Providers/Oracle/ToolCallTest.php
+++ b/tests/Feature/Providers/Oracle/ToolCallTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+
+beforeEach(fn () => $this->configureOracle());
+
+function oracleGenericToolCallPayload(): array
+{
+    return [
+        'modelId' => 'meta.llama-3.3-70b-instruct',
+        'chatResponse' => [
+            'apiFormat' => 'GENERIC',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'ASSISTANT',
+                    'content' => [],
+                    'toolCalls' => [[
+                        'id' => 'call_1',
+                        'type' => 'FUNCTION',
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ]],
+                ],
+                'finishReason' => 'tool_calls',
+            ]],
+            'usage' => ['promptTokens' => 10, 'completionTokens' => 5],
+        ],
+    ];
+}
+
+function oracleGenericTextPayload(string $text): array
+{
+    return [
+        'modelId' => 'meta.llama-3.3-70b-instruct',
+        'chatResponse' => [
+            'apiFormat' => 'GENERIC',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'ASSISTANT', 'content' => [['type' => 'TEXT', 'text' => $text]]],
+                'finishReason' => 'stop',
+            ]],
+            'usage' => ['promptTokens' => 20, 'completionTokens' => 10],
+        ],
+    ];
+}
+
+function oracleCohereToolCallPayload(): array
+{
+    return [
+        'modelId' => 'cohere.command-a-03-2025',
+        'chatResponse' => [
+            'apiFormat' => 'COHERE',
+            'text' => '',
+            'finishReason' => 'COMPLETE',
+            'toolCalls' => [['name' => 'FixedNumberGenerator', 'parameters' => (object) []]],
+            'usage' => ['promptTokens' => 10, 'completionTokens' => 5],
+        ],
+    ];
+}
+
+function oracleCohereTextPayload(string $text): array
+{
+    return [
+        'modelId' => 'cohere.command-a-03-2025',
+        'chatResponse' => [
+            'apiFormat' => 'COHERE',
+            'text' => $text,
+            'finishReason' => 'COMPLETE',
+            'usage' => ['promptTokens' => 20, 'completionTokens' => 10],
+        ],
+    ];
+}
+
+test('generic tool calls are executed and fed back as TOOL messages', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::sequence()
+            ->push(oracleGenericToolCallPayload())
+            ->push(oracleGenericTextPayload('The number is 72019')),
+    ]);
+
+    $response = (new ProviderOptionsWithToolsAgent)->prompt(
+        'Generate a number',
+        provider: 'oracle',
+        model: 'meta.llama-3.3-70b-instruct',
+    );
+
+    expect((string) $response)->toBe('The number is 72019')
+        ->and($response->toolCalls)->toHaveCount(1)
+        ->and($response->toolResults->first()->result)->toBe('72019');
+
+    Http::assertSentCount(2);
+
+    $requests = Http::recorded();
+    $secondBody = $requests[1][0]->data();
+    $roles = array_column($secondBody['chatRequest']['messages'], 'role');
+
+    expect($roles)->toContain('ASSISTANT')->toContain('TOOL');
+});
+
+test('cohere tool calls are executed and fed back as toolResults', function () {
+    Http::fake([
+        'inference.generativeai.us-chicago-1.oci.oraclecloud.com/*' => Http::sequence()
+            ->push(oracleCohereToolCallPayload())
+            ->push(oracleCohereTextPayload('The number is 72019')),
+    ]);
+
+    $response = (new ProviderOptionsWithToolsAgent)->prompt(
+        'Generate a number',
+        provider: 'oracle',
+        model: 'cohere.command-a-03-2025',
+    );
+
+    expect((string) $response)->toBe('The number is 72019')
+        ->and($response->toolCalls)->toHaveCount(1);
+
+    $requests = Http::recorded();
+    $secondBody = $requests[1][0]->data();
+
+    expect($secondBody['chatRequest']['toolResults'][0]['call']['name'])->toBe('FixedNumberGenerator');
+});

--- a/tests/Fixtures/Agents/OracleAgent.php
+++ b/tests/Fixtures/Agents/OracleAgent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Provider('oracle')]
+#[Model('cohere.command-a-03-2025')]
+class OracleAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}

--- a/tests/Fixtures/Agents/ProviderOptionsAgent.php
+++ b/tests/Fixtures/Agents/ProviderOptionsAgent.php
@@ -81,6 +81,10 @@ class ProviderOptionsAgent implements Agent, HasProviderOptions
                     'guardrailVersion' => '1',
                 ],
             ],
+            Lab::Oracle => [
+                'frequencyPenalty' => 0.5,
+                'presencePenalty' => 0.3,
+            ],
             default => [],
         };
     }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,6 +9,7 @@ use Tests\Feature\Providers\Mistral\MistralHelpers;
 use Tests\Feature\Providers\Ollama\OllamaHelpers;
 use Tests\Feature\Providers\OpenAi\OpenAiHelpers;
 use Tests\Feature\Providers\OpenRouter\OpenRouterHelpers;
+use Tests\Feature\Providers\Oracle\OracleHelpers;
 use Tests\Feature\Providers\Xai\XaiHelpers;
 use Tests\TestCase;
 
@@ -29,6 +30,7 @@ pest()->use(OpenAiHelpers::class)->group('provider-openai')->in('Feature/Provide
 pest()->use(XaiHelpers::class)->group('provider-xai')->in('Feature/Providers/Xai');
 
 pest()->use(OpenRouterHelpers::class)->group('provider-openrouter')->in('Feature/Providers/OpenRouter');
+pest()->use(OracleHelpers::class)->group('provider-oracle')->in('Feature/Providers/Oracle');
 uses()->group('providers')->in('Feature/Providers');
 
 uses()->group('integration')->in('Integration');

--- a/tests/Unit/Gateway/Oracle/OracleExceptionTest.php
+++ b/tests/Unit/Gateway/Oracle/OracleExceptionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Gateway\Oracle\OracleException;
+
+function oracleRequestException(int $status, string $body = ''): RequestException
+{
+    return new RequestException(new Response(new Psr7Response($status, [], $body)));
+}
+
+test('rate limited and overloaded statuses map to their exceptions', function () {
+    expect(OracleException::toAiException(oracleRequestException(429), 'oracle', 'm'))
+        ->toBeInstanceOf(RateLimitedException::class)
+        ->and(OracleException::toAiException(oracleRequestException(503), 'oracle', 'm'))
+        ->toBeInstanceOf(ProviderOverloadedException::class)
+        ->and(OracleException::toAiException(oracleRequestException(402), 'oracle', 'm'))
+        ->toBeInstanceOf(InsufficientCreditsException::class);
+});
+
+test('quota errors in the response body map to insufficient credits even on non-402 statuses', function () {
+    $exception = OracleException::toAiException(
+        oracleRequestException(400, json_encode(['message' => 'service limit exceeded: quota for this model'])),
+        'oracle',
+        'cohere.command-a-03-2025',
+    );
+
+    expect($exception)->toBeInstanceOf(InsufficientCreditsException::class);
+});
+
+test('other request errors become an AiException carrying the http status code', function () {
+    $exception = OracleException::toAiException(oracleRequestException(400, 'bad request'), 'oracle', 'm');
+
+    expect($exception)->toBeInstanceOf(AiException::class)
+        ->and($exception->getCode())->toBe(400);
+});
+
+test('existing ai exceptions pass through unchanged', function () {
+    $original = RateLimitedException::forProvider('oracle', 429);
+
+    expect(OracleException::toAiException($original, 'oracle', 'm'))->toBe($original);
+});

--- a/tests/Unit/Gateway/Oracle/OracleRequestSignerTest.php
+++ b/tests/Unit/Gateway/Oracle/OracleRequestSignerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use GuzzleHttp\Psr7\Request;
+use Laravel\Ai\Gateway\Oracle\OracleRequestSigner;
+
+function oracleSignerFixture(): array
+{
+    $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+
+    openssl_pkey_export($key, $pem);
+
+    $public = openssl_pkey_get_details($key)['key'];
+
+    $signer = new OracleRequestSigner(
+        'ocid1.tenancy.oc1..aaaa',
+        'ocid1.user.oc1..bbbb',
+        'aa:bb:cc:dd:ee',
+        $pem,
+    );
+
+    return [$signer, $public];
+}
+
+test('key id concatenates tenancy, user, and fingerprint', function () {
+    [$signer] = oracleSignerFixture();
+
+    expect($signer->keyId())->toBe('ocid1.tenancy.oc1..aaaa/ocid1.user.oc1..bbbb/aa:bb:cc:dd:ee');
+});
+
+test('post request signing string includes the body headers in order', function () {
+    [$signer] = oracleSignerFixture();
+
+    $request = (new Request(
+        'POST',
+        'https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/chat',
+        ['Content-Type' => 'application/json', 'date' => 'Thu, 29 May 2026 12:00:00 GMT'],
+        '{"a":1}',
+    ))->withHeader('host', 'inference.generativeai.us-chicago-1.oci.oraclecloud.com')
+        ->withHeader('x-content-sha256', base64_encode(hash('sha256', '{"a":1}', true)))
+        ->withHeader('content-length', '7');
+
+    $signingString = $signer->buildSigningString($request, [
+        '(request-target)', 'host', 'date', 'x-content-sha256', 'content-type', 'content-length',
+    ]);
+
+    expect($signingString)->toBe(implode("\n", [
+        '(request-target): post /20231130/actions/chat',
+        'host: inference.generativeai.us-chicago-1.oci.oraclecloud.com',
+        'date: Thu, 29 May 2026 12:00:00 GMT',
+        'x-content-sha256: '.base64_encode(hash('sha256', '{"a":1}', true)),
+        'content-type: application/json',
+        'content-length: 7',
+    ]));
+});
+
+test('request target includes the query string', function () {
+    [$signer] = oracleSignerFixture();
+
+    $request = new Request('GET', 'https://host.example.com/path?foo=bar&baz=qux');
+
+    $signingString = $signer->buildSigningString($request, ['(request-target)']);
+
+    expect($signingString)->toBe('(request-target): get /path?foo=bar&baz=qux');
+});
+
+test('signing a post request adds the signature headers', function () {
+    [$signer] = oracleSignerFixture();
+
+    $request = new Request(
+        'POST',
+        'https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/chat',
+        ['Content-Type' => 'application/json'],
+        '{"hello":"world"}',
+    );
+
+    $signed = $signer->sign($request, 'Thu, 29 May 2026 12:00:00 GMT');
+
+    expect($signed->getHeaderLine('date'))->toBe('Thu, 29 May 2026 12:00:00 GMT')
+        ->and($signed->getHeaderLine('x-content-sha256'))->toBe(base64_encode(hash('sha256', '{"hello":"world"}', true)))
+        ->and($signed->getHeaderLine('content-length'))->toBe((string) strlen('{"hello":"world"}'))
+        ->and($signed->getHeaderLine('Authorization'))->toContain('Signature version="1"')
+        ->and($signed->getHeaderLine('Authorization'))->toContain('keyId="ocid1.tenancy.oc1..aaaa/ocid1.user.oc1..bbbb/aa:bb:cc:dd:ee"')
+        ->and($signed->getHeaderLine('Authorization'))->toContain('algorithm="rsa-sha256"')
+        ->and($signed->getHeaderLine('Authorization'))->toContain('headers="(request-target) host date x-content-sha256 content-type content-length"');
+});
+
+test('the produced signature verifies against the public key', function () {
+    [$signer, $public] = oracleSignerFixture();
+
+    $request = new Request(
+        'POST',
+        'https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/chat',
+        ['Content-Type' => 'application/json'],
+        '{"hello":"world"}',
+    );
+
+    $signed = $signer->sign($request, 'Thu, 29 May 2026 12:00:00 GMT');
+
+    preg_match('/signature="([^"]+)"/', $signed->getHeaderLine('Authorization'), $matches);
+
+    $signingString = $signer->buildSigningString($signed, [
+        '(request-target)', 'host', 'date', 'x-content-sha256', 'content-type', 'content-length',
+    ]);
+
+    expect(openssl_verify($signingString, base64_decode($matches[1]), $public, OPENSSL_ALGO_SHA256))->toBe(1);
+});
+
+test('bodyless requests only sign the request-target, host, and date', function () {
+    [$signer] = oracleSignerFixture();
+
+    $signed = $signer->sign(new Request('GET', 'https://host.example.com/20231130/models'), 'Thu, 29 May 2026 12:00:00 GMT');
+
+    expect($signed->getHeaderLine('Authorization'))->toContain('headers="(request-target) host date"')
+        ->and($signed->hasHeader('x-content-sha256'))->toBeFalse();
+});

--- a/tests/Unit/Gateway/Oracle/OracleRequestSignerTest.php
+++ b/tests/Unit/Gateway/Oracle/OracleRequestSignerTest.php
@@ -53,6 +53,14 @@ test('post request signing string includes the body headers in order', function 
     ]));
 });
 
+test('request target defaults an empty path to a slash', function () {
+    [$signer] = oracleSignerFixture();
+
+    $signingString = $signer->buildSigningString(new Request('GET', 'https://host.example.com'), ['(request-target)']);
+
+    expect($signingString)->toBe('(request-target): get /');
+});
+
 test('request target includes the query string', function () {
     [$signer] = oracleSignerFixture();
 

--- a/tests/Unit/Gateway/Oracle/OracleTextGatewayTest.php
+++ b/tests/Unit/Gateway/Oracle/OracleTextGatewayTest.php
@@ -174,7 +174,7 @@ test('format cohere tools produces parameter definitions', function () {
         ->and($tools[0]['name'])->toBe('OracleSampleTool')
         ->and($tools[0]['parameterDefinitions']['city'])->toEqual([
             'description' => 'The city',
-            'type' => 'string',
+            'type' => 'str',
             'isRequired' => true,
         ]);
 });
@@ -197,7 +197,7 @@ test('generic chat request forces the structured tool on the final schema step',
     $request = oracleGateway()->callBuildGenericChatRequest([], $schemaTools, null, true, null, true);
 
     expect($request['tools'])->toBe($schemaTools)
-        ->and($request['toolChoice'])->toEqual(['type' => 'FUNCTION', 'function' => ['name' => 'structured_output']]);
+        ->and($request['toolChoice'])->toEqual(['type' => 'FUNCTION', 'name' => 'structured_output']);
 });
 
 test('generic chat request uses auto tool choice on non-final schema steps', function () {
@@ -205,7 +205,7 @@ test('generic chat request uses auto tool choice on non-final schema steps', fun
 
     $request = oracleGateway()->callBuildGenericChatRequest([], $schemaTools, null, false, null, false);
 
-    expect($request['toolChoice'])->toBe('AUTO');
+    expect($request['toolChoice'])->toEqual(['type' => 'AUTO']);
 });
 
 test('cohere chat request maps message, preamble, history, and force single step for schemas', function () {
@@ -308,8 +308,8 @@ test('schema is converted to cohere parameter definitions', function () {
     ]);
 
     expect($definitions)->toEqual([
-        'name' => ['description' => 'A name', 'type' => 'string', 'isRequired' => true],
-        'age' => ['description' => '', 'type' => 'integer', 'isRequired' => false],
+        'name' => ['description' => 'A name', 'type' => 'str', 'isRequired' => true],
+        'age' => ['description' => '', 'type' => 'int', 'isRequired' => false],
     ]);
 });
 

--- a/tests/Unit/Gateway/Oracle/OracleTextGatewayTest.php
+++ b/tests/Unit/Gateway/Oracle/OracleTextGatewayTest.php
@@ -1,0 +1,330 @@
+<?php
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\Oracle\OracleTextGateway;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Tools\Request;
+use Tests\Fixtures\Agents\ProviderOptionsAgent;
+
+function oracleGateway(): object
+{
+    return new class extends OracleTextGateway
+    {
+        public function callIsCohereModel(string $model): bool
+        {
+            return $this->isCohereModel($model);
+        }
+
+        public function callApiFormat(string $model): string
+        {
+            return $this->apiFormat($model);
+        }
+
+        public function callBuildGenericMessages(array $messages, ?string $instructions): array
+        {
+            return $this->buildGenericMessages($messages, $instructions);
+        }
+
+        public function callBuildCohereState(array $messages, ?string $instructions): array
+        {
+            return $this->buildCohereState($messages, $instructions);
+        }
+
+        public function callFormatGenericTools(array $tools): array
+        {
+            return $this->formatGenericTools($tools);
+        }
+
+        public function callFormatCohereTools(array $tools): array
+        {
+            return $this->formatCohereTools($tools);
+        }
+
+        public function callBuildGenericChatRequest(array $messages, ?array $schemaTools, ?array $formattedTools, bool $toolsEmpty, ?TextGenerationOptions $options, bool $isFinalStep, bool $isStream = false): array
+        {
+            return $this->buildGenericChatRequest($messages, $schemaTools, $formattedTools, $toolsEmpty, $options, $isFinalStep, $isStream);
+        }
+
+        public function callBuildCohereChatRequest(array $state, ?array $formattedTools, ?array $schemaTool, ?TextGenerationOptions $options, array $toolResults = [], bool $isStream = false): array
+        {
+            return $this->buildCohereChatRequest($state, $formattedTools, $schemaTool, $options, $toolResults, $isStream);
+        }
+
+        public function callParseGenericResponse(array $chatResponse): array
+        {
+            return $this->parseGenericResponse($chatResponse);
+        }
+
+        public function callParseCohereResponse(array $chatResponse): array
+        {
+            return $this->parseCohereResponse($chatResponse);
+        }
+
+        public function callGenericFinishReason(string $reason): FinishReason
+        {
+            return $this->genericFinishReason($reason);
+        }
+
+        public function callCohereFinishReason(string $reason): FinishReason
+        {
+            return $this->cohereFinishReason($reason);
+        }
+
+        public function callSchemaToParameterDefinitions(array $jsonSchema): array
+        {
+            return $this->schemaToParameterDefinitions($jsonSchema);
+        }
+
+        public function callBuildGenericSchemaTools(array $schema, array $tools): array
+        {
+            return $this->buildGenericSchemaTools($schema, $tools);
+        }
+
+        public function callBuildCohereSchemaTool(array $schema): array
+        {
+            return $this->buildCohereSchemaTool($schema);
+        }
+
+        public function callResolveMaxSteps(array $tools, ?TextGenerationOptions $options): int
+        {
+            return $this->resolveMaxSteps($tools, $options);
+        }
+
+        public function callStreamTextDelta(array $event): string
+        {
+            return $this->streamTextDelta($event);
+        }
+    };
+}
+
+class OracleSampleTool implements Tool
+{
+    public function description(): string
+    {
+        return 'Sample description';
+    }
+
+    public function handle(Request $request): string
+    {
+        return 'ok';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return ['city' => $schema->string()->description('The city')->required()];
+    }
+}
+
+test('cohere models are detected and mapped to the COHERE api format', function () {
+    $gateway = oracleGateway();
+
+    expect($gateway->callIsCohereModel('cohere.command-a-03-2025'))->toBeTrue()
+        ->and($gateway->callApiFormat('cohere.command-a-03-2025'))->toBe('COHERE')
+        ->and($gateway->callIsCohereModel('meta.llama-3.3-70b-instruct'))->toBeFalse()
+        ->and($gateway->callApiFormat('meta.llama-3.3-70b-instruct'))->toBe('GENERIC')
+        ->and($gateway->callApiFormat('xai.grok-3'))->toBe('GENERIC');
+});
+
+test('generic messages map system instructions and roles into content parts', function () {
+    $messages = oracleGateway()->callBuildGenericMessages([
+        new UserMessage('Hello'),
+        new AssistantMessage('Hi there'),
+    ], 'You are helpful');
+
+    expect($messages)->toEqual([
+        ['role' => 'SYSTEM', 'content' => [['type' => 'TEXT', 'text' => 'You are helpful']]],
+        ['role' => 'USER', 'content' => [['type' => 'TEXT', 'text' => 'Hello']]],
+        ['role' => 'ASSISTANT', 'content' => [['type' => 'TEXT', 'text' => 'Hi there']]],
+    ]);
+});
+
+test('cohere state extracts the latest user turn as message and the rest as history', function () {
+    $state = oracleGateway()->callBuildCohereState([
+        new UserMessage('first question'),
+        new AssistantMessage('an answer'),
+        new UserMessage('second question'),
+    ], 'You are helpful');
+
+    expect($state['message'])->toBe('second question')
+        ->and($state['preamble'])->toBe('You are helpful')
+        ->and($state['chatHistory'])->toEqual([
+            ['role' => 'USER', 'message' => 'first question'],
+            ['role' => 'CHATBOT', 'message' => 'an answer'],
+        ]);
+});
+
+test('format generic tools produces function tool specs', function () {
+    $tools = oracleGateway()->callFormatGenericTools([new OracleSampleTool]);
+
+    expect($tools)->toHaveCount(1)
+        ->and($tools[0]['type'])->toBe('FUNCTION')
+        ->and($tools[0]['function']['name'])->toBe('OracleSampleTool')
+        ->and($tools[0]['function']['description'])->toBe('Sample description')
+        ->and($tools[0]['function']['parameters'])->toBeArray();
+});
+
+test('format cohere tools produces parameter definitions', function () {
+    $tools = oracleGateway()->callFormatCohereTools([new OracleSampleTool]);
+
+    expect($tools)->toHaveCount(1)
+        ->and($tools[0]['name'])->toBe('OracleSampleTool')
+        ->and($tools[0]['parameterDefinitions']['city'])->toEqual([
+            'description' => 'The city',
+            'type' => 'string',
+            'isRequired' => true,
+        ]);
+});
+
+test('generic chat request omits tool fields when no tools or schema present', function () {
+    $request = oracleGateway()->callBuildGenericChatRequest(
+        [['role' => 'USER', 'content' => [['type' => 'TEXT', 'text' => 'hi']]]],
+        null, null, true, null, false,
+    );
+
+    expect($request['apiFormat'])->toBe('GENERIC')
+        ->and($request)->not->toHaveKey('tools')
+        ->and($request)->not->toHaveKey('toolChoice')
+        ->and($request)->not->toHaveKey('isStream');
+});
+
+test('generic chat request forces the structured tool on the final schema step', function () {
+    $schemaTools = oracleGateway()->callBuildGenericSchemaTools([], []);
+
+    $request = oracleGateway()->callBuildGenericChatRequest([], $schemaTools, null, true, null, true);
+
+    expect($request['tools'])->toBe($schemaTools)
+        ->and($request['toolChoice'])->toEqual(['type' => 'FUNCTION', 'function' => ['name' => 'structured_output']]);
+});
+
+test('generic chat request uses auto tool choice on non-final schema steps', function () {
+    $schemaTools = oracleGateway()->callBuildGenericSchemaTools([], [new OracleSampleTool]);
+
+    $request = oracleGateway()->callBuildGenericChatRequest([], $schemaTools, null, false, null, false);
+
+    expect($request['toolChoice'])->toBe('AUTO');
+});
+
+test('cohere chat request maps message, preamble, history, and force single step for schemas', function () {
+    $schemaTool = oracleGateway()->callBuildCohereSchemaTool([]);
+
+    $request = oracleGateway()->callBuildCohereChatRequest(
+        ['message' => 'hi', 'chatHistory' => [['role' => 'USER', 'message' => 'earlier']], 'preamble' => 'be nice'],
+        null, $schemaTool, null,
+    );
+
+    expect($request['apiFormat'])->toBe('COHERE')
+        ->and($request['message'])->toBe('hi')
+        ->and($request['preambleOverride'])->toBe('be nice')
+        ->and($request['chatHistory'])->toEqual([['role' => 'USER', 'message' => 'earlier']])
+        ->and($request['tools'])->toBe($schemaTool)
+        ->and($request['isForceSingleStep'])->toBeTrue();
+});
+
+test('cohere chat request attaches tool results when present', function () {
+    $request = oracleGateway()->callBuildCohereChatRequest(
+        ['message' => 'hi', 'chatHistory' => [], 'preamble' => null],
+        null, null, null,
+        [['call' => ['name' => 'X', 'parameters' => []], 'outputs' => [['output' => 'done']]]],
+    );
+
+    expect($request['toolResults'])->toEqual([
+        ['call' => ['name' => 'X', 'parameters' => []], 'outputs' => [['output' => 'done']]],
+    ]);
+});
+
+test('chat requests flat-merge agent provider options for oracle', function () {
+    $options = TextGenerationOptions::forAgent(new ProviderOptionsAgent);
+
+    $request = oracleGateway()->callBuildGenericChatRequest(
+        [['role' => 'USER', 'content' => [['type' => 'TEXT', 'text' => 'hi']]]],
+        null, null, true, $options, false,
+    );
+
+    expect($request['frequencyPenalty'])->toBe(0.5)
+        ->and($request['presencePenalty'])->toBe(0.3);
+});
+
+test('parse generic response extracts text, tool calls, finish reason, and usage', function () {
+    $parsed = oracleGateway()->callParseGenericResponse([
+        'choices' => [[
+            'message' => [
+                'content' => [['type' => 'TEXT', 'text' => 'Hello world']],
+                'toolCalls' => [['id' => 'call_1', 'name' => 'X', 'arguments' => '{"a":1}']],
+            ],
+            'finishReason' => 'tool_calls',
+        ]],
+        'usage' => ['promptTokens' => 12, 'completionTokens' => 8],
+    ]);
+
+    expect($parsed['text'])->toBe('Hello world')
+        ->and($parsed['toolCalls'][0]->id)->toBe('call_1')
+        ->and($parsed['toolCalls'][0]->name)->toBe('X')
+        ->and($parsed['toolCalls'][0]->arguments)->toEqual(['a' => 1])
+        ->and($parsed['finishReason'])->toBe(FinishReason::ToolCalls)
+        ->and($parsed['usage']->promptTokens)->toBe(12)
+        ->and($parsed['usage']->completionTokens)->toBe(8);
+});
+
+test('parse cohere response extracts text, tool calls, finish reason, and usage', function () {
+    $parsed = oracleGateway()->callParseCohereResponse([
+        'text' => 'The answer',
+        'finishReason' => 'COMPLETE',
+        'toolCalls' => [['name' => 'X', 'parameters' => ['a' => 1]]],
+        'usage' => ['promptTokens' => 3, 'completionTokens' => 4],
+    ]);
+
+    expect($parsed['text'])->toBe('The answer')
+        ->and($parsed['toolCalls'][0]->name)->toBe('X')
+        ->and($parsed['toolCalls'][0]->arguments)->toEqual(['a' => 1])
+        ->and($parsed['finishReason'])->toBe(FinishReason::Stop)
+        ->and($parsed['usage']->promptTokens)->toBe(3);
+});
+
+test('finish reasons are mapped per family', function () {
+    $gateway = oracleGateway();
+
+    expect($gateway->callGenericFinishReason('stop'))->toBe(FinishReason::Stop)
+        ->and($gateway->callGenericFinishReason('length'))->toBe(FinishReason::Length)
+        ->and($gateway->callGenericFinishReason('tool_calls'))->toBe(FinishReason::ToolCalls)
+        ->and($gateway->callGenericFinishReason('content_filter'))->toBe(FinishReason::ContentFilter)
+        ->and($gateway->callCohereFinishReason('COMPLETE'))->toBe(FinishReason::Stop)
+        ->and($gateway->callCohereFinishReason('MAX_TOKENS'))->toBe(FinishReason::Length)
+        ->and($gateway->callCohereFinishReason('ERROR_TOXIC'))->toBe(FinishReason::ContentFilter)
+        ->and($gateway->callCohereFinishReason('ERROR'))->toBe(FinishReason::Error);
+});
+
+test('schema is converted to cohere parameter definitions', function () {
+    $definitions = oracleGateway()->callSchemaToParameterDefinitions([
+        'type' => 'object',
+        'properties' => [
+            'name' => ['type' => 'string', 'description' => 'A name'],
+            'age' => ['type' => 'integer'],
+        ],
+        'required' => ['name'],
+    ]);
+
+    expect($definitions)->toEqual([
+        'name' => ['description' => 'A name', 'type' => 'string', 'isRequired' => true],
+        'age' => ['description' => '', 'type' => 'integer', 'isRequired' => false],
+    ]);
+});
+
+test('resolve max steps returns one without tools and scales with tool count', function () {
+    $gateway = oracleGateway();
+
+    expect($gateway->callResolveMaxSteps([], null))->toBe(1)
+        ->and($gateway->callResolveMaxSteps([new OracleSampleTool, new OracleSampleTool], null))->toBe(3)
+        ->and($gateway->callResolveMaxSteps([new OracleSampleTool], new TextGenerationOptions(maxSteps: 9)))->toBe(9);
+});
+
+test('stream text delta is extracted from both family shapes', function () {
+    $gateway = oracleGateway();
+
+    expect($gateway->callStreamTextDelta(['text' => 'cohere chunk']))->toBe('cohere chunk')
+        ->and($gateway->callStreamTextDelta(['message' => ['content' => [['type' => 'TEXT', 'text' => 'generic chunk']]]]))->toBe('generic chunk')
+        ->and($gateway->callStreamTextDelta(['finishReason' => 'stop']))->toBe('');
+});

--- a/tests/Unit/Gateway/Oracle/OracleTextGatewayTest.php
+++ b/tests/Unit/Gateway/Oracle/OracleTextGatewayTest.php
@@ -1,11 +1,15 @@
 <?php
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Oracle\OracleTextGateway;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Tools\Request;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
@@ -98,7 +102,30 @@ function oracleGateway(): object
         {
             return $this->streamTextDelta($event);
         }
+
+        public function callFinalizeStreamToolCalls(array $event): array
+        {
+            $pending = [];
+            $this->accumulateStreamToolCalls($event, $pending);
+
+            return $this->finalizeStreamToolCalls($pending);
+        }
     };
+}
+
+class OracleReservedOptionsAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'reserved';
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        return ['apiFormat' => 'HACKED', 'messages' => [], 'frequencyPenalty' => 0.5];
+    }
 }
 
 class OracleSampleTool implements Tool
@@ -282,6 +309,39 @@ test('parse cohere response extracts text, tool calls, finish reason, and usage'
         ->and($parsed['toolCalls'][0]->arguments)->toEqual(['a' => 1])
         ->and($parsed['finishReason'])->toBe(FinishReason::Stop)
         ->and($parsed['usage']->promptTokens)->toBe(3);
+});
+
+test('parse cohere response normalizes object tool parameters to an array', function () {
+    $parsed = oracleGateway()->callParseCohereResponse([
+        'text' => '',
+        'finishReason' => 'COMPLETE',
+        'toolCalls' => [['name' => 'X', 'parameters' => (object) ['city' => 'Cairo']]],
+    ]);
+
+    expect($parsed['toolCalls'][0]->arguments)->toBe(['city' => 'Cairo']);
+});
+
+test('streamed object tool parameters are encoded and finalized into tool calls', function () {
+    $toolCalls = oracleGateway()->callFinalizeStreamToolCalls([
+        'toolCalls' => [['name' => 'X', 'parameters' => (object) ['city' => 'Cairo']]],
+    ]);
+
+    expect($toolCalls)->toHaveCount(1)
+        ->and($toolCalls[0]->name)->toBe('X')
+        ->and($toolCalls[0]->arguments)->toBe(['city' => 'Cairo']);
+});
+
+test('provider options cannot override structural request fields', function () {
+    $options = TextGenerationOptions::forAgent(new OracleReservedOptionsAgent);
+
+    $request = oracleGateway()->callBuildGenericChatRequest(
+        [['role' => 'USER', 'content' => [['type' => 'TEXT', 'text' => 'hi']]]],
+        null, null, true, $options, false,
+    );
+
+    expect($request['apiFormat'])->toBe('GENERIC')
+        ->and($request['messages'])->toEqual([['role' => 'USER', 'content' => [['type' => 'TEXT', 'text' => 'hi']]]])
+        ->and($request['frequencyPenalty'])->toBe(0.5);
 });
 
 test('finish reasons are mapped per family', function () {


### PR DESCRIPTION
Refs #673

## What

Adds a first-class `oracle` provider/driver for **OCI Generative AI**:

```php
#[Provider(Lab::Oracle)]
#[Model('cohere.command-a-03-2025')] // or a meta.llama-* / xai.grok-* model
class MyAgent implements Agent { /* ... */ }
```

Text generation, streaming, tool calling, structured output, and embeddings against OCI Generative AI's inference API.

## Why

Brings Oracle Cloud to parity with the other cloud providers (Bedrock/Azure/Gemini/...). See #673 for motivation/scope.

## How

- **`Lab::Oracle`** enum case + **`config/ai.php` `oracle` block** with safe env fallbacks (boots without creds).
- **`OracleProvider`** implements `TextProvider` + `EmbeddingProvider`, mirroring `BedrockProvider`.
- **`Gateway/Oracle/OracleTextGateway`** — HTTP-based (Laravel `Http` client, like Gemini), implements `TextGateway` + `EmbeddingGateway`.
- **`AiManager::createOracleDriver`** wires it up by convention.
- **Auth/signing** — `OracleRequestSigner` implements the OCI HTTP Signature scheme (draft-cavage), `keyId = tenancy/user/fingerprint`, RSA-SHA256 over `(request-target) host date x-content-sha256 content-type content-length`, `x-content-sha256 = base64(sha256(body))`. Wired as a Guzzle `mapRequest` middleware in `CreatesOracleClient` so signing happens over the final serialized body. API-key auth today; structured so instance/resource-principal can be added later.
- **Endpoint** — `https://inference.generativeai.<region>.oci.oraclecloud.com` + `POST /20231130/actions/chat` (and `/actions/embedText`). Region/compartment/serving-type/url configurable.
- **Two request families** — `cohere.*` → `CohereChatRequest`; `meta.llama-*`, `xai.grok-*`, others → `GenericChatRequest`. Detected from the model id.
- **Tools + structured output** — both families; Generic forces the synthetic `structured_output` tool via `toolChoice`, Cohere via `isForceSingleStep`. Degrades gracefully without tools.
- **Streaming** — `isStream: true` + `streamOptions.isIncludeUsage`, parsed via `ParsesServerSentEvents`, emitting the standard `StreamStart`/`TextStart`/`TextDelta`/`TextEnd`/`ToolCall`/`StreamEnd` events.
- **Usage/finish reason** — mapped from OCI's `usage` block and per-family finish reasons.
- **Embeddings** — `cohere.embed-*` via `/actions/embedText`.

## Validation

Wire formats cross-checked against the **official `oracle/oci-python-sdk`** and **`oracle/langchain-oracle`** clients — request envelope, both chat families, response shapes, usage field names, tool/structured-output handling, embeddings, endpoint/paths, and the streaming delta keys all match those clients.

## Tests

- **Unit** (`tests/Unit/Gateway/Oracle`): signer (keyId, signing-string construction, signature headers, round-trip `openssl_verify`), family detection, message/tool mapping, request building, response parsing, finish-reason mapping, schema→parameterDefinitions, max-steps, stream-delta extraction.
- **Feature** (`tests/Feature/Providers/Oracle`, `Http::fake`): request mapping + signing headers, base-url/region resolution, text (Cohere + Generic), streaming (both families), tool-call loop (both families), structured output (both families), embeddings. New `OracleAgent` fixture + `OracleHelpers`.
- Pint + PHPStan clean; full suite green (`1437 passed`, 184 pre-existing external-key skips).

## Assumptions

One transport detail is not exercised against a live tenancy: the **raw SSE framing** (literal `data:` line prefix / terminal sentinel) is abstracted away by the official SDK clients, so it can't be confirmed from their source. The parser follows standard SSE + OCI's documented "data-only server-sent events". Everything else is corroborated by the official clients above. Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)