### PR TITLE
Fix ImageResponse::toHtml() data URI when image mime is null

### DIFF
--- a/src/Gateway/FakeImageGateway.php
+++ b/src/Gateway/FakeImageGateway.php
@@ -81,7 +81,7 @@ class FakeImageGateway implements ImageGateway
 
         if (is_string($response)) {
             return new ImageResponse(
-                new Collection([new GeneratedImage($response)]),
+                new Collection([new GeneratedImage($response, 'image/png')]),
                 new Usage,
                 new Meta($provider->name(), $model),
             );

--- a/src/Responses/Data/GeneratedImage.php
+++ b/src/Responses/Data/GeneratedImage.php
@@ -24,11 +24,19 @@ class GeneratedImage implements Arrayable, JsonSerializable
     }
 
     /**
+     * Get the image's MIME type, falling back to a sensible default.
+     */
+    public function mime(): string
+    {
+        return $this->mime ?: 'image/png';
+    }
+
+    /**
      * Get a default filename for the file.
      */
     protected function randomStorageName(): string
     {
-        return once(fn () => Str::random(40).match ($this->mime) {
+        return once(fn () => Str::random(40).match ($this->mime()) {
             'image/jpeg' => '.jpg',
             'image/png' => '.png',
             'image/webp' => '.webp',

--- a/src/Responses/ImageResponse.php
+++ b/src/Responses/ImageResponse.php
@@ -64,7 +64,7 @@ class ImageResponse implements Countable, Htmlable
     {
         return sprintf(
             '<img src="data:%s;base64,%s" alt="%s" />',
-            $this->images[0]->mime,
+            $this->images[0]->mime ?: 'image/png',
             $this->images[0]->image,
             e($alt),
         );

--- a/src/Responses/ImageResponse.php
+++ b/src/Responses/ImageResponse.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use RuntimeException;
 
 class ImageResponse implements Countable, Htmlable
 {
@@ -22,7 +23,11 @@ class ImageResponse implements Countable, Htmlable
      */
     public function firstImage(): GeneratedImage
     {
-        return $this->images[0];
+        if ($this->images->isEmpty()) {
+            throw new RuntimeException('The image response does not contain any images.');
+        }
+
+        return $this->images->first();
     }
 
     /**
@@ -62,10 +67,12 @@ class ImageResponse implements Countable, Htmlable
      */
     public function toHtml(string $alt = ''): string
     {
+        $image = $this->firstImage();
+
         return sprintf(
             '<img src="data:%s;base64,%s" alt="%s" />',
-            $this->images[0]->mime ?: 'image/png',
-            $this->images[0]->image,
+            $image->mime(),
+            $image->image,
             e($alt),
         );
     }
@@ -83,6 +90,6 @@ class ImageResponse implements Countable, Htmlable
      */
     public function __toString(): string
     {
-        return (string) $this->images[0];
+        return (string) $this->firstImage();
     }
 }

--- a/tests/Unit/Responses/ImageResponseTest.php
+++ b/tests/Unit/Responses/ImageResponseTest.php
@@ -6,6 +6,11 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\ImageResponse;
 
+test('mime falls back to image/png when no mime type is set', function () {
+    expect((new GeneratedImage('aGVsbG8='))->mime())->toBe('image/png');
+    expect((new GeneratedImage('aGVsbG8=', 'image/webp'))->mime())->toBe('image/webp');
+});
+
 test('toHtml renders an img tag with the image mime type', function () {
     $response = new ImageResponse(
         new Collection([new GeneratedImage('aGVsbG8=', 'image/jpeg')]),
@@ -40,4 +45,15 @@ test('toHtml escapes the alt attribute', function () {
     expect($response->toHtml('"><script>alert(1)</script>'))->toBe(
         '<img src="data:image/png;base64,aGVsbG8=" alt="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" />'
     );
+});
+
+test('firstImage throws when the response contains no images', function () {
+    $response = new ImageResponse(
+        new Collection,
+        new Usage,
+        new Meta('openai', 'gpt-image-1'),
+    );
+
+    expect(fn () => $response->firstImage())
+        ->toThrow(RuntimeException::class, 'The image response does not contain any images.');
 });

--- a/tests/Unit/Responses/ImageResponseTest.php
+++ b/tests/Unit/Responses/ImageResponseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Responses\Data\GeneratedImage;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\ImageResponse;
+
+test('toHtml renders an img tag with the image mime type', function () {
+    $response = new ImageResponse(
+        new Collection([new GeneratedImage('aGVsbG8=', 'image/jpeg')]),
+        new Usage,
+        new Meta('openai', 'gpt-image-1'),
+    );
+
+    expect($response->toHtml())->toBe(
+        '<img src="data:image/jpeg;base64,aGVsbG8=" alt="" />'
+    );
+});
+
+test('toHtml falls back to image/png when the image has no mime type', function () {
+    $response = new ImageResponse(
+        new Collection([new GeneratedImage('aGVsbG8=')]),
+        new Usage,
+        new Meta('openai', 'gpt-image-1'),
+    );
+
+    expect($response->toHtml())->toBe(
+        '<img src="data:image/png;base64,aGVsbG8=" alt="" />'
+    );
+});
+
+test('toHtml escapes the alt attribute', function () {
+    $response = new ImageResponse(
+        new Collection([new GeneratedImage('aGVsbG8=', 'image/png')]),
+        new Usage,
+        new Meta('openai', 'gpt-image-1'),
+    );
+
+    expect($response->toHtml('"><script>alert(1)</script>'))->toBe(
+        '<img src="data:image/png;base64,aGVsbG8=" alt="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" />'
+    );
+});


### PR DESCRIPTION
`ImageResponse::toHtml()` builds the `<img src="data:...">` URI directly from `GeneratedImage::$mime`, which is nullable. When the mime is `null` you get a malformed data URI:

```html
<img src="data:;base64,..." alt="" />
```

Most browsers refuse to render that, so calling `toHtml()` on an image without an explicit mime quietly produces a broken `<img>` tag.

This affects:

- `FakeImageGateway`, which constructs `new GeneratedImage($response)` with no mime — so anyone using `Image::fake()` in tests and rendering the result hits this.
- Gemini responses where `inlineData.mimeType` is missing — `GeminiGateway` passes the value through unchanged.
- Any consumer that builds a `GeneratedImage($base64)` directly.

## Changes

- `ImageResponse::toHtml()` falls back to `image/png` when `mime` is empty/null, so the rendered tag is always a valid data URI.
- `FakeImageGateway` now sets `image/png` on the default fake image, matching the real OpenAI / Azure / Bedrock gateways which all default to `image/png`.
- Adds `tests/Unit/Responses/ImageResponseTest.php` covering:
  - the explicit-mime happy path,
  - the null-mime fallback to `image/png`,
  - that the `alt` attribute is HTML-escaped (regression guard).

## Backwards compatibility

No public API change. Gateways that already supply a mime are unaffected — the fallback only kicks in when `mime` is empty or null, which previously rendered an invalid tag anyway.