### PR TITLE
Add collection generics to TextResponse properties

### DIFF
--- a/src/Responses/TextResponse.php
+++ b/src/Responses/TextResponse.php
@@ -36,27 +36,35 @@ class TextResponse
 
     /**
      * Provide the message context for the response.
+     *
+     * @param  Collection<int, Message>  $messages
      */
     public function withMessages(Collection $messages): self
     {
         $this->messages = $messages;
 
-        $this->withToolCallsAndResults(
-            toolCalls: $this->messages
-                ->whereInstanceOf(AssistantMessage::class)
-                ->map(fn ($message) => $message->toolCalls)
-                ->flatten(),
-            toolResults: $this->messages
-                ->whereInstanceOf(ToolResultMessage::class)
-                ->map(fn ($message) => $message->toolResults)
-                ->flatten(),
-        );
+        /** @var Collection<int, ToolCall> $toolCalls */
+        $toolCalls = $this->messages
+            ->whereInstanceOf(AssistantMessage::class)
+            ->map(fn ($message) => $message->toolCalls)
+            ->flatten();
+
+        /** @var Collection<int, ToolResult> $toolResults */
+        $toolResults = $this->messages
+            ->whereInstanceOf(ToolResultMessage::class)
+            ->map(fn ($message) => $message->toolResults)
+            ->flatten();
+
+        $this->withToolCallsAndResults($toolCalls, $toolResults);
 
         return $this;
     }
 
     /**
      * Provide the tool calls and results for the message.
+     *
+     * @param  Collection<int, ToolCall>  $toolCalls
+     * @param  Collection<int, ToolResult>  $toolResults
      */
     public function withToolCallsAndResults(Collection $toolCalls, Collection $toolResults): self
     {
@@ -72,6 +80,8 @@ class TextResponse
 
     /**
      * Provide the steps taken to generate the response.
+     *
+     * @param  Collection<int, Step>  $steps
      */
     public function withSteps(Collection $steps): self
     {

--- a/src/Responses/TextResponse.php
+++ b/src/Responses/TextResponse.php
@@ -4,18 +4,26 @@ namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 
 class TextResponse
 {
+    /** @var Collection<int, Message> */
     public Collection $messages;
 
+    /** @var Collection<int, ToolCall> */
     public Collection $toolCalls;
 
+    /** @var Collection<int, ToolResult> */
     public Collection $toolResults;
 
+    /** @var Collection<int, Step> */
     public Collection $steps;
 
     public function __construct(public string $text, public Usage $usage, public Meta $meta)


### PR DESCRIPTION
`TextResponse` exposes four public `Collection` properties (`$messages`, `$toolCalls`, `$toolResults`, `$steps`) that are currently untyped, so static analysis and IDEs treat their elements as `mixed`. This adds the generic element types, which are unambiguous from how the collections are populated:                                                                                              
                                                                                                                                                                            
  - `$messages`: `Collection<int, Message>` - same type already declared on the `ConversationStore` contract's `getLatestConversationMessages()`                                                                                                      
  - `$toolCalls`: `Collection<int, ToolCall>` - built via `ToolCall::fromArray(...)` / `new ToolCall(...)`                                                                                                                                                
  - `$toolResults`: `Collection<int, ToolResult>` - populated with `ToolResult` instances                                                                                                                                                         
  - `$steps`: `Collection<int, Step>` - every gateway does `$steps->push(new Step(...))`