### PR TITLE
Add native sub-agent activity streaming

### DIFF
--- a/src/Contracts/StreamableTool.php
+++ b/src/Contracts/StreamableTool.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use Generator;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Tools\Request;
+
+interface StreamableTool extends Tool
+{
+    /**
+     * Stream the tool's activity and return its final tool result.
+     *
+     * @return Generator<int, StreamEvent, mixed, string>
+     */
+    public function streamHandle(Request $request): Generator;
+}

--- a/src/Contracts/StreamsActivity.php
+++ b/src/Contracts/StreamsActivity.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+interface StreamsActivity
+{
+    //
+}

--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -408,7 +408,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -479,7 +479,7 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
 
             $conversationMessages[] = $this->buildAssistantConversationMessage($assistantText, $toolCalls, array_values($responseContent));
 
-            $toolResults = $this->executeToolCalls($tools, $toolCalls);
+            $toolResults = yield from $this->executeToolCallsStreaming($tools, $toolCalls, $invocationId);
 
             foreach ($toolResults as $toolResult) {
                 yield (new ToolResultEvent(
@@ -915,6 +915,49 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             ])
             ->values()
             ->all();
+    }
+
+    /**
+     * Execute the tool calls against the provided tools and collect results.
+     *
+     * @param  array<Tool>  $tools
+     * @param  array<ToolCall>  $toolCalls
+     * @return array<ToolResult>
+     */
+    protected function executeToolCallsStreaming(array $tools, array $toolCalls, string $invocationId): Generator
+    {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($tool === null) {
+                $results[] = new ToolResult(
+                    $toolCall->id,
+                    $toolCall->name,
+                    $toolCall->arguments,
+                    'Error: Tool "'.$toolCall->name.'" not found.',
+                );
+
+                continue;
+            }
+
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
+
+            $results[] = new ToolResult(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $result,
+            );
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -3,7 +3,10 @@
 namespace Laravel\Ai\Gateway\Concerns;
 
 use Closure;
+use Generator;
+use Laravel\Ai\Contracts\StreamableTool;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Tools\Request;
 use Laravel\Ai\Tools\ToolNameResolver;
 
@@ -46,6 +49,52 @@ trait InvokesTools
         } finally {
             $this->popToolInvocationCallbacks();
         }
+    }
+
+    /**
+     * Execute the given tool, streaming any events it emits.
+     *
+     * @return Generator<int, StreamEvent, mixed, string>
+     */
+    protected function executeToolStreaming(Tool $tool, array $arguments): Generator
+    {
+        $callbacks = $this->pushToolInvocationCallbacks();
+
+        try {
+            call_user_func($callbacks['invoking'], $tool, $arguments);
+
+            $result = $tool instanceof StreamableTool
+                ? yield from $tool->streamHandle(new Request($arguments))
+                : (string) $tool->handle(new Request($arguments));
+
+            call_user_func($callbacks['invoked'], $tool, $arguments, $result);
+
+            return (string) $result;
+        } finally {
+            $this->popToolInvocationCallbacks();
+        }
+    }
+
+    /**
+     * Execute the given tool and stamp streamed events with their parent tool call.
+     *
+     * @param  array<int, string>  $ancestorToolCallIds
+     * @return Generator<int, StreamEvent, mixed, string>
+     */
+    protected function executeToolStreamingStamped(
+        Tool $tool,
+        array $arguments,
+        string $parentInvocationId,
+        string $parentToolCallId,
+        array $ancestorToolCallIds = [],
+    ): Generator {
+        $stream = $this->executeToolStreaming($tool, $arguments);
+
+        foreach ($stream as $event) {
+            yield (clone $event)->withParent($parentInvocationId, $parentToolCallId, $ancestorToolCallIds);
+        }
+
+        return $stream->getReturn();
     }
 
     /**

--- a/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
@@ -258,7 +258,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -25,6 +25,8 @@ use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 use RuntimeException;
 
 use function Laravel\Ai\generate_fake_data_for_json_schema_type;
@@ -133,7 +135,6 @@ class FakeTextGateway implements TextGateway
 
         // Fake the stream and text starting...
         yield (new StreamStart(ulid(), $provider->name(), $model, time()))->withInvocationId($invocationId);
-        yield (new TextStart(ulid(), $messageId, time()))->withInvocationId($invocationId);
 
         $message = (new Collection($messages))->last(function ($message) {
             return $message instanceof UserMessage;
@@ -142,6 +143,43 @@ class FakeTextGateway implements TextGateway
         $fakeResponse = $this->nextResponse(
             $provider, $model, $message->content, $message->attachments, $schema
         );
+
+        while ($fakeResponse instanceof ToolCall) {
+            yield (new ToolCallEvent(
+                ulid(),
+                $fakeResponse,
+                time(),
+            ))->withInvocationId($invocationId);
+
+            if ($tool = $this->findTool($fakeResponse->name, $tools)) {
+                $result = yield from $this->executeToolStreamingStamped(
+                    $tool,
+                    $fakeResponse->arguments,
+                    $invocationId,
+                    $fakeResponse->id,
+                );
+
+                yield (new ToolResultEvent(
+                    ulid(),
+                    new ToolResult(
+                        $fakeResponse->id,
+                        $fakeResponse->name,
+                        $fakeResponse->arguments,
+                        $result,
+                        $fakeResponse->resultId,
+                    ),
+                    true,
+                    null,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            $fakeResponse = $this->nextResponse(
+                $provider, $model, $message->content, $message->attachments, $schema
+            );
+        }
+
+        yield (new TextStart(ulid(), $messageId, time()))->withInvocationId($invocationId);
 
         $events = Str::of($fakeResponse->text)
             ->explode(' ')

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -246,7 +246,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -208,7 +208,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -207,7 +207,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
@@ -240,7 +240,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -340,7 +340,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -223,7 +223,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -328,7 +328,12 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            $result = $this->executeTool($tool, $toolCall->arguments);
+            $result = yield from $this->executeToolStreamingStamped(
+                $tool,
+                $toolCall->arguments,
+                $invocationId,
+                $toolCall->id,
+            );
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Responses\Concerns;
 
 use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
@@ -30,6 +31,16 @@ trait CanStreamUsingVercelProtocol
             $lastStreamEndEvent = null;
 
             foreach ($this as $event) {
+                if ($event->isNested()) {
+                    $data = $this->nestedEventToVercelDataPart($event);
+
+                    if (! empty($data)) {
+                        yield 'data: '.json_encode($data)."\n\n";
+                    }
+
+                    continue;
+                }
+
                 // Send one stream start event...
                 if ($event instanceof StreamStart) {
                     if ($state->streamStarted) {
@@ -74,5 +85,27 @@ trait CanStreamUsingVercelProtocol
             'Content-Type' => 'text/event-stream',
             'x-vercel-ai-ui-message-stream' => 'v1',
         ]);
+    }
+
+    /**
+     * Convert nested tool/sub-agent activity to a Vercel custom data part.
+     */
+    protected function nestedEventToVercelDataPart(StreamEvent $event): array
+    {
+        $payload = $event->toArray();
+
+        unset($payload['id'], $payload['invocation_id'], $payload['timestamp']);
+
+        return [
+            'type' => 'data-subagent',
+            'id' => $event->nestedVercelPartId(),
+            'data' => [
+                ...$payload,
+                'parent_invocation_id' => $event->parentInvocationId,
+                'parent_tool_call_id' => $event->parentToolCallId,
+                'ancestor_tool_call_ids' => $event->ancestorToolCallIds,
+                'depth' => $event->depth(),
+            ],
+        ];
     }
 }

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -10,6 +10,7 @@ use IteratorAggregate;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Symfony\Component\HttpFoundation\Response;
 use Traversable;
@@ -160,8 +161,14 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         }
 
         $this->events = new Collection($events);
-        $this->text = TextDelta::combine($events);
-        $this->usage = StreamEnd::combineUsage($events);
+
+        $topLevelEvents = array_values(array_filter(
+            $events,
+            fn (StreamEvent $event) => ! $event->isNested(),
+        ));
+
+        $this->text = TextDelta::combine($topLevelEvents);
+        $this->usage = StreamEnd::combineUsage($topLevelEvents);
 
         $this->streamedResponse = new StreamedAgentResponse(
             $this->invocationId,

--- a/src/Streaming/Events/Citation.php
+++ b/src/Streaming/Events/Citation.php
@@ -33,6 +33,7 @@ class Citation extends StreamEvent
                 ],
             },
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/Error.php
+++ b/src/Streaming/Events/Error.php
@@ -28,6 +28,7 @@ class Error extends StreamEvent
             'recoverable' => $this->recoverable,
             'timestamp' => $this->timestamp,
             'metadata' => $this->metadata,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/ProviderToolEvent.php
+++ b/src/Streaming/Events/ProviderToolEvent.php
@@ -28,6 +28,7 @@ class ProviderToolEvent extends StreamEvent
             'data' => $this->data,
             'status' => $this->status,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 }

--- a/src/Streaming/Events/ReasoningDelta.php
+++ b/src/Streaming/Events/ReasoningDelta.php
@@ -27,6 +27,7 @@ class ReasoningDelta extends StreamEvent
             'delta' => $this->delta,
             'timestamp' => $this->timestamp,
             'summary' => $this->summary,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/ReasoningEnd.php
+++ b/src/Streaming/Events/ReasoningEnd.php
@@ -25,6 +25,7 @@ class ReasoningEnd extends StreamEvent
             'reasoning_id' => $this->reasoningId,
             'timestamp' => $this->timestamp,
             'summary' => $this->summary,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/ReasoningStart.php
+++ b/src/Streaming/Events/ReasoningStart.php
@@ -23,6 +23,7 @@ class ReasoningStart extends StreamEvent
             'type' => 'reasoning_start',
             'reasoning_id' => $this->reasoningId,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -44,6 +44,7 @@ class StreamEnd extends StreamEvent
                 ? $this->usage->toArray()
                 : null,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -9,6 +9,15 @@ abstract class StreamEvent
 {
     public ?string $invocationId = null;
 
+    public ?string $parentInvocationId = null;
+
+    public ?string $parentToolCallId = null;
+
+    /**
+     * @var array<int, string>
+     */
+    public array $ancestorToolCallIds = [];
+
     /**
      * Get the array representation of the event.
      *
@@ -51,6 +60,71 @@ abstract class StreamEvent
         $this->invocationId = $id;
 
         return $this;
+    }
+
+    /**
+     * Set the parent invocation and tool call that produced this nested event.
+     *
+     * @param  array<int, string>  $ancestorToolCallIds
+     */
+    public function withParent(string $invocationId, string $toolCallId, array $ancestorToolCallIds = []): self
+    {
+        $wasNested = $this->isNested();
+
+        if (! $wasNested) {
+            $this->parentInvocationId = $invocationId;
+            $this->parentToolCallId = $toolCallId;
+        }
+
+        $prefix = $ancestorToolCallIds === [] ? [$toolCallId] : $ancestorToolCallIds;
+        $current = $wasNested ? $this->ancestorToolCallIds : [$toolCallId];
+
+        $this->ancestorToolCallIds = array_values(array_unique([...$prefix, ...$current]));
+
+        return $this;
+    }
+
+    /**
+     * Determine whether the event came from a nested tool or sub-agent stream.
+     */
+    public function isNested(): bool
+    {
+        return $this->parentInvocationId !== null;
+    }
+
+    /**
+     * Get the nested tool-call depth for this event.
+     */
+    public function depth(): int
+    {
+        return count($this->ancestorToolCallIds);
+    }
+
+    /**
+     * Get the nested provenance fields for serialization.
+     *
+     * @return array<string, mixed>
+     */
+    protected function nestedPayload(): array
+    {
+        if (! $this->isNested()) {
+            return [];
+        }
+
+        return [
+            'parent_invocation_id' => $this->parentInvocationId,
+            'parent_tool_call_id' => $this->parentToolCallId,
+            'ancestor_tool_call_ids' => $this->ancestorToolCallIds,
+            'depth' => $this->depth(),
+        ];
+    }
+
+    /**
+     * Get a stable Vercel data-part ID for this nested event.
+     */
+    public function nestedVercelPartId(): string
+    {
+        return 'subagent:'.implode('/', $this->ancestorToolCallIds);
     }
 
     /**

--- a/src/Streaming/Events/StreamStart.php
+++ b/src/Streaming/Events/StreamStart.php
@@ -27,6 +27,7 @@ class StreamStart extends StreamEvent
             'model' => $this->model,
             'timestamp' => $this->timestamp,
             'metadata' => $this->metadata,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/TextDelta.php
+++ b/src/Streaming/Events/TextDelta.php
@@ -37,6 +37,7 @@ class TextDelta extends StreamEvent
             'message_id' => $this->messageId,
             'delta' => $this->delta,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/TextEnd.php
+++ b/src/Streaming/Events/TextEnd.php
@@ -23,6 +23,7 @@ class TextEnd extends StreamEvent
             'type' => 'text_end',
             'message_id' => $this->messageId,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/TextStart.php
+++ b/src/Streaming/Events/TextStart.php
@@ -23,6 +23,7 @@ class TextStart extends StreamEvent
             'type' => 'text_start',
             'message_id' => $this->messageId,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/ToolCall.php
+++ b/src/Streaming/Events/ToolCall.php
@@ -28,6 +28,7 @@ class ToolCall extends StreamEvent
             'arguments' => $this->toolCall->arguments,
             'reasoning_id' => $this->toolCall->reasoningId,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Streaming/Events/ToolResult.php
+++ b/src/Streaming/Events/ToolResult.php
@@ -31,6 +31,7 @@ class ToolResult extends StreamEvent
             'successful' => $this->successful,
             'error' => $this->error,
             'timestamp' => $this->timestamp,
+            ...$this->nestedPayload(),
         ];
     }
 

--- a/src/Tools/AgentTool.php
+++ b/src/Tools/AgentTool.php
@@ -2,14 +2,17 @@
 
 namespace Laravel\Ai\Tools;
 
+use Generator;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\CanActAsTool;
-use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Contracts\StreamableTool;
+use Laravel\Ai\Contracts\StreamsActivity;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Stringable;
 use Throwable;
 
-class AgentTool implements Tool
+class AgentTool implements StreamableTool
 {
     public function __construct(protected Agent $agent)
     {
@@ -46,6 +49,30 @@ class AgentTool implements Tool
     {
         try {
             return $this->agent->prompt((string) $request['task'])->text;
+        } catch (Throwable $e) {
+            return 'Agent failed: '.$e->getMessage();
+        }
+    }
+
+    /**
+     * Execute the tool while streaming opt-in sub-agent activity.
+     *
+     * @return Generator<int, StreamEvent, mixed, string>
+     */
+    public function streamHandle(Request $request): Generator
+    {
+        try {
+            if (! $this->agent instanceof StreamsActivity) {
+                return $this->handle($request);
+            }
+
+            $response = $this->agent->stream((string) $request['task']);
+
+            foreach ($response as $event) {
+                yield $event;
+            }
+
+            return (string) $response->text;
         } catch (Throwable $e) {
             return 'Agent failed: '.$e->getMessage();
         }

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -13,7 +13,9 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 describe('text streaming', function () {
     test('streaming emits text events', function () {
@@ -50,7 +52,7 @@ describe('tool calls', function () {
                 Http::response(
                     body: $this->ssePayload([
                         $this->messageStart(),
-                        $this->contentBlockStart(0, ['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'FixedNumberGenerator', 'input' => '']),
+                        $this->contentBlockStart(0, ['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'StreamingProgressTool', 'input' => '']),
                         $this->contentBlockDelta(0, ['type' => 'input_json_delta', 'partial_json' => '{}']),
                         $this->contentBlockStop(0),
                         $this->messageDelta('tool_use', 5),
@@ -63,19 +65,21 @@ describe('tool calls', function () {
                     'type' => 'message',
                     'role' => 'assistant',
                     'model' => 'claude-sonnet-4-6',
-                    'content' => [['type' => 'text', 'text' => 'The number is 72019']],
+                    'content' => [['type' => 'text', 'text' => 'Done']],
                     'stop_reason' => 'end_turn',
                     'usage' => ['input_tokens' => 20, 'output_tokens' => 10],
                 ]),
             ]),
         ]);
 
-        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+        $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
         $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
         expect($toolCallEvents)->not->toBeEmpty()
-            ->and($toolCallEvents[0]->toolCall)->name->toBe('FixedNumberGenerator')->id->toBe('toolu_1');
+            ->and($toolCallEvents[0]->toolCall)->name->toBe('StreamingProgressTool')->id->toBe('toolu_1');
+
+        expectNestedStreamingToolDelta($events, 'toolu_1');
     });
 });
 

--- a/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
@@ -9,7 +9,9 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 beforeEach(function () {
     config(['ai.providers.azure' => [
@@ -51,7 +53,7 @@ test('streaming handles tool calls', function () {
             Http::response(
                 body: $this->ssePayload([
                     $this->responseCreated(),
-                    $this->outputItemAdded('fc_1', 'call_1', 'FixedNumberGenerator'),
+                    $this->outputItemAdded('fc_1', 'call_1', 'StreamingProgressTool'),
                     $this->functionCallArgumentsDelta('fc_1', '{}'),
                     $this->functionCallArgumentsDone('fc_1', '{}'),
                     $this->responseCompleted(10, 5),
@@ -62,8 +64,8 @@ test('streaming handles tool calls', function () {
             Http::response(
                 body: $this->ssePayload([
                     $this->responseCreated(),
-                    $this->outputTextDelta('The number is 72019'),
-                    $this->outputTextDone('The number is 72019'),
+                    $this->outputTextDelta('Done'),
+                    $this->outputTextDone('Done'),
                     $this->responseCompleted(20, 10),
                 ]),
                 status: 200,
@@ -72,13 +74,15 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolCallEvents[0]->toolCall->resultId)->toBe('call_1');
+
+    expectNestedStreamingToolDelta($events, 'fc_1');
 });
 
 test('streaming error event stops stream', function () {

--- a/tests/Feature/Providers/Bedrock/StreamingTest.php
+++ b/tests/Feature/Providers/Bedrock/StreamingTest.php
@@ -11,6 +11,7 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\StreamingProgressTool;
 
 describe('text streaming', function () {
     test('streaming handles reasoning and text blocks', function () {
@@ -117,6 +118,38 @@ describe('text streaming', function () {
             ])
             ->and($assistantTurn['content'][1]['toolUse']['toolUseId'])->toBe('t1')
             ->and($assistantTurn['content'][1]['toolUse']['name'])->toBe('FixedNumberGenerator');
+    });
+
+    test('streaming emits nested events from streamable tools', function () {
+        $mock = new MockHandler([
+            new Result(['stream' => [
+                $this->contentBlockStart(0, ['toolUse' => ['toolUseId' => 't_stream', 'name' => 'StreamingProgressTool']]),
+                $this->contentBlockDelta(0, ['toolUse' => ['input' => '{}']]),
+                $this->contentBlockStop(0),
+                $this->messageStop('tool_use'),
+            ]]),
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['text' => 'Done']),
+                $this->contentBlockStop(0),
+                $this->messageStop('end_turn'),
+            ]]),
+        ]);
+
+        $gateway = $this->gatewayWithClient($this->bedrockClient($mock));
+
+        $events = iterator_to_array(
+            $gateway->streamText(
+                'inv-1',
+                $this->bedrockProvider(),
+                'anthropic.claude-opus-4-7-v1:0',
+                null,
+                tools: [new StreamingProgressTool],
+            ),
+            preserve_keys: false,
+        );
+
+        expectNestedStreamingToolDelta($events, 't_stream');
     });
 
     test('streaming round-trips redacted reasoning block', function () {

--- a/tests/Feature/Providers/DeepSeek/StreamingTest.php
+++ b/tests/Feature/Providers/DeepSeek/StreamingTest.php
@@ -10,7 +10,9 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Tests\Feature\Providers\DeepSeek\DeepSeekHelpers;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 uses(DeepSeekHelpers::class);
 
@@ -50,7 +52,7 @@ test('streaming handles tool calls', function () {
         'api.deepseek.com/*' => Http::sequence([
             Http::response(
                 body: $this->ssePayload([
-                    $this->chatChunkToolCallStart(0, 'call_1', 'FixedNumberGenerator'),
+                    $this->chatChunkToolCallStart(0, 'call_1', 'StreamingProgressTool'),
                     $this->chatChunkToolCallDelta(0, '{}'),
                     $this->chatChunkFinish('tool_calls', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
                     '[DONE]',
@@ -60,7 +62,7 @@ test('streaming handles tool calls', function () {
             ),
             Http::response(
                 body: $this->ssePayload([
-                    $this->chatChunk(['role' => 'assistant', 'content' => 'The number is 72019']),
+                    $this->chatChunk(['role' => 'assistant', 'content' => 'Done']),
                     $this->chatChunkFinish('stop', ['prompt_tokens' => 20, 'completion_tokens' => 10]),
                     '[DONE]',
                 ]),
@@ -70,13 +72,15 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolCallEvents[0]->toolCall->id)->toBe('call_1');
+
+    expectNestedStreamingToolDelta($events, 'call_1');
 });
 
 test('streaming error event stops stream', function () {

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -13,6 +13,9 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 describe('text streaming', function () {
     test('streaming emits text events', function () {
@@ -66,7 +69,7 @@ describe('tool calls', function () {
                         $this->geminiChunkWithUsage([[
                             'functionCall' => [
                                 'id' => 'call_1',
-                                'name' => 'FixedNumberGenerator',
+                                'name' => 'StreamingProgressTool',
                                 'args' => (object) [],
                             ],
                         ]], 10, 5),
@@ -76,7 +79,7 @@ describe('tool calls', function () {
                 ),
                 Http::response(
                     body: $this->ssePayload([
-                        $this->geminiChunkWithUsage([['text' => 'The number is 72019']], 20, 10),
+                        $this->geminiChunkWithUsage([['text' => 'Done']], 20, 10),
                     ]),
                     status: 200,
                     headers: ['Content-Type' => 'text/event-stream'],
@@ -84,12 +87,14 @@ describe('tool calls', function () {
             ]),
         ]);
 
-        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+        $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
         $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
         expect($toolCallEvents)->not->toBeEmpty()
-            ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator');
+            ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool');
+
+        expectNestedStreamingToolDelta($events, 'call_1');
     });
 
     test('streaming thinking parts are excluded from tool call continuation', function () {

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -9,7 +9,9 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 beforeEach(function () {
     config(['ai.providers.groq' => [
@@ -47,7 +49,7 @@ test('streaming handles tool calls', function () {
         'api.groq.com/*' => Http::sequence([
             Http::response(
                 body: $this->ssePayload([
-                    $this->chatChunkToolCallStart(0, 'call_1', 'FixedNumberGenerator'),
+                    $this->chatChunkToolCallStart(0, 'call_1', 'StreamingProgressTool'),
                     $this->chatChunkToolCallDelta(0, '{}'),
                     $this->chatChunkFinish('tool_calls', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
                     '[DONE]',
@@ -57,7 +59,7 @@ test('streaming handles tool calls', function () {
             ),
             Http::response(
                 body: $this->ssePayload([
-                    $this->chatChunk(['role' => 'assistant', 'content' => 'The number is 72019']),
+                    $this->chatChunk(['role' => 'assistant', 'content' => 'Done']),
                     $this->chatChunkFinish('stop', ['prompt_tokens' => 20, 'completion_tokens' => 10]),
                     '[DONE]',
                 ]),
@@ -67,13 +69,15 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolCallEvents[0]->toolCall->id)->toBe('call_1');
+
+    expectNestedStreamingToolDelta($events, 'call_1');
 });
 
 test('streaming error event stops stream', function () {

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -10,7 +10,9 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 beforeEach(function () {
     config(['ai.providers.mistral' => [
@@ -47,7 +49,7 @@ test('streaming handles tool calls', function () {
         '*' => Http::sequence([
             Http::response(
                 body: $this->ssePayload([
-                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_1', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_1', 'function' => ['name' => 'StreamingProgressTool', 'arguments' => '']]]], 'finish_reason' => null]]],
                     ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
                     ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5]],
                 ]),
@@ -56,7 +58,7 @@ test('streaming handles tool calls', function () {
             ),
             Http::response(
                 body: $this->ssePayload([
-                    ['id' => 'chatcmpl-456', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
+                    ['id' => 'chatcmpl-456', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Done'], 'finish_reason' => null]]],
                     ['id' => 'chatcmpl-456', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 10]],
                 ]),
                 status: 200,
@@ -65,14 +67,16 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
     $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolResultEvents)->not->toBeEmpty();
+
+    expectNestedStreamingToolDelta($events, 'call_1');
 });
 
 test('streaming captures usage', function () {

--- a/tests/Feature/Providers/Ollama/StreamingTest.php
+++ b/tests/Feature/Providers/Ollama/StreamingTest.php
@@ -11,6 +11,9 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 beforeEach(function () {
     config(['ai.providers.ollama' => [
@@ -68,14 +71,14 @@ test('streaming handles tool calls', function () {
             Http::response(
                 body: $this->ndjsonPayload([
                     $this->chatChunkWithToolCalls([
-                        $this->toolCallChunk('call_1', 'FixedNumberGenerator'),
+                        $this->toolCallChunk('call_1', 'StreamingProgressTool'),
                     ]),
                 ]),
                 status: 200,
             ),
             Http::response(
                 body: $this->ndjsonPayload([
-                    $this->chatChunk('The number is 72019'),
+                    $this->chatChunk('Done'),
                     $this->chatChunk('', true, 'stop', ['prompt_eval_count' => 20, 'eval_count' => 10]),
                 ]),
                 status: 200,
@@ -83,13 +86,15 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolCallEvents[0]->toolCall->id)->toBe('call_1');
+
+    expectNestedStreamingToolDelta($events, 'call_1');
 });
 
 test('streaming error event stops stream with string payload', function () {

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -12,7 +12,9 @@ use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 beforeEach(function () {
     config(['ai.providers.openai' => [
@@ -52,7 +54,7 @@ test('streaming handles tool calls', function () {
             Http::response(
                 body: $this->ssePayload([
                     $this->responseCreated(),
-                    $this->outputItemAdded('fc_1', 'call_1', 'FixedNumberGenerator'),
+                    $this->outputItemAdded('fc_1', 'call_1', 'StreamingProgressTool'),
                     $this->functionCallArgumentsDelta('fc_1', '{}'),
                     $this->functionCallArgumentsDone('fc_1', '{}'),
                     $this->responseCompleted(10, 5),
@@ -66,8 +68,8 @@ test('streaming handles tool calls', function () {
                         'type' => 'response.created',
                         'response' => ['id' => 'resp_2', 'model' => 'gpt-5.4', 'status' => 'in_progress', 'output' => []],
                     ],
-                    $this->outputTextDelta('The number is 72019'),
-                    $this->outputTextDone('The number is 72019'),
+                    $this->outputTextDelta('Done'),
+                    $this->outputTextDone('Done'),
                     $this->responseCompleted(20, 10),
                 ]),
                 status: 200,
@@ -76,13 +78,15 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolCallEvents[0]->toolCall->resultId)->toBe('call_1');
+
+    expectNestedStreamingToolDelta($events, 'fc_1');
 });
 
 test('streaming handles reasoning events', function () {

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -10,7 +10,7 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
-use Tests\Fixtures\Tools\FixedNumberGenerator;
+use Tests\Fixtures\Tools\StreamingProgressTool;
 
 use function Laravel\Ai\agent;
 
@@ -52,19 +52,19 @@ test('streaming handles tool calls', function () {
     Http::fake([
         '*' => Http::sequence([
             Http::response($this->ssePayload([
-                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_123', 'type' => 'function', 'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '']]]], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'tool_calls' => [['index' => 0, 'id' => 'call_123', 'type' => 'function', 'function' => ['name' => 'StreamingProgressTool', 'arguments' => '']]]], 'finish_reason' => null]]],
                 ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['tool_calls' => [['index' => 0, 'function' => ['arguments' => '{}']]]], 'finish_reason' => null]]],
                 ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'tool_calls']], 'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 10]],
             ])),
             Http::response($this->ssePayload([
-                ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'The number is 72019'], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Done'], 'finish_reason' => null]]],
                 ['id' => 'chatcmpl-2', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 20, 'completion_tokens' => 5]],
             ])),
         ]),
     ]);
 
     $events = [];
-    foreach (agent(tools: [new FixedNumberGenerator])->stream('Give me a number', provider: 'openrouter') as $event) {
+    foreach (agent(tools: [new StreamingProgressTool])->stream('Use the tool', provider: 'openrouter') as $event) {
         $events[] = $event;
     }
 
@@ -72,8 +72,10 @@ test('streaming handles tool calls', function () {
     $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
 
     expect($toolCallEvents)->toHaveCount(1)
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolResultEvents)->toHaveCount(1);
+
+    expectNestedStreamingToolDelta($events, 'call_123');
 });
 
 test('streaming error event stops stream', function () {

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -10,7 +10,9 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
-use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\StreamingProgressTool;
+
+use function Laravel\Ai\agent;
 
 beforeEach(function () {
     config(['ai.providers.xai' => [
@@ -50,10 +52,10 @@ test('streaming handles tool calls', function () {
             Http::response(
                 body: $this->ssePayload([
                     ['type' => 'response.created', 'response' => ['id' => 'resp_123', 'model' => 'grok-4-1-fast-reasoning']],
-                    ['type' => 'response.output_item.added', 'output_index' => 0, 'item' => ['type' => 'function_call', 'id' => 'fc_1', 'call_id' => 'call_1', 'name' => 'FixedNumberGenerator']],
+                    ['type' => 'response.output_item.added', 'output_index' => 0, 'item' => ['type' => 'function_call', 'id' => 'fc_1', 'call_id' => 'call_1', 'name' => 'StreamingProgressTool']],
                     ['type' => 'response.function_call_arguments.delta', 'item_id' => 'fc_1', 'delta' => '{}'],
                     ['type' => 'response.function_call_arguments.done', 'item_id' => 'fc_1', 'arguments' => '{}'],
-                    ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'function_call', 'status' => 'completed', 'id' => 'fc_1', 'call_id' => 'call_1', 'name' => 'FixedNumberGenerator', 'arguments' => '{}']], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
+                    ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'function_call', 'status' => 'completed', 'id' => 'fc_1', 'call_id' => 'call_1', 'name' => 'StreamingProgressTool', 'arguments' => '{}']], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
                 ]),
                 status: 200,
                 headers: ['Content-Type' => 'text/event-stream'],
@@ -61,7 +63,7 @@ test('streaming handles tool calls', function () {
             Http::response(
                 body: $this->ssePayload([
                     ['type' => 'response.created', 'response' => ['id' => 'resp_456', 'model' => 'grok-4-1-fast-reasoning']],
-                    ['type' => 'response.output_text.delta', 'delta' => 'The number is 72019'],
+                    ['type' => 'response.output_text.delta', 'delta' => 'Done'],
                     ['type' => 'response.output_text.done'],
                     ['type' => 'response.completed', 'response' => ['id' => 'resp_456', 'status' => 'completed', 'output' => [['type' => 'message', 'status' => 'completed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => '']]]], 'usage' => ['input_tokens' => 20, 'output_tokens' => 10, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
                 ]),
@@ -71,14 +73,16 @@ test('streaming handles tool calls', function () {
         ]),
     ]);
 
-    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+    $events = $this->collectStreamEvents(agent: agent(tools: [new StreamingProgressTool]));
 
     $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
     $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
 
     expect($toolCallEvents)->not->toBeEmpty()
-        ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator')
+        ->and($toolCallEvents[0]->toolCall->name)->toBe('StreamingProgressTool')
         ->and($toolResultEvents)->not->toBeEmpty();
+
+    expectNestedStreamingToolDelta($events, 'fc_1');
 });
 
 test('streaming captures usage', function () {

--- a/tests/Feature/SubAgentTest.php
+++ b/tests/Feature/SubAgentTest.php
@@ -4,11 +4,19 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 use Laravel\Ai\Tools\AgentTool;
+use Laravel\Ai\Tools\Request;
 use Tests\Fixtures\Agents\DelegatingAgent;
 use Tests\Fixtures\Agents\MiddleManagerAgent;
 use Tests\Fixtures\Agents\OrchestratorAgent;
 use Tests\Fixtures\Agents\ResearchAgent;
+use Tests\Fixtures\Agents\StreamingMiddleManagerAgent;
+use Tests\Fixtures\Agents\StreamingOrchestratorAgent;
+use Tests\Fixtures\Agents\StreamingResearchAgent;
 
 test('agent returned from tools is invoked when called by parent agent', function () {
     DelegatingAgent::fake([
@@ -124,4 +132,112 @@ test('nested agent delegates through a middle manager to a research agent', func
         ->and($response->toolCalls->first()->name)->toBe('middle_manager')
         ->and($response->toolResults)->toHaveCount(1)
         ->and($response->toolResults->first()->result)->toBe('Research delegated.');
+});
+
+test('agent tool keeps sub agent streaming opt in', function () {
+    ResearchAgent::fake(['Research result']);
+
+    $stream = (new AgentTool(new ResearchAgent))->streamHandle(new Request([
+        'task' => 'Research topic',
+    ]));
+
+    expect(iterator_to_array($stream, false))->toBeEmpty()
+        ->and($stream->getReturn())->toBe('Research result');
+});
+
+test('streaming sub agent events are stamped with nested tool call provenance', function () {
+    StreamingOrchestratorAgent::fake([
+        new ToolCall('call_001', 'streaming_middle_manager', ['task' => 'Deep-dive on Laravel caching']),
+        'Top done',
+    ]);
+
+    StreamingMiddleManagerAgent::fake([
+        new ToolCall('call_002', 'streaming_research_agent', ['task' => 'Research Laravel caching internals']),
+        'Middle done',
+    ]);
+
+    StreamingResearchAgent::fake(['Deep research result']);
+
+    $response = (new StreamingOrchestratorAgent)->stream('Do a deep dive on Laravel caching');
+    $events = iterator_to_array($response, false);
+
+    $topLevelToolCalls = array_values(array_filter(
+        $events,
+        fn ($event) => $event instanceof ToolCallEvent && ! $event->isNested(),
+    ));
+
+    $middleEvents = array_values(array_filter(
+        $events,
+        fn ($event) => $event->isNested() && $event->parentToolCallId === 'call_001',
+    ));
+
+    $researchEvents = array_values(array_filter(
+        $events,
+        fn ($event) => $event->isNested() && $event->parentToolCallId === 'call_002',
+    ));
+
+    $topLevelToolResults = array_values(array_filter(
+        $events,
+        fn ($event) => $event instanceof ToolResultEvent && ! $event->isNested(),
+    ));
+
+    $nestedToolResults = array_values(array_filter(
+        $events,
+        fn ($event) => $event instanceof ToolResultEvent && $event->isNested(),
+    ));
+
+    expect($topLevelToolCalls)->toHaveCount(1)
+        ->and($topLevelToolCalls[0]->toolCall->name)->toBe('streaming_middle_manager')
+        ->and($middleEvents)->not->toBeEmpty()
+        ->and($researchEvents)->not->toBeEmpty()
+        ->and($middleEvents[0]->ancestorToolCallIds)->toBe(['call_001'])
+        ->and($researchEvents[0]->ancestorToolCallIds)->toBe(['call_001', 'call_002'])
+        ->and($topLevelToolResults)->toHaveCount(1)
+        ->and($topLevelToolResults[0]->toolResult->result)->toBe('Middle done')
+        ->and($nestedToolResults)->toHaveCount(1)
+        ->and($nestedToolResults[0]->toolResult->result)->toBe('Deep research result')
+        ->and($response->text)->toBe('Top done')
+        ->and($response->events)->toHaveCount(count($events));
+});
+
+test('vercel protocol maps nested sub agent activity to data parts', function () {
+    StreamingOrchestratorAgent::fake([
+        new ToolCall('call_001', 'streaming_middle_manager', ['task' => 'Deep-dive on Laravel caching']),
+        'Top done',
+    ]);
+
+    StreamingMiddleManagerAgent::fake([
+        new ToolCall('call_002', 'streaming_research_agent', ['task' => 'Research Laravel caching internals']),
+        'Middle done',
+    ]);
+
+    StreamingResearchAgent::fake(['Deep research result']);
+
+    $response = (new StreamingOrchestratorAgent)->stream('Do a deep dive on Laravel caching');
+    $events = iterator_to_array($response, false);
+
+    $converter = new class('test', fn () => []) extends StreamableAgentResponse
+    {
+        public function convert(StreamEvent $event): array
+        {
+            return $this->nestedEventToVercelDataPart($event);
+        }
+    };
+
+    $subAgentParts = array_map(
+        fn (StreamEvent $event) => $converter->convert($event),
+        array_values(array_filter($events, fn (StreamEvent $event) => $event->isNested())),
+    );
+
+    $topLevelToolResults = array_values(array_filter(
+        $events,
+        fn ($event) => $event instanceof ToolResultEvent && ! $event->isNested(),
+    ));
+
+    expect($subAgentParts)->not->toBeEmpty()
+        ->and(array_column($subAgentParts, 'id'))->toContain('subagent:call_001')
+        ->and(array_column($subAgentParts, 'id'))->toContain('subagent:call_001/call_002')
+        ->and($subAgentParts[0]['type'])->toBe('data-subagent')
+        ->and($topLevelToolResults)->toHaveCount(1)
+        ->and($topLevelToolResults[0]->toolResult->id)->toBe('call_001');
 });

--- a/tests/Fixtures/Agents/StreamingMiddleManagerAgent.php
+++ b/tests/Fixtures/Agents/StreamingMiddleManagerAgent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\StreamsActivity;
+use Laravel\Ai\Promptable;
+
+class StreamingMiddleManagerAgent implements Agent, CanActAsTool, HasTools, StreamsActivity
+{
+    use Promptable;
+
+    public function name(): string
+    {
+        return 'streaming_middle_manager';
+    }
+
+    public function description(): string
+    {
+        return 'Delegate specialized research tasks to streaming research agents.';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a streaming middle manager that delegates to the streaming_research_agent sub-agent.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new StreamingResearchAgent,
+        ];
+    }
+}

--- a/tests/Fixtures/Agents/StreamingOrchestratorAgent.php
+++ b/tests/Fixtures/Agents/StreamingOrchestratorAgent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+
+class StreamingOrchestratorAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a streaming orchestrator that delegates to the streaming_middle_manager sub-agent.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new StreamingMiddleManagerAgent,
+        ];
+    }
+}

--- a/tests/Fixtures/Agents/StreamingResearchAgent.php
+++ b/tests/Fixtures/Agents/StreamingResearchAgent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\StreamsActivity;
+use Laravel\Ai\Promptable;
+
+class StreamingResearchAgent implements Agent, CanActAsTool, StreamsActivity
+{
+    use Promptable;
+
+    public function name(): string
+    {
+        return 'streaming_research_agent';
+    }
+
+    public function description(): string
+    {
+        return 'Research a topic in depth and stream activity while working.';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a streaming research agent. Summarize your findings concisely.';
+    }
+}

--- a/tests/Fixtures/Tools/StreamingProgressTool.php
+++ b/tests/Fixtures/Tools/StreamingProgressTool.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Generator;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\StreamableTool;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Tools\Request;
+
+#[Strict]
+class StreamingProgressTool implements StreamableTool
+{
+    public function description(): string
+    {
+        return 'Streams a progress event before returning a final result.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return 'streaming result';
+    }
+
+    public function streamHandle(Request $request): Generator
+    {
+        yield new TextDelta('evt_progress', 'msg_progress', 'streaming progress', time());
+
+        return 'streaming result';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -2,6 +2,23 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Streaming\Events\TextDelta;
+
+function expectNestedStreamingToolDelta(array $events, string $parentToolCallId): void
+{
+    $nestedDeltas = array_values(array_filter(
+        $events,
+        fn ($event) => $event instanceof TextDelta
+            && $event->isNested()
+            && $event->parentToolCallId === $parentToolCallId
+    ));
+
+    expect($nestedDeltas)->toHaveCount(1)
+        ->and($nestedDeltas[0]->delta)->toBe('streaming progress')
+        ->and($nestedDeltas[0]->parentInvocationId)->not->toBeNull()
+        ->and($nestedDeltas[0]->ancestorToolCallIds)->toBe([$parentToolCallId])
+        ->and($nestedDeltas[0]->depth())->toBe(1);
+}
 
 function requiresApiKey(string ...$keys): void
 {


### PR DESCRIPTION
## Goal

This PR adds the first step toward native streaming of sub-agent activity when sub-agents are invoked as tools.

The scope is intentionally narrow: the core contract, opt-in behavior for sub-agents, provenance for nested tool calls, and mapping nested events to the Vercel data protocol.

This PR is a foundation for follow-up work around a public consumer API for `data-subagent`, documentation, and examples for rendering multiple parallel and nested sub-agents on the client side.

## What changes

- Adds the `StreamableTool` contract, allowing a tool to emit events while it runs and still return a final tool result.
- Adds the `StreamsActivity` marker interface, allowing an agent to opt in to streamed activity when it is used as a sub-agent.
- Keeps `AgentTool` synchronous by default, but for agents implementing `StreamsActivity` it uses `agent->stream(...)` and forwards streamed events.
- Adds provenance to nested sub-agent events:
  - `parent_invocation_id`
  - `parent_tool_call_id`
  - `ancestor_tool_call_ids`
  - `depth`
- Supports parallel and nested sub-agents through the full tool-call path, for example `["call_001", "call_002"]`.
- Ensures `StreamableAgentResponse` does not mix text or usage from nested events into the top-level response.
- Emits nested activity in the Vercel data protocol as `data-subagent` instead of pretending those events are top-level text or tool parts.
- Adds fake gateway support for streaming tool calls so sub-agent streaming can be tested without a real provider.
- Wires streaming tool execution into the streaming paths for:
  - OpenAI
  - Azure OpenAI
  - OpenRouter
  - Anthropic
  - Gemini
  - Groq
  - DeepSeek
  - Mistral
  - Ollama
  - xAI
  - Bedrock

## What this PR does not do

- It does not change the default behavior of regular sub-agents that do not implement `StreamsActivity`.
- It does not change the synchronous `prompt()` / non-streaming tool execution path.
- It does not define the final client-side API or UI for consuming `data-subagent`.

## Tests

Run locally:

- `composer test -- tests/Feature/Providers/OpenAi/StreamingTest.php tests/Feature/Providers/AzureOpenAi/StreamingTest.php tests/Feature/Providers/OpenRouter/StreamingTest.php tests/Feature/Providers/Groq/StreamingTest.php tests/Feature/Providers/DeepSeek/StreamingTest.php tests/Feature/Providers/Mistral/StreamingTest.php tests/Feature/Providers/Gemini/StreamingTest.php tests/Feature/Providers/Anthropic/StreamingTest.php tests/Feature/Providers/Ollama/StreamingTest.php tests/Feature/Providers/Xai/StreamingTest.php tests/Feature/Providers/Bedrock/StreamingTest.php`
- `composer lint`
- `composer test`

Full test suite result: `1499 passed`, `193 skipped`.

The skipped tests require external provider API keys.