### PR TITLE
Allow disabling the embeddings cache per request

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -55,7 +55,9 @@ class AiServiceProvider extends ServiceProvider
                 $request->dimensions($dimensions);
             }
 
-            if ($cache !== false && ! is_null($cache)) {
+            if ($cache === false) {
+                $request->cache(0);
+            } elseif (! is_null($cache)) {
                 $request->cache(is_int($cache) ? $cache : null);
             }
 

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -28,6 +28,8 @@ class PendingEmbeddingsGeneration
 
     protected ?int $cacheSeconds = null;
 
+    protected ?bool $shouldCache = null;
+
     protected int $timeout = 30;
 
     /** @var array<string, mixed>|SerializableClosure */
@@ -68,10 +70,18 @@ class PendingEmbeddingsGeneration
     }
 
     /**
-     * Enable caching for this embedding request.
+     * Enable or disable caching for this embedding request.
      */
     public function cache(?int $seconds = null): self
     {
+        if (! is_null($seconds) && $seconds <= 0) {
+            $this->shouldCache = false;
+            $this->cacheSeconds = null;
+
+            return $this;
+        }
+
+        $this->shouldCache = true;
         $this->cacheSeconds = $seconds ?? config('ai.caching.embeddings.seconds', 60 * 60 * 24 * 30);
 
         return $this;
@@ -290,6 +300,10 @@ class PendingEmbeddingsGeneration
      */
     protected function shouldCache(): bool
     {
-        return ! is_null($this->cacheSeconds) || config('ai.caching.embeddings.cache', false);
+        if (! is_null($this->shouldCache)) {
+            return $this->shouldCache;
+        }
+
+        return (bool) config('ai.caching.embeddings.cache', false);
     }
 }

--- a/tests/Feature/EmbeddingsCacheTest.php
+++ b/tests/Feature/EmbeddingsCacheTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+beforeEach(function () {
+    config([
+        'ai.providers.cohere' => [...config('ai.providers.cohere'), 'key' => 'test-key'],
+        'ai.default_for_embeddings' => 'cohere',
+        'ai.caching.embeddings.store' => 'array',
+    ]);
+
+    Http::fake([
+        'api.cohere.com/*' => Http::response([
+            'embeddings' => ['float' => [[0.1, 0.2, 0.3]]],
+            'meta' => ['billed_units' => ['input_tokens' => 1]],
+        ]),
+    ]);
+});
+
+test('cache is used when enabled explicitly', function () {
+    Embeddings::for(['Hello'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['Hello'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
+test('cache is used when enabled globally via config', function () {
+    config(['ai.caching.embeddings.cache' => true]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
+test('zero cache seconds bypasses an existing cached entry', function () {
+    Embeddings::for(['Hello'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+
+    Embeddings::for(['Hello'])->cache(0)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(2);
+});
+
+test('negative cache seconds bypasses an existing cached entry', function () {
+    Embeddings::for(['Hello'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+
+    Embeddings::for(['Hello'])->cache(-1)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(2);
+});
+
+test('toEmbeddings honors cache false even when enabled globally', function () {
+    config(['ai.caching.embeddings.cache' => true]);
+
+    str('hello world')->toEmbeddings(provider: 'cohere', model: 'embed-v4.0', cache: false);
+    str('hello world')->toEmbeddings(provider: 'cohere', model: 'embed-v4.0', cache: false);
+
+    expect(Http::recorded())->toHaveCount(2);
+});
+
+test('toEmbeddings uses cache when enabled globally', function () {
+    config(['ai.caching.embeddings.cache' => true]);
+
+    str('hello world')->toEmbeddings(provider: 'cohere', model: 'embed-v4.0');
+    str('hello world')->toEmbeddings(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});


### PR DESCRIPTION
Currently there's no way to turn off embeddings caching for a single request once it's enabled globally via `ai.caching.embeddings.cache`. Passing `cache: false` is silently ignored, and `->cache(0)` / `->cache(-1)` still return an existing cached entry.

Now an explicit disable wins over the global config:

```php
// global caching is on in config...

// before: still cached
str('hello world')->toEmbeddings(cache: false);
Embeddings::for(['hello'])->cache(0)->generate();

// after: both bypass the cache and hit the provider
```

Under the hood the request now tracks an explicit cache intent (default to config, or force on/off) instead of inferring it from whether a TTL was set, so a zero/negative TTL means "don't cache" rather than "cache with a 0s TTL". Tests added.

Fixes #691