### PR TITLE
Surface full provider error detail on failed responses

### DIFF
--- a/src/Exceptions/AiException.php
+++ b/src/Exceptions/AiException.php
@@ -3,8 +3,64 @@
 namespace Laravel\Ai\Exceptions;
 
 use Exception;
+use Throwable;
 
 class AiException extends Exception
 {
-    //
+    /**
+     * Create a new AI exception instance.
+     *
+     * @param  array<string, mixed>|null  $errorBody
+     */
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null,
+        protected ?string $provider = null,
+        protected ?int $status = null,
+        protected ?array $errorBody = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * The provider that raised the error, if known.
+     */
+    public function provider(): ?string
+    {
+        return $this->provider;
+    }
+
+    /**
+     * The HTTP status code returned by the provider, if any.
+     */
+    public function status(): ?int
+    {
+        return $this->status;
+    }
+
+    /**
+     * The raw error body returned by the provider, if any.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function errorBody(): ?array
+    {
+        return $this->errorBody;
+    }
+
+    /**
+     * Attach provider error context to the exception.
+     *
+     * @param  array<string, mixed>|null  $errorBody
+     * @return $this
+     */
+    public function withContext(?string $provider, ?int $status, ?array $errorBody): static
+    {
+        $this->provider = $provider;
+        $this->status = $status;
+        $this->errorBody = $errorBody;
+
+        return $this;
+    }
 }

--- a/src/Exceptions/ProviderRequestException.php
+++ b/src/Exceptions/ProviderRequestException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+use Throwable;
+
+class ProviderRequestException extends AiException
+{
+    /**
+     * Create an exception for a failed provider HTTP response.
+     *
+     * @param  array<string, mixed>|null  $errorBody
+     */
+    public static function forResponse(
+        string $provider,
+        int $status,
+        ?array $errorBody = null,
+        ?string $message = null,
+        int $code = 0,
+        ?Throwable $previous = null,
+    ): self {
+        return new self(
+            sprintf(
+                'AI provider [%s] request failed with status [%d]: %s',
+                $provider,
+                $status,
+                $message ?? 'Unknown error.',
+            ),
+            $code,
+            $previous,
+            $provider,
+            $status,
+            $errorBody,
+        );
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -29,11 +29,11 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || ($data['type'] ?? '') === 'error') {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'Anthropic Error: [%s] %s',
                 $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown Anthropic error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Bedrock/BedrockException.php
+++ b/src/Gateway/Bedrock/BedrockException.php
@@ -32,7 +32,7 @@ class BedrockException
     public static function toAiException(Throwable $e, string $provider, string $model): AiException
     {
         if ($e instanceof BedrockRuntimeException) {
-            return match ($e->getAwsErrorCode()) {
+            return (match ($e->getAwsErrorCode()) {
                 'ThrottlingException' => RateLimitedException::forProvider($provider, $e->getStatusCode(), $e),
                 'ServiceUnavailableException',
                 'ModelNotReadyException',
@@ -49,18 +49,19 @@ class BedrockException
                     code: $e->getCode(),
                     previous: $e,
                 ),
-            };
+            })->withContext($provider, $e->getStatusCode(), null);
         }
 
         if (static::isInsufficientCreditsError($e)) {
-            return InsufficientCreditsException::forProvider($provider, $e->getCode(), $e);
+            return InsufficientCreditsException::forProvider($provider, $e->getCode(), $e)
+                ->withContext($provider, null, null);
         }
 
-        return new AiException(
+        return (new AiException(
             $e->getMessage(),
             code: $e->getCode(),
             previous: $e,
-        );
+        ))->withContext($provider, null, null);
     }
 
     /**

--- a/src/Gateway/Concerns/HandlesFailoverErrors.php
+++ b/src/Gateway/Concerns/HandlesFailoverErrors.php
@@ -4,8 +4,11 @@ namespace Laravel\Ai\Gateway\Concerns;
 
 use Closure;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Str;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 trait HandlesFailoverErrors
@@ -23,42 +26,82 @@ trait HandlesFailoverErrors
         try {
             return $callback();
         } catch (RequestException $e) {
-            if ($e->response !== null) {
-                $status = $e->response->status();
+            if ($e->response === null) {
+                throw $e;
+            }
 
-                if ($status === 429) {
-                    throw RateLimitedException::forProvider(
-                        $providerName, $e->getCode(), $e
-                    );
-                }
+            $status = $e->response->status();
+            $body = $this->extractErrorBody($e->response);
+            $message = $this->extractErrorMessage($e->response);
 
-                if ($status === 402) {
-                    throw InsufficientCreditsException::forProvider(
-                        $providerName, $e->getCode(), $e
-                    );
-                }
+            if ($status === 429) {
+                throw RateLimitedException::forProvider($providerName, $e->getCode(), $e)
+                    ->withContext($providerName, $status, $body);
+            }
 
-                if (in_array($status, $this->overloadedStatusCodes())) {
-                    throw ProviderOverloadedException::forProvider(
-                        $providerName, $e->getCode(), $e
-                    );
-                }
+            if ($status === 402) {
+                throw InsufficientCreditsException::forProvider($providerName, $e->getCode(), $e)
+                    ->withContext($providerName, $status, $body);
+            }
 
-                if ($patterns = $this->insufficientCreditPatterns()) {
-                    $message = strtolower($e->response->json('error.message', ''));
+            if (in_array($status, $this->overloadedStatusCodes())) {
+                throw ProviderOverloadedException::forProvider($providerName, $e->getCode(), $e)
+                    ->withContext($providerName, $status, $body);
+            }
 
-                    foreach ($patterns as $pattern) {
-                        if (str_contains($message, $pattern)) {
-                            throw InsufficientCreditsException::forProvider(
-                                $providerName, $e->getCode(), $e
-                            );
-                        }
+            if ($patterns = $this->insufficientCreditPatterns()) {
+                $haystack = strtolower($message ?? '');
+
+                foreach ($patterns as $pattern) {
+                    if (str_contains($haystack, $pattern)) {
+                        throw InsufficientCreditsException::forProvider($providerName, $e->getCode(), $e)
+                            ->withContext($providerName, $status, $body);
                     }
                 }
             }
 
-            throw $e;
+            throw ProviderRequestException::forResponse(
+                $providerName, $status, $body, $message, $e->getCode(), $e,
+            );
         }
+    }
+
+    /**
+     * Extract the raw error body from a provider response.
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function extractErrorBody(Response $response): ?array
+    {
+        $json = $response->json();
+
+        return is_array($json) ? $json : null;
+    }
+
+    /**
+     * Extract a human-readable error message from a provider response.
+     */
+    protected function extractErrorMessage(Response $response): ?string
+    {
+        $body = $this->extractErrorBody($response);
+
+        if ($body !== null) {
+            foreach ([
+                $body['error']['message'] ?? null,
+                $body['error'] ?? null,
+                $body['message'] ?? null,
+                $body['detail'] ?? null,
+                $body['error']['status'] ?? null,
+            ] as $candidate) {
+                if (is_string($candidate) && $candidate !== '') {
+                    return $candidate;
+                }
+            }
+        }
+
+        $raw = trim((string) $response->body());
+
+        return $raw === '' ? null : Str::limit($raw, 500);
     }
 
     /**

--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -29,11 +29,11 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'DeepSeek Error: [%s] %s',
                 $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown DeepSeek error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -30,11 +30,11 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'Gemini Error: [%s] %s',
                 $data['error']['code'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown Gemini error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -29,11 +29,11 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'Groq Error: [%s] %s',
                 $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown Groq error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -28,11 +28,11 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error']) || ($data['object'] ?? null) === 'error') {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'Mistral Error: [%s] %s',
                 $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown Mistral error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
@@ -29,10 +29,10 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'Ollama Error: %s',
                 $data['error'] ?? 'Unknown Ollama error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -153,10 +153,10 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
         $data = $response->json();
 
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'Ollama Error: %s',
                 $data['error'] ?? 'Unknown Ollama error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
 
         return new EmbeddingsResponse(

--- a/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextStreaming.php
@@ -4,6 +4,8 @@ namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -56,15 +58,43 @@ trait HandlesTextStreaming
             $type = $data['type'] ?? '';
 
             if ($type === 'error') {
-                yield (new Error(
-                    $this->generateEventId(),
-                    $data['error']['code'] ?? 'unknown_error',
-                    $data['error']['message'] ?? 'Unknown error',
-                    false,
-                    time(),
-                ))->withInvocationId($invocationId);
+                yield $this->streamErrorEvent(
+                    $provider,
+                    $invocationId,
+                    $data['code'] ?? $data['error']['code'] ?? null,
+                    $data['message'] ?? $data['error']['message'] ?? null,
+                );
 
                 return;
+            }
+
+            if ($type === 'response.failed') {
+                $error = $data['response']['error'] ?? [];
+
+                yield $this->streamErrorEvent(
+                    $provider,
+                    $invocationId,
+                    $error['code'] ?? null,
+                    $error['message'] ?? null,
+                );
+
+                return;
+            }
+
+            if ($type === 'response.incomplete') {
+                $response = $data['response'] ?? [];
+                $responseData = $response;
+                $responseUsage = $response['usage'] ?? [];
+
+                $usage = new Usage(
+                    ($responseUsage['input_tokens'] ?? 0) - ($responseUsage['input_tokens_details']['cached_tokens'] ?? 0),
+                    $responseUsage['output_tokens'] ?? 0,
+                    0,
+                    $responseUsage['input_tokens_details']['cached_tokens'] ?? 0,
+                    $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
+                );
+
+                continue;
             }
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
@@ -422,6 +452,49 @@ trait HandlesTextStreaming
             $tc['reasoning_summary'] ?? null,
             $tc['reasoning_encrypted_content'] ?? null,
         ), array_values($toolCalls));
+    }
+
+    /**
+     * Build a streaming error event, or throw a failoverable exception for
+     * rate-limit and quota errors so the stream surfaces a real error instead
+     * of ending empty. The Responses API opens the stream with HTTP 200 and
+     * only reports these failures via a stream event, so they never reach the
+     * HTTP-level error handling.
+     */
+    protected function streamErrorEvent(
+        Provider $provider,
+        string $invocationId,
+        ?string $code,
+        ?string $message,
+    ): Error {
+        $haystack = strtolower(trim(($code ?? '').' '.($message ?? '')));
+
+        $errorBody = ['error' => array_filter([
+            'code' => $code,
+            'message' => $message,
+        ], fn ($value) => $value !== null)];
+
+        if ($code === 'rate_limit_exceeded' ||
+            str_contains($haystack, 'rate limit') ||
+            str_contains($haystack, 'per min')) {
+            throw RateLimitedException::forProvider($provider->name())
+                ->withContext($provider->name(), 429, $errorBody);
+        }
+
+        if ($code === 'insufficient_quota' ||
+            str_contains($haystack, 'quota') ||
+            str_contains($haystack, 'billing')) {
+            throw InsufficientCreditsException::forProvider($provider->name())
+                ->withContext($provider->name(), 402, $errorBody);
+        }
+
+        return (new Error(
+            $this->generateEventId(),
+            $code ?? 'unknown_error',
+            $message ?? 'Unknown error',
+            false,
+            time(),
+        ))->withInvocationId($invocationId);
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -29,21 +29,21 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'OpenAI Error: [%s] %s',
                 $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown OpenAI error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
 
         if (($data['status'] ?? '') === 'failed') {
             $error = $data['error'] ?? [];
 
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'OpenAI Error: [%s] %s',
                 $error['code'] ?? 'unknown',
                 $error['message'] ?? 'The response failed without an error message.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -29,11 +29,11 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'OpenRouter Error: [%s] %s',
                 $data['error']['type'] ?? $data['error']['code'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown OpenRouter error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -3,6 +3,8 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Generator;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -57,15 +59,43 @@ trait HandlesTextStreaming
             $type = $data['type'] ?? '';
 
             if ($type === 'error') {
-                yield (new Error(
-                    $this->generateEventId(),
-                    $data['error']['code'] ?? 'unknown_error',
-                    $data['error']['message'] ?? 'Unknown error',
-                    false,
-                    time(),
-                ))->withInvocationId($invocationId);
+                yield $this->streamErrorEvent(
+                    $provider,
+                    $invocationId,
+                    $data['code'] ?? $data['error']['code'] ?? null,
+                    $data['message'] ?? $data['error']['message'] ?? null,
+                );
 
                 return;
+            }
+
+            if ($type === 'response.failed') {
+                $error = $data['response']['error'] ?? [];
+
+                yield $this->streamErrorEvent(
+                    $provider,
+                    $invocationId,
+                    $error['code'] ?? null,
+                    $error['message'] ?? null,
+                );
+
+                return;
+            }
+
+            if ($type === 'response.incomplete') {
+                $response = $data['response'] ?? [];
+                $responseData = $response;
+                $responseUsage = $response['usage'] ?? [];
+
+                $usage = new Usage(
+                    ($responseUsage['input_tokens'] ?? 0) - ($responseUsage['input_tokens_details']['cached_tokens'] ?? 0),
+                    $responseUsage['output_tokens'] ?? 0,
+                    0,
+                    $responseUsage['input_tokens_details']['cached_tokens'] ?? 0,
+                    $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
+                );
+
+                continue;
             }
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
@@ -413,6 +443,49 @@ trait HandlesTextStreaming
             $tc['reasoning_id'] ?? null,
             $tc['reasoning_summary'] ?? null,
         ), array_values($toolCalls));
+    }
+
+    /**
+     * Build a streaming error event, or throw a failoverable exception for
+     * rate-limit and quota errors so the stream surfaces a real error instead
+     * of ending empty. The Responses API opens the stream with HTTP 200 and
+     * only reports these failures via a stream event, so they never reach the
+     * HTTP-level error handling.
+     */
+    protected function streamErrorEvent(
+        Provider $provider,
+        string $invocationId,
+        ?string $code,
+        ?string $message,
+    ): Error {
+        $haystack = strtolower(trim(($code ?? '').' '.($message ?? '')));
+
+        $errorBody = ['error' => array_filter([
+            'code' => $code,
+            'message' => $message,
+        ], fn ($value) => $value !== null)];
+
+        if ($code === 'rate_limit_exceeded' ||
+            str_contains($haystack, 'rate limit') ||
+            str_contains($haystack, 'per min')) {
+            throw RateLimitedException::forProvider($provider->name())
+                ->withContext($provider->name(), 429, $errorBody);
+        }
+
+        if ($code === 'insufficient_quota' ||
+            str_contains($haystack, 'quota') ||
+            str_contains($haystack, 'billing')) {
+            throw InsufficientCreditsException::forProvider($provider->name())
+                ->withContext($provider->name(), 402, $errorBody);
+        }
+
+        return (new Error(
+            $this->generateEventId(),
+            $code ?? 'unknown_error',
+            $message ?? 'Unknown error',
+            false,
+            time(),
+        ))->withInvocationId($invocationId);
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -3,10 +3,10 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Generator;
-use Laravel\Ai\Exceptions\InsufficientCreditsException;
-use Laravel\Ai\Exceptions\RateLimitedException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;

--- a/src/Gateway/Xai/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Xai/Concerns/ParsesTextResponses.php
@@ -30,21 +30,21 @@ trait ParsesTextResponses
     protected function validateTextResponse(array $data): void
     {
         if (! $data || isset($data['error'])) {
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'xAI Error: [%s] %s',
                 $data['error']['type'] ?? 'unknown',
                 $data['error']['message'] ?? 'Unknown xAI error.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
 
         if (($data['status'] ?? '') === 'failed') {
             $error = $data['error'] ?? [];
 
-            throw new AiException(sprintf(
+            throw (new AiException(sprintf(
                 'xAI Error: [%s] %s',
                 $error['code'] ?? 'unknown',
                 $error['message'] ?? 'The response failed without an error message.',
-            ));
+            )))->withContext(provider: null, status: 200, errorBody: $data ?: null);
         }
     }
 

--- a/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -23,7 +23,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'anthropic',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/AzureOpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/EmbeddingTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -126,7 +126,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'azure', model: 'text-embedding-3-small');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('embeddings request includes provider options in the request body', function () {
     Http::fake(['*' => fakeAzureEmbeddingsResponse()]);

--- a/tests/Feature/Providers/AzureOpenAi/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -30,7 +30,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'azure',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ImageGenerationTest.php
@@ -2,9 +2,9 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Image;
@@ -253,4 +253,4 @@ test('image http error response throws request exception', function () {
     ]);
 
     Image::of('A red apple')->generate(provider: 'azure', model: 'gpt-image-1');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -85,7 +86,7 @@ test('streaming error event stops stream', function () {
     Http::fake([
         'my-resource.cognitiveservices.azure.com/*' => Http::response(
             body: $this->ssePayload([
-                ['type' => 'error', 'error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit exceeded']],
+                ['type' => 'error', 'error' => ['code' => 'server_error', 'message' => 'Server overloaded']],
             ]),
             status: 200,
             headers: ['Content-Type' => 'text/event-stream'],
@@ -96,8 +97,22 @@ test('streaming error event stops stream', function () {
 
     expect($events)->toHaveCount(1)
         ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('rate_limit_exceeded')
-        ->and($events[0]->message)->toBe('Rate limit exceeded');
+        ->and($events[0]->type)->toBe('server_error')
+        ->and($events[0]->message)->toBe('Server overloaded');
+});
+
+test('streaming rate limit error event throws a rate limited exception', function () {
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'error', 'code' => 'rate_limit_exceeded', 'message' => 'Rate limit exceeded'],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    expect(fn () => $this->collectStreamEvents())->toThrow(RateLimitedException::class);
 });
 
 test('streaming captures usage from completed event', function () {

--- a/tests/Feature/Providers/Cohere/EmbeddingTest.php
+++ b/tests/Feature/Providers/Cohere/EmbeddingTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 
 beforeEach(function () {
     config(['ai.providers.cohere' => [
@@ -103,7 +103,7 @@ test('embeddings throw when the API returns an error', function () {
     Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
 
     Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 function fakeCohereEmbeddingsResponse()
 {

--- a/tests/Feature/Providers/Cohere/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Cohere/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 
@@ -36,7 +36,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'cohere', model: 'embed-v4.0');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('reranking rate limit response throws rate limited exception', function () {
     Http::fake([
@@ -60,4 +60,4 @@ test('reranking http error response throws request exception', function () {
     ]);
 
     Reranking::of(['doc1'])->rerank('What is AI?', provider: 'cohere', model: 'rerank-v3.5');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/Cohere/RerankingTest.php
+++ b/tests/Feature/Providers/Cohere/RerankingTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
@@ -98,7 +98,7 @@ test('reranking throws when the API returns an error', function () {
     Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
 
     Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('reranking rate limit response throws rate limited exception', function () {
     Http::fake(['api.cohere.com/*' => Http::response(['message' => 'rate limit exceeded'], 429)]);

--- a/tests/Feature/Providers/DeepSeek/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/DeepSeek/ErrorHandlingTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -29,7 +29,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'deepseek',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/ElevenLabs/AudioTest.php
+++ b/tests/Feature/Providers/ElevenLabs/AudioTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -75,7 +75,7 @@ test('audio throws when the API returns an error', function () {
     Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
 
     Audio::of('Hello')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('audio rate limit response throws rate limited exception', function () {
     Http::fake(['api.elevenlabs.io/*' => Http::response(['detail' => 'rate limit exceeded'], 429)]);

--- a/tests/Feature/Providers/ElevenLabs/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/ElevenLabs/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Transcription;
 
@@ -36,7 +36,7 @@ test('audio http error response throws request exception', function () {
     ]);
 
     Audio::of('Hello world')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('transcription rate limit response throws rate limited exception', function () {
     Http::fake([
@@ -60,4 +60,4 @@ test('transcription http error response throws request exception', function () {
     ]);
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'eleven');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/ElevenLabs/TranscriptionTest.php
+++ b/tests/Feature/Providers/ElevenLabs/TranscriptionTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Transcription;
 
 beforeEach(function () {
@@ -109,7 +109,7 @@ test('transcription throws when the API returns an error', function () {
     Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
 
     Transcription::of(base64_encode('fake-audio'))->generate(provider: 'eleven', model: 'scribe_v2');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 function fakeElevenTranscriptionResponse(bool $diarized = false)
 {

--- a/tests/Feature/Providers/Gemini/EmbeddingTest.php
+++ b/tests/Feature/Providers/Gemini/EmbeddingTest.php
@@ -2,10 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -160,7 +160,7 @@ test('http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'gemini', model: 'gemini-embedding-001');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('request sends x-goog-api-key header', function () {
     Http::fake([

--- a/tests/Feature/Providers/Gemini/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Gemini/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -22,7 +22,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'gemini',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/Gemini/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Gemini/ImageGenerationTest.php
@@ -2,9 +2,9 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Image;
@@ -294,7 +294,7 @@ test('image http error response throws request exception', function () {
     ]);
 
     Image::of('A red apple')->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('image response is empty when prompt is blocked and candidates array is empty', function () {
     Http::fake([

--- a/tests/Feature/Providers/Groq/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Groq/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -28,7 +28,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'groq',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/Jina/EmbeddingTest.php
+++ b/tests/Feature/Providers/Jina/EmbeddingTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 
 beforeEach(function () {
     config(['ai.providers.jina' => [
@@ -60,7 +60,7 @@ test('embeddings throw when the API returns an error', function () {
     Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
 
     Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('multiple inputs return multiple embeddings', function () {
     Http::fake(['*' => Http::response([

--- a/tests/Feature/Providers/Jina/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Jina/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 
@@ -36,7 +36,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'jina', model: 'jina-embeddings-v4');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('reranking rate limit response throws rate limited exception', function () {
     Http::fake([
@@ -60,4 +60,4 @@ test('reranking http error response throws request exception', function () {
     ]);
 
     Reranking::of(['doc1'])->rerank('What is AI?', provider: 'jina', model: 'jina-reranker-v3');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/Jina/RerankingTest.php
+++ b/tests/Feature/Providers/Jina/RerankingTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
@@ -100,7 +100,7 @@ test('reranking throws when the API returns an error', function () {
     Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
 
     Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'jina', model: 'jina-reranker-v3');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('reranking rate limit response throws rate limited exception', function () {
     Http::fake(['api.jina.ai/*' => Http::response(['detail' => 'rate limit exceeded'], 429)]);

--- a/tests/Feature/Providers/Mistral/EmbeddingTest.php
+++ b/tests/Feature/Providers/Mistral/EmbeddingTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -100,7 +100,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'mistral', model: 'mistral-embed');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('embeddings request includes provider options in the request body', function () {
     Http::fake(['*' => fakeEmbeddingsResponse()]);

--- a/tests/Feature/Providers/Mistral/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Mistral/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -24,7 +24,7 @@ test('http error response throws request exception', function () {
     ]);
 
     (new AssistantAgent)->prompt('Hi', provider: 'mistral');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/Mistral/TranscriptionTest.php
+++ b/tests/Feature/Providers/Mistral/TranscriptionTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Transcription;
 
 beforeEach(function () {
@@ -161,7 +161,7 @@ test('transcription throws when the API returns an error', function () {
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
         ->generate(provider: 'mistral');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 function fakeTranscriptionResponse(string $text = 'Hello, world!')
 {

--- a/tests/Feature/Providers/Ollama/EmbeddingTest.php
+++ b/tests/Feature/Providers/Ollama/EmbeddingTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -107,7 +107,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'ollama', model: 'nomic-embed-text');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('embeddings request includes provider options in the request body', function () {
     Http::fake(['*' => fakeOllamaEmbeddingsResponse()]);

--- a/tests/Feature/Providers/Ollama/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Ollama/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -25,7 +25,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'ollama',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/OpenAi/AudioTest.php
+++ b/tests/Feature/Providers/OpenAi/AudioTest.php
@@ -2,9 +2,9 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -119,7 +119,7 @@ test('audio http error response throws request exception', function () {
     ]);
 
     Audio::of('Hello')->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('audio request sends bearer token', function () {
     Http::fake(['*' => fakeOpenAiAudioResponse()]);

--- a/tests/Feature/Providers/OpenAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/OpenAi/EmbeddingTest.php
@@ -2,10 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -162,4 +162,4 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'openai', model: 'text-embedding-3-small');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/OpenAi/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/OpenAi/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -28,7 +28,7 @@ test('http error response throws request exception', function () {
         'Hi',
         provider: 'openai',
     );
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageGenerationTest.php
@@ -2,9 +2,9 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Image;
 
@@ -235,4 +235,4 @@ test('image http error response throws request exception', function () {
     ]);
 
     Image::of('A red apple')->generate(provider: 'openai', model: 'gpt-image-1');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -133,6 +135,117 @@ test('streaming error event stops stream', function () {
         ->and($events[0])->toBeInstanceOf(Error::class)
         ->and($events[0]->type)->toBe('server_error')
         ->and($events[0]->message)->toBe('Server overloaded');
+});
+
+test('streaming rate limit error event throws a rate limited exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'error', 'code' => 'rate_limit_exceeded', 'message' => 'Rate limit reached on tokens per min (TPM).'],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    try {
+        $this->collectStreamEvents();
+
+        $this->fail('Expected RateLimitedException to be thrown.');
+    } catch (RateLimitedException $e) {
+        expect($e->provider())->toBe('openai')
+            ->and($e->status())->toBe(429)
+            ->and($e->errorBody())->toBe(['error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit reached on tokens per min (TPM).']]);
+    }
+});
+
+test('streaming response.failed with rate limit throws a rate limited exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                ['type' => 'response.failed', 'response' => [
+                    'id' => 'resp_1',
+                    'status' => 'failed',
+                    'error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit reached.'],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    expect(fn () => $this->collectStreamEvents())->toThrow(RateLimitedException::class);
+});
+
+test('streaming response.failed with insufficient quota throws an insufficient credits exception', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.failed', 'response' => [
+                    'status' => 'failed',
+                    'error' => ['code' => 'insufficient_quota', 'message' => 'You exceeded your current quota.'],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    expect(fn () => $this->collectStreamEvents())->toThrow(InsufficientCreditsException::class);
+});
+
+test('streaming response.failed with a generic error yields an error event', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.failed', 'response' => [
+                    'status' => 'failed',
+                    'error' => ['code' => 'server_error', 'message' => 'Internal error.'],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events)->toHaveCount(1)
+        ->and($events[0])->toBeInstanceOf(Error::class)
+        ->and($events[0]->type)->toBe('server_error')
+        ->and($events[0]->message)->toBe('Internal error.');
+});
+
+test('streaming response.incomplete ends the stream with usage instead of emptiness', function () {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                $this->outputTextDelta('Partial'),
+                ['type' => 'response.incomplete', 'response' => [
+                    'id' => 'resp_1',
+                    'status' => 'incomplete',
+                    'incomplete_details' => ['reason' => 'max_output_tokens'],
+                    'usage' => [
+                        'input_tokens' => 12,
+                        'output_tokens' => 8,
+                        'input_tokens_details' => ['cached_tokens' => 0],
+                    ],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+    expect($streamEnd->reason)->toBe(FinishReason::Length->value)
+        ->and($streamEnd->usage->promptTokens)->toBe(12)
+        ->and($streamEnd->usage->completionTokens)->toBe(8);
 });
 
 test('streaming captures usage from response completed', function () {

--- a/tests/Feature/Providers/OpenAi/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenAi/TranscriptionTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Transcription;
 
@@ -163,7 +163,7 @@ test('transcription http error response throws request exception', function () {
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
         ->generate(provider: 'openai', model: 'gpt-4o-transcribe');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 function fakeOpenAiTranscriptionResponse(string $text = 'Hello, world!')
 {

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -2,10 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -203,4 +203,4 @@ test('audio http error response throws request exception', function () {
     ]);
 
     Audio::of('Hello')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/OpenRouter/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ErrorHandlingTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -19,7 +19,7 @@ test('http error response throws request exception', function () {
     Http::fake(['openrouter.ai/*' => Http::response(['error' => ['message' => 'Bad request']], 400)]);
 
     (new AssistantAgent)->prompt('Hello', provider: 'openrouter');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake(['openrouter.ai/*' => Http::response(['error' => ['message' => 'Rate limited']], 429)]);

--- a/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
@@ -2,9 +2,9 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\RemoteImage;
@@ -235,4 +235,4 @@ test('image http error response throws request exception', function () {
     ]);
 
     Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -2,10 +2,10 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Transcription;
 use LogicException;
@@ -228,4 +228,4 @@ test('transcription http error response throws request exception', function () {
 
     Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
         ->generate(provider: 'openrouter', model: 'openai/whisper-1');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
 beforeEach(function () {
@@ -98,7 +98,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('embeddings request includes provider options in the request body', function () {
     Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);

--- a/tests/Feature/Providers/VoyageAi/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/VoyageAi/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 
@@ -36,7 +36,7 @@ test('embeddings http error response throws request exception', function () {
     ]);
 
     Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('reranking rate limit response throws rate limited exception', function () {
     Http::fake([
@@ -60,4 +60,4 @@ test('reranking http error response throws request exception', function () {
     ]);
 
     Reranking::of(['doc1'])->rerank('What is AI?', provider: 'voyageai', model: 'rerank-2.5-lite');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/VoyageAi/RerankingTest.php
+++ b/tests/Feature/Providers/VoyageAi/RerankingTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
@@ -87,7 +87,7 @@ test('reranking http error response throws request exception', function () {
     ]);
 
     Reranking::of(['Doc A', 'Doc B'])->rerank('query', provider: 'voyageai', model: 'rerank-2.5-lite');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 function fakeVoyageRerankingResponse()
 {

--- a/tests/Feature/Providers/Xai/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Xai/ErrorHandlingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
 
@@ -25,7 +25,7 @@ test('http error response throws request exception', function () {
     ]);
 
     (new AssistantAgent)->prompt('Hi', provider: 'xai');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);
 
 test('rate limit response throws rate limited exception', function () {
     Http::fake([

--- a/tests/Feature/Providers/Xai/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Xai/ImageGenerationTest.php
@@ -2,9 +2,9 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Image;
 
@@ -132,4 +132,4 @@ test('image http error response throws request exception', function () {
     ]);
 
     Image::of('A red apple')->generate(provider: 'xai', model: 'grok-imagine-image');
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -122,6 +124,91 @@ test('streaming error event stops stream', function () {
         ->and($events[0])->toBeInstanceOf(Error::class)
         ->and($events[0]->type)->toBe('server_error')
         ->and($events[0]->message)->toBe('Internal server error');
+});
+
+test('streaming rate limit error event throws a rate limited exception', function () {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'error', 'code' => 'rate_limit_exceeded', 'message' => 'Rate limit reached on tokens per min (TPM).'],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    try {
+        $this->collectStreamEvents();
+
+        $this->fail('Expected RateLimitedException to be thrown.');
+    } catch (RateLimitedException $e) {
+        expect($e->provider())->toBe('xai')
+            ->and($e->status())->toBe(429);
+    }
+});
+
+test('streaming response.failed with rate limit throws a rate limited exception', function () {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.failed', 'response' => [
+                    'status' => 'failed',
+                    'error' => ['code' => 'rate_limit_exceeded', 'message' => 'Rate limit reached.'],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    expect(fn () => $this->collectStreamEvents())->toThrow(RateLimitedException::class);
+});
+
+test('streaming response.failed with insufficient quota throws an insufficient credits exception', function () {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.failed', 'response' => [
+                    'status' => 'failed',
+                    'error' => ['code' => 'insufficient_quota', 'message' => 'You exceeded your current quota.'],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    expect(fn () => $this->collectStreamEvents())->toThrow(InsufficientCreditsException::class);
+});
+
+test('streaming response.incomplete ends the stream with usage instead of emptiness', function () {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.created', 'response' => ['id' => 'resp_1', 'model' => 'grok-4-1-fast-reasoning', 'status' => 'in_progress']],
+                ['type' => 'response.incomplete', 'response' => [
+                    'id' => 'resp_1',
+                    'status' => 'incomplete',
+                    'incomplete_details' => ['reason' => 'max_output_tokens'],
+                    'usage' => [
+                        'input_tokens' => 12,
+                        'output_tokens' => 8,
+                        'input_tokens_details' => ['cached_tokens' => 0],
+                    ],
+                ]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+    expect($streamEnd->reason)->toBe(FinishReason::Length->value)
+        ->and($streamEnd->usage->promptTokens)->toBe(12)
+        ->and($streamEnd->usage->completionTokens)->toBe(8);
 });
 
 test('streaming finish reason maps correctly', function (string $status, string $type, $expected) {

--- a/tests/Integration/FileTest.php
+++ b/tests/Integration/FileTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Events\FileDeleted;
 use Laravel\Ai\Events\FileStored;
 use Laravel\Ai\Events\StoringFile;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Files\Document;
 
 beforeEach(function () {
@@ -96,4 +96,4 @@ test('can delete files', function () {
     Document::fromId($stored->id)->delete(provider: $this->provider);
 
     Document::fromId($stored->id)->get(provider: $this->provider);
-})->throws(RequestException::class);
+})->throws(ProviderRequestException::class);

--- a/tests/Unit/Gateway/Concerns/HandlesFailoverErrorsTest.php
+++ b/tests/Unit/Gateway/Concerns/HandlesFailoverErrorsTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\ProviderRequestException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 
@@ -43,7 +44,7 @@ test('overriding overloadedStatusCodes replaces the default 503', function () {
     expect(fn () => $this->gateway->withErrorHandling(
         'anthropic',
         fn () => throw failoverableException(503),
-    ))->toThrow(RequestException::class);
+    ))->toThrow(ProviderRequestException::class);
 });
 
 test('429 takes precedence over insufficient credit pattern matching', function () {
@@ -71,11 +72,70 @@ test('402 throws InsufficientCreditsException without requiring patterns', funct
     ))->toThrow(InsufficientCreditsException::class);
 });
 
-test('non-matching message is rethrown as the original RequestException', function () {
-    expect(fn () => $this->gateway->withErrorHandling(
-        'anthropic',
-        fn () => throw failoverableException(400, [
-            'error' => ['message' => 'invalid prompt'],
-        ]),
-    ))->toThrow(RequestException::class);
+test('unmapped status is wrapped in a ProviderRequestException with provider error context', function () {
+    try {
+        $this->gateway->withErrorHandling(
+            'anthropic',
+            fn () => throw failoverableException(400, [
+                'error' => ['message' => "Invalid 'model' provided."],
+            ]),
+        );
+
+        $this->fail('Expected ProviderRequestException to be thrown.');
+    } catch (ProviderRequestException $e) {
+        expect($e->provider())->toBe('anthropic')
+            ->and($e->status())->toBe(400)
+            ->and($e->errorBody())->toBe(['error' => ['message' => "Invalid 'model' provided."]])
+            ->and($e->getMessage())->toContain("Invalid 'model' provided.")
+            ->and($e->getMessage())->toContain('400')
+            ->and($e->getPrevious())->toBeInstanceOf(RequestException::class);
+    }
+});
+
+test('the full raw body is used as the message when no structured error field exists', function () {
+    try {
+        $this->gateway->withErrorHandling(
+            'anthropic',
+            fn () => throw failoverableException(418, ['unexpected' => 'shape']),
+        );
+
+        $this->fail('Expected ProviderRequestException to be thrown.');
+    } catch (ProviderRequestException $e) {
+        expect($e->status())->toBe(418)
+            ->and($e->getMessage())->toContain('unexpected')
+            ->and($e->errorBody())->toBe(['unexpected' => 'shape']);
+    }
+});
+
+test('the provider error message is extracted from varying body shapes', function (array $body, string $expected) {
+    try {
+        $this->gateway->withErrorHandling(
+            'anthropic',
+            fn () => throw failoverableException(400, $body),
+        );
+
+        $this->fail('Expected ProviderRequestException to be thrown.');
+    } catch (ProviderRequestException $e) {
+        expect($e->getMessage())->toContain($expected);
+    }
+})->with([
+    'error.message' => [['error' => ['message' => 'nested message']], 'nested message'],
+    'error string' => [['error' => 'plain string error'], 'plain string error'],
+    'top-level message' => [['message' => 'top message'], 'top message'],
+    'detail' => [['detail' => 'detail message'], 'detail message'],
+]);
+
+test('failover exceptions also carry the provider error context', function () {
+    try {
+        $this->gateway->withErrorHandling(
+            'anthropic',
+            fn () => throw failoverableException(429, ['error' => ['message' => 'slow down']]),
+        );
+
+        $this->fail('Expected RateLimitedException to be thrown.');
+    } catch (RateLimitedException $e) {
+        expect($e->provider())->toBe('anthropic')
+            ->and($e->status())->toBe(429)
+            ->and($e->errorBody())->toBe(['error' => ['message' => 'slow down']]);
+    }
 });


### PR DESCRIPTION
Unmapped provider HTTP errors (e.g. 400/401) previously rethrew the raw Guzzle RequestException, whose message is truncated to ~120 chars and drops the provider's JSON error body entirely, so the calling app only saw a bare status code with no actionable detail.

Centralize error enrichment in HandlesFailoverErrors::withErrorHandling:
- Add ProviderRequestException (extends AiException, non-failoverable) carrying provider name, HTTP status, and the full provider error body, with a rich message. Add provider()/status()/errorBody() accessors + withContext() to the base AiException so every SDK exception shares them.
- Unmapped statuses now throw ProviderRequestException with the extracted provider message and body; 429/402/503 keep their failover types but also carry status + body via withContext().
- Shared extractErrorMessage()/extractErrorBody() helpers handle the varying provider payload shapes (error.message, error string, message, detail, error.status) with a raw-body fallback.
- Unify the 200-body {error:...} validations across all text providers and the Ollama embeddings path to attach the same context (message prefix unchanged).
- Bedrock exceptions carry provider + status for parity.

Update the error-handling test contract: unmapped 4xx now assert ProviderRequestException instead of RequestException across provider feature tests and the file integration test; add coverage for the new context and message extraction.