### PR TITLE
Fix tool-calling model override causing model_not_found errors.

### DIFF
--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -60,6 +60,7 @@ trait ParsesTextResponses
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        string $model
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -67,6 +68,7 @@ trait ParsesTextResponses
             $structured,
             $tools,
             $schema,
+            $model,
             new Collection,
             new Collection,
             maxSteps: $options?->maxSteps,
@@ -84,6 +86,7 @@ trait ParsesTextResponses
         bool $structured,
         array $tools,
         ?array $schema,
+        string $model,
         Collection $steps,
         Collection $messages,
         int $depth = 0,
@@ -93,7 +96,7 @@ trait ParsesTextResponses
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
-        $model = $data['model'] ?? '';
+        $model = $model ?? '';
 
         $text = $this->extractText($output);
         $citations = $this->extractCitations($output);
@@ -267,7 +270,7 @@ trait ParsesTextResponses
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $model , $steps, $messages, $depth, $maxSteps, $options, $timeout);
     }
 
     /**

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -74,7 +74,7 @@ class OpenAiGateway implements Gateway
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('responses', $body),
         );
-        
+
         $data = $response->json();
 
         $this->validateTextResponse($data);

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -73,12 +73,12 @@ class OpenAiGateway implements Gateway
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('responses', $body),
         );
-
+        
         $data = $response->json();
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout , $model);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/ai/issues/680.

##  Fix tool-calling model override causing `model_not_found` errors

###  Summary

This PR fixes an issue in `generateText` tool-calling flow where the model returned from the API response was incorrectly used for subsequent tool execution steps instead of the original model provided by the developer.

This could lead to `model_not_found` errors when the provider returns a canonical or internal model name different from the configured alias.

---

###  Problem

During tool-calling flows, the following happens:

1. Developer passes a model alias (e.g. `gapgpt-qwen-3.5`)
2. API returns a response with a different internal model name (e.g. `Qwen/Qwen3.6-35B-A3B-FP8`)
3. The SDK incorrectly propagates the response model into subsequent tool execution steps
4. The next request fails with:


---

### Root Cause

The original `$model` parameter is not consistently propagated through the response lifecycle.

Instead, downstream methods (`parseTextResponse`, `processResponse`, and tool invocation flow) may rely on:

---

This PR ensures that the original requested model is preserved and used throughout the entire request lifecycle, including:

parseTextResponse
processResponse
tool-calling continuation steps