### PR TITLE
Add missing return type generics to embeddings and reranking responses

### DIFF
--- a/src/Responses/EmbeddingsResponse.php
+++ b/src/Responses/EmbeddingsResponse.php
@@ -58,6 +58,8 @@ class EmbeddingsResponse implements Arrayable, Countable, IteratorAggregate, Jso
 
     /**
      * Get an iterator for the object.
+     *
+     * @return Traversable<int, array<float>>
      */
     public function getIterator(): Traversable
     {

--- a/src/Responses/EmbeddingsResponse.php
+++ b/src/Responses/EmbeddingsResponse.php
@@ -20,6 +20,8 @@ class EmbeddingsResponse implements Arrayable, Countable, IteratorAggregate, Jso
 
     /**
      * Get the first set of embeddings in the response.
+     *
+     * @return array<float>
      */
     public function first(): array
     {

--- a/src/Responses/RerankingResponse.php
+++ b/src/Responses/RerankingResponse.php
@@ -33,6 +33,8 @@ class RerankingResponse implements Arrayable, Countable, IteratorAggregate, Json
 
     /**
      * Get the documents in their reranked order.
+     *
+     * @return Collection<int, string>
      */
     public function documents(): Collection
     {
@@ -49,6 +51,8 @@ class RerankingResponse implements Arrayable, Countable, IteratorAggregate, Json
 
     /**
      * Get the results as a collection.
+     *
+     * @return Collection<int, RankedDocument>
      */
     public function collect(): Collection
     {

--- a/src/Responses/RerankingResponse.php
+++ b/src/Responses/RerankingResponse.php
@@ -80,6 +80,8 @@ class RerankingResponse implements Arrayable, Countable, IteratorAggregate, Json
 
     /**
      * Get an iterator for the results.
+     *
+     * @return Traversable<int, RankedDocument>
      */
     public function getIterator(): Traversable
     {


### PR DESCRIPTION
The constructors of `EmbeddingsResponse` and `RerankingResponse` already declare their element types (`@param array<int, array<float>> $embeddings` and `@param array<int, RankedDocument> $results`), but the methods exposing that data were typed as bare `array` and `Collection`, causing IDEs and static analysis tools to lose the underlying element types.                                                                                                         
                                                                                                                                                                                                                                         
  - `EmbeddingsResponse::first()` now declares `@return array<float>`, matching the existing `Embeddings::fakeEmbedding()` annotation.                                                                                                   
  - `RerankingResponse::collect()` now declares `@return Collection<int, RankedDocument>`, matching the constructor annotation.                                                                                                          
  - `RerankingResponse::documents()` now declares `@return Collection<int, string>`, since it maps `RankedDocument::$document`.                                                                                                          
                                                                                                                                                                                                                                         
  This improves type inference and static analysis without changing runtime behavior.   