### PR TITLE
Pass the original prompt to AgentStreamed when a stream is short-circuited

### DIFF
--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -68,9 +68,9 @@ trait StreamsText
                     },
                     $meta,
                 );
-            })->then(function (StreamedAgentResponse $response) use ($invocationId, &$processedPrompt) {
+            })->then(function (StreamedAgentResponse $response) use ($invocationId, $prompt, &$processedPrompt) {
                 $this->events->dispatch(
-                    new AgentStreamed($invocationId, $processedPrompt, $response)
+                    new AgentStreamed($invocationId, $processedPrompt ?? $prompt, $response)
                 );
             });
     }

--- a/tests/Feature/AgentMiddlewareTest.php
+++ b/tests/Feature/AgentMiddlewareTest.php
@@ -3,11 +3,15 @@
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\TextDelta;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\RememberingAssistantAgent;
 use Tests\Fixtures\FakeConversationStore;
@@ -61,6 +65,27 @@ test('agent prompted event receives prompt when middleware short circuits', func
         ->prompt('Test prompt');
 
     Event::assertDispatched(AgentPrompted::class, function (AgentPrompted $event) {
+        return $event->prompt instanceof AgentPrompt
+            && $event->prompt->prompt === 'Test prompt';
+    });
+});
+
+test('agent streamed event receives prompt when middleware short circuits a stream', function () {
+    Event::fake();
+
+    AssistantAgent::fake([
+        'Fake response',
+    ]);
+
+    $response = (new AssistantAgent)
+        ->withMiddleware([streamingShortCircuitingMiddleware()])
+        ->stream('Test prompt');
+
+    foreach ($response as $event) {
+        // Drain the stream so the post-stream then() callback dispatches AgentStreamed.
+    }
+
+    Event::assertDispatched(AgentStreamed::class, function (AgentStreamed $event) {
         return $event->prompt instanceof AgentPrompt
             && $event->prompt->prompt === 'Test prompt';
     });
@@ -163,6 +188,35 @@ function shortCircuitingMiddleware(): object
                 'test-invocation-id',
                 'Short-circuited response',
                 new Usage,
+                new Meta,
+            );
+        }
+    };
+}
+
+function streamingShortCircuitingMiddleware(): object
+{
+    return new class
+    {
+        public function handle(AgentPrompt $prompt, Closure $next)
+        {
+            return new StreamableAgentResponse(
+                'test-invocation-id',
+                function () {
+                    yield new TextDelta(
+                        id: 'test-0',
+                        messageId: 'test-invocation-id',
+                        delta: 'Short-circuited response',
+                        timestamp: 0,
+                    );
+
+                    yield new StreamEnd(
+                        id: 'test-end',
+                        reason: 'short_circuit',
+                        usage: new Usage,
+                        timestamp: 0,
+                    );
+                },
                 new Meta,
             );
         }


### PR DESCRIPTION
Fixes #683.

### Problem

When an agent middleware short-circuits the pipeline by returning a response **without calling `$next($prompt)`**, the streaming path dispatches `AgentStreamed` with a `null` prompt and throws — *after* the stream has already yielded all of its events:

```
Laravel\Ai\Events\AgentPrompted::__construct(): Argument #2 ($prompt) must be of type Laravel\Ai\Prompts\AgentPrompt, null given, called in src/Providers/Concerns/StreamsText.php on line 73
```

In `StreamsText::stream()`, `$processedPrompt` is only assigned inside the pipeline destination closure, which never runs when a middleware short-circuits. The deferred post-stream `then()` callback then constructs `AgentStreamed` with `null`.

The non-streaming path already handles this in `GeneratesText::prompt()` with `$processedPrompt ?? $prompt`; the streaming path was missing the same fallback (still missing on `0.x` HEAD and v0.7.2).

### Fix

Apply the same fallback in `StreamsText`. Because the dispatch lives in a nested closure, `$prompt` is also captured in the `use()`:

```diff
-            })->then(function (StreamedAgentResponse $response) use ($invocationId, &$processedPrompt) {
+            })->then(function (StreamedAgentResponse $response) use ($invocationId, $prompt, &$processedPrompt) {
                 $this->events->dispatch(
-                    new AgentStreamed($invocationId, $processedPrompt, $response)
+                    new AgentStreamed($invocationId, $processedPrompt ?? $prompt, $response)
                 );
             });
```

### Test

Added a streaming counterpart to the existing sync short-circuit test in `tests/Feature/AgentMiddlewareTest.php` (`agent streamed event receives prompt when middleware short circuits a stream`). It drains a short-circuited stream and asserts `AgentStreamed` is dispatched with the original `AgentPrompt`. The test fails with the `TypeError` before this change and passes after it. `vendor/bin/pint` is clean and the rest of the `Feature`/`Unit` suites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
