### PR TITLE
Merge all plain-object anyOf branches instead of keeping only the first

### DIFF
--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -231,6 +231,10 @@ class SchemaNormalizer
 
             [$branch, $branchSeen] = $this->inlineRefs($branch, $root, $seen);
 
+            if ($branch === []) {
+                continue;
+            }
+
             if (in_array($branch['type'] ?? null, ['null', ['null']], true)) {
                 $nullable = true;
             } else {
@@ -245,7 +249,8 @@ class SchemaNormalizer
         }
 
         if ($resolved !== []) {
-            $schema = $this->mergeObjectVariants($schema, $resolved) ?? $this->mergeSchema($schema, $resolved[0]);
+            $schema = $this->mergeObjectVariants($schema, $resolved)
+                ?? $this->mergeSchema($schema, $this->firstObjectBranch($resolved) ?? $resolved[0]);
         }
 
         if (! $nullable) {
@@ -259,7 +264,7 @@ class SchemaNormalizer
     }
 
     /**
-     * Union all plain-object variants' properties; null if any branch is not a plain object.
+     * Union every plain-object variant's properties, ignoring scalar branches; null when fewer than two objects remain.
      *
      * @param  array<string, mixed>  $schema
      * @param  array<int, array<string, mixed>>  $branches
@@ -267,28 +272,20 @@ class SchemaNormalizer
      */
     private function mergeObjectVariants(array $schema, array $branches): ?array
     {
-        if (count($branches) < 2) {
+        $objects = array_values(array_filter($branches, fn ($branch) => $this->isObjectBranch($branch)));
+
+        if (count($objects) < 2) {
             return null;
         }
 
         $allProperties = [];
         $requiredSets = [];
         $nullable = false;
+        $description = null;
+        $closed = true;
 
-        foreach ($branches as $branch) {
-            $type = $branch['type'] ?? null;
-
-            if (is_array($type)) {
-                $nonNull = array_values(array_filter($type, fn ($t) => $t !== 'null'));
-
-                if ($nonNull !== ['object']) {
-                    return null;
-                }
-
-                $nullable = true;
-            } elseif ($type !== 'object') {
-                return null;
-            }
+        foreach ($objects as $branch) {
+            $nullable = $nullable || is_array($branch['type'] ?? null);
 
             foreach ($branch['properties'] ?? [] as $key => $prop) {
                 if (! isset($allProperties[$key])) {
@@ -303,6 +300,12 @@ class SchemaNormalizer
             if (is_array($branch['required'] ?? null)) {
                 $requiredSets[] = $branch['required'];
             }
+
+            if ($description === null && is_string($branch['description'] ?? null)) {
+                $description = $branch['description'];
+            }
+
+            $closed = $closed && (($branch['additionalProperties'] ?? null) === false);
         }
 
         $result = $schema;
@@ -327,7 +330,45 @@ class SchemaNormalizer
             unset($result['required']);
         }
 
+        if ($description !== null && ! isset($result['description'])) {
+            $result['description'] = $description;
+        }
+
+        if ($closed && ! isset($result['additionalProperties'])) {
+            $result['additionalProperties'] = false;
+        }
+
         return $result;
+    }
+
+    /**
+     * Find the first branch whose type resolves to a plain object, used as a structure-preserving fallback.
+     *
+     * @param  array<int, array<string, mixed>>  $branches
+     * @return array<string, mixed>|null
+     */
+    private function firstObjectBranch(array $branches): ?array
+    {
+        foreach ($branches as $branch) {
+            if ($this->isObjectBranch($branch)) {
+                return $branch;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine whether a normalized branch's type is a plain object, optionally nullable.
+     *
+     * @param  array<string, mixed>  $branch
+     */
+    private function isObjectBranch(array $branch): bool
+    {
+        $type = $branch['type'] ?? null;
+        $nonNull = array_values(array_filter(is_array($type) ? $type : [$type], fn ($value) => $value !== 'null'));
+
+        return $nonNull === ['object'];
     }
 
     /**

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -278,49 +278,64 @@ class SchemaNormalizer
             return null;
         }
 
-        $allProperties = [];
+        return $this->reduceObjectGroup($objects, $schema);
+    }
+
+    /**
+     * Merge a group of object variants into one object, layering an optional conjunctive outer schema on top.
+     *
+     * @param  array<int, array<string, mixed>>  $variants
+     * @param  array<string, mixed>  $outer
+     * @return array<string, mixed>
+     */
+    private function reduceObjectGroup(array $variants, array $outer = []): array
+    {
+        $propertyLists = [];
         $requiredSets = [];
         $nullable = false;
         $description = null;
         $closed = true;
 
-        foreach ($objects as $branch) {
-            $nullable = $nullable || is_array($branch['type'] ?? null);
+        foreach ($variants as $variant) {
+            $nullable = $nullable || is_array($variant['type'] ?? null);
 
-            foreach ($branch['properties'] ?? [] as $key => $prop) {
-                if (! isset($allProperties[$key])) {
-                    $allProperties[$key] = $prop;
-                } elseif (isset($allProperties[$key]['enum'], $prop['enum']) && is_array($allProperties[$key]['enum']) && is_array($prop['enum'])) {
-                    $allProperties[$key]['enum'] = array_values(array_unique(
-                        array_merge($allProperties[$key]['enum'], $prop['enum'])
-                    ));
-                }
+            foreach (is_array($variant['properties'] ?? null) ? $variant['properties'] : [] as $key => $prop) {
+                $propertyLists[$key][] = $prop;
             }
 
-            if (is_array($branch['required'] ?? null)) {
-                $requiredSets[] = $branch['required'];
+            if (is_array($variant['required'] ?? null)) {
+                $requiredSets[] = $variant['required'];
             }
 
-            if ($description === null && is_string($branch['description'] ?? null)) {
-                $description = $branch['description'];
+            if ($description === null && is_string($variant['description'] ?? null)) {
+                $description = $variant['description'];
             }
 
-            $closed = $closed && (($branch['additionalProperties'] ?? null) === false);
+            $closed = $closed && (($variant['additionalProperties'] ?? null) === false);
         }
 
-        $result = $schema;
+        $properties = [];
+
+        foreach ($propertyLists as $key => $list) {
+            $properties[$key] = $this->mergeVariantValues($list);
+        }
+
+        foreach (is_array($outer['properties'] ?? null) ? $outer['properties'] : [] as $key => $prop) {
+            $properties[$key] = isset($properties[$key]) && is_array($properties[$key]) && is_array($prop)
+                ? $this->mergeVariantValues([$properties[$key], $prop])
+                : $prop;
+        }
+
+        $result = $outer;
         $result['type'] = $nullable ? ['object', 'null'] : 'object';
 
-        $outerProperties = is_array($schema['properties'] ?? null) ? $schema['properties'] : [];
-        $mergedProperties = array_merge($allProperties, $outerProperties);
-
-        if ($mergedProperties !== []) {
-            $result['properties'] = $mergedProperties;
+        if ($properties !== []) {
+            $result['properties'] = $properties;
         } else {
             unset($result['properties']);
         }
 
-        $outerRequired = is_array($schema['required'] ?? null) ? $schema['required'] : [];
+        $outerRequired = is_array($outer['required'] ?? null) ? $outer['required'] : [];
         $branchRequired = count($requiredSets) >= 2 ? array_values(array_intersect(...$requiredSets)) : [];
         $required = array_values(array_unique(array_merge($outerRequired, $branchRequired)));
 
@@ -339,6 +354,77 @@ class SchemaNormalizer
         }
 
         return $result;
+    }
+
+    /**
+     * Reduce the schemas a single property takes across variants into one schema, recursing on object variants.
+     *
+     * @param  array<int, mixed>  $list
+     * @return array<string, mixed>
+     */
+    private function mergeVariantValues(array $list): array
+    {
+        $list = array_values(array_filter($list, 'is_array'));
+
+        if (count($list) <= 1) {
+            return $list[0] ?? [];
+        }
+
+        $objects = array_values(array_filter($list, fn ($value) => $this->isObjectBranch($value)));
+
+        if (count($objects) >= 2) {
+            return $this->reduceObjectGroup($objects);
+        }
+
+        if (count($objects) === 1) {
+            return $objects[0];
+        }
+
+        return $this->unionScalarValues($list);
+    }
+
+    /**
+     * Union a property's scalar variants, combining their type and enum constraints.
+     *
+     * @param  array<int, array<string, mixed>>  $list
+     * @return array<string, mixed>
+     */
+    private function unionScalarValues(array $list): array
+    {
+        $merged = [];
+        $types = [];
+        $enums = [];
+
+        foreach ($list as $value) {
+            $merged = array_merge($merged, $value);
+            $types = [...$types, ...$this->typeList($value['type'] ?? null)];
+
+            if (is_array($value['enum'] ?? null)) {
+                $enums = [...$enums, ...$value['enum']];
+            }
+        }
+
+        $types = array_values(array_unique(array_filter($types, fn ($type) => $type !== null)));
+
+        if (! isset($merged['items']) && $types !== []) {
+            $merged['type'] = count($types) === 1 ? $types[0] : $types;
+        }
+
+        if ($enums !== []) {
+            $merged['enum'] = array_values(array_unique($enums));
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Normalize a "type" declaration into a list of type strings.
+     *
+     * @return array<int, mixed>
+     */
+    private function typeList(mixed $type): array
+    {
+        return is_array($type) ? $type : [$type];
     }
 
     /**

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -60,9 +60,7 @@ class SchemaNormalizer
         $schema = $this->mergeAllOf($schema, $root, $seen);
         $schema = $this->collapseUnions($schema, $root, $seen);
         $schema = $this->collapseMultiType($schema);
-        $schema = $this->dropUnsupportedKeywords($schema);
-        $schema = $this->rewriteConstAndDefault($schema);
-        $schema = $this->normalizeAdditionalProperties($schema);
+        $schema = $this->normalizeKeywords($schema);
         $schema = $this->normalizeChildren($schema, $root, $seen);
 
         return $this->ensureType($schema);
@@ -161,13 +159,13 @@ class SchemaNormalizer
     private function mergeSchema(array $base, array $overlay): array
     {
         $required = array_values(array_unique(array_merge(
-            $this->arrayValue($base, 'required'),
-            $this->arrayValue($overlay, 'required'),
+            is_array($base['required'] ?? null) ? $base['required'] : [],
+            is_array($overlay['required'] ?? null) ? $overlay['required'] : [],
         )));
 
-        $properties = $this->arrayValue($base, 'properties');
+        $properties = is_array($base['properties'] ?? null) ? $base['properties'] : [];
 
-        foreach ($this->arrayValue($overlay, 'properties') as $key => $value) {
+        foreach (is_array($overlay['properties'] ?? null) ? $overlay['properties'] : [] as $key => $value) {
             $properties[$key] = isset($properties[$key]) && is_array($properties[$key]) && is_array($value)
                 ? $this->mergeSchema($properties[$key], $value)
                 : $value;
@@ -212,8 +210,8 @@ class SchemaNormalizer
     }
 
     /**
-     * Reduce union branches into the node: a scalar multi-type union, or the first
-     * branch (lossy) since the deserializer only accepts a single schema plus null.
+     * Reduce union branches into the node: scalar multi-type union, merged object variants,
+     * or the first branch (lossy fallback) since the deserializer only accepts a single schema plus null.
      *
      * @param  array<string, mixed>  $schema
      * @param  array<int, mixed>  $branches
@@ -247,10 +245,89 @@ class SchemaNormalizer
         }
 
         if ($resolved !== []) {
-            $schema = array_merge($schema, $resolved[0]);
+            $schema = $this->mergeObjectVariants($schema, $resolved) ?? $this->mergeSchema($schema, $resolved[0]);
         }
 
-        return $nullable ? $this->makeNullable($schema) : $schema;
+        if (! $nullable) {
+            return $schema;
+        }
+
+        $type = $schema['type'] ?? $this->baseType($schema);
+        $schema['type'] = array_values(array_unique([...(is_array($type) ? $type : [$type]), 'null']));
+
+        return $schema;
+    }
+
+    /**
+     * Union all plain-object variants' properties; null if any branch is not a plain object.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<int, array<string, mixed>>  $branches
+     * @return array<string, mixed>|null
+     */
+    private function mergeObjectVariants(array $schema, array $branches): ?array
+    {
+        if (count($branches) < 2) {
+            return null;
+        }
+
+        $allProperties = [];
+        $requiredSets = [];
+        $nullable = false;
+
+        foreach ($branches as $branch) {
+            $type = $branch['type'] ?? null;
+
+            if (is_array($type)) {
+                $nonNull = array_values(array_filter($type, fn ($t) => $t !== 'null'));
+
+                if ($nonNull !== ['object']) {
+                    return null;
+                }
+
+                $nullable = true;
+            } elseif ($type !== 'object') {
+                return null;
+            }
+
+            foreach ($branch['properties'] ?? [] as $key => $prop) {
+                if (! isset($allProperties[$key])) {
+                    $allProperties[$key] = $prop;
+                } elseif (isset($allProperties[$key]['enum'], $prop['enum']) && is_array($allProperties[$key]['enum']) && is_array($prop['enum'])) {
+                    $allProperties[$key]['enum'] = array_values(array_unique(
+                        array_merge($allProperties[$key]['enum'], $prop['enum'])
+                    ));
+                }
+            }
+
+            if (is_array($branch['required'] ?? null)) {
+                $requiredSets[] = $branch['required'];
+            }
+        }
+
+        $result = $schema;
+        $result['type'] = $nullable ? ['object', 'null'] : 'object';
+
+        $outerProperties = is_array($schema['properties'] ?? null) ? $schema['properties'] : [];
+        $mergedProperties = array_merge($allProperties, $outerProperties);
+
+        if ($mergedProperties !== []) {
+            $result['properties'] = $mergedProperties;
+        } else {
+            unset($result['properties']);
+        }
+
+        $outerRequired = is_array($schema['required'] ?? null) ? $schema['required'] : [];
+        $branchRequired = count($requiredSets) >= 2 ? array_values(array_intersect(...$requiredSets)) : [];
+        $required = array_values(array_unique(array_merge($outerRequired, $branchRequired)));
+
+        if ($required !== []) {
+            $result['required'] = $required;
+        } else {
+            unset($result['required']);
+        }
+
+        return $result;
     }
 
     /**
@@ -280,22 +357,6 @@ class SchemaNormalizer
         }
 
         return $types;
-    }
-
-    /**
-     * Mark a node nullable in a form the deserializer understands (type + "null").
-     *
-     * @param  array<string, mixed>  $schema
-     * @return array<string, mixed>
-     */
-    private function makeNullable(array $schema): array
-    {
-        $type = $schema['type'] ?? $this->baseType($schema);
-        $type = is_array($type) ? $type : [$type];
-
-        $schema['type'] = array_values(array_unique([...$type, 'null']));
-
-        return $schema;
     }
 
     /**
@@ -337,12 +398,12 @@ class SchemaNormalizer
     }
 
     /**
-     * Drop keywords the deserializer cannot represent, along with definitions.
+     * Drop unsupported keywords, rewrite const to enum, and normalize additionalProperties.
      *
      * @param  array<string, mixed>  $schema
      * @return array<string, mixed>
      */
-    private function dropUnsupportedKeywords(array $schema): array
+    private function normalizeKeywords(array $schema): array
     {
         foreach (self::UNSUPPORTED as $keyword) {
             unset($schema[$keyword]);
@@ -350,20 +411,8 @@ class SchemaNormalizer
 
         unset($schema['$defs'], $schema['definitions']);
 
-        return $schema;
-    }
-
-    /**
-     * Rewrite "const" to a single-value enum and drop an unsupported null default.
-     *
-     * @param  array<string, mixed>  $schema
-     * @return array<string, mixed>
-     */
-    private function rewriteConstAndDefault(array $schema): array
-    {
         if (array_key_exists('const', $schema)) {
             $schema['enum'] = [$schema['const']];
-
             unset($schema['const']);
         }
 
@@ -371,17 +420,6 @@ class SchemaNormalizer
             unset($schema['default']);
         }
 
-        return $schema;
-    }
-
-    /**
-     * Infer an object type from additionalProperties, then drop its permissive forms.
-     *
-     * @param  array<string, mixed>  $schema
-     * @return array<string, mixed>
-     */
-    private function normalizeAdditionalProperties(array $schema): array
-    {
         if (! isset($schema['type']) && array_key_exists('additionalProperties', $schema)) {
             $schema['type'] = 'object';
         }
@@ -443,25 +481,21 @@ class SchemaNormalizer
      */
     private function ensureType(array $schema): array
     {
-        if ($this->usableType($schema['type'] ?? null) || isset($schema['anyOf']) || isset($schema['oneOf']) || isset($schema['allOf'])) {
+        if (isset($schema['anyOf']) || isset($schema['oneOf']) || isset($schema['allOf'])) {
+            return $schema;
+        }
+
+        $type = $schema['type'] ?? null;
+        $nonNull = array_filter(is_array($type) ? $type : [$type], fn ($t) => $t !== 'null');
+
+        if ($nonNull !== [] && array_filter($nonNull, fn ($t) => ! in_array($t, self::TYPES, true)) === []) {
             return $schema;
         }
 
         unset($schema['type']);
-
         $schema['type'] = $this->baseType($schema);
 
         return $schema;
-    }
-
-    /**
-     * Determine whether a node's type resolves to a non-null type the deserializer accepts.
-     */
-    private function usableType(mixed $type): bool
-    {
-        $types = array_filter(is_array($type) ? $type : [$type], fn ($value) => $value !== 'null');
-
-        return $types !== [] && array_filter($types, fn ($value) => ! in_array($value, self::TYPES, true)) === [];
     }
 
     /**
@@ -518,16 +552,5 @@ class SchemaNormalizer
         }
 
         return $resolved ?? 'string';
-    }
-
-    /**
-     * Read an array-typed key, defaulting to an empty array.
-     *
-     * @param  array<string, mixed>  $schema
-     * @return array<mixed>
-     */
-    private function arrayValue(array $schema, string $key): array
-    {
-        return is_array($schema[$key] ?? null) ? $schema[$key] : [];
     }
 }

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -85,6 +85,11 @@ describe('request structure', function () {
     });
 
     test('request omits the api key header when no key is configured', function () {
+        config(['ai.providers.gemini' => [
+            ...config('ai.providers.gemini'),
+            'key' => null,
+        ]]);
+
         Http::fake([
             'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
         ]);

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -383,6 +383,160 @@ test('it infers object type from additionalProperties', function (array $raw) {
     'false form' => [['additionalProperties' => false]],
 ]);
 
+test('it merges all object variants from anyOf instead of discarding all but the first', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'questions' => [
+                'type' => 'array',
+                'items' => [
+                    'anyOf' => [
+                        [
+                            'type' => 'object',
+                            'properties' => ['type' => ['type' => 'string', 'enum' => ['open']], 'text' => ['type' => 'string']],
+                            'required' => ['type', 'text'],
+                        ],
+                        [
+                            'type' => 'object',
+                            'properties' => ['type' => ['type' => 'string', 'enum' => ['multiple_choice']], 'choices' => ['type' => 'array']],
+                            'required' => ['type', 'choices'],
+                        ],
+                        [
+                            'type' => 'object',
+                            'properties' => ['type' => ['type' => 'string', 'enum' => ['rating']], 'scale' => ['type' => 'integer']],
+                            'required' => ['type'],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $item = $normalized['properties']['questions']['items'];
+
+    expect($item['type'])->toBe('object');
+    expect($item['properties'])->toHaveKeys(['type', 'text', 'choices', 'scale']);
+    expect($item['required'])->toBe(['type']);
+});
+
+test('it falls back to the first branch when anyOf branches are not all plain objects', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'value' => [
+                'anyOf' => [
+                    ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]],
+                    ['type' => 'string'],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['value']['type'])->toBe('object');
+    expect($normalized['properties']['value']['properties'])->toHaveKey('x');
+    expect($normalized['properties']['value']['properties'])->not->toHaveKey('y');
+});
+
+test('it preserves outer schema properties and required when merging anyOf object variants', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['kind' => ['type' => 'string']],
+        'required' => ['kind'],
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['name' => ['type' => 'string']], 'required' => ['name']],
+            ['type' => 'object', 'properties' => ['age' => ['type' => 'integer']], 'required' => ['age']],
+        ],
+    ]);
+
+    expect($normalized['properties'])->toHaveKeys(['kind', 'name', 'age']);
+    expect($normalized['required'])->toContain('kind');
+});
+
+test('it treats a branch with no required key as no-opinion rather than zero-required', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'questions' => [
+                'type' => 'array',
+                'items' => [
+                    'anyOf' => [
+                        ['type' => 'object', 'properties' => ['type' => ['type' => 'string'], 'text' => ['type' => 'string']], 'required' => ['type', 'text']],
+                        ['type' => 'object', 'properties' => ['type' => ['type' => 'string'], 'choices' => ['type' => 'array']], 'required' => ['type']],
+                        ['type' => 'object', 'properties' => ['type' => ['type' => 'string'], 'scale' => ['type' => 'integer']]],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $item = $normalized['properties']['questions']['items'];
+
+    expect($item['type'])->toBe('object');
+    expect($item['properties'])->toHaveKeys(['type', 'text', 'choices', 'scale']);
+    expect($item['required'])->toBe(['type']);
+});
+
+test('it merges nullable object variants and marks result nullable', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'payload' => [
+                'anyOf' => [
+                    ['type' => ['object', 'null'], 'properties' => ['x' => ['type' => 'string']]],
+                    ['type' => 'object', 'properties' => ['y' => ['type' => 'integer']]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['payload']['type'])->toBe(['object', 'null']);
+    expect($normalized['properties']['payload']['properties'])->toHaveKeys(['x', 'y']);
+});
+
+test('it does not promote required fields when only one of multiple branches declares required', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'string'], 'name' => ['type' => 'string']], 'required' => ['id']],
+            ['type' => 'object', 'properties' => ['code' => ['type' => 'string']]],
+        ],
+    ]);
+
+    expect($normalized)->not->toHaveKey('required');
+    expect($normalized['properties'])->toHaveKeys(['id', 'name', 'code']);
+});
+
+test('it unions enum values for overlapping discriminator properties across anyOf variants', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['open']],    'text'    => ['type' => 'string']]],
+            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['choice']],  'choices' => ['type' => 'array']]],
+            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['rating']],  'scale'   => ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['kind']['enum'])->toContain('open')
+        ->toContain('choice')
+        ->toContain('rating');
+    expect($normalized['properties'])->toHaveKeys(['kind', 'text', 'choices', 'scale']);
+});
+
+test('it does not bleed branch-specific keys like additionalProperties into the merged result', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'value' => [
+                'anyOf' => [
+                    ['type' => 'object', 'properties' => ['x' => ['type' => 'string']], 'additionalProperties' => false],
+                    ['type' => 'object', 'properties' => ['y' => ['type' => 'integer']]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['value']['properties'])->toHaveKeys(['x', 'y']);
+    expect($normalized['properties']['value'])->not->toHaveKey('additionalProperties');
+});
+
 test('it deep-merges overlapping properties across allOf branches', function () {
     $normalized = normalizesWithoutThrowing([
         'allOf' => [

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -419,7 +419,7 @@ test('it merges all object variants from anyOf instead of discarding all but the
     expect($item['required'])->toBe(['type']);
 });
 
-test('it falls back to the first branch when anyOf branches are not all plain objects', function () {
+test('it falls back to the single object branch when fewer than two object variants are present', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
@@ -435,6 +435,126 @@ test('it falls back to the first branch when anyOf branches are not all plain ob
     expect($normalized['properties']['value']['type'])->toBe('object');
     expect($normalized['properties']['value']['properties'])->toHaveKey('x');
     expect($normalized['properties']['value']['properties'])->not->toHaveKey('y');
+});
+
+test('it merges the object variants and ignores scalar branches when two or more objects are present', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'value' => [
+                'anyOf' => [
+                    ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]],
+                    ['type' => 'object', 'properties' => ['y' => ['type' => 'integer']]],
+                    ['type' => 'string'],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['value']['type'])->toBe('object');
+    expect($normalized['properties']['value']['properties'])->toHaveKeys(['x', 'y']);
+});
+
+test('it recursively merges branch refinements into a generic outer property', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['kind' => ['type' => 'string']],
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['kind' => ['const' => 'a']]],
+            ['type' => 'object', 'properties' => ['kind' => ['const' => 'b']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['kind']['enum'])->toBe(['a', 'b']);
+});
+
+test('it recursively merges duplicate nested object properties across object variants', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'item' => [
+                'anyOf' => [
+                    ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']]]]],
+                    ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['b' => ['type' => 'string']]]]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['item']['properties']['payload']['properties'])->toHaveKeys(['a', 'b']);
+});
+
+test('it ignores a no-opinion variant when intersecting required on a nested object property', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string'], 'b' => ['type' => 'string']], 'required' => ['a']]]],
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string'], 'c' => ['type' => 'string']], 'required' => ['a']]]],
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string'], 'd' => ['type' => 'string']]]]],
+        ],
+    ]);
+
+    expect($normalized['properties']['payload']['required'])->toBe(['a']);
+});
+
+test('it keeps a nested object property open unless every variant closes it', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false]]],
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']]]]],
+        ],
+    ]);
+
+    expect($normalized['properties']['payload'])->not->toHaveKey('additionalProperties');
+});
+
+test('it closes a nested object property only when every variant closes it', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false]]],
+            ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['b' => ['type' => 'string']], 'additionalProperties' => false]]],
+        ],
+    ]);
+
+    expect($normalized['properties']['payload']['additionalProperties'])->toBeFalse();
+});
+
+test('it unions scalar property types when the same key differs across object variants', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'string']]],
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['id']['type'])->toBe(['string', 'integer']);
+});
+
+test('it keeps the nested object shape when one variant types a property as an object', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'object', 'properties' => ['n' => ['type' => 'string']]]]],
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'string']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['id']['type'])->toBe('object');
+    expect($normalized['properties']['id']['properties'])->toHaveKey('n');
+});
+
+test('it does not throw when an object variant has a malformed scalar properties value', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'item' => [
+                'anyOf' => [
+                    ['type' => 'object', 'properties' => 'malformed-scalar'],
+                    ['type' => 'object', 'properties' => ['b' => ['type' => 'string']]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($normalized['properties']['item']['properties'])->toHaveKey('b');
 });
 
 test('it preserves outer schema properties and required when merging anyOf object variants', function () {

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -537,6 +537,86 @@ test('it does not bleed branch-specific keys like additionalProperties into the 
     expect($normalized['properties']['value'])->not->toHaveKey('additionalProperties');
 });
 
+test('it prefers the object branch over a scalar branch regardless of branch order', function () {
+    $stringFirst = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'string'],
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'string']], 'required' => ['id']],
+        ],
+    ]);
+
+    $objectFirst = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'string']], 'required' => ['id']],
+            ['type' => 'string'],
+        ],
+    ]);
+
+    expect($stringFirst['type'])->toBe('object');
+    expect($stringFirst['properties'])->toHaveKey('id');
+    expect($stringFirst['required'])->toBe(['id']);
+    expect($objectFirst)->toBe($stringFirst);
+});
+
+test('it skips an empty no-opinion branch when intersecting required across object variants', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['type' => ['type' => 'string', 'enum' => ['behavioral']], 'key' => ['type' => 'string'], 'value' => ['type' => 'string'], 'event_type' => ['type' => 'string']], 'required' => ['type', 'key', 'value', 'event_type']],
+            ['type' => 'object', 'properties' => ['type' => ['type' => 'string', 'enum' => ['person']], 'key' => ['type' => 'string'], 'value' => ['type' => 'string']], 'required' => ['type', 'key', 'value']],
+            ['type' => 'object', 'properties' => ['type' => ['type' => 'string', 'enum' => ['cohort']], 'key' => ['type' => 'string']], 'required' => ['type', 'key']],
+            [],
+        ],
+    ]);
+
+    expect($normalized['type'])->toBe('object');
+    expect($normalized['required'])->toBe(['type', 'key']);
+    expect($normalized['properties']['type']['enum'])->toBe(['behavioral', 'person', 'cohort']);
+});
+
+test('it skips a leading empty branch instead of degrading the union to a string', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            [],
+            ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'required' => ['a']],
+            ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']], 'required' => ['b']],
+        ],
+    ]);
+
+    expect($normalized['type'])->toBe('object');
+    expect($normalized['properties'])->toHaveKeys(['a', 'b']);
+});
+
+test('it carries the first object branch description into the merged result', function () {
+    $normalized = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'description' => 'Variant A', 'properties' => ['a' => ['type' => 'string']]],
+            ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($normalized['description'])->toBe('Variant A');
+    expect($normalized['properties'])->toHaveKeys(['a', 'b']);
+});
+
+test('it keeps additionalProperties false only when every merged object branch agrees', function () {
+    $unanimous = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false],
+            ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']], 'additionalProperties' => false],
+        ],
+    ]);
+
+    $mixed = normalizesWithoutThrowing([
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false],
+            ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($unanimous['additionalProperties'])->toBeFalse();
+    expect($mixed)->not->toHaveKey('additionalProperties');
+});
+
 test('it deep-merges overlapping properties across allOf branches', function () {
     $normalized = normalizesWithoutThrowing([
         'allOf' => [

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -508,9 +508,9 @@ test('it does not promote required fields when only one of multiple branches dec
 test('it unions enum values for overlapping discriminator properties across anyOf variants', function () {
     $normalized = normalizesWithoutThrowing([
         'anyOf' => [
-            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['open']],    'text'    => ['type' => 'string']]],
+            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['open']],    'text' => ['type' => 'string']]],
             ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['choice']],  'choices' => ['type' => 'array']]],
-            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['rating']],  'scale'   => ['type' => 'integer']]],
+            ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['rating']],  'scale' => ['type' => 'integer']]],
         ],
     ]);
 


### PR DESCRIPTION
The normalizer currently collapses `anyOf`/`oneOf` to the first branch, so discriminated union schemas lose all variant-specific properties:

```php
// before — choices and scale are gone
{type: object, properties: {kind: {enum: ['open']}, text: ...}, required: [kind, text]}

// after
{type: object, properties: {kind: {enum: ['open', 'choice', 'rating']}, text: ..., choices: ..., scale: ...}, required: [kind]}
```

All plain-object branches are unioned into one schema. For a shared discriminator property with `enum` values in each branch, the enums are merged. The `required` intersection keeps only fields required in every opinionated branch.

Three correctness fixes are also included: `required` was incorrectly promoted when only one of multiple branches declared it; the `array_merge` fallback now uses `mergeSchema` to avoid shallow-overwriting already-merged properties when both `anyOf` and `oneOf` appear on the same node; and `is_array` guards prevent a `TypeError` from non-array `enum` values in malformed MCP tool schemas.