### PR TITLE
Expose the provider's native response ID on `Meta`

### DIFF
--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -88,7 +88,8 @@ trait ParsesTextResponses
         $citations = $this->extractCitations($content);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($data);
-        $meta = new Meta($provider->name(), $model, $citations);
+        $responseId = $data['id'] ?? null;
+        $meta = new Meta($provider->name(), $model, $citations, $responseId);
 
         $realToolCalls = array_filter($toolCalls, fn (ToolCall $tc) => $tc->name !== 'output_structured_data');
         $hasStructuredToolCall = count($realToolCalls) < count($toolCalls);

--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -92,6 +92,7 @@ trait ParsesTextResponses
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
+        $responseId = $data['id'] ?? null;
 
         $text = $message['content'] ?? '';
         $rawToolCalls = $message['tool_calls'] ?? [];
@@ -111,7 +112,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, responseId: $responseId),
         );
 
         $steps->push($step);
@@ -138,7 +139,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, responseId: $responseId),
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -172,7 +173,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, responseId: $responseId),
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -182,7 +183,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, responseId: $responseId),
         ))->withMessages($messages)->withSteps($steps);
     }
 

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -99,7 +99,8 @@ trait ParsesTextResponses
         $finishReason = $this->extractFinishReason($data, $rawToolCalls);
 
         $mappedToolCalls = $this->mapToolCalls($rawToolCalls);
-        $meta = new Meta($provider->name(), $model, $citations);
+        $responseId = $data['responseId'] ?? null;
+        $meta = new Meta($provider->name(), $model, $citations, $responseId);
         $toolResults = [];
 
         $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -88,6 +88,7 @@ trait ParsesTextResponses
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
+        $responseId = $data['id'] ?? null;
 
         $text = $message['content'] ?? '';
         $rawToolCalls = $message['tool_calls'] ?? [];
@@ -107,7 +108,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, responseId: $responseId),
         );
 
         $steps->push($step);
@@ -129,7 +130,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, responseId: $responseId),
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -163,7 +164,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, responseId: $responseId),
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -173,7 +174,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, responseId: $responseId),
         ))->withMessages($messages)->withSteps($steps);
     }
 

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -106,7 +106,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model, $citations),
+            new Meta($provider->name(), $model, $citations, $responseId ?: null),
         );
 
         $steps->push($step);
@@ -128,7 +128,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model, $citations),
+                new Meta($provider->name(), $model, $citations, $responseId ?: null),
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -164,7 +164,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
+                new Meta($provider->name(), $model, $citations, $responseId ?: null),
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -174,7 +174,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
+            new Meta($provider->name(), $model, $citations, $responseId ?: null),
         ))->withMessages($messages)->withSteps($steps);
     }
 

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -88,6 +88,7 @@ trait ParsesTextResponses
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
+        $responseId = $data['id'] ?? null;
 
         $text = $message['content'] ?? '';
         $rawToolCalls = $message['tool_calls'] ?? [];
@@ -107,7 +108,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, responseId: $responseId),
         );
 
         $steps->push($step);
@@ -129,7 +130,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, responseId: $responseId),
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -163,7 +164,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, responseId: $responseId),
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -173,7 +174,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, responseId: $responseId),
         ))->withMessages($messages)->withSteps($steps);
     }
 

--- a/src/Gateway/Xai/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Xai/Concerns/ParsesTextResponses.php
@@ -107,7 +107,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model, $citations),
+            new Meta($provider->name(), $model, $citations, $responseId ?: null),
         );
 
         $steps->push($step);
@@ -129,7 +129,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model, $citations),
+                new Meta($provider->name(), $model, $citations, $responseId ?: null),
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -151,7 +151,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
+                new Meta($provider->name(), $model, $citations, $responseId ?: null),
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -161,7 +161,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
+            new Meta($provider->name(), $model, $citations, $responseId ?: null),
         ))->withMessages($messages)->withSteps($steps);
     }
 

--- a/src/Responses/Data/Meta.php
+++ b/src/Responses/Data/Meta.php
@@ -14,6 +14,7 @@ class Meta implements Arrayable, JsonSerializable
         public ?string $provider = null,
         public ?string $model = null,
         ?Collection $citations = null,
+        public ?string $responseId = null,
     ) {
         $this->citations = $citations ?? new Collection;
     }
@@ -26,6 +27,7 @@ class Meta implements Arrayable, JsonSerializable
         return [
             'provider' => $this->provider,
             'model' => $this->model,
+            'response_id' => $this->responseId,
             'citations' => $this->citations
                 ? $this->citations->all()
                 : [],

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -314,6 +314,20 @@ describe('response parsing', function () {
         expect($response->text)->toBe('Laravel is a PHP framework');
     });
 
+    test('response meta exposes the provider native response id', function () {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse('Laravel is a PHP framework'),
+        ]);
+
+        $response = (new AssistantAgent)->prompt(
+            'What is Laravel?',
+            provider: 'anthropic',
+        );
+
+        expect($response->meta->responseId)->toBe('msg_123')
+            ->and($response->steps->first()->meta->responseId)->toBe('msg_123');
+    });
+
     test('response usage is correctly parsed', function () {
         Http::fake([
             'api.anthropic.com/*' => Http::response([

--- a/tests/Feature/Providers/DeepSeek/RequestMappingTest.php
+++ b/tests/Feature/Providers/DeepSeek/RequestMappingTest.php
@@ -173,6 +173,15 @@ test('response text is correctly parsed', function () {
         ->and($response->meta->provider)->toBe('deepseek');
 });
 
+test('response meta exposes the provider native response id', function () {
+    Http::fake(['*' => fakeDeepSeekResponse('Laravel is great')]);
+
+    $response = agent()->prompt('Tell me about Laravel', provider: 'deepseek');
+
+    expect($response->meta->responseId)->toBe('chatcmpl-deepseek-123')
+        ->and($response->steps->first()->meta->responseId)->toBe('chatcmpl-deepseek-123');
+});
+
 test('response usage is correctly parsed', function () {
     Http::fake(['*' => Http::response([
         'id' => 'chatcmpl-123',

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -273,6 +273,27 @@ describe('usage parsing', function () {
             ->completionTokens->toBe(50);
     });
 
+    test('response meta exposes the provider native response id', function () {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response([
+                'candidates' => [[
+                    'content' => ['parts' => [['text' => 'Hi']], 'role' => 'model'],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => [
+                    'promptTokenCount' => 10,
+                    'candidatesTokenCount' => 5,
+                ],
+                'responseId' => 'gemini-resp-123',
+            ]),
+        ]);
+
+        $response = (new AssistantAgent)->prompt('Hi', provider: 'gemini');
+
+        expect($response->meta->responseId)->toBe('gemini-resp-123')
+            ->and($response->steps->first()->meta->responseId)->toBe('gemini-resp-123');
+    });
+
     test('thinking response parts are separated from text', function () {
         Http::fake([
             'generativelanguage.googleapis.com/*' => Http::response([

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -181,6 +181,15 @@ test('response text is correctly parsed', function () {
         ->and($response->meta->provider)->toBe('groq');
 });
 
+test('response meta exposes the provider native response id', function () {
+    Http::fake(['*' => fakeGroqResponse('Laravel is great')]);
+
+    $response = agent()->prompt('Tell me about Laravel', provider: 'groq');
+
+    expect($response->meta->responseId)->toBe('chatcmpl-123')
+        ->and($response->steps->first()->meta->responseId)->toBe('chatcmpl-123');
+});
+
 test('response usage is correctly parsed', function () {
     Http::fake(['*' => Http::response([
         'id' => 'chatcmpl-123',

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -162,6 +162,15 @@ test('response text is correctly parsed', function () {
         ->and($response->meta->provider)->toBe('openai');
 });
 
+test('response meta exposes the provider native response id', function () {
+    Http::fake(['*' => fakeOpenAiResponse('Laravel is great')]);
+
+    $response = agent()->prompt('Tell me about Laravel', provider: 'openai');
+
+    expect($response->meta->responseId)->toBe('resp_123')
+        ->and($response->steps->first()->meta->responseId)->toBe('resp_123');
+});
+
 test('response usage is correctly parsed', function () {
     Http::fake(['*' => Http::response([
         'id' => 'resp_123',

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -175,6 +175,15 @@ test('response text is correctly parsed', function () {
         ->and($response->meta->provider)->toBe('openrouter');
 });
 
+test('response meta exposes the provider native response id', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Laravel is great')]);
+
+    $response = agent()->prompt('Tell me about Laravel', provider: 'openrouter');
+
+    expect($response->meta->responseId)->toBe('chatcmpl-123')
+        ->and($response->steps->first()->meta->responseId)->toBe('chatcmpl-123');
+});
+
 test('response usage is correctly parsed', function () {
     Http::fake(['*' => Http::response([
         'id' => 'chatcmpl-123',

--- a/tests/Feature/Providers/Xai/RequestMappingTest.php
+++ b/tests/Feature/Providers/Xai/RequestMappingTest.php
@@ -167,6 +167,15 @@ test('response text is correctly parsed', function () {
         ->and($response->meta->provider)->toBe('xai');
 });
 
+test('response meta exposes the provider native response id', function () {
+    Http::fake(['*' => fakeXaiRequestMappingResponse('Laravel is great')]);
+
+    $response = agent()->prompt('Tell me about Laravel', provider: 'xai');
+
+    expect($response->meta->responseId)->toBe('resp_123')
+        ->and($response->steps->first()->meta->responseId)->toBe('resp_123');
+});
+
 test('response usage is correctly parsed', function () {
     Http::fake(['*' => Http::response([
         'id' => 'resp_123',

--- a/tests/Unit/Responses/Data/MetaTest.php
+++ b/tests/Unit/Responses/Data/MetaTest.php
@@ -40,3 +40,36 @@ test('meta json serialize returns to array', function () {
     expect($json['provider'])->toBe('anthropic')
         ->and($json['model'])->toBe('claude-3-opus');
 });
+
+test('meta defaults response id to null', function () {
+    $meta = new Meta('openai', 'gpt-4o');
+
+    expect($meta->responseId)->toBeNull();
+});
+
+test('meta stores response id passed as the last argument', function () {
+    $meta = new Meta('openai', 'gpt-4o', null, 'resp_123');
+
+    expect($meta->responseId)->toBe('resp_123');
+});
+
+test('meta to array includes response id', function () {
+    $meta = new Meta('openai', 'gpt-4o', null, 'resp_123');
+
+    $array = $meta->toArray();
+
+    expect($array)->toHaveKey('response_id')
+        ->and($array['response_id'])->toBe('resp_123');
+});
+
+test('meta to array response id is null when not provided', function () {
+    $meta = new Meta('openai', 'gpt-4o');
+
+    expect($meta->toArray()['response_id'])->toBeNull();
+});
+
+test('meta json serialize includes response id', function () {
+    $meta = new Meta('openai', 'gpt-4o', null, 'resp_123');
+
+    expect($meta->jsonSerialize()['response_id'])->toBe('resp_123');
+});


### PR DESCRIPTION
Closes #675.

## Problem

Every provider returns a native response identifier (OpenAI Responses API `resp_...`, xAI response `id`, Anthropic message `id`, Gemini `responseId`, OpenAI-compatible providers `chatcmpl-...`). Providers reference this ID in their dashboards, usage/billing exports, and support tickets, so it's the natural key for correlating an SDK call with provider-side records.

Until now the SDK never surfaced it: the OpenAI/xAI gateways already read `$data['id']`, but only to feed `previous_response_id` on tool follow-ups, then discarded it. `Meta` exposed only `provider` / `model` / `citations`. The only identifier available to consumers was `invocationId`, a locally generated UUID that is meaningless to the provider.

## Change

Add a nullable `responseId` to `Meta`, appended as the **last** constructor parameter so existing positional `new Meta($provider, $model[, $citations])` call sites are unaffected. `toArray()` / `jsonSerialize()` gain a `response_id` key.

Each text gateway populates it from the provider's native field:

| Provider | Source |
| --- | --- |
| OpenAI / xAI | `$data['id']` (`resp_...`) |
| Anthropic | `$data['id']` (`msg_...`) |
| Gemini | `$data['responseId']` |
| Groq / DeepSeek / OpenRouter | `$data['id']` (`chatcmpl-...`) |

**Ollama and Bedrock are intentionally left `null`:** Ollama's chat response carries no id field, and Bedrock's request id is only returned in HTTP headers (not the response body) — both are out of scope for this body-level change.

Streaming responses are likewise out of scope for now (the id arrives through stream events on a different code path); streamed `Meta` keeps `null` and can be wired in a follow-up.

## Backwards compatibility

`responseId` is nullable, defaults to `null`, and is the last constructor parameter, so existing positional construction and consumer code are unaffected. The OpenAI/xAI `previous_response_id` tool-loop behavior is untouched (that variable is left exactly as-is; only the value passed to `Meta` is normalized to `null` when empty).

## Tests

- Unit (`MetaTest`): defaults to `null`, stores the value when passed, and exposes `response_id` in `toArray()` / `jsonSerialize()`.
- Feature: each of the seven wired providers asserts that `$response->meta->responseId` (and the step-level `Meta`) carries the native id.

`composer test` (1537 passed), `pint`, and `phpstan` all pass.

---

Related to #636 (exposing the underlying response headers) — same theme of surfacing more of the underlying provider response.
