### PR TITLE
Respect morph map aliases when storing the agent on conversation messages

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Storage;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -70,7 +71,7 @@ class DatabaseConversationStore implements ConversationStore
             'id' => $messageId,
             'conversation_id' => $conversationId,
             'user_id' => $userId,
-            'agent' => $prompt->agent::class,
+            'agent' => Relation::getMorphAlias($prompt->agent::class),
             'role' => 'user',
             'content' => $prompt->prompt,
             'attachments' => $prompt->attachments->toJson(),
@@ -100,7 +101,7 @@ class DatabaseConversationStore implements ConversationStore
             'id' => $messageId,
             'conversation_id' => $conversationId,
             'user_id' => $userId,
-            'agent' => $prompt->agent::class,
+            'agent' => Relation::getMorphAlias($prompt->agent::class),
             'role' => 'assistant',
             'content' => $response->text,
             'attachments' => '[]',

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
@@ -21,6 +22,10 @@ use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
+
+afterEach(function () {
+    Relation::morphMap([], false);
+});
 
 test('it writes conversations to the default tables', function () {
     $store = new DatabaseConversationStore;
@@ -139,6 +144,46 @@ test('it stores sparse keyed tool calls and results as JSON arrays', function ()
 
     expect(array_is_list(json_decode($record->tool_calls, true)))->toBeTrue()
         ->and(array_is_list(json_decode($record->tool_results, true)))->toBeTrue();
+});
+
+test('it stores the agent morph alias when one is registered in the morph map', function () {
+    Relation::morphMap(['tool-using-agent' => ToolUsingAgent::class]);
+
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Morph map conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $store->storeUserMessage($conversationId, 1, $prompt);
+    $store->storeAssistantMessage($conversationId, 1, $prompt, new AgentResponse('invocation-id', 'The order has shipped.', new Usage, new Meta));
+
+    expect(DB::table('agent_conversation_messages')->where('conversation_id', $conversationId)->pluck('agent')->all())
+        ->toBe(['tool-using-agent', 'tool-using-agent']);
+});
+
+test('it stores the agent class name when no morph alias is registered', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Unmapped conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $store->storeUserMessage($conversationId, 1, $prompt);
+    $store->storeAssistantMessage($conversationId, 1, $prompt, new AgentResponse('invocation-id', 'The order has shipped.', new Usage, new Meta));
+
+    expect(DB::table('agent_conversation_messages')->where('conversation_id', $conversationId)->pluck('agent')->all())
+        ->toBe([ToolUsingAgent::class, ToolUsingAgent::class]);
 });
 
 test('it reloads legacy sparse keyed tool calls and results as lists', function () {


### PR DESCRIPTION
While integrating conversations in my app I noticed the `agent` column on `agent_conversation_messages` always ends up with the full class name (`App\Ai\Agents\ConsumerAgent` in my case), even though my app registers a morph map. The store writes `$prompt->agent::class` directly, so the morph map never applies.

That means renaming or moving an agent class leaves stale class names behind, and any query I do on that column (listing conversations per agent, some basic stats) silently misses older rows. Same reason `_type` columns go through the morph map.

This changes both write sites in `DatabaseConversationStore` to use `Relation::getMorphAlias()` instead. When no alias is registered it just returns the class name, so apps without a morph map are unaffected. The package itself never reads the column back, so existing rows with FQCNs keep working too.

Added tests for both the mapped and unmapped case.