### PR TITLE
Propagate invocation context through agents

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai;
 
 use Closure;
+use Illuminate\Queue\Events\Looping;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Stringable;
@@ -39,6 +40,8 @@ class AiServiceProvider extends ServiceProvider
             $this->registerCommands();
             $this->registerPublishing();
         }
+
+        $this->resetInvocationContextBetweenRequests();
 
         // Embeddings macro...
         Stringable::macro('toEmbeddings', function (
@@ -119,6 +122,27 @@ class AiServiceProvider extends ServiceProvider
                 fn ($result) => $this->values()[$result->index]
             );
         });
+    }
+
+    /**
+     * Clear the active invocation-context stack at long-lived process
+     * boundaries so a context leaked by an abandoned stream (whose generator
+     * never finalized) cannot bleed into a subsequent request or queued job.
+     */
+    protected function resetInvocationContextBetweenRequests(): void
+    {
+        $flush = fn () => InvocationContext::flush();
+
+        // Between jobs in a long-running queue worker...
+        $this->app['events']->listen(Looping::class, $flush);
+
+        // At Octane request and task boundaries, listened to by event name so Octane is not a hard dependency
+        $this->app['events']->listen([
+            'Laravel\Octane\Events\RequestReceived',
+            'Laravel\Octane\Events\RequestTerminated',
+            'Laravel\Octane\Events\TaskReceived',
+            'Laravel\Octane\Events\TickReceived',
+        ], $flush);
     }
 
     /**

--- a/src/InvocationContext.php
+++ b/src/InvocationContext.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Laravel\Ai;
+
+use Closure;
+
+class InvocationContext
+{
+    /**
+     * The stack of active invocation contexts for the current execution.
+     *
+     * @var array<int, self>
+     */
+    protected static array $active = [];
+
+    public function __construct(
+        public readonly string $id,
+        public readonly ?string $parentId = null,
+        public readonly ?string $rootId = null,
+    ) {}
+
+    /**
+     * Create a new root invocation context.
+     */
+    public static function root(string $id): self
+    {
+        return new self($id, null, $id);
+    }
+
+    /**
+     * Create an invocation context for the given id, nesting it beneath the
+     * currently active context when one is present.
+     */
+    public static function for(string $id): self
+    {
+        $parent = static::current();
+
+        if ($parent === null) {
+            return static::root($id);
+        }
+
+        return new self($id, $parent->id, $parent->rootId);
+    }
+
+    /**
+     * Reconstruct a context from ids carried across a boundary (e.g. a queued
+     * job) so a child can nest beneath it. The source context's own parent is
+     * not tracked - for() only needs its id and root.
+     */
+    public static function rehydrate(string $id, ?string $rootId = null): self
+    {
+        return new self($id, null, $rootId ?? $id);
+    }
+
+    /**
+     * Get the currently active invocation context, if any.
+     */
+    public static function current(): ?self
+    {
+        return static::$active === []
+            ? null
+            : static::$active[array_key_last(static::$active)];
+    }
+
+    /**
+     * Run the given callback with the context active, so any agent invoked
+     * within it (such as a sub-agent used as a tool) nests beneath it.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function run(self $context, Closure $callback): mixed
+    {
+        static::push($context);
+
+        try {
+            return $callback();
+        } finally {
+            static::pop();
+        }
+    }
+
+    /**
+     * Push the context onto the active stack. Pair with pop() in a finally
+     * block; prefer run() unless the work is a lazily-consumed generator
+     * (streaming) that cannot be wrapped in a single callback.
+     */
+    public static function push(self $context): void
+    {
+        static::$active[] = $context;
+    }
+
+    /**
+     * Deactivate the most recently pushed context.
+     */
+    public static function pop(): void
+    {
+        array_pop(static::$active);
+    }
+
+    /**
+     * Flush the active context stack.
+     */
+    public static function flush(): void
+    {
+        static::$active = [];
+    }
+
+    /**
+     * Determine if the context is a top-level (root) invocation.
+     */
+    public function isRoot(): bool
+    {
+        return $this->parentId === null;
+    }
+}

--- a/src/InvocationContext.php
+++ b/src/InvocationContext.php
@@ -53,6 +53,26 @@ class InvocationContext
     }
 
     /**
+     * Run the given callback within a context rehydrated from ids carried
+     * across a boundary (e.g. a queued job). When no parent id is present the
+     * callback runs without establishing a context, so the work behaves as a
+     * fresh top-level invocation.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function runRehydrated(?string $parentId, ?string $rootId, Closure $callback): mixed
+    {
+        if ($parentId === null) {
+            return $callback();
+        }
+
+        return static::run(static::rehydrate($parentId, $rootId), $callback);
+    }
+
+    /**
      * Get the currently active invocation context, if any.
      */
     public static function current(): ?self
@@ -93,11 +113,28 @@ class InvocationContext
     }
 
     /**
-     * Deactivate the most recently pushed context.
+     * Deactivate a context.
+     *
+     * With no argument the most recently pushed context is removed. Pass a
+     * specific context to remove that exact entry instead - lazily-consumed
+     * streams can unwind out of order, so the top of the stack is not always
+     * the context that is finishing.
      */
-    public static function pop(): void
+    public static function pop(?self $context = null): void
     {
-        array_pop(static::$active);
+        if ($context === null) {
+            array_pop(static::$active);
+
+            return;
+        }
+
+        for ($i = count(static::$active) - 1; $i >= 0; $i--) {
+            if (static::$active[$i] === $context) {
+                array_splice(static::$active, $i, 1);
+
+                return;
+            }
+        }
     }
 
     /**

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Throwable;
@@ -32,6 +33,8 @@ class BroadcastAgent implements ShouldQueue
         public array $attachments = [],
         public Lab|array|string|null $provider = null,
         public ?string $model = null,
+        public ?string $parentInvocationId = null,
+        public ?string $rootInvocationId = null,
     ) {
         $this->invocationId = (string) Str::uuid7();
     }
@@ -41,17 +44,24 @@ class BroadcastAgent implements ShouldQueue
      */
     public function handle(): void
     {
-        $streamedResponse = null;
+        // Re-establish the dispatching invocation so the streamed agent nests beneath it...
+        InvocationContext::runRehydrated(
+            $this->parentInvocationId,
+            $this->rootInvocationId,
+            function () {
+                $streamedResponse = null;
 
-        $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
-            ->each(function (StreamEvent $event) {
-                $event->withInvocationId($this->invocationId)->broadcastNow($this->channels);
-            })
-            ->then(function ($response) use (&$streamedResponse) {
-                $streamedResponse = $response;
-            });
+                $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
+                    ->each(function (StreamEvent $event) {
+                        $event->withInvocationId($this->invocationId)->broadcastNow($this->channels);
+                    })
+                    ->then(function ($response) use (&$streamedResponse) {
+                        $streamedResponse = $response;
+                    });
 
-        $this->withCallbacks(fn () => $streamedResponse);
+                $this->withCallbacks(fn () => $streamedResponse);
+            },
+        );
     }
 
     /**

--- a/src/Jobs/InvokeAgent.php
+++ b/src/Jobs/InvokeAgent.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\InvocationContext;
 
 class InvokeAgent implements ShouldQueue
 {
@@ -19,19 +20,36 @@ class InvokeAgent implements ShouldQueue
         public string $prompt,
         public array $attachments = [],
         public Lab|array|string|null $provider = null,
-        public ?string $model = null) {}
+        public ?string $model = null,
+        public ?string $parentInvocationId = null,
+        public ?string $rootInvocationId = null) {}
 
     /**
      * Execute the job.
      */
     public function handle(): void
     {
-        $this->withCallbacks(fn () => $this->agent->prompt(
+        $invoke = fn () => $this->withCallbacks(fn () => $this->agent->prompt(
             $this->prompt,
             $this->attachments,
             $this->provider,
             $this->model,
         ));
+
+        // No dispatching context to nest beneath - parent and root travel together, set by queue()...
+        $parentId = $this->parentInvocationId;
+
+        if ($parentId === null) {
+            $invoke();
+
+            return;
+        }
+
+        // Re-establish the dispatching invocation so the queued agent nests beneath it...
+        InvocationContext::run(
+            InvocationContext::rehydrate($parentId, $this->rootInvocationId),
+            $invoke,
+        );
     }
 
     /**

--- a/src/Jobs/InvokeAgent.php
+++ b/src/Jobs/InvokeAgent.php
@@ -29,26 +29,16 @@ class InvokeAgent implements ShouldQueue
      */
     public function handle(): void
     {
-        $invoke = fn () => $this->withCallbacks(fn () => $this->agent->prompt(
-            $this->prompt,
-            $this->attachments,
-            $this->provider,
-            $this->model,
-        ));
-
-        // No dispatching context to nest beneath - parent and root travel together, set by queue()...
-        $parentId = $this->parentInvocationId;
-
-        if ($parentId === null) {
-            $invoke();
-
-            return;
-        }
-
         // Re-establish the dispatching invocation so the queued agent nests beneath it...
-        InvocationContext::run(
-            InvocationContext::rehydrate($parentId, $this->rootInvocationId),
-            $invoke,
+        InvocationContext::runRehydrated(
+            $this->parentInvocationId,
+            $this->rootInvocationId,
+            fn () => $this->withCallbacks(fn () => $this->agent->prompt(
+                $this->prompt,
+                $this->attachments,
+                $this->provider,
+                $this->model,
+            )),
         );
     }
 

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -80,11 +80,15 @@ trait Promptable
 
         $invocationId = (string) Str::uuid7();
 
+        // Capture the context now so lazily-resolved multi-provider streams still nest beneath the dispatching invocation...
+        $context = InvocationContext::for($invocationId);
+
         if (count($providers) === 1) {
             [$resolved, $resolvedModel] = $this->iterateProvidersWithFailover($providers)->current();
 
             return $resolved->stream(
-                new AgentPrompt($this, $prompt, $attachments, $resolved, $resolvedModel, $resolvedTimeout, $invocationId)
+                (new AgentPrompt($this, $prompt, $attachments, $resolved, $resolvedModel, $resolvedTimeout, $invocationId))
+                    ->withInvocationContext($context)
             );
         }
 
@@ -93,7 +97,7 @@ trait Promptable
 
         $outer = new StreamableAgentResponse(
             $invocationId,
-            function () use ($providers, $prompt, $attachments, $resolvedTimeout, $invocationId, &$outer) {
+            function () use ($providers, $prompt, $attachments, $resolvedTimeout, $invocationId, $context, &$outer) {
                 $lastException = null;
 
                 foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
@@ -101,7 +105,8 @@ trait Promptable
 
                     try {
                         $innerResponse = $provider->stream(
-                            new AgentPrompt($this, $prompt, $attachments, $provider, $model, $resolvedTimeout, $invocationId)
+                            (new AgentPrompt($this, $prompt, $attachments, $provider, $model, $resolvedTimeout, $invocationId))
+                                ->withInvocationContext($context)
                         );
 
                         $innerResponse->then(fn (StreamedAgentResponse $response) => $outer->adoptStateFrom($response));
@@ -126,6 +131,8 @@ trait Promptable
             },
             $meta,
         );
+
+        $outer->withInvocationContext($context);
 
         return $outer;
     }
@@ -186,8 +193,14 @@ trait Promptable
             return new QueuedAgentResponse(new FakePendingDispatch);
         }
 
+        // Carry the active context across the queue boundary so a queued broadcast dispatched within an invocation nests beneath it...
+        $context = InvocationContext::current();
+
         return new QueuedAgentResponse(
-            BroadcastAgent::dispatch($this, $prompt, $channels, $attachments, $provider, $model)
+            BroadcastAgent::dispatch(
+                $this, $prompt, $channels, $attachments, $provider, $model,
+                $context?->id, $context?->rootId,
+            )
         );
     }
 

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -143,8 +143,14 @@ trait Promptable
             return new QueuedAgentResponse(new FakePendingDispatch);
         }
 
+        // Carry the active context across the queue boundary so a queued agent dispatched within an invocation nests beneath it...
+        $context = InvocationContext::current();
+
         return new QueuedAgentResponse(
-            InvokeAgent::dispatch($this, $prompt, $attachments, $provider, $model)
+            InvokeAgent::dispatch(
+                $this, $prompt, $attachments, $provider, $model,
+                $context?->id, $context?->rootId,
+            )
         );
     }
 

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -98,6 +98,16 @@ class AgentPrompt extends Prompt
     }
 
     /**
+     * Build an invocation context from the ids carried on the prompt, if any.
+     */
+    public function invocationContext(): ?InvocationContext
+    {
+        return $this->invocationId === null
+            ? null
+            : new InvocationContext($this->invocationId, $this->parentInvocationId, $this->rootInvocationId);
+    }
+
+    /**
      * Set the invocation context on the prompt, returning a new prompt instance.
      */
     public function withInvocationContext(InvocationContext $context): AgentPrompt

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\InvocationContext;
 
 class AgentPrompt extends Prompt
 {
@@ -17,6 +18,10 @@ class AgentPrompt extends Prompt
 
     public readonly ?string $invocationId;
 
+    public readonly ?string $parentInvocationId;
+
+    public readonly ?string $rootInvocationId;
+
     public function __construct(
         Agent $agent,
         string $prompt,
@@ -25,6 +30,8 @@ class AgentPrompt extends Prompt
         string $model,
         ?int $timeout = null,
         ?string $invocationId = null,
+        ?string $parentInvocationId = null,
+        ?string $rootInvocationId = null,
     ) {
         parent::__construct($prompt, $provider, $model);
 
@@ -32,6 +39,8 @@ class AgentPrompt extends Prompt
         $this->attachments = Collection::make($attachments);
         $this->timeout = $timeout;
         $this->invocationId = $invocationId;
+        $this->parentInvocationId = $parentInvocationId;
+        $this->rootInvocationId = $rootInvocationId;
     }
 
     /**
@@ -75,6 +84,8 @@ class AgentPrompt extends Prompt
             $this->model,
             $this->timeout,
             $this->invocationId,
+            $this->parentInvocationId,
+            $this->rootInvocationId,
         );
     }
 
@@ -84,6 +95,24 @@ class AgentPrompt extends Prompt
     public function withAttachments(Collection|array $attachments): AgentPrompt
     {
         return $this->revise($this->prompt, $attachments);
+    }
+
+    /**
+     * Set the invocation context on the prompt, returning a new prompt instance.
+     */
+    public function withInvocationContext(InvocationContext $context): AgentPrompt
+    {
+        return new self(
+            $this->agent,
+            $this->prompt,
+            $this->attachments,
+            $this->provider,
+            $this->model,
+            $this->timeout,
+            $context->id,
+            $context->parentId,
+            $context->rootId,
+        );
     }
 
     /**

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -19,6 +19,7 @@ use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Middleware\RememberConversation;
 use Laravel\Ai\Prompts\AgentPrompt;
@@ -37,52 +38,61 @@ trait GeneratesText
      */
     public function prompt(AgentPrompt $prompt): AgentResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $context = InvocationContext::for($prompt->invocationId ?? (string) Str::uuid7());
+
+        $prompt = $prompt->withInvocationContext($context);
 
         $processedPrompt = null;
 
-        $response = pipeline()
-            ->send($prompt)
-            ->through($this->gatherMiddlewareFor($prompt->agent))
-            ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt) {
-                $processedPrompt = $prompt;
+        $response = InvocationContext::run($context, function () use ($prompt, $context, &$processedPrompt) {
+            return pipeline()
+                ->send($prompt)
+                ->through($this->gatherMiddlewareFor($prompt->agent))
+                ->then(function (AgentPrompt $prompt) use ($context, &$processedPrompt) {
+                    $processedPrompt = $prompt;
 
-                $this->events->dispatch(new PromptingAgent($invocationId, $prompt));
+                    $this->events->dispatch(new PromptingAgent($context->id, $prompt));
 
-                $agent = $prompt->agent;
+                    $agent = $prompt->agent;
 
-                $messages = [
-                    ...($agent instanceof Conversational ? $agent->messages() : []),
-                    new UserMessage($prompt->prompt, $prompt->attachments->all()),
-                ];
+                    $messages = [
+                        ...($agent instanceof Conversational ? $agent->messages() : []),
+                        new UserMessage($prompt->prompt, $prompt->attachments->all()),
+                    ];
 
-                $this->listenForToolInvocations($invocationId, $agent);
+                    $this->listenForToolInvocations($context->id, $agent);
 
-                $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
+                    $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
 
-                $response = $this->textGateway()->generateText(
-                    $this,
-                    $prompt->model,
-                    (string) $agent->instructions(),
-                    $messages,
-                    $this->resolveTools($agent),
-                    $schema,
-                    TextGenerationOptions::forAgent($agent),
-                    $prompt->timeout,
-                );
+                    $response = $this->textGateway()->generateText(
+                        $this,
+                        $prompt->model,
+                        (string) $agent->instructions(),
+                        $messages,
+                        $this->resolveTools($agent),
+                        $schema,
+                        TextGenerationOptions::forAgent($agent),
+                        $prompt->timeout,
+                    );
 
-                return ! empty($schema)
-                    ? (new StructuredAgentResponse($invocationId, $response->structured, $response->text, $response->usage, $response->meta))
-                        ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
-                        ->withSteps($response->steps)
-                    : (new AgentResponse($invocationId, $response->text, $response->usage, $response->meta))
-                        ->withMessages($response->messages)
-                        ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
-                        ->withSteps($response->steps);
-            });
+                    return ! empty($schema)
+                        ? (new StructuredAgentResponse($context->id, $response->structured, $response->text, $response->usage, $response->meta))
+                            ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
+                            ->withSteps($response->steps)
+                        : (new AgentResponse($context->id, $response->text, $response->usage, $response->meta))
+                            ->withMessages($response->messages)
+                            ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
+                            ->withSteps($response->steps);
+                });
+        });
+
+        // Stamp after the pipeline so a short-circuiting middleware's response is covered too...
+        if ($response instanceof AgentResponse) {
+            $response->withInvocationContext($context);
+        }
 
         $this->events->dispatch(
-            new AgentPrompted($invocationId, $processedPrompt ?? $prompt, $response)
+            new AgentPrompted($context->id, $processedPrompt ?? $prompt, $response)
         );
 
         return $response;

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -25,67 +25,70 @@ trait StreamsText
      */
     public function stream(AgentPrompt $prompt): StreamableAgentResponse
     {
-        $context = InvocationContext::for($prompt->invocationId ?? (string) Str::uuid7());
+        // Honor a context established upstream (e.g. a multi-provider stream), else nest beneath the active one...
+        $context = $prompt->invocationContext()
+            ?? InvocationContext::for($prompt->invocationId ?? (string) Str::uuid7());
 
         $prompt = $prompt->withInvocationContext($context);
 
         $processedPrompt = null;
 
-        return pipeline()
-            ->send($prompt)
-            ->through($this->gatherMiddlewareFor($prompt->agent))
-            ->then(function (AgentPrompt $prompt) use ($context, &$processedPrompt) {
-                $processedPrompt = $prompt;
+        // Activate the context around the middleware pipeline so a middleware that invokes a sub-agent nests beneath this invocation...
+        $streamable = InvocationContext::run($context, function () use ($prompt, $context, &$processedPrompt) {
+            return pipeline()
+                ->send($prompt)
+                ->through($this->gatherMiddlewareFor($prompt->agent))
+                ->then(function (AgentPrompt $prompt) use ($context, &$processedPrompt) {
+                    $processedPrompt = $prompt;
 
-                $agent = $prompt->agent;
+                    $agent = $prompt->agent;
 
-                if ($agent instanceof HasStructuredOutput) {
-                    throw new InvalidArgumentException('Streaming structured output is not currently supported.');
-                }
+                    if ($agent instanceof HasStructuredOutput) {
+                        throw new InvalidArgumentException('Streaming structured output is not currently supported.');
+                    }
 
-                $meta = new Meta($this->name(), $prompt->model);
+                    $meta = new Meta($this->name(), $prompt->model);
 
-                return new StreamableAgentResponse(
-                    $context->id,
-                    function () use ($context, $prompt, $agent) {
-                        // The generator runs lazily, after stream() returns, so re-activate the
-                        // context for its lifetime - a sub-agent invoked mid-stream nests beneath
-                        // it. Paired with pop() in finally so the stack unwinds on early exit.
-                        InvocationContext::push($context);
+                    return (new StreamableAgentResponse(
+                        $context->id,
+                        function () use ($context, $prompt, $agent) {
+                            // Re-activate the context for the lazily-consumed generator; pop() this exact context so out-of-order streams unwind correctly...
+                            InvocationContext::push($context);
 
-                        try {
-                            $this->events->dispatch(new StreamingAgent($context->id, $prompt));
+                            try {
+                                $this->events->dispatch(new StreamingAgent($context->id, $prompt));
 
-                            $messages = [
-                                ...($agent instanceof Conversational ? $agent->messages() : []),
-                                new UserMessage($prompt->prompt, $prompt->attachments->all()),
-                            ];
+                                $messages = [
+                                    ...($agent instanceof Conversational ? $agent->messages() : []),
+                                    new UserMessage($prompt->prompt, $prompt->attachments->all()),
+                                ];
 
-                            $this->listenForToolInvocations($context->id, $agent);
+                                $this->listenForToolInvocations($context->id, $agent);
 
-                            yield from $this->textGateway()->streamText(
-                                $context->id,
-                                $this,
-                                $prompt->model,
-                                (string) $agent->instructions(),
-                                $messages,
-                                $this->resolveTools($agent),
-                                null,
-                                TextGenerationOptions::forAgent($agent),
-                                $prompt->timeout,
-                            );
-                        } finally {
-                            InvocationContext::pop();
-                        }
-                    },
-                    $meta,
-                );
-            })->then(function (StreamedAgentResponse $response) use ($context, $prompt, &$processedPrompt) {
-                $response->withInvocationContext($context);
+                                yield from $this->textGateway()->streamText(
+                                    $context->id,
+                                    $this,
+                                    $prompt->model,
+                                    (string) $agent->instructions(),
+                                    $messages,
+                                    $this->resolveTools($agent),
+                                    null,
+                                    TextGenerationOptions::forAgent($agent),
+                                    $prompt->timeout,
+                                );
+                            } finally {
+                                InvocationContext::pop($context);
+                            }
+                        },
+                        $meta,
+                    ))->withInvocationContext($context);
+                });
+        });
 
-                $this->events->dispatch(
-                    new AgentStreamed($context->id, $processedPrompt ?? $prompt, $response)
-                );
-            });
+        return $streamable->then(function (StreamedAgentResponse $response) use ($context, $prompt, &$processedPrompt) {
+            $this->events->dispatch(
+                new AgentStreamed($context->id, $processedPrompt ?? $prompt, $response)
+            );
+        });
     }
 }

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\Meta;
@@ -24,14 +25,16 @@ trait StreamsText
      */
     public function stream(AgentPrompt $prompt): StreamableAgentResponse
     {
-        $invocationId = $prompt->invocationId ?? (string) Str::uuid7();
+        $context = InvocationContext::for($prompt->invocationId ?? (string) Str::uuid7());
+
+        $prompt = $prompt->withInvocationContext($context);
 
         $processedPrompt = null;
 
         return pipeline()
             ->send($prompt)
             ->through($this->gatherMiddlewareFor($prompt->agent))
-            ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt) {
+            ->then(function (AgentPrompt $prompt) use ($context, &$processedPrompt) {
                 $processedPrompt = $prompt;
 
                 $agent = $prompt->agent;
@@ -43,34 +46,45 @@ trait StreamsText
                 $meta = new Meta($this->name(), $prompt->model);
 
                 return new StreamableAgentResponse(
-                    $invocationId,
-                    function () use ($invocationId, $prompt, $agent) {
-                        $this->events->dispatch(new StreamingAgent($invocationId, $prompt));
+                    $context->id,
+                    function () use ($context, $prompt, $agent) {
+                        // The generator runs lazily, after stream() returns, so re-activate the
+                        // context for its lifetime - a sub-agent invoked mid-stream nests beneath
+                        // it. Paired with pop() in finally so the stack unwinds on early exit.
+                        InvocationContext::push($context);
 
-                        $messages = [
-                            ...($agent instanceof Conversational ? $agent->messages() : []),
-                            new UserMessage($prompt->prompt, $prompt->attachments->all()),
-                        ];
+                        try {
+                            $this->events->dispatch(new StreamingAgent($context->id, $prompt));
 
-                        $this->listenForToolInvocations($invocationId, $agent);
+                            $messages = [
+                                ...($agent instanceof Conversational ? $agent->messages() : []),
+                                new UserMessage($prompt->prompt, $prompt->attachments->all()),
+                            ];
 
-                        yield from $this->textGateway()->streamText(
-                            $invocationId,
-                            $this,
-                            $prompt->model,
-                            (string) $agent->instructions(),
-                            $messages,
-                            $this->resolveTools($agent),
-                            null,
-                            TextGenerationOptions::forAgent($agent),
-                            $prompt->timeout,
-                        );
+                            $this->listenForToolInvocations($context->id, $agent);
+
+                            yield from $this->textGateway()->streamText(
+                                $context->id,
+                                $this,
+                                $prompt->model,
+                                (string) $agent->instructions(),
+                                $messages,
+                                $this->resolveTools($agent),
+                                null,
+                                TextGenerationOptions::forAgent($agent),
+                                $prompt->timeout,
+                            );
+                        } finally {
+                            InvocationContext::pop();
+                        }
                     },
                     $meta,
                 );
-            })->then(function (StreamedAgentResponse $response) use ($invocationId, $prompt, &$processedPrompt) {
+            })->then(function (StreamedAgentResponse $response) use ($context, $prompt, &$processedPrompt) {
+                $response->withInvocationContext($context);
+
                 $this->events->dispatch(
-                    new AgentStreamed($invocationId, $processedPrompt ?? $prompt, $response)
+                    new AgentStreamed($context->id, $processedPrompt ?? $prompt, $response)
                 );
             });
     }

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -2,12 +2,17 @@
 
 namespace Laravel\Ai\Responses;
 
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 
 class AgentResponse extends TextResponse
 {
     public string $invocationId;
+
+    public ?string $parentInvocationId = null;
+
+    public ?string $rootInvocationId = null;
 
     public ?string $conversationId = null;
 
@@ -18,6 +23,17 @@ class AgentResponse extends TextResponse
         $this->invocationId = $invocationId;
 
         parent::__construct($text, $usage, $meta);
+    }
+
+    /**
+     * Set the invocation context on the response.
+     */
+    public function withInvocationContext(InvocationContext $context): self
+    {
+        $this->parentInvocationId = $context->parentId;
+        $this->rootInvocationId = $context->rootId;
+
+        return $this;
     }
 
     /**

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -23,6 +24,10 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     public ?Usage $usage;
 
     public Collection $events;
+
+    public ?string $parentInvocationId = null;
+
+    public ?string $rootInvocationId = null;
 
     public ?string $conversationId = null;
 
@@ -76,6 +81,17 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     }
 
     /**
+     * Set the invocation context carried by this stream.
+     */
+    public function withInvocationContext(InvocationContext $context): self
+    {
+        $this->parentInvocationId = $context->parentId;
+        $this->rootInvocationId = $context->rootId;
+
+        return $this;
+    }
+
+    /**
      * Set the conversation UUID for this response.
      */
     public function withinConversation(?string $conversationId, ?object $conversationUser = null): self
@@ -100,6 +116,9 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         if ($response->conversationId !== null) {
             $this->withinConversation($response->conversationId, $response->conversationUser);
         }
+
+        $this->parentInvocationId ??= $response->parentInvocationId;
+        $this->rootInvocationId ??= $response->rootInvocationId;
 
         return $this;
     }
@@ -168,6 +187,9 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
             $this->events,
             $this->meta,
         );
+
+        $this->streamedResponse->parentInvocationId = $this->parentInvocationId;
+        $this->streamedResponse->rootInvocationId = $this->rootInvocationId;
 
         if ($this->conversationId !== null) {
             $this->streamedResponse->withinConversation(

--- a/tests/Feature/AgentStreamFailoverTest.php
+++ b/tests/Feature/AgentStreamFailoverTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
@@ -261,6 +262,71 @@ test('stream does not fail over when primary throws non failoverable exception',
     expect($backupStreamed)->toBeFalse();
 
     Event::assertNotDispatched(AgentFailedOver::class);
+});
+
+test('failover stream stamps the streamed response as a root invocation', function () {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(fakeGroqStreamBodyForStreamFailover(), 200);
+
+    $response = (new AssistantAgent)->stream('Hello', provider: ['primary', 'backup']);
+
+    $streamed = null;
+    $response->then(function (StreamedAgentResponse $r) use (&$streamed) {
+        $streamed = $r;
+    });
+
+    foreach ($response as $_) {
+    }
+
+    expect($streamed)->toBeInstanceOf(StreamedAgentResponse::class)
+        ->and($streamed->parentInvocationId)->toBeNull()
+        ->and($streamed->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('failover stream nests beneath the active invocation context', function () {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(fakeGroqStreamBodyForStreamFailover(), 200);
+
+    $streamed = null;
+    $invocationId = null;
+
+    InvocationContext::run(InvocationContext::root('parent-inv'), function () use (&$streamed, &$invocationId) {
+        $response = (new AssistantAgent)->stream('Hello', provider: ['primary', 'backup']);
+
+        $invocationId = $response->invocationId;
+
+        $response->then(function (StreamedAgentResponse $r) use (&$streamed) {
+            $streamed = $r;
+        });
+
+        foreach ($response as $_) {
+        }
+    });
+
+    expect($streamed->invocationId)->toBe($invocationId)
+        ->and($streamed->invocationId)->not->toBe('parent-inv')
+        ->and($streamed->parentInvocationId)->toBe('parent-inv')
+        ->and($streamed->rootInvocationId)->toBe('parent-inv');
 });
 
 test('stream conversation state survives failover', function () {

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -3,9 +3,73 @@
 use Illuminate\Broadcasting\AnonymousEvent;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Jobs\BroadcastAgent;
+use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Tests\Fixtures\Agents\AssistantAgent;
+
+afterEach(function () {
+    InvocationContext::flush();
+
+    unset($_SERVER['__testing.broadcast-prompt']);
+});
+
+test('broadcastOnQueue forwards the active invocation context to the job', function () {
+    Queue::fake();
+
+    InvocationContext::run(InvocationContext::root('parent-inv'), function () {
+        (new AssistantAgent)->broadcastOnQueue('Do it', new Channel('test-channel'));
+    });
+
+    Queue::assertPushed(BroadcastAgent::class, function (BroadcastAgent $job) {
+        return $job->parentInvocationId === 'parent-inv'
+            && $job->rootInvocationId === 'parent-inv';
+    });
+});
+
+test('broadcastOnQueue outside any invocation forwards no lineage', function () {
+    Queue::fake();
+
+    (new AssistantAgent)->broadcastOnQueue('Do it', new Channel('test-channel'));
+
+    Queue::assertPushed(BroadcastAgent::class, function (BroadcastAgent $job) {
+        return $job->parentInvocationId === null
+            && $job->rootInvocationId === null;
+    });
+});
+
+test('a queued broadcast re-establishes the dispatching context so its stream nests beneath it', function () {
+    Event::fake();
+    AssistantAgent::fake(['Hello world']);
+
+    $agent = (new AssistantAgent)->withMiddleware([new class
+    {
+        public function handle(AgentPrompt $prompt, Closure $next)
+        {
+            $_SERVER['__testing.broadcast-prompt'] = $prompt;
+
+            return $next($prompt);
+        }
+    }]);
+
+    $job = new BroadcastAgent(
+        agent: $agent,
+        prompt: 'Say hello',
+        channels: new Channel('test-channel'),
+        parentInvocationId: 'parent-inv',
+        rootInvocationId: 'root-inv',
+    );
+
+    $job->handle();
+
+    $prompt = $_SERVER['__testing.broadcast-prompt'];
+
+    expect($prompt->invocationId)->not->toBe('parent-inv')
+        ->and($prompt->parentInvocationId)->toBe('parent-inv')
+        ->and($prompt->rootInvocationId)->toBe('root-inv');
+});
 
 test('then callback receives streamed agent response', function () {
     Event::fake();

--- a/tests/Feature/InvocationContextPropagationTest.php
+++ b/tests/Feature/InvocationContextPropagationTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use Laravel\Ai\InvocationContext;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\StreamedAgentResponse;
+use Laravel\Ai\Responses\StructuredAgentResponse;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\InvocationContextChildAgent;
+use Tests\Fixtures\Agents\InvocationContextGrandchildAgent;
+use Tests\Fixtures\Agents\InvocationContextParentAgent;
+use Tests\Fixtures\Agents\ToolUsingAgent;
+
+afterEach(function () {
+    InvocationContext::flush();
+
+    unset(
+        $_SERVER['__testing.context-root-prompt'],
+        $_SERVER['__testing.context-child-prompt'],
+        $_SERVER['__testing.context-child-response'],
+        $_SERVER['__testing.context-grandchild-prompt'],
+    );
+});
+
+test('a top-level prompt is stamped as a root invocation', function () {
+    AssistantAgent::fake(['Done']);
+
+    $response = (new AssistantAgent)
+        ->withMiddleware([new class
+        {
+            public function handle(AgentPrompt $prompt, Closure $next)
+            {
+                $_SERVER['__testing.context-root-prompt'] = $prompt;
+
+                return $next($prompt);
+            }
+        }])
+        ->prompt('Hello');
+
+    $prompt = $_SERVER['__testing.context-root-prompt'];
+
+    expect($prompt->invocationId)->not->toBeNull()
+        ->and($prompt->parentInvocationId)->toBeNull()
+        ->and($prompt->rootInvocationId)->toBe($prompt->invocationId)
+        ->and($response->parentInvocationId)->toBeNull()
+        ->and($response->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('a sub-agent invoked as a tool inherits the parent trace and root', function () {
+    InvocationContextChildAgent::fake(['Child done']);
+
+    InvocationContextParentAgent::fake([
+        new ToolCall('call-1', 'context_child', ['task' => 'do research']),
+        'Parent done',
+    ]);
+
+    $response = (new InvocationContextParentAgent)->prompt('Delegate this');
+
+    $childPrompt = $_SERVER['__testing.context-child-prompt'] ?? null;
+
+    expect($childPrompt)->toBeInstanceOf(AgentPrompt::class)
+        ->and($childPrompt->invocationId)->not->toBeNull()
+        ->and($childPrompt->invocationId)->not->toBe($response->invocationId)
+        ->and($childPrompt->parentInvocationId)->toBe($response->invocationId)
+        ->and($childPrompt->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('a sub-agent response is stamped with the parent trace and root', function () {
+    InvocationContextChildAgent::fake(['Child done']);
+
+    InvocationContextParentAgent::fake([
+        new ToolCall('call-1', 'context_child', ['task' => 'do research']),
+        'Parent done',
+    ]);
+
+    $response = (new InvocationContextParentAgent)->prompt('Delegate this');
+
+    $childResponse = $_SERVER['__testing.context-child-response'] ?? null;
+
+    expect($childResponse->parentInvocationId)->toBe($response->invocationId)
+        ->and($childResponse->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('a deeply nested sub-agent chain shares one root and chains its parents', function () {
+    InvocationContextGrandchildAgent::fake(['Grandchild done']);
+
+    InvocationContextChildAgent::fake([
+        new ToolCall('call-2', 'context_grandchild', ['task' => 'deep work']),
+        'Child done',
+    ]);
+
+    InvocationContextParentAgent::fake([
+        new ToolCall('call-1', 'context_child', ['task' => 'do research']),
+        'Parent done',
+    ]);
+
+    $response = (new InvocationContextParentAgent)->prompt('Delegate this');
+
+    $childPrompt = $_SERVER['__testing.context-child-prompt'];
+    $grandchildPrompt = $_SERVER['__testing.context-grandchild-prompt'];
+
+    expect($childPrompt->parentInvocationId)->toBe($response->invocationId)
+        ->and($childPrompt->rootInvocationId)->toBe($response->invocationId)
+        ->and($grandchildPrompt->invocationId)->not->toBe($childPrompt->invocationId)
+        ->and($grandchildPrompt->parentInvocationId)->toBe($childPrompt->invocationId)
+        ->and($grandchildPrompt->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('a structured-output response is stamped with the invocation context', function () {
+    ToolUsingAgent::fake([['number' => 7]]);
+
+    $response = (new ToolUsingAgent)->prompt('Give me a number');
+
+    expect($response)->toBeInstanceOf(StructuredAgentResponse::class)
+        ->and($response->parentInvocationId)->toBeNull()
+        ->and($response->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('a streamed top-level response is stamped as a root invocation', function () {
+    AssistantAgent::fake(['Streamed response']);
+
+    $response = (new AssistantAgent)
+        ->withMiddleware([new class
+        {
+            public function handle(AgentPrompt $prompt, Closure $next)
+            {
+                $_SERVER['__testing.context-root-prompt'] = $prompt;
+
+                return $next($prompt);
+            }
+        }])
+        ->stream('Hello');
+
+    $streamed = null;
+    $response->then(function (StreamedAgentResponse $r) use (&$streamed) {
+        $streamed = $r;
+    });
+
+    foreach ($response as $event) {
+        expect($event)->not->toBeNull();
+    }
+
+    $prompt = $_SERVER['__testing.context-root-prompt'];
+
+    expect($prompt->parentInvocationId)->toBeNull()
+        ->and($prompt->rootInvocationId)->toBe($prompt->invocationId)
+        ->and($streamed)->toBeInstanceOf(StreamedAgentResponse::class)
+        ->and($streamed->parentInvocationId)->toBeNull()
+        ->and($streamed->rootInvocationId)->toBe($streamed->invocationId);
+});
+
+test('the invocation context is active while a stream is consumed', function () {
+    AssistantAgent::fake(['one two three']);
+
+    $response = (new AssistantAgent)->stream('Hello');
+
+    $idsDuringStream = [];
+    foreach ($response as $event) {
+        $idsDuringStream[] = InvocationContext::current()?->id;
+    }
+
+    expect($idsDuringStream)->not->toBeEmpty()
+        ->and(collect($idsDuringStream)->unique()->values()->all())->toBe([$response->invocationId])
+        ->and(InvocationContext::current())->toBeNull();
+});

--- a/tests/Feature/InvocationContextPropagationTest.php
+++ b/tests/Feature/InvocationContextPropagationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\InvocationContext;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -147,6 +149,55 @@ test('a streamed top-level response is stamped as a root invocation', function (
         ->and($streamed)->toBeInstanceOf(StreamedAgentResponse::class)
         ->and($streamed->parentInvocationId)->toBeNull()
         ->and($streamed->rootInvocationId)->toBe($streamed->invocationId);
+});
+
+test('a sub-agent invoked from streaming middleware nests beneath the streaming agent', function () {
+    InvocationContextChildAgent::fake(['Child done']);
+    AssistantAgent::fake(['Streamed']);
+
+    $response = (new AssistantAgent)
+        ->withMiddleware([new class
+        {
+            public function handle(AgentPrompt $prompt, Closure $next)
+            {
+                // A guardrail/classifier middleware delegating to a sub-agent while streaming.
+                (new InvocationContextChildAgent)->prompt('classify during streaming');
+
+                return $next($prompt);
+            }
+        }])
+        ->stream('Hello');
+
+    foreach ($response as $_) {
+    }
+
+    $childPrompt = $_SERVER['__testing.context-child-prompt'] ?? null;
+
+    expect($childPrompt)->toBeInstanceOf(AgentPrompt::class)
+        ->and($childPrompt->parentInvocationId)->toBe($response->invocationId)
+        ->and($childPrompt->rootInvocationId)->toBe($response->invocationId);
+});
+
+test('a streamed completion event carries the middleware-processed prompt', function () {
+    Event::fake();
+    AssistantAgent::fake(['Streamed']);
+
+    $response = (new AssistantAgent)
+        ->withMiddleware([new class
+        {
+            public function handle(AgentPrompt $prompt, Closure $next)
+            {
+                return $next($prompt->append('PROCESSED-MARKER'));
+            }
+        }])
+        ->stream('Hello');
+
+    foreach ($response as $_) {
+    }
+
+    Event::assertDispatched(AgentStreamed::class, function (AgentStreamed $event) {
+        return str_contains($event->prompt->prompt, 'PROCESSED-MARKER');
+    });
 });
 
 test('the invocation context is active while a stream is consumed', function () {

--- a/tests/Feature/InvocationContextQueueTest.php
+++ b/tests/Feature/InvocationContextQueueTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Support\Facades\Queue;
+use Laravel\Ai\InvocationContext;
+use Laravel\Ai\Jobs\InvokeAgent;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+afterEach(function () {
+    InvocationContext::flush();
+
+    unset($_SERVER['__testing.queued-prompt']);
+});
+
+test('queue() forwards the active invocation context to the job', function () {
+    Queue::fake();
+
+    InvocationContext::run(InvocationContext::root('parent-inv'), function () {
+        (new AssistantAgent)->queue('Do it');
+    });
+
+    Queue::assertPushed(InvokeAgent::class, function (InvokeAgent $job) {
+        return $job->parentInvocationId === 'parent-inv'
+            && $job->rootInvocationId === 'parent-inv';
+    });
+});
+
+test('queue() outside any invocation forwards no lineage', function () {
+    Queue::fake();
+
+    (new AssistantAgent)->queue('Do it');
+
+    Queue::assertPushed(InvokeAgent::class, function (InvokeAgent $job) {
+        return $job->parentInvocationId === null
+            && $job->rootInvocationId === null;
+    });
+});
+
+test('a queued job re-establishes the dispatching context so its agent nests beneath it', function () {
+    AssistantAgent::fake(['Done']);
+
+    $agent = (new AssistantAgent)->withMiddleware([new class
+    {
+        public function handle(AgentPrompt $prompt, Closure $next)
+        {
+            $_SERVER['__testing.queued-prompt'] = $prompt;
+
+            return $next($prompt);
+        }
+    }]);
+
+    (new InvokeAgent($agent, 'Do it', [], null, null, 'parent-inv', 'root-inv'))->handle();
+
+    $prompt = $_SERVER['__testing.queued-prompt'];
+
+    expect($prompt->invocationId)->not->toBe('parent-inv')
+        ->and($prompt->parentInvocationId)->toBe('parent-inv')
+        ->and($prompt->rootInvocationId)->toBe('root-inv');
+});
+
+test('a queued job with no lineage runs its agent as a root', function () {
+    AssistantAgent::fake(['Done']);
+
+    $agent = (new AssistantAgent)->withMiddleware([new class
+    {
+        public function handle(AgentPrompt $prompt, Closure $next)
+        {
+            $_SERVER['__testing.queued-prompt'] = $prompt;
+
+            return $next($prompt);
+        }
+    }]);
+
+    (new InvokeAgent($agent, 'Do it'))->handle();
+
+    $prompt = $_SERVER['__testing.queued-prompt'];
+
+    expect($prompt->parentInvocationId)->toBeNull()
+        ->and($prompt->rootInvocationId)->toBe($prompt->invocationId);
+});

--- a/tests/Feature/InvocationContextResetTest.php
+++ b/tests/Feature/InvocationContextResetTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Queue\Events\Looping;
+use Laravel\Ai\InvocationContext;
+
+afterEach(fn () => InvocationContext::flush());
+
+test('the queue worker looping event flushes a leaked invocation context', function () {
+    // Simulate a previous job that leaked context onto the worker-global stack.
+    InvocationContext::push(InvocationContext::root('leaked-from-prior-job'));
+
+    expect(InvocationContext::current())->not->toBeNull();
+
+    event(new Looping('redis', 'default'));
+
+    expect(InvocationContext::current())->toBeNull();
+});
+
+test('an octane request boundary flushes a leaked invocation context', function () {
+    InvocationContext::push(InvocationContext::root('leaked-from-prior-request'));
+
+    expect(InvocationContext::current())->not->toBeNull();
+
+    event('Laravel\Octane\Events\RequestReceived');
+
+    expect(InvocationContext::current())->toBeNull();
+});

--- a/tests/Fixtures/Agents/InvocationContextChildAgent.php
+++ b/tests/Fixtures/Agents/InvocationContextChildAgent.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Closure;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+class InvocationContextChildAgent implements Agent, CanActAsTool, HasMiddleware, HasTools
+{
+    use Promptable;
+
+    public function name(): string
+    {
+        return 'context_child';
+    }
+
+    public function description(): string
+    {
+        return 'Records the invocation context it receives so it can be asserted.';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a sub-agent used to verify invocation context propagation.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new InvocationContextGrandchildAgent,
+        ];
+    }
+
+    public function middleware(): array
+    {
+        return [
+            new class
+            {
+                public function handle(AgentPrompt $prompt, Closure $next)
+                {
+                    $_SERVER['__testing.context-child-prompt'] = $prompt;
+
+                    $response = $next($prompt);
+
+                    $_SERVER['__testing.context-child-response'] = $response;
+
+                    return $response;
+                }
+            },
+        ];
+    }
+}

--- a/tests/Fixtures/Agents/InvocationContextGrandchildAgent.php
+++ b/tests/Fixtures/Agents/InvocationContextGrandchildAgent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Closure;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+class InvocationContextGrandchildAgent implements Agent, CanActAsTool, HasMiddleware
+{
+    use Promptable;
+
+    public function name(): string
+    {
+        return 'context_grandchild';
+    }
+
+    public function description(): string
+    {
+        return 'A leaf sub-agent used to verify deep invocation-context nesting.';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a leaf sub-agent used to verify deep context nesting.';
+    }
+
+    public function middleware(): array
+    {
+        return [
+            new class
+            {
+                public function handle(AgentPrompt $prompt, Closure $next)
+                {
+                    $_SERVER['__testing.context-grandchild-prompt'] = $prompt;
+
+                    return $next($prompt);
+                }
+            },
+        ];
+    }
+}

--- a/tests/Fixtures/Agents/InvocationContextParentAgent.php
+++ b/tests/Fixtures/Agents/InvocationContextParentAgent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+
+class InvocationContextParentAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You delegate work to the context_child sub-agent.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new InvocationContextChildAgent,
+        ];
+    }
+}

--- a/tests/Unit/InvocationContextTest.php
+++ b/tests/Unit/InvocationContextTest.php
@@ -100,6 +100,53 @@ test('push and pop activate and deactivate the context manually', function () {
     expect(InvocationContext::current())->toBeNull();
 });
 
+test('runRehydrated runs the callback with no active context when no parent id is given', function () {
+    $seen = InvocationContext::runRehydrated(null, null, fn () => InvocationContext::current());
+
+    expect($seen)->toBeNull()
+        ->and(InvocationContext::current())->toBeNull();
+});
+
+test('runRehydrated re-establishes the carried context for the callback and restores after', function () {
+    $seen = InvocationContext::runRehydrated('parent-inv', 'root-inv', fn () => InvocationContext::current());
+
+    expect($seen)->toBeInstanceOf(InvocationContext::class)
+        ->and($seen->id)->toBe('parent-inv')
+        ->and($seen->rootId)->toBe('root-inv')
+        ->and(InvocationContext::current())->toBeNull();
+});
+
+test('pop removes a specific context even when it is not on top', function () {
+    $a = InvocationContext::root('a');
+    $b = InvocationContext::root('b');
+
+    InvocationContext::push($a);
+    InvocationContext::push($b);
+
+    // 'a' unwinds before 'b' (e.g. two interleaved streams consumed out of order).
+    InvocationContext::pop($a);
+
+    expect(InvocationContext::current())->toBe($b);
+
+    InvocationContext::pop($b);
+
+    expect(InvocationContext::current())->toBeNull();
+});
+
+test('popping a specific context is a no-op when it is no longer on the stack', function () {
+    $a = InvocationContext::root('a');
+
+    InvocationContext::push($a);
+    InvocationContext::pop($a);
+
+    // Popping again must not remove an unrelated entry.
+    $b = InvocationContext::root('b');
+    InvocationContext::push($b);
+    InvocationContext::pop($a);
+
+    expect(InvocationContext::current())->toBe($b);
+});
+
 test('a failed nested invocation does not leak context to its parent', function () {
     InvocationContext::run(InvocationContext::root('parent'), function () {
         try {

--- a/tests/Unit/InvocationContextTest.php
+++ b/tests/Unit/InvocationContextTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Laravel\Ai\InvocationContext;
+
+afterEach(fn () => InvocationContext::flush());
+
+test('a root context has no parent and is its own root', function () {
+    $context = InvocationContext::root('inv-1');
+
+    expect($context->id)->toBe('inv-1')
+        ->and($context->parentId)->toBeNull()
+        ->and($context->rootId)->toBe('inv-1')
+        ->and($context->isRoot())->toBeTrue();
+});
+
+test('there is no active context outside of run', function () {
+    expect(InvocationContext::current())->toBeNull();
+});
+
+test('for() creates a root when no context is active', function () {
+    $context = InvocationContext::for('inv-1');
+
+    expect($context->parentId)->toBeNull()
+        ->and($context->rootId)->toBe('inv-1');
+});
+
+test('for() nests beneath the active context', function () {
+    InvocationContext::run(InvocationContext::root('parent'), function () {
+        $child = InvocationContext::for('child');
+
+        expect($child->id)->toBe('child')
+            ->and($child->parentId)->toBe('parent')
+            ->and($child->rootId)->toBe('parent')
+            ->and($child->isRoot())->toBeFalse();
+    });
+});
+
+test('rehydrate reconstructs a context with no tracked parent', function () {
+    $context = InvocationContext::rehydrate('parent-inv', 'root-inv');
+
+    expect($context->id)->toBe('parent-inv')
+        ->and($context->parentId)->toBeNull()
+        ->and($context->rootId)->toBe('root-inv');
+});
+
+test('rehydrate defaults the root to the id when none is given', function () {
+    expect(InvocationContext::rehydrate('inv-1')->rootId)->toBe('inv-1');
+});
+
+test('run activates the context for the callback and restores the previous state after', function () {
+    expect(InvocationContext::current())->toBeNull();
+
+    $context = InvocationContext::root('inv-1');
+
+    $seen = InvocationContext::run($context, fn () => InvocationContext::current());
+
+    expect($seen)->toBe($context)
+        ->and(InvocationContext::current())->toBeNull();
+});
+
+test('nested runs preserve the root across every level', function () {
+    InvocationContext::run(InvocationContext::for('root'), function () {
+        InvocationContext::run(InvocationContext::for('level-1'), function () {
+            $level2 = InvocationContext::for('level-2');
+
+            expect($level2->parentId)->toBe('level-1')
+                ->and($level2->rootId)->toBe('root');
+        });
+
+        expect(InvocationContext::current()->id)->toBe('root');
+    });
+});
+
+test('run pops the context even when the callback throws', function () {
+    try {
+        InvocationContext::run(InvocationContext::root('inv-1'), function () {
+            throw new RuntimeException('boom');
+        });
+    } catch (RuntimeException) {
+        // Intentionally ignored - we only care that the stack was restored.
+    }
+
+    expect(InvocationContext::current())->toBeNull();
+});
+
+test('push and pop activate and deactivate the context manually', function () {
+    $a = InvocationContext::root('a');
+    $b = InvocationContext::root('b');
+
+    InvocationContext::push($a);
+    expect(InvocationContext::current())->toBe($a);
+
+    InvocationContext::push($b);
+    expect(InvocationContext::current())->toBe($b);
+
+    InvocationContext::pop();
+    expect(InvocationContext::current())->toBe($a);
+
+    InvocationContext::pop();
+    expect(InvocationContext::current())->toBeNull();
+});
+
+test('a failed nested invocation does not leak context to its parent', function () {
+    InvocationContext::run(InvocationContext::root('parent'), function () {
+        try {
+            InvocationContext::run(InvocationContext::for('child'), function () {
+                throw new RuntimeException('failover');
+            });
+        } catch (RuntimeException) {
+            // Simulates a provider failover that aborts the child invocation.
+        }
+
+        expect(InvocationContext::current()->id)->toBe('parent');
+    });
+
+    expect(InvocationContext::current())->toBeNull();
+});


### PR DESCRIPTION
# The problem
I was integrating PostHog LLM observability on top of agent middleware and ran
into a wall with sub-agents. When an agent is used as a tool, `AgentTool::handle()`
calls `$this->agent->prompt(...)` and the sub-agent gets a brand new `invocationId`
with nothing tying it back to the agent that called it. So in Posthog the parent
and sub-agent show up as two separate traces instead of one tree, with no way to
reconstruct "this agent delegated to that one."

### The solution
I added a `InvocationContext` that carries the current invocation's id plus its parent and root, and keeps it active for the duration of a `prompt()` or ` stream()`. A sub-agent's `prompt()` runs on the same call stack, so it inherits them automatically. The ids are exposed as `parentInvocationId` and `rootInvocationId` on `AgentPrompt` and `AgentResponse` for middleware or a listener to read. Streaming re-establishes the context inside the lazy generator, and the queue path serializes the ids onto the `InvokeAgent` job so a queued agent dispatched inside an invocation still nests under it.

I built this for PostHog, but I checked the tracing models for a few other tools (OpenTelemetry, Langfuse, LangSmith, Helicone) and they all group by a root/trace id and nest children under a parent, so the same parent/root invocation ids map onto them too. Helicone is the one slight outlier, it nests by a session path rather than a parent id, but the lineage still feeds it.

### Heads up
I mostly work in React but we have a Laravel backend, so some of my PHP might _less_ than ideal. Happy to
adjust anything. I did use Claude to help me through some of this, but I have gone through and reviewed it. 