### PR TITLE
Add search query extraction to Gemini and OpenAI response processing

### DIFF
--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -95,11 +95,12 @@ trait ParsesTextResponses
         $text = $this->extractText($parts);
         $rawToolCalls = $this->extractRawToolCalls($parts);
         $citations = $this->extractCitations($data);
+        $searchQueries = $this->extractSearchQueries($data);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data, $rawToolCalls);
 
         $mappedToolCalls = $this->mapToolCalls($rawToolCalls);
-        $meta = new Meta($provider->name(), $model, $citations);
+        $meta = new Meta($provider->name(), $model, $citations, $searchQueries);
         $toolResults = [];
 
         $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
@@ -373,6 +374,17 @@ trait ParsesTextResponses
         }
 
         return $citations->unique('url')->values();
+    }
+
+    /**
+     * Extract Google Search grounding queries from the response data.
+     */
+    protected function extractSearchQueries(array $data): Collection
+    {
+        return collect(data_get($data, 'candidates.0.groundingMetadata.webSearchQueries', []))
+            ->filter(fn (mixed $query): bool => is_string($query) && $query !== '')
+            ->unique()
+            ->values();
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -97,8 +97,10 @@ trait ParsesTextResponses
 
         $text = $this->extractText($output);
         $citations = $this->extractCitations($output);
+        $searchQueries = $this->extractSearchQueries($output);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data);
+        $meta = new Meta($provider->name(), $model, $citations, $searchQueries);
 
         // Associate reasoning with tool calls...
         $mappedToolCalls = $this->mapToolCallsWithReasoning($output);
@@ -109,7 +111,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model, $citations),
+            $meta,
         );
 
         $steps->push($step);
@@ -134,7 +136,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model, $citations),
+                $meta,
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -168,7 +170,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
+                $meta,
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -178,7 +180,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
+            $meta,
         ))->withMessages($messages)->withSteps($steps);
     }
 
@@ -343,6 +345,26 @@ trait ParsesTextResponses
         }
 
         return $citations->values();
+    }
+
+    /**
+     * Extract web search queries from OpenAI provider tool calls.
+     */
+    protected function extractSearchQueries(array $output): Collection
+    {
+        return collect($output)
+            ->filter(fn (array $item): bool => ($item['type'] ?? null) === 'web_search_call')
+            ->filter(fn (array $item): bool => data_get($item, 'action.type') === 'search')
+            ->flatMap(function (array $item): array {
+                return collect([
+                    ...Arr::wrap(data_get($item, 'action.queries')),
+                    data_get($item, 'action.query'),
+                ])
+                    ->filter(fn (mixed $query): bool => is_string($query) && $query !== '')
+                    ->all();
+            })
+            ->unique()
+            ->values();
     }
 
     /**

--- a/src/Responses/Data/Meta.php
+++ b/src/Responses/Data/Meta.php
@@ -10,12 +10,16 @@ class Meta implements Arrayable, JsonSerializable
 {
     public Collection $citations;
 
+    public Collection $searchQueries;
+
     public function __construct(
         public ?string $provider = null,
         public ?string $model = null,
         ?Collection $citations = null,
+        ?Collection $searchQueries = null,
     ) {
         $this->citations = $citations ?? new Collection;
+        $this->searchQueries = $searchQueries ?? new Collection;
     }
 
     /**
@@ -28,6 +32,9 @@ class Meta implements Arrayable, JsonSerializable
             'model' => $this->model,
             'citations' => $this->citations
                 ? $this->citations->all()
+                : [],
+            'search_queries' => $this->searchQueries
+                ? $this->searchQueries->all()
                 : [],
         ];
     }

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -95,6 +95,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
             $this->meta->provider = $response->meta->provider;
             $this->meta->model = $response->meta->model;
             $this->meta->citations = $response->meta->citations;
+            $this->meta->searchQueries = $response->meta->searchQueries;
         }
 
         if ($response->conversationId !== null) {

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Ai\Responses;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolCall;
@@ -15,6 +17,11 @@ class StreamedAgentResponse extends AgentResponse
 
     public function __construct(string $invocationId, Collection $events, Meta $meta)
     {
+        $meta->searchQueries = $meta->searchQueries
+            ->merge($this->extractSearchQueries($events))
+            ->unique()
+            ->values();
+
         parent::__construct(
             $invocationId,
             TextDelta::combine($events),
@@ -28,5 +35,22 @@ class StreamedAgentResponse extends AgentResponse
         );
 
         $this->events = $events;
+    }
+
+    protected function extractSearchQueries(Collection $events): Collection
+    {
+        return $events
+            ->whereInstanceOf(ProviderToolEvent::class)
+            ->filter(fn (ProviderToolEvent $event): bool => $event->type === 'web_search_call')
+            ->filter(fn (ProviderToolEvent $event): bool => data_get($event->data, 'action.type') === 'search')
+            ->flatMap(function (ProviderToolEvent $event): array {
+                return collect([
+                    ...Arr::wrap(data_get($event->data, 'action.queries')),
+                    data_get($event->data, 'action.query'),
+                ])
+                    ->filter(fn (mixed $query): bool => is_string($query) && $query !== '')
+                    ->all();
+            })
+            ->values();
     }
 }

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -327,7 +327,8 @@ describe('citations', function () {
 
         expect($response->meta->citations)->toHaveCount(2)
             ->and($response->meta->citations[0]->url)->toBe('https://example.com/euro')
-            ->and($response->meta->citations[1]->url)->toBe('https://example.com/spain');
+            ->and($response->meta->citations[1]->url)->toBe('https://example.com/spain')
+            ->and($response->meta->searchQueries->all())->toBe(['who won euro 2024']);
     });
 
     test('legacy citation metadata is also extracted', function () {

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -281,3 +281,51 @@ test('citations omit span indices when not provided by the api', function () {
         ->and($response->meta->citations[0]->startIndex)->toBeNull()
         ->and($response->meta->citations[0]->endIndex)->toBeNull();
 });
+
+test('web search queries are extracted from provider tool calls', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'resp_123',
+        'status' => 'completed',
+        'model' => 'gpt-5.4',
+        'output' => [
+            [
+                'id' => 'ws_1',
+                'type' => 'web_search_call',
+                'status' => 'completed',
+                'action' => [
+                    'type' => 'search',
+                    'query' => 'laravel ai search',
+                    'queries' => ['laravel ai search', 'openai responses web search'],
+                ],
+            ],
+            [
+                'id' => 'ws_2',
+                'type' => 'web_search_call',
+                'status' => 'completed',
+                'action' => [
+                    'type' => 'open_page',
+                    'url' => 'https://example.com',
+                ],
+            ],
+            [
+                'type' => 'message',
+                'status' => 'completed',
+                'content' => [[
+                    'type' => 'output_text',
+                    'text' => 'Found it',
+                ]],
+            ],
+        ],
+        'usage' => [
+            'input_tokens' => 10,
+            'output_tokens' => 5,
+        ],
+    ])]);
+
+    $response = agent()->prompt('Search the web', provider: 'openai');
+
+    expect($response->meta->searchQueries->all())->toBe([
+        'laravel ai search',
+        'openai responses web search',
+    ]);
+});

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
@@ -12,6 +13,7 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 
 beforeEach(function () {
@@ -156,6 +158,49 @@ test('streaming captures usage from response completed', function () {
     expect($streamEnd->usage->promptTokens)->toBe(37)
         ->and($streamEnd->usage->completionTokens)->toBe(10)
         ->and($streamEnd->usage->cacheReadInputTokens)->toBe(5);
+});
+
+test('streamed responses collect web search queries from provider tool events', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                [
+                    'type' => 'response.output_item.done',
+                    'item' => [
+                        'id' => 'ws_1',
+                        'type' => 'web_search_call',
+                        'status' => 'completed',
+                        'action' => [
+                            'type' => 'search',
+                            'query' => 'laravel ai search',
+                            'queries' => ['laravel ai search', 'openai responses web search'],
+                        ],
+                    ],
+                ],
+                $this->responseCompleted(10, 5),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $streamedResponse = null;
+
+    $response = (new AssistantAgent)->stream('Search the web', provider: 'openai');
+    $response->then(function (StreamedAgentResponse $response) use (&$streamedResponse) {
+        $streamedResponse = $response;
+    });
+
+    foreach ($response as $_) {
+        //
+    }
+
+    expect($streamedResponse)->toBeInstanceOf(StreamedAgentResponse::class)
+        ->and($streamedResponse->meta->searchQueries->all())->toBe([
+            'laravel ai search',
+            'openai responses web search',
+        ]);
 });
 
 test('streaming finish reason maps correctly', function (string $status, string $type, $expected) {

--- a/tests/Unit/Responses/Data/MetaTest.php
+++ b/tests/Unit/Responses/Data/MetaTest.php
@@ -19,17 +19,19 @@ test('meta accepts null provider and model', function () {
 test('meta returns empty citations when not provided', function () {
     $meta = new Meta('openai', 'gpt-4o');
 
-    expect($meta->citations)->toBeEmpty();
+    expect($meta->citations)->toBeEmpty()
+        ->and($meta->searchQueries)->toBeEmpty();
 });
 
-test('meta to array includes provider model and citations', function () {
+test('meta to array includes provider model citations and search queries', function () {
     $meta = new Meta('openai', 'gpt-4o');
 
     $array = $meta->toArray();
 
     expect($array['provider'])->toBe('openai')
         ->and($array['model'])->toBe('gpt-4o')
-        ->and($array['citations'])->toBe([]);
+        ->and($array['citations'])->toBe([])
+        ->and($array['search_queries'])->toBe([]);
 });
 
 test('meta json serialize returns to array', function () {


### PR DESCRIPTION
- Implemented `extractSearchQueries` method in both `ParsesTextResponses` classes for Gemini and OpenAI to gather web search queries from response data.
- Updated the `Meta` class to include `searchQueries` property.
- Modified response processing to include extracted search queries in the `Meta` object.
- Enhanced tests to verify the correct extraction of search queries from provider tool calls and responses.

Relevant Docs:
[OpenAI](developers.openai.com/api/reference/resources/responses)
[Google](https://ai.google.dev/gemini-api/docs/google-search#understanding_the_grounding_response)