### PR TITLE
Normalize MCP tool schemas into the deserializable JSON Schema subset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/serializable-closure": "^2.0"
     },
     "require-dev": {
-        "laravel/mcp": "^0.7",
+        "laravel/mcp": "^0.8",
         "laravel/pint": "^1.26",
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.6|^11.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^12.0|^13.0",
         "illuminate/database": "^12.0|^13.0",
         "illuminate/filesystem": "^12.0|^13.0",
-        "illuminate/json-schema": "^12.61.2|^13.14",
+        "illuminate/json-schema": "^12.62|^13.15",
         "illuminate/support": "^12.0|^13.0",
         "laravel/prompts": "^0.3.6",
         "laravel/serializable-closure": "^2.0"

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -27,7 +27,6 @@ use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Tools\AgentTool;
 use Laravel\Ai\Tools\McpServerTool;
 use Laravel\Ai\Tools\McpTool;
-use Throwable;
 
 use function Laravel\Ai\pipeline;
 
@@ -121,25 +120,10 @@ trait GeneratesText
             return [];
         }
 
-        return collect($agent->tools())
-            ->map(fn ($tool) => $this->resolveTool($tool))
-            ->reject(fn ($tool) => $tool instanceof McpTool && ! $this->mcpToolIsUsable($tool))
-            ->values()
-            ->all();
-    }
-
-    /**
-     * Determine whether the given MCP client tool can be prepared for the provider.
-     */
-    protected function mcpToolIsUsable(McpTool $tool): bool
-    {
-        try {
-            $tool->schema(new JsonSchemaTypeFactory);
-
-            return true;
-        } catch (Throwable) {
-            return false;
-        }
+        return array_map(
+            fn ($tool) => $this->resolveTool($tool),
+            [...$agent->tools()],
+        );
     }
 
     /**

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -27,6 +27,7 @@ use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Tools\AgentTool;
 use Laravel\Ai\Tools\McpServerTool;
 use Laravel\Ai\Tools\McpTool;
+use Throwable;
 
 use function Laravel\Ai\pipeline;
 
@@ -120,10 +121,25 @@ trait GeneratesText
             return [];
         }
 
-        return array_map(
-            fn ($tool) => $this->resolveTool($tool),
-            [...$agent->tools()],
-        );
+        return collect($agent->tools())
+            ->map(fn ($tool) => $this->resolveTool($tool))
+            ->reject(fn ($tool) => $tool instanceof McpTool && ! $this->mcpToolIsUsable($tool))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Determine whether the given MCP client tool can be prepared for the provider.
+     */
+    protected function mcpToolIsUsable(McpTool $tool): bool
+    {
+        try {
+            $tool->schema(new JsonSchemaTypeFactory);
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
     }
 
     /**

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -1,0 +1,380 @@
+<?php
+
+namespace Laravel\Ai\Schema;
+
+class SchemaNormalizer
+{
+    /**
+     * Type-specific constraint keywords the deserializer rejects on a multi-type union.
+     */
+    private const TYPE_KEYWORDS = [
+        'minLength', 'maxLength', 'pattern', 'format',
+        'minimum', 'maximum', 'multipleOf',
+        'items', 'minItems', 'maxItems', 'uniqueItems',
+        'properties', 'required', 'additionalProperties',
+    ];
+
+    /**
+     * Keywords the Laravel JSON Schema deserializer cannot represent and that
+     * are either ignored or cause it to throw. Drop them up front.
+     */
+    private const UNSUPPORTED = [
+        '$schema', '$id', '$anchor', '$comment', 'not', 'if', 'then', 'else',
+        'patternProperties', 'dependentSchemas', 'dependentRequired', 'unevaluatedProperties',
+        'contains', 'minContains', 'maxContains', 'prefixItems', 'examples', 'deprecated',
+        'readOnly', 'writeOnly', 'minProperties', 'maxProperties', 'exclusiveMinimum', 'exclusiveMaximum',
+    ];
+
+    /**
+     * Rewrite a raw JSON Schema into the subset Illuminate\JsonSchema can deserialize.
+     *
+     * Lossy by design: constructs the typed schema cannot represent (rich unions,
+     * allOf, tuples) are collapsed or dropped rather than rejected.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    public static function normalize(array $schema): array
+    {
+        $defs = match (true) {
+            is_array($schema['$defs'] ?? null) => $schema['$defs'],
+            is_array($schema['definitions'] ?? null) => $schema['definitions'],
+            default => [],
+        };
+
+        return (new self)->node($schema, $defs, []);
+    }
+
+    /**
+     * Normalize a single schema node.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $defs
+     * @param  array<string, true>  $seen
+     * @return array<string, mixed>
+     */
+    private function node(array $schema, array $defs, array $seen): array
+    {
+        [$schema, $seen] = $this->inlineRefs($schema, $defs, $seen);
+
+        $schema = $this->mergeAllOf($schema, $defs, $seen);
+        $schema = $this->collapseUnions($schema, $defs, $seen);
+        $schema = $this->collapseMultiType($schema);
+
+        // Strip after merging so keywords pulled in from allOf branches are dropped too.
+        foreach (self::UNSUPPORTED as $keyword) {
+            unset($schema[$keyword]);
+        }
+
+        unset($schema['$defs'], $schema['definitions']);
+
+        if (array_key_exists('default', $schema) && $schema['default'] === null) {
+            unset($schema['default']);
+        }
+
+        if (($schema['additionalProperties'] ?? false) !== false) {
+            unset($schema['additionalProperties']);
+        }
+
+        if (is_array($schema['properties'] ?? null)) {
+            $properties = [];
+
+            foreach ($schema['properties'] as $key => $definition) {
+                if (is_array($definition)) {
+                    $properties[$key] = $this->node($definition, $defs, $seen);
+                }
+            }
+
+            $schema['properties'] = $properties;
+
+            if (is_array($schema['required'] ?? null)) {
+                $schema['required'] = array_values(array_filter(
+                    $schema['required'],
+                    fn ($name) => is_string($name) && array_key_exists($name, $properties),
+                ));
+            }
+        }
+
+        if (isset($schema['items'])) {
+            if (is_array($schema['items']) && ! array_is_list($schema['items'])) {
+                $schema['items'] = $this->node($schema['items'], $defs, $seen);
+            } else {
+                unset($schema['items']);
+            }
+        }
+
+        return $this->ensureType($schema);
+    }
+
+    /**
+     * Inline local "$ref" pointers (cycle-safe); drop remote or unresolvable ones.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $defs
+     * @param  array<string, true>  $seen
+     * @return array{0: array<string, mixed>, 1: array<string, true>}
+     */
+    private function inlineRefs(array $schema, array $defs, array $seen): array
+    {
+        while (isset($schema['$ref']) && is_string($schema['$ref'])) {
+            $ref = $schema['$ref'];
+
+            unset($schema['$ref']);
+
+            $key = match (true) {
+                str_starts_with($ref, '#/$defs/') => substr($ref, 8),
+                str_starts_with($ref, '#/definitions/') => substr($ref, 14),
+                default => null,
+            };
+
+            if ($key === null || ! is_array($defs[$key] ?? null) || isset($seen[$key])) {
+                break;
+            }
+
+            $seen[$key] = true;
+            $schema = array_merge($defs[$key], $schema);
+        }
+
+        return [$schema, $seen];
+    }
+
+    /**
+     * Merge "allOf" branches into the node; the deserializer has no intersection type.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $defs
+     * @param  array<string, true>  $seen
+     * @return array<string, mixed>
+     */
+    private function mergeAllOf(array $schema, array $defs, array $seen): array
+    {
+        // Loop so an allOf branch that itself carries allOf is flattened too.
+        while (is_array($schema['allOf'] ?? null)) {
+            $branches = $schema['allOf'];
+
+            unset($schema['allOf']);
+
+            $merged = [];
+
+            foreach ($branches as $branch) {
+                if (is_array($branch)) {
+                    [$branch] = $this->inlineRefs($branch, $defs, $seen);
+                    $merged = $this->mergeSchema($merged, $branch);
+                }
+            }
+
+            $schema = $this->mergeSchema($merged, $schema);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Merge two schema fragments, unioning "required" and "properties" rather
+     * than letting one side clobber the other.
+     *
+     * @param  array<string, mixed>  $base
+     * @param  array<string, mixed>  $overlay
+     * @return array<string, mixed>
+     */
+    private function mergeSchema(array $base, array $overlay): array
+    {
+        $required = array_values(array_unique(array_merge(
+            is_array($base['required'] ?? null) ? $base['required'] : [],
+            is_array($overlay['required'] ?? null) ? $overlay['required'] : [],
+        )));
+
+        $properties = array_merge(
+            is_array($base['properties'] ?? null) ? $base['properties'] : [],
+            is_array($overlay['properties'] ?? null) ? $overlay['properties'] : [],
+        );
+
+        $merged = array_merge($base, $overlay);
+
+        if ($required !== []) {
+            $merged['required'] = $required;
+        }
+
+        if ($properties !== []) {
+            $merged['properties'] = $properties;
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Collapse "anyOf"/"oneOf" to a single branch, since the deserializer only
+     * accepts a nullable union (one schema plus a "null" branch).
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $defs
+     * @param  array<string, true>  $seen
+     * @return array<string, mixed>
+     */
+    private function collapseUnions(array $schema, array $defs, array $seen): array
+    {
+        foreach (['anyOf', 'oneOf'] as $key) {
+            if (! is_array($schema[$key] ?? null)) {
+                continue;
+            }
+
+            $nullable = false;
+            $branches = [];
+
+            foreach ($schema[$key] as $branch) {
+                if (! is_array($branch)) {
+                    continue;
+                }
+
+                [$branch] = $this->inlineRefs($branch, $defs, $seen);
+
+                if (in_array($branch['type'] ?? null, ['null', ['null']], true)) {
+                    $nullable = true;
+                } else {
+                    $branches[] = $this->node($branch, $defs, $seen);
+                }
+            }
+
+            unset($schema[$key]);
+
+            if ($branches !== []) {
+                $schema = array_merge($schema, $branches[0]);
+            }
+
+            if ($nullable) {
+                $schema = $this->makeNullable($schema);
+            }
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Mark a node nullable in a form the deserializer understands (type + "null").
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function makeNullable(array $schema): array
+    {
+        $type = $schema['type'] ?? $this->baseType($schema);
+        $type = is_array($type) ? $type : [$type];
+
+        $schema['type'] = array_values(array_unique([...$type, 'null']));
+
+        return $schema;
+    }
+
+    /**
+     * Keep multi-type unions deserializable, and drop "null"-only types which
+     * the deserializer cannot represent.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function collapseMultiType(array $schema): array
+    {
+        $type = $schema['type'] ?? null;
+
+        if ($type === 'null') {
+            unset($schema['type']);
+
+            return $schema;
+        }
+
+        if (! is_array($type)) {
+            return $schema;
+        }
+
+        $nonNull = array_values(array_filter($type, fn ($value) => $value !== 'null'));
+
+        if ($nonNull === []) {
+            unset($schema['type']);
+
+            return $schema;
+        }
+
+        if (count($nonNull) > 1) {
+            foreach (self::TYPE_KEYWORDS as $keyword) {
+                unset($schema[$keyword]);
+            }
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Give a node an explicit, deserializable type. Mirrors the deserializer's
+     * own inference so a typeless node never reaches it and throws.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function ensureType(array $schema): array
+    {
+        if (isset($schema['type']) || isset($schema['anyOf']) || isset($schema['oneOf']) || isset($schema['allOf'])) {
+            return $schema;
+        }
+
+        $schema['type'] = $this->baseType($schema);
+
+        return $schema;
+    }
+
+    /**
+     * Infer a single base type from a node's shape, defaulting to "string".
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    private function baseType(array $schema): string
+    {
+        return match (true) {
+            isset($schema['properties']), isset($schema['required']) => 'object',
+            isset($schema['items']), isset($schema['minItems']), isset($schema['maxItems']), isset($schema['uniqueItems']) => 'array',
+            isset($schema['enum']) && is_array($schema['enum']) => $this->inferEnumType($schema['enum']),
+            isset($schema['minimum']), isset($schema['maximum']), isset($schema['multipleOf']) => 'number',
+            default => 'string',
+        };
+    }
+
+    /**
+     * Infer the scalar type shared by an enum, defaulting to "string" for an
+     * empty or heterogeneous enum (which the deserializer cannot type).
+     *
+     * @param  array<int, mixed>  $enum
+     */
+    private function inferEnumType(array $enum): string
+    {
+        $resolved = null;
+
+        foreach ($enum as $value) {
+            $current = match (true) {
+                is_bool($value) => 'boolean',
+                is_int($value) => 'integer',
+                is_float($value) => 'number',
+                is_string($value) => 'string',
+                default => null,
+            };
+
+            if ($current === null) {
+                return 'string';
+            }
+
+            if ($resolved === null || $resolved === $current) {
+                $resolved = $current;
+
+                continue;
+            }
+
+            if (in_array($resolved, ['integer', 'number'], true) && in_array($current, ['integer', 'number'], true)) {
+                $resolved = 'number';
+
+                continue;
+            }
+
+            return 'string';
+        }
+
+        return $resolved ?? 'string';
+    }
+}

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -30,6 +30,11 @@ class SchemaNormalizer
     private const SCALAR_TYPES = ['string', 'integer', 'number', 'boolean'];
 
     /**
+     * The JSON Schema type strings the deserializer understands.
+     */
+    private const TYPES = ['string', 'integer', 'number', 'boolean', 'object', 'array', 'null'];
+
+    /**
      * Rewrite a raw JSON Schema into the subset Illuminate\JsonSchema can deserialize.
      *
      * @param  array<string, mixed>  $schema
@@ -304,18 +309,25 @@ class SchemaNormalizer
         $type = $schema['type'] ?? null;
 
         if (! is_array($type)) {
-            if ($type === 'null') {
+            if ($type === 'null' || ($type !== null && ! in_array($type, self::TYPES, true))) {
                 unset($schema['type']);
             }
 
             return $schema;
         }
 
-        $nonNull = array_values(array_filter($type, fn ($value) => $value !== 'null'));
+        $valid = array_values(array_filter($type, fn ($value) => in_array($value, self::TYPES, true)));
+        $nonNull = array_values(array_filter($valid, fn ($value) => $value !== 'null'));
 
         if ($nonNull === []) {
             unset($schema['type']);
-        } elseif (count($nonNull) > 1) {
+
+            return $schema;
+        }
+
+        $schema['type'] = count($valid) === 1 ? $valid[0] : $valid;
+
+        if (count($nonNull) > 1) {
             foreach (self::TYPE_KEYWORDS as $keyword) {
                 unset($schema[$keyword]);
             }
@@ -431,13 +443,25 @@ class SchemaNormalizer
      */
     private function ensureType(array $schema): array
     {
-        if (isset($schema['type']) || isset($schema['anyOf']) || isset($schema['oneOf']) || isset($schema['allOf'])) {
+        if ($this->usableType($schema['type'] ?? null) || isset($schema['anyOf']) || isset($schema['oneOf']) || isset($schema['allOf'])) {
             return $schema;
         }
+
+        unset($schema['type']);
 
         $schema['type'] = $this->baseType($schema);
 
         return $schema;
+    }
+
+    /**
+     * Determine whether a node's type resolves to a non-null type the deserializer accepts.
+     */
+    private function usableType(mixed $type): bool
+    {
+        $types = array_filter(is_array($type) ? $type : [$type], fn ($value) => $value !== 'null');
+
+        return $types !== [] && array_filter($types, fn ($value) => ! in_array($value, self::TYPES, true)) === [];
     }
 
     /**

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -15,8 +15,7 @@ class SchemaNormalizer
     ];
 
     /**
-     * Keywords the Laravel JSON Schema deserializer cannot represent and that
-     * are either ignored or cause it to throw. Drop them up front.
+     * Keywords the deserializer cannot represent and that are dropped.
      */
     private const UNSUPPORTED = [
         '$schema', '$id', '$anchor', '$comment', 'not', 'if', 'then', 'else',
@@ -26,82 +25,40 @@ class SchemaNormalizer
     ];
 
     /**
+     * Scalar types that can be combined into a multi-type union.
+     */
+    private const SCALAR_TYPES = ['string', 'integer', 'number', 'boolean'];
+
+    /**
      * Rewrite a raw JSON Schema into the subset Illuminate\JsonSchema can deserialize.
-     *
-     * Lossy by design: constructs the typed schema cannot represent (rich unions,
-     * allOf, tuples) are collapsed or dropped rather than rejected.
      *
      * @param  array<string, mixed>  $schema
      * @return array<string, mixed>
      */
     public static function normalize(array $schema): array
     {
-        $defs = match (true) {
-            is_array($schema['$defs'] ?? null) => $schema['$defs'],
-            is_array($schema['definitions'] ?? null) => $schema['definitions'],
-            default => [],
-        };
-
-        return (new self)->node($schema, $defs, []);
+        return (new self)->node($schema, $schema, []);
     }
 
     /**
-     * Normalize a single schema node.
+     * Normalize a single schema node into the deserializable subset.
      *
      * @param  array<string, mixed>  $schema
-     * @param  array<string, mixed>  $defs
+     * @param  array<string, mixed>  $root
      * @param  array<string, true>  $seen
      * @return array<string, mixed>
      */
-    private function node(array $schema, array $defs, array $seen): array
+    private function node(array $schema, array $root, array $seen): array
     {
-        [$schema, $seen] = $this->inlineRefs($schema, $defs, $seen);
+        [$schema, $seen] = $this->inlineRefs($schema, $root, $seen);
 
-        $schema = $this->mergeAllOf($schema, $defs, $seen);
-        $schema = $this->collapseUnions($schema, $defs, $seen);
+        $schema = $this->mergeAllOf($schema, $root, $seen);
+        $schema = $this->collapseUnions($schema, $root, $seen);
         $schema = $this->collapseMultiType($schema);
-
-        // Strip after merging so keywords pulled in from allOf branches are dropped too.
-        foreach (self::UNSUPPORTED as $keyword) {
-            unset($schema[$keyword]);
-        }
-
-        unset($schema['$defs'], $schema['definitions']);
-
-        if (array_key_exists('default', $schema) && $schema['default'] === null) {
-            unset($schema['default']);
-        }
-
-        if (($schema['additionalProperties'] ?? false) !== false) {
-            unset($schema['additionalProperties']);
-        }
-
-        if (is_array($schema['properties'] ?? null)) {
-            $properties = [];
-
-            foreach ($schema['properties'] as $key => $definition) {
-                if (is_array($definition)) {
-                    $properties[$key] = $this->node($definition, $defs, $seen);
-                }
-            }
-
-            $schema['properties'] = $properties;
-
-            if (is_array($schema['required'] ?? null)) {
-                $schema['required'] = array_values(array_filter(
-                    $schema['required'],
-                    fn ($name) => is_string($name) && array_key_exists($name, $properties),
-                ));
-            }
-        }
-
-        if (isset($schema['items'])) {
-            if (is_array($schema['items']) && ! array_is_list($schema['items'])) {
-                $schema['items'] = $this->node($schema['items'], $defs, $seen);
-            } else {
-                unset($schema['items']);
-            }
-        }
+        $schema = $this->dropUnsupportedKeywords($schema);
+        $schema = $this->rewriteConstAndDefault($schema);
+        $schema = $this->normalizeAdditionalProperties($schema);
+        $schema = $this->normalizeChildren($schema, $root, $seen);
 
         return $this->ensureType($schema);
     }
@@ -110,45 +67,65 @@ class SchemaNormalizer
      * Inline local "$ref" pointers (cycle-safe); drop remote or unresolvable ones.
      *
      * @param  array<string, mixed>  $schema
-     * @param  array<string, mixed>  $defs
+     * @param  array<string, mixed>  $root
      * @param  array<string, true>  $seen
      * @return array{0: array<string, mixed>, 1: array<string, true>}
      */
-    private function inlineRefs(array $schema, array $defs, array $seen): array
+    private function inlineRefs(array $schema, array $root, array $seen): array
     {
         while (isset($schema['$ref']) && is_string($schema['$ref'])) {
             $ref = $schema['$ref'];
 
             unset($schema['$ref']);
 
-            $key = match (true) {
-                str_starts_with($ref, '#/$defs/') => substr($ref, 8),
-                str_starts_with($ref, '#/definitions/') => substr($ref, 14),
-                default => null,
-            };
-
-            if ($key === null || ! is_array($defs[$key] ?? null) || isset($seen[$key])) {
+            if (isset($seen[$ref]) || ($resolved = $this->lookupRef($ref, $root)) === null) {
                 break;
             }
 
-            $seen[$key] = true;
-            $schema = array_merge($defs[$key], $schema);
+            $seen[$ref] = true;
+            $schema = array_merge($resolved, $schema);
         }
 
         return [$schema, $seen];
     }
 
     /**
-     * Merge "allOf" branches into the node; the deserializer has no intersection type.
+     * Resolve a local JSON pointer against the root schema.
+     *
+     * @param  array<string, mixed>  $root
+     * @return array<string, mixed>|null
+     */
+    private function lookupRef(string $ref, array $root): ?array
+    {
+        if (! str_starts_with($ref, '#/')) {
+            return null;
+        }
+
+        $target = $root;
+
+        foreach (explode('/', substr($ref, 2)) as $segment) {
+            $segment = str_replace(['~1', '~0'], ['/', '~'], rawurldecode($segment));
+
+            if (! is_array($target) || ! array_key_exists($segment, $target)) {
+                return null;
+            }
+
+            $target = $target[$segment];
+        }
+
+        return is_array($target) ? $target : null;
+    }
+
+    /**
+     * Flatten "allOf" branches into the node; the deserializer has no intersection type.
      *
      * @param  array<string, mixed>  $schema
-     * @param  array<string, mixed>  $defs
+     * @param  array<string, mixed>  $root
      * @param  array<string, true>  $seen
      * @return array<string, mixed>
      */
-    private function mergeAllOf(array $schema, array $defs, array $seen): array
+    private function mergeAllOf(array $schema, array $root, array $seen): array
     {
-        // Loop so an allOf branch that itself carries allOf is flattened too.
         while (is_array($schema['allOf'] ?? null)) {
             $branches = $schema['allOf'];
 
@@ -158,7 +135,7 @@ class SchemaNormalizer
 
             foreach ($branches as $branch) {
                 if (is_array($branch)) {
-                    [$branch] = $this->inlineRefs($branch, $defs, $seen);
+                    [$branch, $seen] = $this->inlineRefs($branch, $root, $seen);
                     $merged = $this->mergeSchema($merged, $branch);
                 }
             }
@@ -170,8 +147,7 @@ class SchemaNormalizer
     }
 
     /**
-     * Merge two schema fragments, unioning "required" and "properties" rather
-     * than letting one side clobber the other.
+     * Merge two schema fragments, unioning "required" and recursively merging "properties".
      *
      * @param  array<string, mixed>  $base
      * @param  array<string, mixed>  $overlay
@@ -180,14 +156,17 @@ class SchemaNormalizer
     private function mergeSchema(array $base, array $overlay): array
     {
         $required = array_values(array_unique(array_merge(
-            is_array($base['required'] ?? null) ? $base['required'] : [],
-            is_array($overlay['required'] ?? null) ? $overlay['required'] : [],
+            $this->arrayValue($base, 'required'),
+            $this->arrayValue($overlay, 'required'),
         )));
 
-        $properties = array_merge(
-            is_array($base['properties'] ?? null) ? $base['properties'] : [],
-            is_array($overlay['properties'] ?? null) ? $overlay['properties'] : [],
-        );
+        $properties = $this->arrayValue($base, 'properties');
+
+        foreach ($this->arrayValue($overlay, 'properties') as $key => $value) {
+            $properties[$key] = isset($properties[$key]) && is_array($properties[$key]) && is_array($value)
+                ? $this->mergeSchema($properties[$key], $value)
+                : $value;
+        }
 
         $merged = array_merge($base, $overlay);
 
@@ -203,50 +182,99 @@ class SchemaNormalizer
     }
 
     /**
-     * Collapse "anyOf"/"oneOf" to a single branch, since the deserializer only
-     * accepts a nullable union (one schema plus a "null" branch).
+     * Collapse "anyOf"/"oneOf" into a deserializable form.
      *
      * @param  array<string, mixed>  $schema
-     * @param  array<string, mixed>  $defs
+     * @param  array<string, mixed>  $root
      * @param  array<string, true>  $seen
      * @return array<string, mixed>
      */
-    private function collapseUnions(array $schema, array $defs, array $seen): array
+    private function collapseUnions(array $schema, array $root, array $seen): array
     {
         foreach (['anyOf', 'oneOf'] as $key) {
             if (! is_array($schema[$key] ?? null)) {
                 continue;
             }
 
-            $nullable = false;
-            $branches = [];
-
-            foreach ($schema[$key] as $branch) {
-                if (! is_array($branch)) {
-                    continue;
-                }
-
-                [$branch] = $this->inlineRefs($branch, $defs, $seen);
-
-                if (in_array($branch['type'] ?? null, ['null', ['null']], true)) {
-                    $nullable = true;
-                } else {
-                    $branches[] = $this->node($branch, $defs, $seen);
-                }
-            }
+            $branches = $schema[$key];
 
             unset($schema[$key]);
 
-            if ($branches !== []) {
-                $schema = array_merge($schema, $branches[0]);
-            }
-
-            if ($nullable) {
-                $schema = $this->makeNullable($schema);
-            }
+            $schema = $this->mergeUnion($schema, $branches, $root, $seen);
         }
 
         return $schema;
+    }
+
+    /**
+     * Reduce union branches into the node: a scalar multi-type union, or the first
+     * branch (lossy) since the deserializer only accepts a single schema plus null.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, mixed>  $branches
+     * @param  array<string, mixed>  $root
+     * @param  array<string, true>  $seen
+     * @return array<string, mixed>
+     */
+    private function mergeUnion(array $schema, array $branches, array $root, array $seen): array
+    {
+        $nullable = false;
+        $resolved = [];
+
+        foreach ($branches as $branch) {
+            if (! is_array($branch)) {
+                continue;
+            }
+
+            [$branch, $branchSeen] = $this->inlineRefs($branch, $root, $seen);
+
+            if (in_array($branch['type'] ?? null, ['null', ['null']], true)) {
+                $nullable = true;
+            } else {
+                $resolved[] = $this->node($branch, $root, $branchSeen);
+            }
+        }
+
+        if (($scalarTypes = $this->scalarUnionTypes($resolved)) !== null) {
+            $schema['type'] = array_values(array_unique($nullable ? [...$scalarTypes, 'null'] : $scalarTypes));
+
+            return $schema;
+        }
+
+        if ($resolved !== []) {
+            $schema = array_merge($schema, $resolved[0]);
+        }
+
+        return $nullable ? $this->makeNullable($schema) : $schema;
+    }
+
+    /**
+     * Get the unioned scalar types when every branch is a plain scalar, else null.
+     *
+     * @param  array<int, array<string, mixed>>  $branches
+     * @return array<int, string>|null
+     */
+    private function scalarUnionTypes(array $branches): ?array
+    {
+        if (count($branches) < 2) {
+            return null;
+        }
+
+        $types = [];
+
+        foreach ($branches as $branch) {
+            $branchTypes = is_array($branch['type'] ?? null) ? $branch['type'] : [$branch['type'] ?? null];
+
+            foreach ($branchTypes as $type) {
+                if (! in_array($type, self::SCALAR_TYPES, true)) {
+                    return null;
+                }
+
+                $types[] = $type;
+            }
+        }
+
+        return $types;
     }
 
     /**
@@ -266,8 +294,7 @@ class SchemaNormalizer
     }
 
     /**
-     * Keep multi-type unions deserializable, and drop "null"-only types which
-     * the deserializer cannot represent.
+     * Keep multi-type unions deserializable and drop unrepresentable "null"-only types.
      *
      * @param  array<string, mixed>  $schema
      * @return array<string, mixed>
@@ -276,13 +303,11 @@ class SchemaNormalizer
     {
         $type = $schema['type'] ?? null;
 
-        if ($type === 'null') {
-            unset($schema['type']);
-
-            return $schema;
-        }
-
         if (! is_array($type)) {
+            if ($type === 'null') {
+                unset($schema['type']);
+            }
+
             return $schema;
         }
 
@@ -290,11 +315,7 @@ class SchemaNormalizer
 
         if ($nonNull === []) {
             unset($schema['type']);
-
-            return $schema;
-        }
-
-        if (count($nonNull) > 1) {
+        } elseif (count($nonNull) > 1) {
             foreach (self::TYPE_KEYWORDS as $keyword) {
                 unset($schema[$keyword]);
             }
@@ -304,8 +325,106 @@ class SchemaNormalizer
     }
 
     /**
-     * Give a node an explicit, deserializable type. Mirrors the deserializer's
-     * own inference so a typeless node never reaches it and throws.
+     * Drop keywords the deserializer cannot represent, along with definitions.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function dropUnsupportedKeywords(array $schema): array
+    {
+        foreach (self::UNSUPPORTED as $keyword) {
+            unset($schema[$keyword]);
+        }
+
+        unset($schema['$defs'], $schema['definitions']);
+
+        return $schema;
+    }
+
+    /**
+     * Rewrite "const" to a single-value enum and drop an unsupported null default.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function rewriteConstAndDefault(array $schema): array
+    {
+        if (array_key_exists('const', $schema)) {
+            $schema['enum'] = [$schema['const']];
+
+            unset($schema['const']);
+        }
+
+        if (array_key_exists('default', $schema) && $schema['default'] === null) {
+            unset($schema['default']);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Infer an object type from additionalProperties, then drop its permissive forms.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private function normalizeAdditionalProperties(array $schema): array
+    {
+        if (! isset($schema['type']) && array_key_exists('additionalProperties', $schema)) {
+            $schema['type'] = 'object';
+        }
+
+        if (($schema['additionalProperties'] ?? false) !== false) {
+            unset($schema['additionalProperties']);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Recurse into "properties" (pruning orphaned "required") and "items".
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $root
+     * @param  array<string, true>  $seen
+     * @return array<string, mixed>
+     */
+    private function normalizeChildren(array $schema, array $root, array $seen): array
+    {
+        if (is_array($schema['properties'] ?? null)) {
+            $properties = [];
+
+            foreach ($schema['properties'] as $key => $definition) {
+                if (is_array($definition)) {
+                    $properties[$key] = $this->node($definition, $root, $seen);
+                }
+            }
+
+            $schema['properties'] = $properties;
+
+            if (is_array($schema['required'] ?? null)) {
+                $schema['required'] = array_values(array_filter(
+                    $schema['required'],
+                    fn ($name) => is_string($name) && array_key_exists($name, $properties),
+                ));
+            }
+        }
+
+        if (isset($schema['items'])) {
+            $schema['items'] = is_array($schema['items']) && ! array_is_list($schema['items'])
+                ? $this->node($schema['items'], $root, $seen)
+                : null;
+
+            if ($schema['items'] === null) {
+                unset($schema['items']);
+            }
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Give a node an explicit type so a typeless node never reaches the deserializer.
      *
      * @param  array<string, mixed>  $schema
      * @return array<string, mixed>
@@ -329,7 +448,7 @@ class SchemaNormalizer
     private function baseType(array $schema): string
     {
         return match (true) {
-            isset($schema['properties']), isset($schema['required']) => 'object',
+            isset($schema['properties']), isset($schema['required']), isset($schema['additionalProperties']) => 'object',
             isset($schema['items']), isset($schema['minItems']), isset($schema['maxItems']), isset($schema['uniqueItems']) => 'array',
             isset($schema['enum']) && is_array($schema['enum']) => $this->inferEnumType($schema['enum']),
             isset($schema['minimum']), isset($schema['maximum']), isset($schema['multipleOf']) => 'number',
@@ -338,8 +457,7 @@ class SchemaNormalizer
     }
 
     /**
-     * Infer the scalar type shared by an enum, defaulting to "string" for an
-     * empty or heterogeneous enum (which the deserializer cannot type).
+     * Infer the scalar type shared by an enum, defaulting to "string".
      *
      * @param  array<int, mixed>  $enum
      */
@@ -376,5 +494,16 @@ class SchemaNormalizer
         }
 
         return $resolved ?? 'string';
+    }
+
+    /**
+     * Read an array-typed key, defaulting to an empty array.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<mixed>
+     */
+    private function arrayValue(array $schema, string $key): array
+    {
+        return is_array($schema[$key] ?? null) ? $schema[$key] : [];
     }
 }

--- a/src/Tools/McpTool.php
+++ b/src/Tools/McpTool.php
@@ -9,6 +9,7 @@ use Illuminate\JsonSchema\Types\Type;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Schema\SchemaNormalizer;
 use Laravel\Ai\Tools\Concerns\NormalizesMcpResult;
+use Throwable;
 
 class McpTool implements Tool
 {
@@ -74,7 +75,11 @@ class McpTool implements Tool
             return [];
         }
 
-        $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize($input));
+        try {
+            $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize($input));
+        } catch (Throwable) {
+            return [];
+        }
 
         return $type instanceof ObjectType
             ? (fn (): array => $this->properties)->call($type)

--- a/src/Tools/McpTool.php
+++ b/src/Tools/McpTool.php
@@ -7,7 +7,9 @@ use Illuminate\JsonSchema\JsonSchema as JsonSchemaFactory;
 use Illuminate\JsonSchema\Types\ObjectType;
 use Illuminate\JsonSchema\Types\Type;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Schema\SchemaNormalizer;
 use Laravel\Ai\Tools\Concerns\NormalizesMcpResult;
+use Throwable;
 
 class McpTool implements Tool
 {
@@ -69,11 +71,17 @@ class McpTool implements Tool
     {
         $input = $this->tool->inputSchema ?? [];
 
-        if (! is_array($input) || ($input['type'] ?? 'object') !== 'object') {
+        if (! is_array($input) || $input === []) {
             return [];
         }
 
-        $type = JsonSchemaFactory::fromArray($input);
+        // Normalization makes the schema deserializable, but a malformed server
+        // schema should degrade to "no parameters" rather than fail the prompt.
+        try {
+            $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize($input));
+        } catch (Throwable) {
+            return [];
+        }
 
         return $type instanceof ObjectType
             ? (fn (): array => $this->properties)->call($type)

--- a/src/Tools/McpTool.php
+++ b/src/Tools/McpTool.php
@@ -9,7 +9,6 @@ use Illuminate\JsonSchema\Types\Type;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Schema\SchemaNormalizer;
 use Laravel\Ai\Tools\Concerns\NormalizesMcpResult;
-use Throwable;
 
 class McpTool implements Tool
 {
@@ -75,13 +74,7 @@ class McpTool implements Tool
             return [];
         }
 
-        // Normalization makes the schema deserializable, but a malformed server
-        // schema should degrade to "no parameters" rather than fail the prompt.
-        try {
-            $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize($input));
-        } catch (Throwable) {
-            return [];
-        }
+        $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize($input));
 
         return $type instanceof ObjectType
             ? (fn (): array => $this->properties)->call($type)

--- a/tests/Feature/McpToolTest.php
+++ b/tests/Feature/McpToolTest.php
@@ -4,6 +4,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Tools\McpTool;
 use Tests\Fixtures\Mcp\FakeMcpClient;
 use Tests\Fixtures\Mcp\FakeMcpTool;
 use Tests\Fixtures\Mcp\FakeMcpToolResult;
@@ -59,6 +60,109 @@ test('agents can return mcp client tools directly', function () {
         ->toolResults->toHaveCount(1);
 
     expect($response->toolResults->first())->toHaveProperty('result', 'Found results.');
+
+    expect($client)->toHaveProperty(
+        'toolCalls',
+        [
+            ['name' => 'search', 'arguments' => ['query' => 'laravel']],
+        ]
+    );
+});
+
+test('it skips mcp client tools whose schema cannot be represented', function () {
+    $client = new FakeMcpClient;
+
+    $union = new McpTool(new FakeMcpTool($client, 'set_value', null, 'Set a value.', [
+        'type' => 'object',
+        'properties' => [
+            'value' => ['type' => ['string', 'number', 'boolean']],
+        ],
+        'required' => ['value'],
+    ]));
+
+    $client->results['set_value'] = new FakeMcpToolResult([
+        ['type' => 'text', 'text' => 'Should not run.'],
+    ], false);
+
+    $agent = new class($union) implements Agent, HasTools
+    {
+        use Promptable;
+
+        public function __construct(public object $tool) {}
+
+        public function instructions(): string
+        {
+            return 'Use available tools.';
+        }
+
+        public function tools(): iterable
+        {
+            return [$this->tool];
+        }
+    };
+
+    $agent::fake([
+        new ToolCall('call_skip', 'mcp_tools_set_value', ['value' => 'bug']),
+        'Done.',
+    ]);
+
+    $response = $agent->prompt('Set the value');
+
+    expect($response->toolResults)->toHaveCount(0);
+
+    expect($client)->toHaveProperty('toolCalls', []);
+});
+
+test('it does not over-filter convertible mcp client tools alongside an unrepresentable one', function () {
+    $client = new FakeMcpClient;
+
+    $search = new McpTool(new FakeMcpTool($client, 'search', null, 'Search records.', [
+        'type' => 'object',
+        'properties' => [
+            'query' => ['type' => 'string'],
+        ],
+        'required' => ['query'],
+    ]));
+
+    $union = new McpTool(new FakeMcpTool($client, 'set_value', null, 'Set a value.', [
+        'type' => 'object',
+        'properties' => [
+            'value' => ['type' => ['string', 'number', 'boolean']],
+        ],
+        'required' => ['value'],
+    ]));
+
+    $client->results['search'] = new FakeMcpToolResult([
+        ['type' => 'text', 'text' => 'Found results.'],
+    ], false);
+
+    $agent = new class($search, $union) implements Agent, HasTools
+    {
+        use Promptable;
+
+        public function __construct(public object $search, public object $union) {}
+
+        public function instructions(): string
+        {
+            return 'Use available tools.';
+        }
+
+        public function tools(): iterable
+        {
+            return [$this->union, $this->search];
+        }
+    };
+
+    $agent::fake([
+        new ToolCall('call_ok', 'mcp_tools_search', ['query' => 'laravel']),
+        'Done.',
+    ]);
+
+    $response = $agent->prompt('Search for Laravel');
+
+    expect($response->toolResults)
+        ->toHaveCount(1)
+        ->first()->toHaveProperty('result', 'Found results.');
 
     expect($client)->toHaveProperty(
         'toolCalls',

--- a/tests/Feature/McpToolTest.php
+++ b/tests/Feature/McpToolTest.php
@@ -63,19 +63,20 @@ test('agents can return mcp client tools directly', function () {
     );
 });
 
-test('it skips mcp client tools whose schema cannot be represented', function () {
+test('it runs mcp client tools whose schema uses unrepresentable json schema', function () {
     $client = new FakeMcpClient;
 
     $union = new McpTool(new FakeMcpTool($client, 'set_value', null, 'Set a value.', [
         'type' => 'object',
         'properties' => [
             'value' => ['type' => ['string', 'number', 'boolean']],
+            'mode' => ['oneOf' => [['const' => 'fast'], ['const' => 'slow']]],
         ],
         'required' => ['value'],
     ]));
 
     $client->results['set_value'] = new FakeMcpToolResult([
-        ['type' => 'text', 'text' => 'Should not run.'],
+        ['type' => 'text', 'text' => 'Value set.'],
     ], false);
 
     $agent = new class($union) implements Agent, HasTools
@@ -96,72 +97,20 @@ test('it skips mcp client tools whose schema cannot be represented', function ()
     };
 
     $agent::fake([
-        new ToolCall('call_skip', 'mcp_tools_set_value', ['value' => 'bug']),
+        new ToolCall('call_union', 'mcp_tools_set_value', ['value' => 'bug']),
         'Done.',
     ]);
 
     $response = $agent->prompt('Set the value');
 
-    expect($response->toolResults)->toHaveCount(0);
-
-    expect($client)->toHaveProperty('toolCalls', []);
-});
-
-test('it does not over-filter convertible mcp client tools alongside an unrepresentable one', function () {
-    $client = new FakeMcpClient;
-
-    $search = new McpTool(new FakeMcpTool($client, 'search', null, 'Search records.', [
-        'type' => 'object',
-        'properties' => [
-            'query' => ['type' => 'string'],
-        ],
-        'required' => ['query'],
-    ]));
-
-    $union = new McpTool(new FakeMcpTool($client, 'set_value', null, 'Set a value.', [
-        'type' => 'object',
-        'properties' => [
-            'value' => ['type' => ['string', 'number', 'boolean']],
-        ],
-        'required' => ['value'],
-    ]));
-
-    $client->results['search'] = new FakeMcpToolResult([
-        ['type' => 'text', 'text' => 'Found results.'],
-    ], false);
-
-    $agent = new class($search, $union) implements Agent, HasTools
-    {
-        use Promptable;
-
-        public function __construct(public object $search, public object $union) {}
-
-        public function instructions(): string
-        {
-            return 'Use available tools.';
-        }
-
-        public function tools(): iterable
-        {
-            return [$this->union, $this->search];
-        }
-    };
-
-    $agent::fake([
-        new ToolCall('call_ok', 'mcp_tools_search', ['query' => 'laravel']),
-        'Done.',
-    ]);
-
-    $response = $agent->prompt('Search for Laravel');
-
     expect($response->toolResults)
         ->toHaveCount(1)
-        ->first()->toHaveProperty('result', 'Found results.');
+        ->first()->toHaveProperty('result', 'Value set.');
 
     expect($client)->toHaveProperty(
         'toolCalls',
         [
-            ['name' => 'search', 'arguments' => ['query' => 'laravel']],
+            ['name' => 'set_value', 'arguments' => ['value' => 'bug']],
         ]
     );
 });

--- a/tests/Feature/McpToolTest.php
+++ b/tests/Feature/McpToolTest.php
@@ -9,12 +9,6 @@ use Tests\Fixtures\Mcp\FakeMcpClient;
 use Tests\Fixtures\Mcp\FakeMcpTool;
 use Tests\Fixtures\Mcp\FakeMcpToolResult;
 
-beforeAll(function () {
-    if (! class_exists('Laravel\\Mcp\\Client\\Primitives\\Tool')) {
-        class_alias(FakeMcpTool::class, 'Laravel\\Mcp\\Client\\Primitives\\Tool');
-    }
-});
-
 test('agents can return mcp client tools directly', function () {
     $client = new FakeMcpClient;
     $mcpTool = new FakeMcpTool($client, 'search', null, 'Search records.', [

--- a/tests/Fixtures/Mcp/FakeMcpTool.php
+++ b/tests/Fixtures/Mcp/FakeMcpTool.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Fixtures\Mcp;
 
-class FakeMcpTool
+use Laravel\Mcp\Client\Primitives\Tool;
+use Laravel\Mcp\Client\Schema\ToolResult;
+
+class FakeMcpTool extends Tool
 {
     /**
      * @param  array<string, mixed>  $inputSchema
@@ -11,21 +14,23 @@ class FakeMcpTool
      * @param  array<string, mixed>|null  $meta
      */
     public function __construct(
-        protected FakeMcpClient $client,
-        public readonly string $name,
-        public readonly ?string $title,
-        public readonly ?string $description,
-        public readonly array $inputSchema,
-        public readonly ?array $outputSchema = null,
-        public readonly array $annotations = [],
-        public readonly ?array $meta = null,
-    ) {}
+        protected FakeMcpClient $fakeClient,
+        string $name,
+        ?string $title,
+        ?string $description,
+        array $inputSchema,
+        ?array $outputSchema = null,
+        array $annotations = [],
+        ?array $meta = null,
+    ) {
+        parent::__construct(null, $name, $title, $description, $inputSchema, $outputSchema, $annotations, $meta);
+    }
 
     /**
      * @param  array<string, mixed>  $arguments
      */
-    public function call(array $arguments = []): FakeMcpToolResult
+    public function call(array $arguments = []): ToolResult
     {
-        return $this->client->callTool($this->name, $arguments);
+        return $this->fakeClient->callTool($this->name, $arguments);
     }
 }

--- a/tests/Fixtures/Mcp/FakeMcpToolResult.php
+++ b/tests/Fixtures/Mcp/FakeMcpToolResult.php
@@ -2,37 +2,6 @@
 
 namespace Tests\Fixtures\Mcp;
 
-use Stringable;
+use Laravel\Mcp\Client\Schema\ToolResult;
 
-class FakeMcpToolResult implements Stringable
-{
-    /**
-     * @param  array<int, array<string, mixed>>  $content
-     * @param  array<string, mixed>|null  $structuredContent
-     * @param  array<string, mixed>|null  $meta
-     */
-    public function __construct(
-        public array $content,
-        public bool $isError,
-        public ?array $structuredContent = null,
-        public ?array $meta = null,
-    ) {}
-
-    public function text(): string
-    {
-        $text = [];
-
-        foreach ($this->content as $item) {
-            if (($item['type'] ?? null) === 'text' && is_string($item['text'] ?? null)) {
-                $text[] = $item['text'];
-            }
-        }
-
-        return implode('', $text);
-    }
-
-    public function __toString(): string
-    {
-        return $this->text();
-    }
-}
+class FakeMcpToolResult extends ToolResult {}

--- a/tests/Integration/McpClientTest.php
+++ b/tests/Integration/McpClientTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Tools\McpTool;
+use Laravel\Mcp\Client;
+
+use function Laravel\Ai\agent;
+
+function requiresMcpServerEverything(): void
+{
+    if (! is_executable(trim((string) shell_exec('command -v npx 2>/dev/null')))) {
+        test()->markTestSkipped('Missing npx — skipping live MCP server test.');
+    }
+}
+
+test('it connects to a live MCP server and fetches tools', function () {
+    requiresMcpServerEverything();
+
+    $client = Client::local('npx', ['-y', '@modelcontextprotocol/server-everything'])
+        ->withTimeout(60)
+        ->connect();
+
+    try {
+        $tools = $client->tools();
+
+        expect($tools)->not->toBeEmpty();
+
+        $names = $tools->map(fn ($tool) => $tool->name)->all();
+
+        expect($names)->toContain('echo', 'get-sum');
+
+        foreach ($tools as $tool) {
+            expect(McpTool::supports($tool))->toBeTrue();
+
+            $wrapped = new McpTool($tool);
+
+            expect($wrapped->name())->toStartWith('mcp_tools_');
+
+            // Every live tool schema normalizes into the deserializable subset without throwing.
+            expect($wrapped->schema(new JsonSchemaTypeFactory))->toBeArray();
+        }
+    } finally {
+        $client->disconnect();
+    }
+});
+
+test('an agent uses live MCP tools and responds correctly', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+    requiresMcpServerEverything();
+
+    $client = Client::local('npx', ['-y', '@modelcontextprotocol/server-everything'])
+        ->withTimeout(60)
+        ->connect();
+
+    try {
+        $response = agent(
+            instructions: 'You echo text for the user. Always call the echo tool with the exact text the user provides, then reply with the tool output verbatim.',
+            tools: $client->tools()->all(),
+        )->prompt(
+            "Echo the text 'hello-mcp-123' using the echo tool.",
+            provider: $provider,
+            model: $model,
+        );
+
+        expect($response->toolCalls)->not->toBeEmpty()
+            ->and($response->toolCalls->contains(fn ($call) => $call->name === 'mcp_tools_echo'))->toBeTrue()
+            ->and($response->text)->toContain('hello-mcp-123');
+    } finally {
+        $client->disconnect();
+    }
+})->with('agent-providers');

--- a/tests/Integration/McpClientTest.php
+++ b/tests/Integration/McpClientTest.php
@@ -13,7 +13,8 @@ function requiresMcpServerEverything(): void
     }
 }
 
-test('it connects to a live MCP server and fetches tools', function () {
+test('every weird MCP tool from the everything server works across providers', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
     requiresMcpServerEverything();
 
     $client = Client::local('npx', ['-y', '@modelcontextprotocol/server-everything'])
@@ -25,45 +26,20 @@ test('it connects to a live MCP server and fetches tools', function () {
 
         expect($tools)->not->toBeEmpty();
 
-        $names = $tools->map(fn ($tool) => $tool->name)->all();
-
-        expect($names)->toContain('echo', 'get-sum');
-
         foreach ($tools as $tool) {
-            expect(McpTool::supports($tool))->toBeTrue();
-
-            $wrapped = new McpTool($tool);
-
-            expect($wrapped->name())->toStartWith('mcp_tools_');
-
-            // Every live tool schema normalizes into the deserializable subset without throwing.
-            expect($wrapped->schema(new JsonSchemaTypeFactory))->toBeArray();
+            expect((new McpTool($tool))->schema(new JsonSchemaTypeFactory))->toBeArray();
         }
-    } finally {
-        $client->disconnect();
-    }
-});
 
-test('an agent uses live MCP tools and responds correctly', function (string $provider, string $apiKey, string $model) {
-    requiresApiKey($apiKey);
-    requiresMcpServerEverything();
-
-    $client = Client::local('npx', ['-y', '@modelcontextprotocol/server-everything'])
-        ->withTimeout(60)
-        ->connect();
-
-    try {
         $response = agent(
-            instructions: 'You echo text for the user. Always call the echo tool with the exact text the user provides, then reply with the tool output verbatim.',
-            tools: $client->tools()->all(),
+            instructions: 'You echo text for the user. Always call the echo tool with the exact text provided, then reply with the tool output verbatim.',
+            tools: $tools->all(),
         )->prompt(
             "Echo the text 'hello-mcp-123' using the echo tool.",
             provider: $provider,
             model: $model,
         );
 
-        expect($response->toolCalls)->not->toBeEmpty()
-            ->and($response->toolCalls->contains(fn ($call) => $call->name === 'mcp_tools_echo'))->toBeTrue()
+        expect($response->toolCalls->contains(fn ($call) => $call->name === 'mcp_tools_echo'))->toBeTrue()
             ->and($response->text)->toContain('hello-mcp-123');
     } finally {
         $client->disconnect();

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -40,7 +40,7 @@ test('it collapses a nullable anyOf to a nullable single type', function () {
     ]);
 });
 
-test('it collapses a non-nullable multi-branch oneOf to the first branch', function () {
+test('it collapses a non-nullable scalar oneOf to a multi-type union', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
@@ -48,7 +48,8 @@ test('it collapses a non-nullable multi-branch oneOf to the first branch', funct
         ],
     ]);
 
-    expect($normalized['properties']['choice'])->toMatchArray(['type' => 'string', 'maxLength' => 5]);
+    expect($normalized['properties']['choice'])->toMatchArray(['type' => ['string', 'integer']]);
+    expect($normalized['properties']['choice'])->not->toHaveKey('maxLength');
 });
 
 test('it strips type-specific keywords from a multi-type union so it deserializes', function () {
@@ -165,7 +166,6 @@ test('it breaks circular $ref without infinite recursion', function () {
     ]);
 
     expect($normalized['properties']['node']['type'])->toBe('object');
-    // The cycle is broken: the self-referential branch drops its $ref and falls back to a scalar.
     expect($normalized['properties']['node']['properties']['child'])->toBe(['type' => 'string']);
 });
 
@@ -281,4 +281,90 @@ test('it produces an ObjectType for a gnarly real-world schema', function () {
     ]));
 
     expect($type)->toBeInstanceOf(ObjectType::class);
+});
+
+test('it terminates on a recursive allOf instead of hanging', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['node' => ['$ref' => '#/$defs/Node']],
+        '$defs' => [
+            'Node' => [
+                'type' => 'object',
+                'allOf' => [['$ref' => '#/$defs/Node']],
+                'properties' => ['v' => ['type' => 'string']],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['node']['type'])->toBe('object');
+    expect($normalized['properties']['node']['properties'])->toHaveKey('v');
+});
+
+test('it terminates on a nullable recursive union instead of hanging', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['node' => ['$ref' => '#/$defs/Node']],
+        '$defs' => [
+            'Node' => [
+                'type' => 'object',
+                'properties' => [
+                    'child' => ['anyOf' => [['$ref' => '#/$defs/Node'], ['type' => 'null']]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['node']['properties'])->toHaveKey('child');
+});
+
+test('it resolves arbitrary local JSON pointers, including escaped keys', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'a' => ['$ref' => '#/$defs/a~1b'],
+            'b' => ['$ref' => '#/properties/a'],
+        ],
+        '$defs' => [
+            'a/b' => ['type' => 'integer', 'minimum' => 1],
+        ],
+    ]);
+
+    expect($normalized['properties']['a'])->toMatchArray(['type' => 'integer', 'minimum' => 1]);
+    expect($normalized['properties']['b'])->toMatchArray(['type' => 'integer', 'minimum' => 1]);
+});
+
+test('it converts const to a single-value enum', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['mode' => ['const' => 'fast']],
+    ]);
+
+    expect($normalized['properties']['mode'])->toBe(['enum' => ['fast'], 'type' => 'string']);
+});
+
+test('it infers object type from additionalProperties', function (array $raw) {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['opts' => $raw],
+    ]);
+
+    expect($normalized['properties']['opts']['type'])->toBe('object');
+})->with([
+    'schema form' => [['additionalProperties' => ['type' => 'string']]],
+    'false form' => [['additionalProperties' => false]],
+]);
+
+test('it deep-merges overlapping properties across allOf branches', function () {
+    $normalized = normalizesWithoutThrowing([
+        'allOf' => [
+            ['properties' => ['value' => ['type' => 'string', 'minLength' => 5]]],
+            ['properties' => ['value' => ['type' => 'string', 'maxLength' => 10]]],
+        ],
+    ]);
+
+    expect($normalized['properties']['value'])->toMatchArray([
+        'type' => 'string',
+        'minLength' => 5,
+        'maxLength' => 10,
+    ]);
 });

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -266,6 +266,35 @@ test('it replaces a null-only type with a scalar so it deserializes', function (
     'null-only array' => [['type' => ['null']]],
 ]);
 
+test('it re-infers a type when the declared type is not a known JSON Schema type', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'a' => ['type' => 'frobnicate'],
+            'b' => ['type' => 'widget', 'properties' => ['x' => ['type' => 'string']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['a']['type'])->toBe('string');
+    expect($normalized['properties']['b']['type'])->toBe('object');
+    expect($normalized['properties']['b']['properties'])->toHaveKey('x');
+});
+
+test('it drops unknown members from a multi-type union but keeps the rest', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'v' => ['type' => ['string', 'frobnicate', 'integer']],
+            'n' => ['type' => ['string', 'frobnicate', 'null']],
+            'only' => ['type' => ['frobnicate']],
+        ],
+    ]);
+
+    expect($normalized['properties']['v']['type'])->toBe(['string', 'integer']);
+    expect($normalized['properties']['n']['type'])->toBe(['string', 'null']);
+    expect($normalized['properties']['only']['type'])->toBe('string');
+});
+
 test('it produces an ObjectType for a gnarly real-world schema', function () {
     $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize([
         '$schema' => 'http://json-schema.org/draft-07/schema#',

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -1,0 +1,284 @@
+<?php
+
+use Illuminate\JsonSchema\JsonSchema as JsonSchemaFactory;
+use Illuminate\JsonSchema\Types\ObjectType;
+use Laravel\Ai\Schema\SchemaNormalizer;
+
+/**
+ * Assert that a raw schema normalizes into something the deserializer accepts.
+ */
+function normalizesWithoutThrowing(array $raw): array
+{
+    $normalized = SchemaNormalizer::normalize($raw);
+
+    expect(fn () => JsonSchemaFactory::fromArray($normalized))->not->toThrow(Throwable::class);
+
+    return $normalized;
+}
+
+test('it passes a plain object schema through unchanged', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => ['name' => ['type' => 'string', 'description' => 'A name.']],
+        'required' => ['name'],
+    ];
+
+    expect(SchemaNormalizer::normalize($raw))->toBe($raw);
+});
+
+test('it collapses a nullable anyOf to a nullable single type', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'nickname' => ['anyOf' => [['type' => 'string', 'minLength' => 1], ['type' => 'null']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['nickname'])->toMatchArray([
+        'type' => ['string', 'null'],
+        'minLength' => 1,
+    ]);
+});
+
+test('it collapses a non-nullable multi-branch oneOf to the first branch', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'choice' => ['oneOf' => [['type' => 'string', 'maxLength' => 5], ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['choice'])->toMatchArray(['type' => 'string', 'maxLength' => 5]);
+});
+
+test('it strips type-specific keywords from a multi-type union so it deserializes', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'value' => ['type' => ['string', 'number'], 'minLength' => 3, 'minimum' => 1],
+        ],
+    ]);
+
+    expect($normalized['properties']['value']['type'])->toBe(['string', 'number']);
+    expect($normalized['properties']['value'])->not->toHaveKey('minLength');
+    expect($normalized['properties']['value'])->not->toHaveKey('minimum');
+});
+
+test('it merges allOf branches into the node', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'merged' => ['allOf' => [['type' => 'string'], ['description' => 'Merged.', 'minLength' => 2]]],
+        ],
+    ]);
+
+    expect($normalized['properties']['merged'])->toMatchArray([
+        'type' => 'string',
+        'description' => 'Merged.',
+        'minLength' => 2,
+    ]);
+});
+
+test('it drops keywords the deserializer cannot represent', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'properties' => [
+            'a' => [
+                'type' => 'string',
+                'not' => ['const' => 'x'],
+                'patternProperties' => ['^x' => ['type' => 'string']],
+                'exclusiveMinimum' => 1,
+                'examples' => ['foo'],
+            ],
+        ],
+    ]);
+
+    expect($normalized)->not->toHaveKey('$schema');
+    expect($normalized['properties']['a'])->toBe(['type' => 'string']);
+});
+
+test('it drops boolean property schemas', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'anything' => true,
+            'name' => ['type' => 'string'],
+        ],
+        'required' => ['anything', 'name'],
+    ]);
+
+    expect($normalized['properties'])->toHaveKey('name');
+    expect($normalized['properties'])->not->toHaveKey('anything');
+    expect($normalized['required'])->toBe(['name']);
+});
+
+test('it drops tuple and boolean array items', function () {
+    $tuple = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['list' => ['type' => 'array', 'items' => [['type' => 'string'], ['type' => 'integer']]]],
+    ]);
+
+    expect($tuple['properties']['list'])->not->toHaveKey('items');
+
+    $single = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['list' => ['type' => 'array', 'items' => ['type' => 'string']]],
+    ]);
+
+    expect($single['properties']['list']['items'])->toBe(['type' => 'string']);
+});
+
+test('it inlines local $ref and drops remote or unresolvable $ref', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'local' => ['$ref' => '#/$defs/Tag', 'description' => 'A tag.'],
+            'remote' => ['$ref' => 'https://example.com/schema.json'],
+            'missing' => ['$ref' => '#/$defs/Nope'],
+        ],
+        '$defs' => [
+            'Tag' => ['type' => 'string', 'enum' => ['a', 'b']],
+        ],
+    ]);
+
+    expect($normalized['properties']['local'])->toMatchArray([
+        'type' => 'string',
+        'enum' => ['a', 'b'],
+        'description' => 'A tag.',
+    ]);
+    expect($normalized['properties']['remote'])->toBe(['type' => 'string']);
+    expect($normalized['properties']['missing'])->toBe(['type' => 'string']);
+    expect($normalized)->not->toHaveKey('$defs');
+});
+
+test('it breaks circular $ref without infinite recursion', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['node' => ['$ref' => '#/$defs/Node']],
+        '$defs' => [
+            'Node' => [
+                'type' => 'object',
+                'properties' => ['child' => ['$ref' => '#/$defs/Node']],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['node']['type'])->toBe('object');
+    // The cycle is broken: the self-referential branch drops its $ref and falls back to a scalar.
+    expect($normalized['properties']['node']['properties']['child'])->toBe(['type' => 'string']);
+});
+
+test('it drops a null default', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['flag' => ['type' => 'boolean', 'default' => null]],
+    ]);
+
+    expect($normalized['properties']['flag'])->not->toHaveKey('default');
+});
+
+test('it keeps additionalProperties false but drops permissive forms', function () {
+    $normalized = SchemaNormalizer::normalize([
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'open' => ['type' => 'object', 'additionalProperties' => true, 'properties' => ['x' => ['type' => 'string']]],
+        ],
+    ]);
+
+    expect($normalized['additionalProperties'])->toBeFalse();
+    expect($normalized['properties']['open'])->not->toHaveKey('additionalProperties');
+});
+
+test('it assigns a type to an otherwise-typeless allOf root so it does not throw', function () {
+    $normalized = normalizesWithoutThrowing([
+        'allOf' => [['description' => 'x'], ['title' => 'y']],
+    ]);
+
+    expect($normalized['type'])->toBe('string');
+    expect($normalized)->not->toHaveKey('allOf');
+});
+
+test('it unions required across allOf branches and the outer node', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'required' => ['c'],
+        'properties' => ['c' => ['type' => 'string']],
+        'allOf' => [
+            ['properties' => ['a' => ['type' => 'string']], 'required' => ['a']],
+            ['properties' => ['b' => ['type' => 'integer']], 'required' => ['b']],
+        ],
+    ]);
+
+    expect($normalized['required'])->toEqualCanonicalizing(['a', 'b', 'c']);
+    expect($normalized['properties'])->toHaveKeys(['a', 'b', 'c']);
+});
+
+test('it strips unsupported keywords pulled in from an allOf branch', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'n' => ['allOf' => [['type' => 'integer'], ['exclusiveMinimum' => 5, 'patternProperties' => ['^x' => []]]]],
+        ],
+    ]);
+
+    expect($normalized['properties']['n'])->toBe(['type' => 'integer']);
+});
+
+test('it preserves object shape for a nullable object branch', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'addr' => ['anyOf' => [
+                ['properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+                ['type' => 'null'],
+            ]],
+        ],
+    ]);
+
+    expect($normalized['properties']['addr']['type'])->toBe(['object', 'null']);
+    expect($normalized['properties']['addr']['properties'])->toHaveKey('city');
+});
+
+test('it types heterogeneous, empty, and homogeneous enums without throwing', function (array $enum, $expected) {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['e' => ['enum' => $enum]],
+    ]);
+
+    expect($normalized['properties']['e']['type'])->toBe($expected);
+})->with([
+    'heterogeneous' => [['low', 0, true], 'string'],
+    'empty' => [[], 'string'],
+    'homogeneous int' => [[1, 2, 3], 'integer'],
+]);
+
+test('it replaces a null-only type with a scalar so it deserializes', function (array $raw) {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['n' => $raw],
+    ]);
+
+    expect($normalized['properties']['n']['type'])->toBe('string');
+})->with([
+    'scalar null' => [['type' => 'null']],
+    'null-only array' => [['type' => ['null']]],
+]);
+
+test('it produces an ObjectType for a gnarly real-world schema', function () {
+    $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize([
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        'type' => 'object',
+        'properties' => [
+            'mode' => ['oneOf' => [['const' => 'fast'], ['const' => 'slow']]],
+            'value' => ['type' => ['string', 'number', 'boolean']],
+            'tags' => ['type' => 'array', 'items' => ['anyOf' => [['type' => 'string'], ['type' => 'null']]]],
+            'opts' => ['allOf' => [['type' => 'object'], ['properties' => ['x' => ['type' => 'integer']]]]],
+        ],
+        'required' => ['value'],
+        'additionalProperties' => false,
+    ]));
+
+    expect($type)->toBeInstanceOf(ObjectType::class);
+});

--- a/tests/Unit/Tools/McpToolTest.php
+++ b/tests/Unit/Tools/McpToolTest.php
@@ -182,18 +182,6 @@ test('it keeps the properties of a nullable object root', function () {
     expect($schema['properties']['query'])->toMatchArray(['type' => 'string']);
 });
 
-test('it degrades to no parameters instead of throwing on a schema the deserializer rejects', function () {
-    $tool = new McpTool(mcpTool(new FakeMcpClient, inputSchema: [
-        'type' => 'object',
-        'properties' => [
-            // A non-numeric numeric bound makes the deserializer throw; the tool must not.
-            'amount' => ['type' => 'integer', 'minimum' => 'not-a-number'],
-        ],
-    ]));
-
-    expect($tool->schema(new JsonSchemaTypeFactory))->toBe([]);
-});
-
 test('it marks fields nullable when anyOf or oneOf lists null after the typed branch', function () {
     $tool = new McpTool(mcpTool(new FakeMcpClient, inputSchema: [
         'type' => 'object',

--- a/tests/Unit/Tools/McpToolTest.php
+++ b/tests/Unit/Tools/McpToolTest.php
@@ -144,16 +144,55 @@ test('it resolves $ref against $defs and merges sibling keys', function () {
     ]);
 });
 
-test('it throws when a $ref cannot be resolved', function () {
+test('it drops an unresolvable $ref instead of failing the whole tool', function () {
     $tool = new McpTool(mcpTool(new FakeMcpClient, inputSchema: [
         'type' => 'object',
         'properties' => [
-            'address' => ['$ref' => '#/$defs/Missing'],
+            'address' => ['$ref' => '#/$defs/Missing', 'description' => 'Shipping address.'],
+            'name' => ['type' => 'string'],
+        ],
+        'required' => ['name'],
+    ]));
+
+    $schema = (new ObjectSchema($tool->schema(new JsonSchemaTypeFactory)))->toSchema();
+
+    expect($schema['properties'])->toHaveKeys(['address', 'name']);
+    expect($schema['properties']['address'])->toMatchArray([
+        'type' => 'string',
+        'description' => 'Shipping address.',
+    ]);
+    expect($schema['properties']['name'])->toMatchArray(['type' => 'string']);
+});
+
+test('it keeps the properties of a nullable object root', function () {
+    $tool = new McpTool(mcpTool(new FakeMcpClient, inputSchema: [
+        'anyOf' => [
+            [
+                'type' => 'object',
+                'properties' => ['query' => ['type' => 'string']],
+                'required' => ['query'],
+            ],
+            ['type' => 'null'],
         ],
     ]));
 
-    $tool->schema(new JsonSchemaTypeFactory);
-})->throws(InvalidArgumentException::class, 'Unable to resolve JSON Schema $ref [#/$defs/Missing].');
+    $schema = (new ObjectSchema($tool->schema(new JsonSchemaTypeFactory)))->toSchema();
+
+    expect($schema['properties'])->toHaveKey('query');
+    expect($schema['properties']['query'])->toMatchArray(['type' => 'string']);
+});
+
+test('it degrades to no parameters instead of throwing on a schema the deserializer rejects', function () {
+    $tool = new McpTool(mcpTool(new FakeMcpClient, inputSchema: [
+        'type' => 'object',
+        'properties' => [
+            // A non-numeric numeric bound makes the deserializer throw; the tool must not.
+            'amount' => ['type' => 'integer', 'minimum' => 'not-a-number'],
+        ],
+    ]));
+
+    expect($tool->schema(new JsonSchemaTypeFactory))->toBe([]);
+});
 
 test('it marks fields nullable when anyOf or oneOf lists null after the typed branch', function () {
     $tool = new McpTool(mcpTool(new FakeMcpClient, inputSchema: [

--- a/tests/Unit/Tools/McpToolTest.php
+++ b/tests/Unit/Tools/McpToolTest.php
@@ -8,12 +8,6 @@ use Tests\Fixtures\Mcp\FakeMcpClient;
 use Tests\Fixtures\Mcp\FakeMcpTool;
 use Tests\Fixtures\Mcp\FakeMcpToolResult;
 
-beforeAll(function () {
-    if (! class_exists('Laravel\\Mcp\\Client\\Primitives\\Tool')) {
-        class_alias(FakeMcpTool::class, 'Laravel\\Mcp\\Client\\Primitives\\Tool');
-    }
-});
-
 test('it detects mcp client tool primitives', function () {
     expect([
         McpTool::supports(mcpTool(new FakeMcpClient)),


### PR DESCRIPTION
MCP tools from real-world servers regularly use JSON Schema features that `Illuminate\JsonSchema` can't deserialize — `$ref`, `allOf`, `anyOf`/`oneOf`, multi-type unions, `const`, unsupported keywords like `not` and `patternProperties`. Currently those tools either throw or are silently skipped.

This PR introduces `SchemaNormalizer`, which rewrites an arbitrary schema into the subset the deserializer accepts:

- inlines local `$ref` pointers (cycle-safe)
- flattens `allOf` branches into the parent node
- collapses `anyOf`/`oneOf` into scalar multi-type unions or nullable wrappers
- strips unsupported keywords
- rewrites `const` to a single-value `enum`
- infers a type from node shape when none is present

`McpTool` now runs every input schema through the normalizer before handing it to `JsonSchemaFactory`, and wraps the factory call in a try/catch so a still-unrepresentable schema returns an empty properties list rather than aborting the tool entirely.

Also bumps `laravel/mcp` to `^0.8` and adapts the fixtures to extend the real `Tool` / `ToolResult` classes rather than hand-rolling fakes.