### PR TITLE
Add collection generics to AssistantMessage toolCalls

### DIFF
--- a/src/Messages/AssistantMessage.php
+++ b/src/Messages/AssistantMessage.php
@@ -3,9 +3,11 @@
 namespace Laravel\Ai\Messages;
 
 use Illuminate\Support\Collection;
+use Laravel\Ai\Responses\Data\ToolCall;
 
 class AssistantMessage extends Message
 {
+    /** @var Collection<int, ToolCall> */
     public Collection $toolCalls;
 
     /**
@@ -18,6 +20,7 @@ class AssistantMessage extends Message
     /**
      * Create a new text conversation message instance.
      *
+     * @param  Collection<int, ToolCall>|null  $toolCalls
      * @param  array<int, array<string, mixed>>  $providerContentBlocks
      */
     public function __construct(string $content, ?Collection $toolCalls = null, array $providerContentBlocks = [])


### PR DESCRIPTION
`AssistantMessage::$toolCalls` is an untyped `Collection`, so static analysis and IDEs see its elements as `mixed`. This types it as `Collection<int, ToolCall>` (property and constructor `@param`), matching how the collection is always                                                                                                                                                             
  populated:                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - `DatabaseConversationStore` builds it via `$toolCalls->map(ToolCall::fromArray(...))`.                                                                                                                                               
  - Every gateway passes a collection of `ToolCall` instances (`collect($mappedToolCalls)`, `new Collection($toolCalls)`, etc.). 