### PR TITLE
Filter orphan tool calls when rehydrating database conversations

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -156,19 +156,30 @@ class DatabaseConversationStore implements ConversationStore
                 }
 
                 if ($toolCalls->isNotEmpty()) {
+                    $resultIds = $toolResults->pluck('id')->filter()->all();
+
+                    $matchedToolCalls = $toolCalls->filter(
+                        fn ($toolCall) => isset($toolCall['id'])
+                            && in_array($toolCall['id'], $resultIds, true)
+                    )->values();
+
                     $messages = [];
 
-                    $messages[] = new AssistantMessage(
-                        $record->content ?: '',
-                        $toolCalls->map(fn ($toolCall) => new ToolCall(
-                            id: $toolCall['id'],
-                            name: $toolCall['name'],
-                            arguments: $toolCall['arguments'],
-                            resultId: $toolCall['result_id'] ?? null,
-                            reasoningId: $toolCall['reasoning_id'] ?? null,
-                            reasoningSummary: $toolCall['reasoning_summary'] ?? null,
-                        ))
-                    );
+                    if ($matchedToolCalls->isNotEmpty()) {
+                        $messages[] = new AssistantMessage(
+                            $record->content ?: '',
+                            $matchedToolCalls->map(fn ($toolCall) => new ToolCall(
+                                id: $toolCall['id'],
+                                name: $toolCall['name'],
+                                arguments: $toolCall['arguments'],
+                                resultId: $toolCall['result_id'] ?? null,
+                                reasoningId: $toolCall['reasoning_id'] ?? null,
+                                reasoningSummary: $toolCall['reasoning_summary'] ?? null,
+                            ))
+                        );
+                    } elseif ($record->content) {
+                        $messages[] = new AssistantMessage($record->content);
+                    }
 
                     if ($toolResults->isNotEmpty()) {
                         $messages[] = new ToolResultMessage(

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -290,6 +290,99 @@ test('malformed stored attachment JSON fails loudly', function () {
         ->toThrow(InvalidArgumentException::class, 'Stored conversation attachments must be a JSON array.');
 });
 
+test('orphan tool calls without matching tool results are filtered on rehydration', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Orphan tool call conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call_a', 'name' => 'lookup', 'arguments' => ['q' => 'one']],
+            ['id' => 'call_b', 'name' => 'lookup', 'arguments' => ['q' => 'two']],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call_a', 'name' => 'lookup', 'arguments' => ['q' => 'one'], 'result' => 'first result'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(2)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->toolCalls)->toHaveCount(1)
+        ->and($messages[0]->toolCalls[0]->id)->toBe('call_a')
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults)->toHaveCount(1)
+        ->and($messages[1]->toolResults[0]->id)->toBe('call_a');
+});
+
+test('assistant turn with only orphan tool calls and content keeps the content', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'maxSteps interrupted conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Let me look that up.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call_unexecuted', 'name' => 'lookup', 'arguments' => []],
+        ]),
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->content)->toBe('Let me look that up.')
+        ->and($messages[0]->toolCalls)->toHaveCount(0);
+});
+
+test('assistant turn with only orphan tool calls and no content emits no message', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'fully interrupted conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call_unexecuted', 'name' => 'lookup', 'arguments' => []],
+        ]),
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(0);
+});
+
 test('malformed known stored attachments fail loudly', function () {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation(1, 'Malformed attachment conversation');


### PR DESCRIPTION
Fixes #639.

`DatabaseConversationStore::getLatestConversationMessages()` currently rehydrates every stored tool call on an assistant row, even if that tool call has no matching tool result.

That can happen when a multi-step agent turn hits its `maxSteps` limit after the model has requested tools, but before those tool calls are executed. The assistant message can then be stored with pending `tool_calls` and no corresponding `tool_results`.

On the next prompt, the stored conversation history is replayed with orphan tool-use IDs. Providers such as Anthropic reject that history with:

```text
tool_use ids were found without tool_result blocks immediately after


Changes
------------------
Filters stored assistant tool_calls during database conversation rehydration so only calls with a matching tool_results.id are replayed.
Preserves assistant text content when all stored tool calls are orphaned.
Skips fully empty assistant rows that only contain orphaned tool calls.
Adds regression coverage for mixed matched/orphan calls, orphan calls with assistant content, and orphan calls without content.

Why
--------------

This prevents one interrupted or max-step-limited agent turn from permanently corrupting future conversation replays.