### PR TITLE
Support native anyOf schemas

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -96,6 +96,10 @@ function generate_fake_data_for_json_schema_type(Type $type): mixed
             return $result;
         })(),
 
+        'Illuminate\\JsonSchema\\Types\\AnyOfType' => (function () use ($attributes) {
+            return generate_fake_data_for_json_schema_type($attributes['schemas'][0] ?? throw new \RuntimeException('AnyOf schema must contain at least one branch.'));
+        })(),
+
         StringType::class => (function () use ($attributes) {
             if (isset($attributes['format'])) {
                 return match ($attributes['format']) {

--- a/src/ObjectSchema.php
+++ b/src/ObjectSchema.php
@@ -55,6 +55,12 @@ class ObjectSchema extends Schema
             $schema['items'] = static::disableAdditionalProperties($schema['items']);
         }
 
+        foreach ($schema['anyOf'] ?? [] as $key => $branch) {
+            if (is_array($branch)) {
+                $schema['anyOf'][$key] = static::disableAdditionalProperties($branch);
+            }
+        }
+
         return $schema;
     }
 

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -58,6 +58,7 @@ class SchemaNormalizer
         [$schema, $seen] = $this->inlineRefs($schema, $root, $seen);
 
         $schema = $this->mergeAllOf($schema, $root, $seen);
+        $schema = $this->preserveAnyOf($schema, $root, $seen);
         $schema = $this->collapseUnions($schema, $root, $seen);
         $schema = $this->collapseMultiType($schema);
         $schema = $this->dropUnsupportedKeywords($schema);
@@ -201,12 +202,55 @@ class SchemaNormalizer
                 continue;
             }
 
+            if ($key === 'anyOf' && $this->supportsAnyOf()) {
+                continue;
+            }
+
             $branches = $schema[$key];
 
             unset($schema[$key]);
 
             $schema = $this->mergeUnion($schema, $branches, $root, $seen);
         }
+
+        return $schema;
+    }
+
+    /**
+     * Keep anyOf compositions intact when the installed deserializer supports them.
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $root
+     * @param  array<string, true>  $seen
+     * @return array<string, mixed>
+     */
+    private function preserveAnyOf(array $schema, array $root, array $seen): array
+    {
+        if (! $this->supportsAnyOf() || ! is_array($schema['anyOf'] ?? null)) {
+            return $schema;
+        }
+
+        $branches = [];
+
+        foreach ($schema['anyOf'] as $branch) {
+            if (! is_array($branch)) {
+                continue;
+            }
+
+            [$branch, $branchSeen] = $this->inlineRefs($branch, $root, $seen);
+
+            $branches[] = $this->isNullBranch($branch)
+                ? ['type' => 'null']
+                : $this->node($branch, $root, $branchSeen);
+        }
+
+        if ($branches === []) {
+            unset($schema['anyOf']);
+
+            return $schema;
+        }
+
+        $schema['anyOf'] = $branches;
 
         return $schema;
     }
@@ -233,7 +277,7 @@ class SchemaNormalizer
 
             [$branch, $branchSeen] = $this->inlineRefs($branch, $root, $seen);
 
-            if (in_array($branch['type'] ?? null, ['null', ['null']], true)) {
+            if ($this->isNullBranch($branch)) {
                 $nullable = true;
             } else {
                 $resolved[] = $this->node($branch, $root, $branchSeen);
@@ -251,6 +295,24 @@ class SchemaNormalizer
         }
 
         return $nullable ? $this->makeNullable($schema) : $schema;
+    }
+
+    /**
+     * Determine if the installed Illuminate JSON schema package supports anyOf.
+     */
+    private function supportsAnyOf(): bool
+    {
+        return class_exists('Illuminate\\JsonSchema\\Types\\AnyOfType');
+    }
+
+    /**
+     * Determine whether the branch only represents null.
+     *
+     * @param  array<string, mixed>  $schema
+     */
+    private function isNullBranch(array $schema): bool
+    {
+        return in_array($schema['type'] ?? null, ['null', ['null']], true);
     }
 
     /**

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -217,6 +217,12 @@ class SchemaNormalizer
     /**
      * Keep anyOf compositions intact when the installed deserializer supports them.
      *
+     * The deserializer builds an anyOf composition from the branches alone and keeps only
+     * the keywords applied to every type (title, description, enum, default); any structural
+     * sibling (type, properties, required, items, constraints) would be silently dropped. To
+     * preserve them we fold the siblings into each branch, which is equivalent since
+     * "base AND (A OR B)" distributes to "(base AND A) OR (base AND B)".
+     *
      * @param  array<string, mixed>  $schema
      * @param  array<string, mixed>  $root
      * @param  array<string, true>  $seen
@@ -228,26 +234,36 @@ class SchemaNormalizer
             return $schema;
         }
 
+        $carry = ['anyOf' => true, 'title' => true, 'description' => true, 'enum' => true, 'default' => true];
+        $base = array_diff_key($schema, $carry);
+
         $branches = [];
+        $resolved = false;
 
         foreach ($schema['anyOf'] as $branch) {
-            if (! is_array($branch)) {
+            if (! is_array($branch) || $branch === []) {
                 continue;
             }
 
             [$branch, $branchSeen] = $this->inlineRefs($branch, $root, $seen);
 
-            $branches[] = $this->isNullBranch($branch)
-                ? ['type' => 'null']
-                : $this->node($branch, $root, $branchSeen);
+            if ($this->isNullBranch($branch)) {
+                $branches[] = ['type' => 'null'];
+
+                continue;
+            }
+
+            $branches[] = $this->node($base === [] ? $branch : $this->mergeSchema($base, $branch), $root, $branchSeen);
+            $resolved = true;
         }
 
-        if ($branches === []) {
+        if (! $resolved) {
             unset($schema['anyOf']);
 
             return $schema;
         }
 
+        $schema = array_intersect_key($schema, $carry);
         $schema['anyOf'] = $branches;
 
         return $schema;

--- a/src/Schema/SchemaNormalizer.php
+++ b/src/Schema/SchemaNormalizer.php
@@ -217,12 +217,6 @@ class SchemaNormalizer
     /**
      * Keep anyOf compositions intact when the installed deserializer supports them.
      *
-     * The deserializer builds an anyOf composition from the branches alone and keeps only
-     * the keywords applied to every type (title, description, enum, default); any structural
-     * sibling (type, properties, required, items, constraints) would be silently dropped. To
-     * preserve them we fold the siblings into each branch, which is equivalent since
-     * "base AND (A OR B)" distributes to "(base AND A) OR (base AND B)".
-     *
      * @param  array<string, mixed>  $schema
      * @param  array<string, mixed>  $root
      * @param  array<string, true>  $seen
@@ -246,6 +240,10 @@ class SchemaNormalizer
             }
 
             [$branch, $branchSeen] = $this->inlineRefs($branch, $root, $seen);
+
+            if ($branch === []) {
+                continue;
+            }
 
             if ($this->isNullBranch($branch)) {
                 $branches[] = ['type' => 'null'];

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\JsonSchema\JsonSchema as JsonSchemaFactory;
+use Illuminate\JsonSchema\Serializer;
 use Illuminate\JsonSchema\Types\ObjectType;
 use Laravel\Ai\Schema\SchemaNormalizer;
 
@@ -301,6 +302,76 @@ test('it preserves anyOf compositions when the framework deserializer supports t
         'enum' => ['article'],
         'type' => 'string',
     ]);
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
+
+test('it folds outer object siblings into each branch so the deserializer keeps them', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['kind' => ['type' => 'string']],
+        'required' => ['kind'],
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['name' => ['type' => 'string']], 'required' => ['name']],
+            ['type' => 'object', 'properties' => ['age' => ['type' => 'integer']], 'required' => ['age']],
+        ],
+    ]);
+
+    expect($normalized)->not->toHaveKey('properties');
+    expect($normalized['anyOf'])->toHaveCount(2);
+
+    expect($normalized['anyOf'][0]['properties'])->toHaveKeys(['kind', 'name']);
+    expect($normalized['anyOf'][0]['required'])->toEqualCanonicalizing(['kind', 'name']);
+    expect($normalized['anyOf'][1]['properties'])->toHaveKeys(['kind', 'age']);
+    expect($normalized['anyOf'][1]['required'])->toEqualCanonicalizing(['kind', 'age']);
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
+
+test('it keeps the shared base property after round-tripping a sibling anyOf through the deserializer', function () {
+    $type = JsonSchemaFactory::fromArray(SchemaNormalizer::normalize([
+        'type' => 'object',
+        'properties' => ['kind' => ['type' => 'string']],
+        'required' => ['kind'],
+        'anyOf' => [
+            ['type' => 'object', 'properties' => ['name' => ['type' => 'string']], 'required' => ['name']],
+            ['type' => 'object', 'properties' => ['age' => ['type' => 'integer']], 'required' => ['age']],
+        ],
+    ]));
+
+    expect(json_encode((new Serializer)->serialize($type)))->toContain('"kind"');
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
+
+test('it keeps the outer description on a preserved anyOf composition', function () {
+    $normalized = normalizesWithoutThrowing([
+        'description' => 'A union.',
+        'anyOf' => [['type' => 'string'], ['type' => 'integer']],
+    ]);
+
+    expect($normalized['description'])->toBe('A union.');
+    expect($normalized['anyOf'])->toHaveCount(2);
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
+
+test('it drops empty branches from a preserved anyOf instead of inventing a string branch', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'v' => ['anyOf' => [[], ['type' => 'string'], ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['v']['anyOf'])->toBe([
+        ['type' => 'string'],
+        ['type' => 'integer'],
+    ]);
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
+
+test('it drops a preserved anyOf made up entirely of null branches', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'v' => ['anyOf' => [['type' => 'null'], ['type' => 'null']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['v'])->not->toHaveKey('anyOf');
+    expect($normalized['properties']['v']['type'])->toBe('string');
 })->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
 
 test('it types heterogeneous, empty, and homogeneous enums without throwing', function (array $enum, $expected) {

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -362,6 +362,18 @@ test('it drops empty branches from a preserved anyOf instead of inventing a stri
     ]);
 })->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
 
+test('it drops a cyclic anyOf branch instead of inventing a string branch', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => ['node' => ['$ref' => '#/$defs/Node']],
+        '$defs' => [
+            'Node' => ['anyOf' => [['$ref' => '#/$defs/Node'], ['type' => 'integer']]],
+        ],
+    ]);
+
+    expect($normalized['properties']['node']['anyOf'])->toBe([['type' => 'integer']]);
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
+
 test('it drops a preserved anyOf made up entirely of null branches', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -4,6 +4,11 @@ use Illuminate\JsonSchema\JsonSchema as JsonSchemaFactory;
 use Illuminate\JsonSchema\Types\ObjectType;
 use Laravel\Ai\Schema\SchemaNormalizer;
 
+function illuminateSupportsAnyOf(): bool
+{
+    return class_exists('Illuminate\\JsonSchema\\Types\\AnyOfType');
+}
+
 /**
  * Assert that a raw schema normalizes into something the deserializer accepts.
  */
@@ -33,6 +38,17 @@ test('it collapses a nullable anyOf to a nullable single type', function () {
             'nickname' => ['anyOf' => [['type' => 'string', 'minLength' => 1], ['type' => 'null']]],
         ],
     ]);
+
+    if (illuminateSupportsAnyOf()) {
+        expect($normalized['properties']['nickname'])->toMatchArray([
+            'anyOf' => [
+                ['type' => 'string', 'minLength' => 1],
+                ['type' => 'null'],
+            ],
+        ]);
+
+        return;
+    }
 
     expect($normalized['properties']['nickname'])->toMatchArray([
         'type' => ['string', 'null'],
@@ -237,8 +253,45 @@ test('it preserves object shape for a nullable object branch', function () {
         ],
     ]);
 
+    if (illuminateSupportsAnyOf()) {
+        expect($normalized['properties']['addr']['anyOf'][0]['type'])->toBe('object');
+        expect($normalized['properties']['addr']['anyOf'][0]['properties'])->toHaveKey('city');
+
+        return;
+    }
+
     expect($normalized['properties']['addr']['type'])->toBe(['object', 'null']);
     expect($normalized['properties']['addr']['properties'])->toHaveKey('city');
+});
+
+test('it preserves anyOf compositions when the framework deserializer supports them', function () {
+    if (! illuminateSupportsAnyOf()) {
+        $this->markTestSkipped('The installed Illuminate JSON schema package does not support anyOf.');
+    }
+
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'content' => ['anyOf' => [
+                [
+                    'type' => 'object',
+                    'properties' => ['type' => ['const' => 'article'], 'title' => ['type' => 'string']],
+                    'required' => ['type', 'title'],
+                ],
+                [
+                    'type' => 'object',
+                    'properties' => ['type' => ['const' => 'image'], 'url' => ['type' => 'string']],
+                    'required' => ['type', 'url'],
+                ],
+            ]],
+        ],
+    ]);
+
+    expect($normalized['properties']['content']['anyOf'])->toHaveCount(2);
+    expect($normalized['properties']['content']['anyOf'][0]['properties']['type'])->toBe([
+        'enum' => ['article'],
+        'type' => 'string',
+    ]);
 });
 
 test('it types heterogeneous, empty, and homogeneous enums without throwing', function (array $enum, $expected) {

--- a/tests/Unit/Schema/SchemaNormalizerTest.php
+++ b/tests/Unit/Schema/SchemaNormalizerTest.php
@@ -4,14 +4,9 @@ use Illuminate\JsonSchema\JsonSchema as JsonSchemaFactory;
 use Illuminate\JsonSchema\Types\ObjectType;
 use Laravel\Ai\Schema\SchemaNormalizer;
 
-function illuminateSupportsAnyOf(): bool
+function supportsNativeAnyOf(): bool
 {
     return class_exists('Illuminate\\JsonSchema\\Types\\AnyOfType');
-}
-
-function fallbackCompositionKeyword(): string
-{
-    return illuminateSupportsAnyOf() ? 'oneOf' : 'anyOf';
 }
 
 /**
@@ -36,7 +31,7 @@ test('it passes a plain object schema through unchanged', function () {
     expect(SchemaNormalizer::normalize($raw))->toBe($raw);
 });
 
-test('it collapses a nullable anyOf to a nullable single type', function () {
+test('it preserves a nullable anyOf when the framework supports it natively', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
@@ -44,22 +39,27 @@ test('it collapses a nullable anyOf to a nullable single type', function () {
         ],
     ]);
 
-    if (illuminateSupportsAnyOf()) {
-        expect($normalized['properties']['nickname'])->toMatchArray([
-            'anyOf' => [
-                ['type' => 'string', 'minLength' => 1],
-                ['type' => 'null'],
-            ],
-        ]);
+    expect($normalized['properties']['nickname'])->toMatchArray([
+        'anyOf' => [
+            ['type' => 'string', 'minLength' => 1],
+            ['type' => 'null'],
+        ],
+    ]);
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
 
-        return;
-    }
+test('it collapses a nullable anyOf to a nullable single type when native support is unavailable', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'nickname' => ['anyOf' => [['type' => 'string', 'minLength' => 1], ['type' => 'null']]],
+        ],
+    ]);
 
     expect($normalized['properties']['nickname'])->toMatchArray([
         'type' => ['string', 'null'],
         'minLength' => 1,
     ]);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback collapse.');
 
 test('it collapses a non-nullable scalar oneOf to a multi-type union', function () {
     $normalized = normalizesWithoutThrowing([
@@ -247,7 +247,7 @@ test('it strips unsupported keywords pulled in from an allOf branch', function (
     expect($normalized['properties']['n'])->toBe(['type' => 'integer']);
 });
 
-test('it preserves object shape for a nullable object branch', function () {
+test('it preserves object shape inside nullable anyOf when the framework supports it natively', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
@@ -258,22 +258,26 @@ test('it preserves object shape for a nullable object branch', function () {
         ],
     ]);
 
-    if (illuminateSupportsAnyOf()) {
-        expect($normalized['properties']['addr']['anyOf'][0]['type'])->toBe('object');
-        expect($normalized['properties']['addr']['anyOf'][0]['properties'])->toHaveKey('city');
+    expect($normalized['properties']['addr']['anyOf'][0]['type'])->toBe('object');
+    expect($normalized['properties']['addr']['anyOf'][0]['properties'])->toHaveKey('city');
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
 
-        return;
-    }
+test('it preserves object shape for a nullable object branch when native support is unavailable', function () {
+    $normalized = normalizesWithoutThrowing([
+        'type' => 'object',
+        'properties' => [
+            'addr' => ['anyOf' => [
+                ['properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+                ['type' => 'null'],
+            ]],
+        ],
+    ]);
 
     expect($normalized['properties']['addr']['type'])->toBe(['object', 'null']);
     expect($normalized['properties']['addr']['properties'])->toHaveKey('city');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback collapse.');
 
 test('it preserves anyOf compositions when the framework deserializer supports them', function () {
-    if (! illuminateSupportsAnyOf()) {
-        $this->markTestSkipped('The installed Illuminate JSON schema package does not support anyOf.');
-    }
-
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
@@ -297,7 +301,7 @@ test('it preserves anyOf compositions when the framework deserializer supports t
         'enum' => ['article'],
         'type' => 'string',
     ]);
-});
+})->skip(! supportsNativeAnyOf(), 'The installed Illuminate JSON schema package does not support anyOf.');
 
 test('it types heterogeneous, empty, and homogeneous enums without throwing', function (array $enum, $expected) {
     $normalized = normalizesWithoutThrowing([
@@ -448,7 +452,7 @@ test('it merges all object variants from anyOf instead of discarding all but the
             'questions' => [
                 'type' => 'array',
                 'items' => [
-                    fallbackCompositionKeyword() => [
+                    'anyOf' => [
                         [
                             'type' => 'object',
                             'properties' => ['type' => ['type' => 'string', 'enum' => ['open']], 'text' => ['type' => 'string']],
@@ -475,14 +479,14 @@ test('it merges all object variants from anyOf instead of discarding all but the
     expect($item['type'])->toBe('object');
     expect($item['properties'])->toHaveKeys(['type', 'text', 'choices', 'scale']);
     expect($item['required'])->toBe(['type']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it falls back to the single object branch when fewer than two object variants are present', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
             'value' => [
-                fallbackCompositionKeyword() => [
+                'anyOf' => [
                     ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]],
                     ['type' => 'string'],
                 ],
@@ -493,14 +497,14 @@ test('it falls back to the single object branch when fewer than two object varia
     expect($normalized['properties']['value']['type'])->toBe('object');
     expect($normalized['properties']['value']['properties'])->toHaveKey('x');
     expect($normalized['properties']['value']['properties'])->not->toHaveKey('y');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it merges the object variants and ignores scalar branches when two or more objects are present', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
             'value' => [
-                fallbackCompositionKeyword() => [
+                'anyOf' => [
                     ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]],
                     ['type' => 'object', 'properties' => ['y' => ['type' => 'integer']]],
                     ['type' => 'string'],
@@ -511,27 +515,27 @@ test('it merges the object variants and ignores scalar branches when two or more
 
     expect($normalized['properties']['value']['type'])->toBe('object');
     expect($normalized['properties']['value']['properties'])->toHaveKeys(['x', 'y']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it recursively merges branch refinements into a generic outer property', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => ['kind' => ['type' => 'string']],
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['kind' => ['const' => 'a']]],
             ['type' => 'object', 'properties' => ['kind' => ['const' => 'b']]],
         ],
     ]);
 
     expect($normalized['properties']['kind']['enum'])->toBe(['a', 'b']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it recursively merges duplicate nested object properties across object variants', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
             'item' => [
-                fallbackCompositionKeyword() => [
+                'anyOf' => [
                     ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']]]]],
                     ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['b' => ['type' => 'string']]]]],
                 ],
@@ -540,11 +544,11 @@ test('it recursively merges duplicate nested object properties across object var
     ]);
 
     expect($normalized['properties']['item']['properties']['payload']['properties'])->toHaveKeys(['a', 'b']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it ignores a no-opinion variant when intersecting required on a nested object property', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string'], 'b' => ['type' => 'string']], 'required' => ['a']]]],
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string'], 'c' => ['type' => 'string']], 'required' => ['a']]]],
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string'], 'd' => ['type' => 'string']]]]],
@@ -552,44 +556,44 @@ test('it ignores a no-opinion variant when intersecting required on a nested obj
     ]);
 
     expect($normalized['properties']['payload']['required'])->toBe(['a']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it keeps a nested object property open unless every variant closes it', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false]]],
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']]]]],
         ],
     ]);
 
     expect($normalized['properties']['payload'])->not->toHaveKey('additionalProperties');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it closes a nested object property only when every variant closes it', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false]]],
             ['type' => 'object', 'properties' => ['payload' => ['type' => 'object', 'properties' => ['b' => ['type' => 'string']], 'additionalProperties' => false]]],
         ],
     ]);
 
     expect($normalized['properties']['payload']['additionalProperties'])->toBeFalse();
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it unions scalar property types when the same key differs across object variants', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['id' => ['type' => 'string']]],
             ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
         ],
     ]);
 
     expect($normalized['properties']['id']['type'])->toBe(['string', 'integer']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it keeps the nested object shape when one variant types a property as an object', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['id' => ['type' => 'object', 'properties' => ['n' => ['type' => 'string']]]]],
             ['type' => 'object', 'properties' => ['id' => ['type' => 'string']]],
         ],
@@ -597,14 +601,14 @@ test('it keeps the nested object shape when one variant types a property as an o
 
     expect($normalized['properties']['id']['type'])->toBe('object');
     expect($normalized['properties']['id']['properties'])->toHaveKey('n');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it does not throw when an object variant has a malformed scalar properties value', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
             'item' => [
-                fallbackCompositionKeyword() => [
+                'anyOf' => [
                     ['type' => 'object', 'properties' => 'malformed-scalar'],
                     ['type' => 'object', 'properties' => ['b' => ['type' => 'string']]],
                 ],
@@ -613,14 +617,14 @@ test('it does not throw when an object variant has a malformed scalar properties
     ]);
 
     expect($normalized['properties']['item']['properties'])->toHaveKey('b');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it preserves outer schema properties and required when merging anyOf object variants', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => ['kind' => ['type' => 'string']],
         'required' => ['kind'],
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['name' => ['type' => 'string']], 'required' => ['name']],
             ['type' => 'object', 'properties' => ['age' => ['type' => 'integer']], 'required' => ['age']],
         ],
@@ -628,7 +632,7 @@ test('it preserves outer schema properties and required when merging anyOf objec
 
     expect($normalized['properties'])->toHaveKeys(['kind', 'name', 'age']);
     expect($normalized['required'])->toContain('kind');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it treats a branch with no required key as no-opinion rather than zero-required', function () {
     $normalized = normalizesWithoutThrowing([
@@ -637,7 +641,7 @@ test('it treats a branch with no required key as no-opinion rather than zero-req
             'questions' => [
                 'type' => 'array',
                 'items' => [
-                    fallbackCompositionKeyword() => [
+                    'anyOf' => [
                         ['type' => 'object', 'properties' => ['type' => ['type' => 'string'], 'text' => ['type' => 'string']], 'required' => ['type', 'text']],
                         ['type' => 'object', 'properties' => ['type' => ['type' => 'string'], 'choices' => ['type' => 'array']], 'required' => ['type']],
                         ['type' => 'object', 'properties' => ['type' => ['type' => 'string'], 'scale' => ['type' => 'integer']]],
@@ -652,14 +656,14 @@ test('it treats a branch with no required key as no-opinion rather than zero-req
     expect($item['type'])->toBe('object');
     expect($item['properties'])->toHaveKeys(['type', 'text', 'choices', 'scale']);
     expect($item['required'])->toBe(['type']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it merges nullable object variants and marks result nullable', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
             'payload' => [
-                fallbackCompositionKeyword() => [
+                'anyOf' => [
                     ['type' => ['object', 'null'], 'properties' => ['x' => ['type' => 'string']]],
                     ['type' => 'object', 'properties' => ['y' => ['type' => 'integer']]],
                 ],
@@ -669,11 +673,11 @@ test('it merges nullable object variants and marks result nullable', function ()
 
     expect($normalized['properties']['payload']['type'])->toBe(['object', 'null']);
     expect($normalized['properties']['payload']['properties'])->toHaveKeys(['x', 'y']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it does not promote required fields when only one of multiple branches declares required', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['id' => ['type' => 'string'], 'name' => ['type' => 'string']], 'required' => ['id']],
             ['type' => 'object', 'properties' => ['code' => ['type' => 'string']]],
         ],
@@ -681,11 +685,11 @@ test('it does not promote required fields when only one of multiple branches dec
 
     expect($normalized)->not->toHaveKey('required');
     expect($normalized['properties'])->toHaveKeys(['id', 'name', 'code']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it unions enum values for overlapping discriminator properties across anyOf variants', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['open']],    'text' => ['type' => 'string']]],
             ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['choice']],  'choices' => ['type' => 'array']]],
             ['type' => 'object', 'properties' => ['kind' => ['type' => 'string', 'enum' => ['rating']],  'scale' => ['type' => 'integer']]],
@@ -696,14 +700,14 @@ test('it unions enum values for overlapping discriminator properties across anyO
         ->toContain('choice')
         ->toContain('rating');
     expect($normalized['properties'])->toHaveKeys(['kind', 'text', 'choices', 'scale']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it does not bleed branch-specific keys like additionalProperties into the merged result', function () {
     $normalized = normalizesWithoutThrowing([
         'type' => 'object',
         'properties' => [
             'value' => [
-                fallbackCompositionKeyword() => [
+                'anyOf' => [
                     ['type' => 'object', 'properties' => ['x' => ['type' => 'string']], 'additionalProperties' => false],
                     ['type' => 'object', 'properties' => ['y' => ['type' => 'integer']]],
                 ],
@@ -713,18 +717,18 @@ test('it does not bleed branch-specific keys like additionalProperties into the 
 
     expect($normalized['properties']['value']['properties'])->toHaveKeys(['x', 'y']);
     expect($normalized['properties']['value'])->not->toHaveKey('additionalProperties');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it prefers the object branch over a scalar branch regardless of branch order', function () {
     $stringFirst = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'string'],
             ['type' => 'object', 'properties' => ['id' => ['type' => 'string']], 'required' => ['id']],
         ],
     ]);
 
     $objectFirst = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['id' => ['type' => 'string']], 'required' => ['id']],
             ['type' => 'string'],
         ],
@@ -734,11 +738,11 @@ test('it prefers the object branch over a scalar branch regardless of branch ord
     expect($stringFirst['properties'])->toHaveKey('id');
     expect($stringFirst['required'])->toBe(['id']);
     expect($objectFirst)->toBe($stringFirst);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it skips an empty no-opinion branch when intersecting required across object variants', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['type' => ['type' => 'string', 'enum' => ['behavioral']], 'key' => ['type' => 'string'], 'value' => ['type' => 'string'], 'event_type' => ['type' => 'string']], 'required' => ['type', 'key', 'value', 'event_type']],
             ['type' => 'object', 'properties' => ['type' => ['type' => 'string', 'enum' => ['person']], 'key' => ['type' => 'string'], 'value' => ['type' => 'string']], 'required' => ['type', 'key', 'value']],
             ['type' => 'object', 'properties' => ['type' => ['type' => 'string', 'enum' => ['cohort']], 'key' => ['type' => 'string']], 'required' => ['type', 'key']],
@@ -749,11 +753,11 @@ test('it skips an empty no-opinion branch when intersecting required across obje
     expect($normalized['type'])->toBe('object');
     expect($normalized['required'])->toBe(['type', 'key']);
     expect($normalized['properties']['type']['enum'])->toBe(['behavioral', 'person', 'cohort']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it skips a leading empty branch instead of degrading the union to a string', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             [],
             ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'required' => ['a']],
             ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']], 'required' => ['b']],
@@ -762,11 +766,11 @@ test('it skips a leading empty branch instead of degrading the union to a string
 
     expect($normalized['type'])->toBe('object');
     expect($normalized['properties'])->toHaveKeys(['a', 'b']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it carries the first object branch description into the merged result', function () {
     $normalized = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'description' => 'Variant A', 'properties' => ['a' => ['type' => 'string']]],
             ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']]],
         ],
@@ -774,18 +778,18 @@ test('it carries the first object branch description into the merged result', fu
 
     expect($normalized['description'])->toBe('Variant A');
     expect($normalized['properties'])->toHaveKeys(['a', 'b']);
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it keeps additionalProperties false only when every merged object branch agrees', function () {
     $unanimous = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false],
             ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']], 'additionalProperties' => false],
         ],
     ]);
 
     $mixed = normalizesWithoutThrowing([
-        fallbackCompositionKeyword() => [
+        'anyOf' => [
             ['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false],
             ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']]],
         ],
@@ -793,7 +797,7 @@ test('it keeps additionalProperties false only when every merged object branch a
 
     expect($unanimous['additionalProperties'])->toBeFalse();
     expect($mixed)->not->toHaveKey('additionalProperties');
-});
+})->skip(supportsNativeAnyOf(), 'Native anyOf support preserves compositions instead of using the fallback merge.');
 
 test('it deep-merges overlapping properties across allOf branches', function () {
     $normalized = normalizesWithoutThrowing([


### PR DESCRIPTION
This is a follow-up to https://github.com/laravel/framework/pull/60509

Now that Illuminate JSON Schema can represent `anyOf` natively, Laravel AI should preserve `anyOf` schemas instead of always collapsing them through the compatibility path.

Older framework versions remain supported: if native `AnyOfType` is not available, Laravel AI keeps using the existing fallback behavior.