### PR TITLE
Recursively remove additionalProperties for Gemini tools

### DIFF
--- a/src/Gateway/Gemini/Concerns/MapsTools.php
+++ b/src/Gateway/Gemini/Concerns/MapsTools.php
@@ -67,14 +67,13 @@ trait MapsTools
         if (filled($schema)) {
             $schemaArray = (new ObjectSchema($schema))->toSchema();
 
-            $definition['parameters'] = Arr::except(
-                $this->convertNullableTypes([
-                    'type' => 'object',
-                    'properties' => $schemaArray['properties'] ?? [],
-                    'required' => $schemaArray['required'] ?? [],
-                ]),
-                ['additionalProperties'],
-            );
+            $convertedNullableTypes = $this->convertNullableTypes([
+                'type' => 'object',
+                'properties' => $schemaArray['properties'] ?? [],
+                'required' => $schemaArray['required'] ?? [],
+            ]);
+
+            $definition['parameters'] = $this->removeAdditionalProperties($convertedNullableTypes);
         }
 
         return $definition;
@@ -106,6 +105,25 @@ trait MapsTools
 
         if (isset($schema['items']) && is_array($schema['items'])) {
             $schema['items'] = $this->convertNullableTypes($schema['items']);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Recursively remove additinalProperties from nested objects.
+     * 
+     * @param  array<string, mixed> $schema
+     * @return array<string, mixed>
+     */
+    protected function removeAdditionalProperties(array $schema): array
+    {
+        foreach ($schema as $key => &$value) {
+            if ($key === 'additionalProperties') {
+                $schema = Arr::except($schema, ['additionalProperties']);
+            } elseif (is_array($value)) {
+                $value = $this->removeAdditionalProperties($value);
+            }
         }
 
         return $schema;

--- a/src/Gateway/Gemini/Concerns/MapsTools.php
+++ b/src/Gateway/Gemini/Concerns/MapsTools.php
@@ -67,13 +67,11 @@ trait MapsTools
         if (filled($schema)) {
             $schemaArray = (new ObjectSchema($schema))->toSchema();
 
-            $convertedNullableTypes = $this->convertNullableTypes([
+            $definition['parameters'] = $this->convertNullableTypes([
                 'type' => 'object',
                 'properties' => $schemaArray['properties'] ?? [],
                 'required' => $schemaArray['required'] ?? [],
             ]);
-
-            $definition['parameters'] = $this->removeAdditionalProperties($convertedNullableTypes);
         }
 
         return $definition;
@@ -87,6 +85,8 @@ trait MapsTools
      */
     protected function convertNullableTypes(array $schema): array
     {
+        unset($schema['additionalProperties']);
+
         if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true)) {
             $remaining = array_values(array_diff($schema['type'], ['null']));
 
@@ -105,25 +105,6 @@ trait MapsTools
 
         if (isset($schema['items']) && is_array($schema['items'])) {
             $schema['items'] = $this->convertNullableTypes($schema['items']);
-        }
-
-        return $schema;
-    }
-
-    /**
-     * Recursively remove additinalProperties from nested objects.
-     * 
-     * @param  array<string, mixed> $schema
-     * @return array<string, mixed>
-     */
-    protected function removeAdditionalProperties(array $schema): array
-    {
-        foreach ($schema as $key => &$value) {
-            if ($key === 'additionalProperties') {
-                $schema = Arr::except($schema, ['additionalProperties']);
-            } elseif (is_array($value)) {
-                $value = $this->removeAdditionalProperties($value);
-            }
         }
 
         return $schema;

--- a/tests/Feature/Providers/Gemini/ToolMappingTest.php
+++ b/tests/Feature/Providers/Gemini/ToolMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Agents\NamedToolAgent;
+use Tests\Fixtures\Agents\NestedObjectToolAgent;
 use Tests\Fixtures\Agents\NullableToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
@@ -58,6 +59,42 @@ test('tool parameters exclude additional properties', function () {
         }
 
         return false;
+    });
+});
+
+test('nested object parameters recursively exclude additional properties', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    (new NestedObjectToolAgent)->prompt('Test nested params', provider: 'gemini');
+
+    $hasAdditionalProperties = function ($node) use (&$hasAdditionalProperties) {
+        if (! is_array($node)) {
+            return false;
+        }
+
+        if (array_key_exists('additionalProperties', $node)) {
+            return true;
+        }
+
+        foreach ($node as $value) {
+            if ($hasAdditionalProperties($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    Http::assertSent(function ($request) use ($hasAdditionalProperties) {
+        $params = $request->data()['tools'][0]['function_declarations'][0]['parameters'];
+
+        // The nested object lives under the array's items and must survive the strip.
+        expect($params['properties']['items']['items']['properties'])
+            ->toHaveKeys(['name', 'description']);
+
+        return $hasAdditionalProperties($params) === false;
     });
 });
 

--- a/tests/Fixtures/Agents/NestedObjectToolAgent.php
+++ b/tests/Fixtures/Agents/NestedObjectToolAgent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\NestedObjectTool;
+
+class NestedObjectToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     */
+    public function tools(): iterable
+    {
+        return [
+            new NestedObjectTool,
+        ];
+    }
+}

--- a/tests/Fixtures/Tools/NestedObjectTool.php
+++ b/tests/Fixtures/Tools/NestedObjectTool.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class NestedObjectTool implements Tool
+{
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'A tool with nested object parameters for testing.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        return 'ok';
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'items' => $schema->array()
+                ->items($schema->object([
+                    'name' => $schema->string()->required(),
+                    'description' => $schema->string()->required(),
+                ]))
+                ->required(),
+        ];
+    }
+}


### PR DESCRIPTION
Similar to the issue highlighted in #139. Tools containing nested schema objects used by Gemini throw an error for `additionalProperties`.

```
"code": 400,
"message": "Invalid JSON payload received. Unknown name \"additionalProperties\"" 
```

For example in a tool such as:
```
class ExampleTool implements Tool
{
    public function description(): Stringable|string
    {
        return '';
    }

    public function handle(Request $request): Stringable|string
    {
        return '';
    } 

    public function schema(JsonSchema): array
    {
        return [
            'array' => $schema->array()
                ->items($schema->object([
                    'name' => $schema->string()->required(),
                    'description' => $schema->string()->required(),
                ]))
                ->required(),
        ];
    }
}
```

To fix this I have updated the `MapsTools` concern to recursively remove the key from the schema.