### PR TITLE
Omit null header and multipart values for Laravel 13 compatibility

### DIFF
--- a/src/Gateway/Anthropic/AnthropicFileGateway.php
+++ b/src/Gateway/Anthropic/AnthropicFileGateway.php
@@ -71,11 +71,11 @@ class AnthropicFileGateway implements FileGateway
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
         return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders([
+            ->withHeaders(array_filter([
                 'x-api-key' => $provider->providerCredentials()['key'],
                 'anthropic-version' => $provider->additionalConfiguration()['version'] ?? '2023-06-01',
                 'anthropic-beta' => 'files-api-2025-04-14',
-            ])
+            ]))
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
+++ b/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
@@ -15,11 +15,11 @@ trait CreatesAnthropicClient
     {
         $config = $provider->additionalConfiguration();
 
-        $headers = [
+        $headers = array_filter([
             'x-api-key' => $provider->providerCredentials()['key'],
             'anthropic-version' => $config['version'] ?? '2023-06-01',
             'anthropic-beta' => $config['anthropic_beta'] ?? 'web-fetch-2025-09-10',
-        ];
+        ]);
 
         return Http::baseUrl($this->baseUrl($provider))
             ->withHeaders($headers)

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -66,12 +66,12 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         array $providerOptions = [],
     ): TranscriptionResponse {
         $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
-            ->attach('file', $audio->content(), 'file', ['Content-Type' => $audio->mimeType()])
-            ->post('speech-to-text', array_merge($providerOptions, [
+            ->attach('file', $audio->content(), 'file', array_filter(['Content-Type' => $audio->mimeType()]))
+            ->post('speech-to-text', array_merge($providerOptions, array_filter([
                 'model_id' => $model,
                 'language' => $language,
                 'diarize' => $diarize ? 'true' : 'false',
-            ]))->throw());
+            ])))->throw());
 
         $response = $response->json();
 
@@ -104,7 +104,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
     protected function client(AudioProvider|TranscriptionProvider $provider, int $timeout = 30): PendingRequest
     {
         return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders(['xi-api-key' => $provider->providerCredentials()['key']])
+            ->withHeaders(array_filter(['xi-api-key' => $provider->providerCredentials()['key']]))
             ->timeout($timeout);
     }
 

--- a/src/Gateway/Gemini/Concerns/CreatesGeminiClient.php
+++ b/src/Gateway/Gemini/Concerns/CreatesGeminiClient.php
@@ -14,7 +14,7 @@ trait CreatesGeminiClient
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
         return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders(['x-goog-api-key' => $provider->providerCredentials()['key']])
+            ->withHeaders(array_filter(['x-goog-api-key' => $provider->providerCredentials()['key']]))
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Gemini/GeminiFileGateway.php
+++ b/src/Gateway/Gemini/GeminiFileGateway.php
@@ -24,9 +24,9 @@ class GeminiFileGateway implements FileGateway
     {
         $fileId = str_starts_with($fileId, 'files/') ? $fileId : "files/{$fileId}";
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->get($this->baseUrl($provider)."/{$fileId}")->throw());
+        ]))->get($this->baseUrl($provider)."/{$fileId}")->throw());
 
         return new FileResponse(
             id: $response->json('name'),
@@ -45,9 +45,9 @@ class GeminiFileGateway implements FileGateway
 
         $uploadUrl = str_replace('/v1beta', '/upload/v1beta', $this->baseUrl($provider));
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->attach(
+        ]))->attach(
             'file', $content, $name, ['Content-Type' => $mime]
         )->post("{$uploadUrl}/files", [
             'file' => ['display_name' => $name],
@@ -63,9 +63,9 @@ class GeminiFileGateway implements FileGateway
     {
         $fileId = str_starts_with($fileId, 'files/') ? $fileId : "files/{$fileId}";
 
-        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->delete($this->baseUrl($provider)."/{$fileId}")->throw());
+        ]))->delete($this->baseUrl($provider)."/{$fileId}")->throw());
     }
 
     /**

--- a/src/Gateway/Gemini/GeminiStoreGateway.php
+++ b/src/Gateway/Gemini/GeminiStoreGateway.php
@@ -23,9 +23,9 @@ class GeminiStoreGateway implements StoreGateway
     {
         $storeId = $this->normalizeStoreId($storeId);
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->get($this->baseUrl($provider)."/{$storeId}")->throw());
+        ]))->get($this->baseUrl($provider)."/{$storeId}")->throw());
 
         return new Store(
             provider: $provider,
@@ -52,9 +52,9 @@ class GeminiStoreGateway implements StoreGateway
     ): Store {
         $fileIds ??= new Collection;
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->post($this->baseUrl($provider).'/fileSearchStores', [
+        ]))->post($this->baseUrl($provider).'/fileSearchStores', [
             'displayName' => $name,
         ])->throw());
 
@@ -77,9 +77,9 @@ class GeminiStoreGateway implements StoreGateway
         $storeId = $this->normalizeStoreId($storeId);
         $fileId = $this->normalizeFileId($fileId);
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->post($this->baseUrl($provider)."/{$storeId}:importFile", array_filter([
+        ]))->post($this->baseUrl($provider)."/{$storeId}:importFile", array_filter([
             'fileName' => $fileId,
             'customMetadata' => ! empty($metadata) ? $this->formatMetadata($metadata) : null,
         ]))->throw());
@@ -109,9 +109,9 @@ class GeminiStoreGateway implements StoreGateway
         $storeId = $this->normalizeStoreId($storeId);
         $documentId = $this->normalizeDocumentId($storeId, $documentId);
 
-        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->delete($this->baseUrl($provider)."/{$documentId}", [
+        ]))->delete($this->baseUrl($provider)."/{$documentId}", [
             'force' => true,
         ])->throw());
 
@@ -125,9 +125,9 @@ class GeminiStoreGateway implements StoreGateway
     {
         $storeId = $this->normalizeStoreId($storeId);
 
-        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders([
+        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ])->delete($this->baseUrl($provider)."/{$storeId}")->throw());
+        ]))->delete($this->baseUrl($provider)."/{$storeId}")->throw());
 
         return true;
     }

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -186,7 +186,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)
-                ->attach('file', $audio->content(), $this->audioFilename($audio), ['Content-Type' => $audio->mimeType()])
+                ->attach('file', $audio->content(), $this->audioFilename($audio), array_filter(['Content-Type' => $audio->mimeType()]))
                 ->post('audio/transcriptions', $this->multipartParams(array_merge($providerOptions, $params))),
         );
 

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -287,7 +287,7 @@ class OpenAiGateway implements Gateway
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)
-                ->attach('file', $audio->content(), $this->audioFilename($audio), ['Content-Type' => $audio->mimeType()])
+                ->attach('file', $audio->content(), $this->audioFilename($audio), array_filter(['Content-Type' => $audio->mimeType()]))
                 ->post('audio/transcriptions', array_merge($providerOptions, array_filter([
                     'model' => $model,
                     'language' => $language,

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -137,6 +137,11 @@ describe('request structure', function () {
     });
 
     test('request sends correct authentication headers', function () {
+        config(['ai.providers.anthropic' => [
+            ...config('ai.providers.anthropic'),
+            'key' => 'test-key',
+        ]]);
+
         Http::fake([
             'api.anthropic.com/*' => $this->fakeTextResponse(),
         ]);
@@ -147,7 +152,23 @@ describe('request structure', function () {
         );
 
         Http::assertSent(function ($request) {
-            return $request->hasHeader('x-api-key')
+            return $request->hasHeader('x-api-key', 'test-key')
+                && $request->hasHeader('anthropic-version', '2023-06-01');
+        });
+    });
+
+    test('request omits the api key header when no key is configured', function () {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            return ! $request->hasHeader('x-api-key')
                 && $request->hasHeader('anthropic-version', '2023-06-01');
         });
     });

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -65,6 +65,11 @@ describe('request structure', function () {
     });
 
     test('request sends api key header', function () {
+        config(['ai.providers.gemini' => [
+            ...config('ai.providers.gemini'),
+            'key' => 'test-key',
+        ]]);
+
         Http::fake([
             'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
         ]);
@@ -75,7 +80,22 @@ describe('request structure', function () {
         );
 
         Http::assertSent(function ($request) {
-            return $request->hasHeader('x-goog-api-key');
+            return $request->hasHeader('x-goog-api-key', 'test-key');
+        });
+    });
+
+    test('request omits the api key header when no key is configured', function () {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        (new AssistantAgent)->prompt(
+            'Hi',
+            provider: 'gemini',
+        );
+
+        Http::assertSent(function ($request) {
+            return ! $request->hasHeader('x-goog-api-key');
         });
     });
 


### PR DESCRIPTION
Currently `0.x` is red on every Laravel 13 CI leg (PHP 8.3/8.4/8.5), and so is every open PR. Laravel 13 tightened HTTP client validation: `PendingRequest` now throws when a header or multipart value is `null`, where Laravel 12 silently dropped it.

```
InvalidArgumentException: HTTP header values must be scalar, Laravel Stringable, or arrays of scalar or Laravel Stringable values.
```

