### PR TITLE
Add `contains` method to `QueuedAgentPrompt`

### DIFF
--- a/src/QueuedAgentPrompt.php
+++ b/src/QueuedAgentPrompt.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
 
@@ -15,4 +16,12 @@ class QueuedAgentPrompt
         public Lab|array|string|null $provider,
         public ?string $model
     ) {}
+
+    /**
+     * Determine if the prompt contains the given string.
+     */
+    public function contains(string $string): bool
+    {
+        return Str::contains($this->prompt, $string);
+    }
 }


### PR DESCRIPTION
This PR adds a `contains` method to the `Laravel\Ai\QueuedAgentPrompt` class. Most of the other prompt classes have this and the [testing section](https://laravel.com/docs/13.x/ai-sdk#testing-agents) in the docs currently shows this method being available.