### PR TITLE
Use native Anthropic structured outputs by default

### DIFF
--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -84,6 +84,9 @@ trait BuildsTextRequests
             : ['type' => 'tool', 'name' => 'output_structured_data'];
     }
 
+    /**
+    * Determine if the provider supports native structured output via output_config.
+    */
     protected function supportsNativeStructuredOutput(Provider $provider): bool
     {
         $config = $provider->additionalConfiguration();

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -84,20 +84,12 @@ trait BuildsTextRequests
             : ['type' => 'tool', 'name' => 'output_structured_data'];
     }
 
-    /**
-     * Determine if the provider should use native structured output via output_config.
-     *
-     * Structured outputs are generally available, so they are used by default.
-     * Callers targeting models that don't support them can opt out by setting the
-     * `native_structured_output` configuration flag to false, which falls back to
-     * the synthetic tool approach.
-     */
     protected function supportsNativeStructuredOutput(Provider $provider): bool
     {
         $config = $provider->additionalConfiguration();
 
-        if (array_key_exists('native_structured_output', $config)) {
-            return (bool) $config['native_structured_output'];
+        if (array_key_exists('use_native_structured_output', $config)) {
+            return (bool) $config['use_native_structured_output'];
         }
 
         return true;

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -85,8 +85,8 @@ trait BuildsTextRequests
     }
 
     /**
-    * Determine if the provider supports native structured output via output_config.
-    */
+     * Determine if the provider supports native structured output via output_config.
+     */
     protected function supportsNativeStructuredOutput(Provider $provider): bool
     {
         $config = $provider->additionalConfiguration();

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -85,13 +85,22 @@ trait BuildsTextRequests
     }
 
     /**
-     * Determine if the provider supports native structured output via output_config.
+     * Determine if the provider should use native structured output via output_config.
+     *
+     * Structured outputs are generally available, so they are used by default.
+     * Callers targeting models that don't support them can opt out by setting the
+     * `native_structured_output` configuration flag to false, which falls back to
+     * the synthetic tool approach.
      */
     protected function supportsNativeStructuredOutput(Provider $provider): bool
     {
-        $beta = $provider->additionalConfiguration()['anthropic_beta'] ?? '';
+        $config = $provider->additionalConfiguration();
 
-        return str_contains($beta, 'structured-outputs');
+        if (array_key_exists('native_structured_output', $config)) {
+            return (bool) $config['native_structured_output'];
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Feature/Providers/Anthropic/AnthropicHelpers.php
+++ b/tests/Feature/Providers/Anthropic/AnthropicHelpers.php
@@ -47,6 +47,22 @@ trait AnthropicHelpers
             'role' => 'assistant',
             'model' => 'claude-sonnet-4-6',
             'content' => [[
+                'type' => 'text',
+                'text' => json_encode($data),
+            ]],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]);
+    }
+
+    protected function fakeSyntheticStructuredResponse(array $data): PromiseInterface
+    {
+        return Http::response([
+            'id' => 'msg_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
                 'type' => 'tool_use',
                 'id' => 'toolu_123',
                 'name' => 'output_structured_data',

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -99,7 +99,12 @@ describe('request structure', function () {
         });
     });
 
-    test('tools with structured output use tool choice any', function () {
+    test('tools with structured output use tool choice any when native structured output is disabled', function () {
+        config(['ai.providers.anthropic' => [
+            ...config('ai.providers.anthropic'),
+            'native_structured_output' => false,
+        ]]);
+
         Http::fake([
             'api.anthropic.com/*' => $this->fakeTextResponse('The number is 42'),
         ]);
@@ -175,9 +180,40 @@ describe('request structure', function () {
 });
 
 describe('structured output', function () {
-    test('structured output uses synthetic tool', function () {
+    test('structured output uses native output_config by default', function () {
         Http::fake([
             'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Taylor', 'age' => 30]),
+        ]);
+
+        (new StructuredAgent)->prompt(
+            'Tell me about Taylor',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $body = $request->data();
+
+            $hasStructuredTool = false;
+
+            foreach ($body['tools'] ?? [] as $tool) {
+                if ($tool['name'] === 'output_structured_data') {
+                    $hasStructuredTool = true;
+                }
+            }
+
+            return $body['output_config']['format']['type'] === 'json_schema'
+                && ! $hasStructuredTool;
+        });
+    });
+
+    test('structured output falls back to the synthetic tool when native structured output is disabled', function () {
+        config(['ai.providers.anthropic' => [
+            ...config('ai.providers.anthropic'),
+            'native_structured_output' => false,
+        ]]);
+
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
         ]);
 
         (new StructuredAgent)->prompt(
@@ -202,9 +238,14 @@ describe('structured output', function () {
         });
     });
 
-    test('structured output with thinking uses auto tool choice', function () {
+    test('structured output with thinking uses auto tool choice when native structured output is disabled', function () {
+        config(['ai.providers.anthropic' => [
+            ...config('ai.providers.anthropic'),
+            'native_structured_output' => false,
+        ]]);
+
         Http::fake([
-            'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Taylor', 'age' => 30]),
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
         ]);
 
         (new StructuredWithThinkingAgent)->prompt(
@@ -229,9 +270,26 @@ describe('structured output', function () {
         });
     });
 
-    test('structured response is correctly parsed', function () {
+    test('native structured response is correctly parsed', function () {
         Http::fake([
             'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Taylor', 'age' => 30]),
+        ]);
+
+        $response = (new StructuredAgent)->prompt(
+            'Tell me about Taylor',
+            provider: 'anthropic',
+        );
+        expect($response->structured)->toMatchArray(['name' => 'Taylor', 'age' => 30]);
+    });
+
+    test('synthetic tool structured response is correctly parsed when native structured output is disabled', function () {
+        config(['ai.providers.anthropic' => [
+            ...config('ai.providers.anthropic'),
+            'native_structured_output' => false,
+        ]]);
+
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeSyntheticStructuredResponse(['name' => 'Taylor', 'age' => 30]),
         ]);
 
         $response = (new StructuredAgent)->prompt(

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -102,7 +102,7 @@ describe('request structure', function () {
     test('tools with structured output use tool choice any when native structured output is disabled', function () {
         config(['ai.providers.anthropic' => [
             ...config('ai.providers.anthropic'),
-            'native_structured_output' => false,
+            'use_native_structured_output' => false,
         ]]);
 
         Http::fake([
@@ -209,7 +209,7 @@ describe('structured output', function () {
     test('structured output falls back to the synthetic tool when native structured output is disabled', function () {
         config(['ai.providers.anthropic' => [
             ...config('ai.providers.anthropic'),
-            'native_structured_output' => false,
+            'use_native_structured_output' => false,
         ]]);
 
         Http::fake([
@@ -241,7 +241,7 @@ describe('structured output', function () {
     test('structured output with thinking uses auto tool choice when native structured output is disabled', function () {
         config(['ai.providers.anthropic' => [
             ...config('ai.providers.anthropic'),
-            'native_structured_output' => false,
+            'use_native_structured_output' => false,
         ]]);
 
         Http::fake([
@@ -285,7 +285,7 @@ describe('structured output', function () {
     test('synthetic tool structured response is correctly parsed when native structured output is disabled', function () {
         config(['ai.providers.anthropic' => [
             ...config('ai.providers.anthropic'),
-            'native_structured_output' => false,
+            'use_native_structured_output' => false,
         ]]);
 
         Http::fake([


### PR DESCRIPTION
## What & why

Anthropic [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) (`output_config.format`) are now generally available and no longer require the `structured-outputs` beta header. The Anthropic gateway still gated native structured output on that beta header, so by default it fell back to the synthetic `output_structured_data` tool even on models that support the native API.

This uses `output_config.format` by default and keeps the synthetic-tool path as an opt-out.

## Changes

- `supportsNativeStructuredOutput()` defaults to `true` instead of checking for the `structured-outputs` beta header.
- New `use_native_structured_output` provider config flag (default `true`); set it to `false` to fall back to the synthetic tool for models/endpoints that don't support `output_config.format`.
- Tests cover both the native (default) and synthetic (opt-out) request/response paths.

## ⚠️ Breaking change

Structured output now defaults to native `output_config.format` instead of the synthetic `output_structured_data` tool.

- **No change for most users.** Anyone using structured output against a current Anthropic model (Opus 4.8, Sonnet 4.6, Haiku 4.5, …) keeps working unchanged — and gets more reliable schema adherence. `$response->structured` is populated exactly as before.
- **Affected:** callers targeting a model or endpoint that does **not** support `output_config.format` — e.g. older Claude models, or an OpenAI-compatible/proxy endpoint reached via the `url` override. The synthetic tool worked anywhere with tool support; native does not, so these requests may now error.

### Migration

If your model or endpoint doesn't support native structured outputs, opt back into the synthetic tool:

```php
// config/ai.php
'anthropic' => [
    'driver' => 'anthropic',
    'key' => env('ANTHROPIC_API_KEY'),
    'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1'),
    'use_native_structured_output' => false,
],
```
