### PR TITLE
feat: allow passing an mcp server to the agent to expose its tools

### DIFF
--- a/src/Contracts/HasTools.php
+++ b/src/Contracts/HasTools.php
@@ -11,8 +11,6 @@ interface HasTools
      * Agent instances (treated as sub-agents), raw MCP client/server primitives,
      * MCP server classes/instances, or McpServer wrappers. The SDK resolves and
      * wraps values as needed before passing them to the model.
-     *
-     * @return iterable
      */
     public function tools(): iterable;
 }

--- a/src/Contracts/HasTools.php
+++ b/src/Contracts/HasTools.php
@@ -2,14 +2,17 @@
 
 namespace Laravel\Ai\Contracts;
 
-use Laravel\Ai\Providers\Tools\ProviderTool;
-
 interface HasTools
 {
     /**
      * Get the tools available to the agent.
      *
-     * @return array<Tool|ProviderTool>
+     * Items may include Tool instances, ProviderTool instances (e.g. WebSearch),
+     * Agent instances (treated as sub-agents), raw MCP client/server primitives,
+     * MCP server classes/instances, or McpServer wrappers. The SDK resolves and
+     * wraps values as needed before passing them to the model.
+     *
+     * @return iterable
      */
     public function tools(): iterable;
 }

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -25,6 +25,7 @@ use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Tools\AgentTool;
+use Laravel\Ai\Tools\McpServer;
 use Laravel\Ai\Tools\McpServerTool;
 use Laravel\Ai\Tools\McpTool;
 
@@ -120,23 +121,26 @@ trait GeneratesText
             return [];
         }
 
-        return array_map(
-            fn ($tool) => $this->resolveTool($tool),
-            [...$agent->tools()],
-        );
+        return collect($agent->tools())
+            ->flatMap(fn ($tool) => $this->resolveTool($tool))
+            ->all();
     }
 
     /**
      * Resolve a tool returned by the agent into a native tool instance when needed.
+     *
+     * @return array<int, mixed>
      */
-    protected function resolveTool(mixed $tool): mixed
+    protected function resolveTool(mixed $tool): array
     {
         return match (true) {
-            $tool instanceof Agent => new AgentTool($tool),
-            $tool instanceof Tool => $tool,
-            McpTool::supports($tool) => new McpTool($tool),
-            McpServerTool::supports($tool) => new McpServerTool($tool),
-            default => $tool,
+            $tool instanceof Agent => [new AgentTool($tool)],
+            $tool instanceof Tool => [$tool],
+            McpTool::supports($tool) => [new McpTool($tool)],
+            McpServerTool::supports($tool) => [new McpServerTool($tool)],
+            $tool instanceof McpServer => $tool->tools(),
+            McpServer::supports($tool) => (new McpServer($tool))->tools(),
+            default => [$tool],
         };
     }
 

--- a/src/Tools/McpServer.php
+++ b/src/Tools/McpServer.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Laravel\Ai\Tools;
+
+use ArrayIterator;
+use Illuminate\Container\Container;
+use IteratorAggregate;
+use Traversable;
+
+class McpServer implements IteratorAggregate
+{
+    /**
+     * The MCP server class name.
+     */
+    protected const MCP_SERVER = 'Laravel\\Mcp\\Server';
+
+    /**
+     * The fake transporter class name used for in-process tool discovery.
+     */
+    protected const FAKE_TRANSPORT = 'Laravel\\Mcp\\Server\\Transport\\FakeTransporter';
+
+    /**
+     * Create a new MCP server wrapper instance.
+     */
+    public function __construct(protected string|object $server) {}
+
+    /**
+     * Create a new MCP server wrapper for the given server class or instance.
+     */
+    public static function make(string|object $server): static
+    {
+        return new static($server);
+    }
+
+    /**
+     * Determine whether the given value is an MCP server definition.
+     */
+    public static function supports(mixed $value): bool
+    {
+        if (! class_exists(self::MCP_SERVER)) {
+            return false;
+        }
+
+        if (is_string($value)) {
+            return class_exists($value) && is_a($value, self::MCP_SERVER, true);
+        }
+
+        return is_object($value) && is_a($value, self::MCP_SERVER);
+    }
+
+    /**
+     * Get the individual MCP server tools wrapped for the AI SDK.
+     *
+     * @return array<int, McpServerTool>
+     */
+    public function tools(): array
+    {
+        $instance = $this->resolveInstance();
+
+        if (! is_object($instance) || ! method_exists($instance, 'createContext')) {
+            return [];
+        }
+
+        return $instance
+            ->createContext()
+            ->tools()
+            ->map(fn (object $tool) => new McpServerTool($tool))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Allow spreading the wrapper directly to yield the wrapped tools.
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->tools());
+    }
+
+    /**
+     * Resolve a server instance, using a fake transport when constructing from a class string.
+     */
+    protected function resolveInstance(): object
+    {
+        if (is_object($this->server)) {
+            return $this->server;
+        }
+
+        $container = Container::getInstance();
+
+        $transportClass = self::FAKE_TRANSPORT;
+        $transport = class_exists($transportClass) ? new $transportClass : null;
+
+        return $container->make($this->server, ['transport' => $transport]);
+    }
+}

--- a/tests/Feature/McpServerIntegrationTest.php
+++ b/tests/Feature/McpServerIntegrationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Tools\McpServer;
+use Tests\Fixtures\Mcp\FakeMcpServer;
+
+test('agents can spread an mcp server wrapper to expose its tools like remote clients', function () {
+    $agent = new class implements Agent, HasTools
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'Use available tools.';
+        }
+
+        public function tools(): iterable
+        {
+            return [
+                ...McpServer::make(FakeMcpServer::class),
+                // mix with regular tools if desired
+            ];
+        }
+    };
+
+    $agent::fake([
+        new ToolCall('call_123', 'fake-mcp-server-tool', ['city' => 'Paris']),
+        'Done.',
+    ]);
+
+    $response = $agent->prompt('What is the weather in Paris?');
+
+    expect($response)
+        ->toolCalls->toHaveCount(1)
+        ->toolResults->toHaveCount(1);
+
+    expect($response->toolResults->first())->toHaveProperty('result', 'Sunny in Paris.');
+});
+
+test('agents can list an mcp server class directly (no spread) and we auto-wrap its tools', function () {
+    $agent = new class implements Agent, HasTools
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'Use available tools.';
+        }
+
+        public function tools(): iterable
+        {
+            return [
+                FakeMcpServer::class,
+            ];
+        }
+    };
+
+    $agent::fake([
+        new ToolCall('call_123', 'fake-structured-mcp-server-tool', ['city' => 'Paris']),
+        'Done.',
+    ]);
+
+    $response = $agent->prompt('Get structured weather');
+
+    expect($response)
+        ->toolCalls->toHaveCount(1)
+        ->toolResults->toHaveCount(1);
+
+    $result = $response->toolResults->first()->result;
+    expect(json_decode($result, true))->toMatchArray([
+        'temperature' => 72,
+        'conditions' => 'Sunny',
+    ]);
+});
+
+test('agents can list a raw mcp server instance directly', function () {
+    $agent = new class implements Agent, HasTools
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'Use available tools.';
+        }
+
+        public function tools(): iterable
+        {
+            return [
+                new FakeMcpServer,
+            ];
+        }
+    };
+
+    $agent::fake([
+        new ToolCall('call_123', 'fake-mcp-server-tool', ['city' => 'Paris']),
+        'Done.',
+    ]);
+
+    $response = $agent->prompt('What is the weather in Paris?');
+
+    expect($response)
+        ->toolCalls->toHaveCount(1)
+        ->toolResults->toHaveCount(1);
+
+    expect($response->toolResults->first())->toHaveProperty('result', 'Sunny in Paris.');
+});

--- a/tests/Fixtures/Mcp/FakeMcpServer.php
+++ b/tests/Fixtures/Mcp/FakeMcpServer.php
@@ -14,6 +14,6 @@ class FakeMcpServer extends Server
 
     public function __construct()
     {
-        parent::__construct(new FakeTransporter());
+        parent::__construct(new FakeTransporter);
     }
 }

--- a/tests/Fixtures/Mcp/FakeMcpServer.php
+++ b/tests/Fixtures/Mcp/FakeMcpServer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Fixtures\Mcp;
+
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Transport\FakeTransporter;
+
+class FakeMcpServer extends Server
+{
+    protected array $tools = [
+        FakeMcpServerTool::class,
+        FakeStructuredMcpServerTool::class,
+    ];
+
+    public function __construct()
+    {
+        parent::__construct(new FakeTransporter());
+    }
+}

--- a/tests/Unit/Tools/McpServerTest.php
+++ b/tests/Unit/Tools/McpServerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Container\Container;
+use Laravel\Ai\Tools\McpServer;
+use Laravel\Ai\Tools\McpServerTool;
+use Tests\Fixtures\Mcp\FakeMcpServer;
+
+beforeEach(function () {
+    Container::setInstance(new Container);
+});
+
+test('it detects mcp server classes and instances', function () {
+    expect([
+        McpServer::supports(FakeMcpServer::class),
+        McpServer::supports(new FakeMcpServer),
+        McpServer::supports(new stdClass),
+        McpServer::supports('NonExistentClass'),
+    ])->sequence(
+        fn ($s) => $s->toBeTrue(),
+        fn ($s) => $s->toBeTrue(),
+        fn ($s) => $s->toBeFalse(),
+        fn ($s) => $s->toBeFalse(),
+    );
+});
+
+test('it returns wrapped tools from a server class string', function () {
+    $server = new McpServer(FakeMcpServer::class);
+
+    $tools = $server->tools();
+
+    expect($tools)->toHaveCount(2);
+    expect($tools[0])->toBeInstanceOf(McpServerTool::class);
+    expect($tools[0]->name())->toBe('fake-mcp-server-tool');
+    expect($tools[1]->name())->toBe('fake-structured-mcp-server-tool');
+});
+
+test('it returns wrapped tools from a server instance', function () {
+    $instance = new FakeMcpServer;
+    $server = new McpServer($instance);
+
+    $tools = $server->tools();
+
+    expect($tools)->toHaveCount(2);
+    expect($tools[0]->name())->toBe('fake-mcp-server-tool');
+});
+
+test('it can be iterated to yield wrapped tools', function () {
+    $server = McpServer::make(FakeMcpServer::class);
+
+    $collected = [];
+    foreach ($server as $tool) {
+        $collected[] = $tool;
+    }
+
+    expect($collected)->toHaveCount(2)
+        ->and($collected[0])->toBeInstanceOf(McpServerTool::class);
+});
+
+test('make is a static factory', function () {
+    $server = McpServer::make(FakeMcpServer::class);
+
+    expect($server)->toBeInstanceOf(McpServer::class);
+    expect($server->tools())->toHaveCount(2);
+});


### PR DESCRIPTION
Hello!

## Support passing local MCP servers directly to agents

When an MCP server lives inside the same application, requiring agents to manually return individual `Laravel\Mcp\Server\Tool` instances (or hard-code URLs) is awkward and fragile across environments.

This adds `McpServer` so agents can reference mcp servers in the same application the same way they already spread remote client tools:

```php
use Laravel\Ai\Tools\McpServer;
use App\Mcp\Servers\AppToolsServer;

public function tools(): iterable
{
    return [
        ...McpServer::make(AppToolsServer::class),
        new SomeOtherTool,
    ];
}

// or simply list the server
public function tools(): iterable
{
    return [AppToolsServer::class];
}
```

- `McpServer::make($server)` (or passing a server class/instance) auto-expands to wrapped tools.
- Fully in-process (no transport/URLs), consistent with existing `McpServerTool` behavior for single tools.
- Works for `prompt` + `stream`, mixes cleanly with other tools/agents/provider tools.
- No changes to individual tool usage or remote MCP clients.

Thanks!