### PR TITLE
Add response cost reporting and per-agent budget guardrails

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -40,6 +40,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Model Pricing
+    |--------------------------------------------------------------------------
+    |
+    | Per-model token rates, in USD per 1,000,000 tokens, used to compute the
+    | cost of responses via $response->cost(). Values defined here are merged
+    | over the SDK's built-in defaults, so you only need to list models you
+    | want to add or override. Models without pricing simply report an
+    | "unknown" cost rather than throwing.
+    |
+    */
+
+    'pricing' => [
+        'models' => [
+            // 'openai' => [
+            //     'gpt-4o' => ['input' => 2.50, 'output' => 10.00],
+            // ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | AI Providers
     |--------------------------------------------------------------------------
     |

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -12,6 +12,9 @@ use Laravel\Ai\Console\Commands\MakeAgentMiddlewareCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Pricing\BudgetMeter;
+use Laravel\Ai\Pricing\CostCalculator;
+use Laravel\Ai\Pricing\PriceList;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 
 class AiServiceProvider extends ServiceProvider
@@ -26,6 +29,12 @@ class AiServiceProvider extends ServiceProvider
         $this->app->singleton(ConversationStore::class, fn () => new DatabaseConversationStore(
             config('ai.conversations.connection'),
         ));
+
+        $this->app->singleton(PriceList::class, fn () => new PriceList(
+            config('ai.pricing.models', []),
+        ));
+        $this->app->singleton(CostCalculator::class);
+        $this->app->singleton(BudgetMeter::class);
 
         $this->mergeConfigFrom(__DIR__.'/../config/ai.php', 'ai');
     }

--- a/src/Attributes/MaxCost.php
+++ b/src/Attributes/MaxCost.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class MaxCost
+{
+    public function __construct(public float $value)
+    {
+        //
+    }
+}

--- a/src/Exceptions/BudgetExceededException.php
+++ b/src/Exceptions/BudgetExceededException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+class BudgetExceededException extends AiException
+{
+    /**
+     * Create an exception for an agent that has exhausted its cost budget.
+     */
+    public static function forAgent(string $agent, float $spent, float $limit): self
+    {
+        return new self(sprintf(
+            'Agent [%s] has exceeded its cost budget of $%s (spent $%s).',
+            $agent,
+            number_format($limit, 4),
+            number_format($spent, 4),
+        ));
+    }
+}

--- a/src/Middleware/EnforceBudget.php
+++ b/src/Middleware/EnforceBudget.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Ai\Middleware;
+
+use Closure;
+use Laravel\Ai\Exceptions\BudgetExceededException;
+use Laravel\Ai\Pricing\BudgetMeter;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\TextResponse;
+
+class EnforceBudget
+{
+    /**
+     * Create a new budget-enforcing middleware instance.
+     */
+    public function __construct(
+        protected BudgetMeter $meter,
+        protected float $limit,
+    ) {}
+
+    /**
+     * Handle the incoming prompt, blocking it once the agent's budget is exhausted.
+     *
+     * Enforcement is pre-flight against accumulated spend within the current
+     * process: once an agent has spent its limit, the next prompt is rejected
+     * before any model call is made. Costs for models without known pricing
+     * record as zero, so an unknown-priced model never trips the budget.
+     */
+    public function handle(AgentPrompt $prompt, Closure $next)
+    {
+        $key = $prompt->agent::class;
+
+        if ($this->meter->spent($key) >= $this->limit) {
+            throw BudgetExceededException::forAgent($key, $this->meter->spent($key), $this->limit);
+        }
+
+        $response = $next($prompt);
+
+        if ($response instanceof TextResponse) {
+            $this->meter->record($key, $response->cost());
+        }
+
+        return $response;
+    }
+}

--- a/src/Pricing/BudgetMeter.php
+++ b/src/Pricing/BudgetMeter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Laravel\Ai\Pricing;
+
+use Laravel\Ai\Responses\Data\Cost;
+
+class BudgetMeter
+{
+    /**
+     * Dollars spent within the current process, keyed by bucket (e.g. agent class).
+     *
+     * @var array<string, float>
+     */
+    protected array $spent = [];
+
+    /**
+     * Record spend against the given bucket.
+     */
+    public function record(string $key, Cost $cost): void
+    {
+        $this->spent[$key] = ($this->spent[$key] ?? 0.0) + $cost->total();
+    }
+
+    /**
+     * Get the amount spent against the given bucket.
+     */
+    public function spent(string $key): float
+    {
+        return $this->spent[$key] ?? 0.0;
+    }
+
+    /**
+     * Get the total amount spent across every bucket.
+     */
+    public function total(): float
+    {
+        return array_sum($this->spent);
+    }
+
+    /**
+     * Reset spend for a single bucket, or all buckets when none is given.
+     */
+    public function reset(?string $key = null): void
+    {
+        if ($key === null) {
+            $this->spent = [];
+
+            return;
+        }
+
+        unset($this->spent[$key]);
+    }
+}

--- a/src/Pricing/CostCalculator.php
+++ b/src/Pricing/CostCalculator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Ai\Pricing;
+
+use Laravel\Ai\Responses\Data\Cost;
+use Laravel\Ai\Responses\Data\Usage;
+
+class CostCalculator
+{
+    public function __construct(protected PriceList $prices) {}
+
+    /**
+     * Calculate the cost of the given usage for a provider and model.
+     *
+     * Returns an "unknown" cost (total 0, isKnown() === false) when no pricing
+     * is available, so cost reporting is always safe and never throws.
+     */
+    public function calculate(Usage $usage, ?string $provider, ?string $model): Cost
+    {
+        $pricing = $this->prices->for($provider, $model);
+
+        if ($pricing === null) {
+            return Cost::unknown();
+        }
+
+        $rate = static fn (int $tokens, ?float $perMillion): float => $perMillion === null
+            ? 0.0
+            : $tokens / 1_000_000 * $perMillion;
+
+        return new Cost(
+            input: $rate($usage->promptTokens, $pricing->input),
+            output: $rate($usage->completionTokens, $pricing->output),
+            cacheRead: $rate($usage->cacheReadInputTokens, $pricing->cacheRead),
+            cacheWrite: $rate($usage->cacheWriteInputTokens, $pricing->cacheWrite),
+            reasoning: $rate($usage->reasoningTokens, $pricing->reasoning),
+            currency: $pricing->currency,
+        );
+    }
+}

--- a/src/Pricing/ModelPricing.php
+++ b/src/Pricing/ModelPricing.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Ai\Pricing;
+
+class ModelPricing
+{
+    /**
+     * Rates are expressed in the given currency per 1,000,000 tokens.
+     *
+     * A null cache/reasoning rate means those tokens are not billed separately
+     * (the common case, where they are already folded into input/output by the
+     * provider), so they contribute nothing to the computed cost.
+     */
+    public function __construct(
+        public float $input = 0.0,
+        public float $output = 0.0,
+        public ?float $cacheRead = null,
+        public ?float $cacheWrite = null,
+        public ?float $reasoning = null,
+        public string $currency = 'USD',
+    ) {}
+
+    /**
+     * Create a pricing instance from a loosely-typed config array.
+     *
+     * @param  array<string, mixed>  $rates
+     */
+    public static function fromArray(array $rates): self
+    {
+        return new self(
+            input: (float) ($rates['input'] ?? 0.0),
+            output: (float) ($rates['output'] ?? 0.0),
+            cacheRead: isset($rates['cache_read']) ? (float) $rates['cache_read'] : null,
+            cacheWrite: isset($rates['cache_write']) ? (float) $rates['cache_write'] : null,
+            reasoning: isset($rates['reasoning']) ? (float) $rates['reasoning'] : null,
+            currency: $rates['currency'] ?? 'USD',
+        );
+    }
+}

--- a/src/Pricing/PriceList.php
+++ b/src/Pricing/PriceList.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Laravel\Ai\Pricing;
+
+class PriceList
+{
+    /**
+     * Pricing registered at runtime, keyed by provider then model.
+     *
+     * @var array<string, array<string, ModelPricing>>
+     */
+    protected array $registered = [];
+
+    /**
+     * @param  array<string, array<string, array<string, mixed>>>  $overrides  Config-supplied rates, merged over the built-in defaults.
+     */
+    public function __construct(protected array $overrides = []) {}
+
+    /**
+     * Register (or override) pricing for a given provider and model.
+     */
+    public function register(string $provider, string $model, ModelPricing $pricing): self
+    {
+        $this->registered[$provider][$model] = $pricing;
+
+        return $this;
+    }
+
+    /**
+     * Resolve the pricing for the given provider and model, if known.
+     *
+     * Resolution order per provider: built-in defaults, then config('ai.pricing.models'),
+     * then anything registered at runtime. Models are matched exactly, otherwise by the
+     * longest key contained in the model id (so versioned ids like "claude-sonnet-4-6"
+     * still resolve to "claude-sonnet-4").
+     */
+    public function for(?string $provider, ?string $model): ?ModelPricing
+    {
+        if ($provider === null || $model === null) {
+            return null;
+        }
+
+        $table = $this->table($provider);
+
+        if ($table === []) {
+            return null;
+        }
+
+        if (isset($table[$model])) {
+            return $this->normalize($table[$model]);
+        }
+
+        $bestKey = null;
+
+        foreach ($table as $key => $rates) {
+            if ($key !== '' && str_contains($model, (string) $key)) {
+                if ($bestKey === null || strlen((string) $key) > strlen($bestKey)) {
+                    $bestKey = (string) $key;
+                }
+            }
+        }
+
+        return $bestKey !== null ? $this->normalize($table[$bestKey]) : null;
+    }
+
+    /**
+     * Get the merged pricing table for the given provider.
+     *
+     * @return array<string, ModelPricing|array<string, mixed>>
+     */
+    protected function table(string $provider): array
+    {
+        return array_replace(
+            static::defaults()[$provider] ?? [],
+            $this->overrides[$provider] ?? [],
+            $this->registered[$provider] ?? [],
+        );
+    }
+
+    /**
+     * Normalize a table entry into a ModelPricing instance.
+     *
+     * @param  ModelPricing|array<string, mixed>  $rates
+     */
+    protected function normalize(ModelPricing|array $rates): ModelPricing
+    {
+        return $rates instanceof ModelPricing ? $rates : ModelPricing::fromArray($rates);
+    }
+
+    /**
+     * The built-in default price table, in USD per 1,000,000 tokens.
+     *
+     * These are estimates as of 2026-06 and are intended as a convenience; they
+     * can drift as providers change pricing. Override or extend them via the
+     * config('ai.pricing.models') array or PriceList::register().
+     *
+     * @return array<string, array<string, array<string, float>>>
+     */
+    public static function defaults(): array
+    {
+        return [
+            'openai' => [
+                'gpt-4o-mini' => ['input' => 0.15, 'output' => 0.60],
+                'gpt-4o' => ['input' => 2.50, 'output' => 10.00],
+                'gpt-4.1-nano' => ['input' => 0.10, 'output' => 0.40],
+                'gpt-4.1-mini' => ['input' => 0.40, 'output' => 1.60],
+                'gpt-4.1' => ['input' => 2.00, 'output' => 8.00],
+                'o4-mini' => ['input' => 1.10, 'output' => 4.40],
+                'o3' => ['input' => 2.00, 'output' => 8.00],
+            ],
+            'anthropic' => [
+                'claude-opus-4' => ['input' => 15.00, 'output' => 75.00],
+                'claude-sonnet-4' => ['input' => 3.00, 'output' => 15.00],
+                'claude-haiku-4' => ['input' => 1.00, 'output' => 5.00],
+                'claude-3-5-haiku' => ['input' => 0.80, 'output' => 4.00],
+                'claude-3-5-sonnet' => ['input' => 3.00, 'output' => 15.00],
+            ],
+            'gemini' => [
+                'gemini-2.5-flash-lite' => ['input' => 0.10, 'output' => 0.40],
+                'gemini-2.5-flash' => ['input' => 0.30, 'output' => 2.50],
+                'gemini-2.5-pro' => ['input' => 1.25, 'output' => 10.00],
+            ],
+        ];
+    }
+}

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Attributes\MaxCost;
 use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
@@ -20,13 +21,16 @@ use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Middleware\EnforceBudget;
 use Laravel\Ai\Middleware\RememberConversation;
+use Laravel\Ai\Pricing\BudgetMeter;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Tools\AgentTool;
 use Laravel\Ai\Tools\McpServerTool;
 use Laravel\Ai\Tools\McpTool;
+use ReflectionClass;
 
 use function Laravel\Ai\pipeline;
 
@@ -104,6 +108,13 @@ trait GeneratesText
         if (in_array(RemembersConversations::class, class_uses_recursive($agent))
             && $agent->hasConversationParticipant()) {
             $middleware[] = new RememberConversation(resolve(ConversationStore::class), $this);
+        }
+
+        if ($budget = (new ReflectionClass($agent))->getAttributes(MaxCost::class)) {
+            array_unshift($middleware, new EnforceBudget(
+                resolve(BudgetMeter::class),
+                (float) $budget[0]->newInstance()->value,
+            ));
         }
 
         return $agent instanceof HasMiddleware

--- a/src/Responses/Data/Cost.php
+++ b/src/Responses/Data/Cost.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Laravel\Ai\Responses\Data;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class Cost implements Arrayable, JsonSerializable
+{
+    public function __construct(
+        public float $input = 0.0,
+        public float $output = 0.0,
+        public float $cacheRead = 0.0,
+        public float $cacheWrite = 0.0,
+        public float $reasoning = 0.0,
+        public string $currency = 'USD',
+        public bool $known = true,
+    ) {}
+
+    /**
+     * Create a cost representing a model with no known pricing.
+     */
+    public static function unknown(string $currency = 'USD'): self
+    {
+        return new self(currency: $currency, known: false);
+    }
+
+    /**
+     * Get the total cost across every component.
+     */
+    public function total(): float
+    {
+        return $this->input + $this->output + $this->cacheRead + $this->cacheWrite + $this->reasoning;
+    }
+
+    /**
+     * Determine if the cost was computed from known pricing.
+     */
+    public function isKnown(): bool
+    {
+        return $this->known;
+    }
+
+    /**
+     * Add the given cost to the current cost and return a new instance.
+     */
+    public function add(Cost $other): self
+    {
+        return new self(
+            $this->input + $other->input,
+            $this->output + $other->output,
+            $this->cacheRead + $other->cacheRead,
+            $this->cacheWrite + $other->cacheWrite,
+            $this->reasoning + $other->reasoning,
+            $this->currency,
+            $this->known && $other->known,
+        );
+    }
+
+    /**
+     * Get a human-readable representation of the total cost.
+     */
+    public function format(int $precision = 4): string
+    {
+        $amount = number_format($this->total(), $precision);
+
+        return $this->currency === 'USD' ? '$'.$amount : $amount.' '.$this->currency;
+    }
+
+    /**
+     * Get the per-component cost breakdown.
+     *
+     * @return array<string, float>
+     */
+    public function breakdown(): array
+    {
+        return [
+            'input' => $this->input,
+            'output' => $this->output,
+            'cache_read' => $this->cacheRead,
+            'cache_write' => $this->cacheWrite,
+            'reasoning' => $this->reasoning,
+        ];
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'total' => $this->total(),
+            'currency' => $this->currency,
+            'known' => $this->known,
+            ...$this->breakdown(),
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Responses/Data/Step.php
+++ b/src/Responses/Data/Step.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Responses\Data;
 
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
+use Laravel\Ai\Pricing\CostCalculator;
 
 class Step implements Arrayable, JsonSerializable
 {
@@ -19,6 +20,18 @@ class Step implements Arrayable, JsonSerializable
         public Usage $usage,
         public Meta $meta,
     ) {}
+
+    /**
+     * Get the estimated cost of this step based on its usage and model pricing.
+     */
+    public function cost(): Cost
+    {
+        return app(CostCalculator::class)->calculate(
+            $this->usage,
+            $this->meta->provider,
+            $this->meta->model,
+        );
+    }
 
     /**
      * Get the instance as an array.

--- a/src/Responses/TextResponse.php
+++ b/src/Responses/TextResponse.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Collection;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Pricing\CostCalculator;
+use Laravel\Ai\Responses\Data\Cost;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -88,6 +90,18 @@ class TextResponse
         $this->steps = $steps;
 
         return $this;
+    }
+
+    /**
+     * Get the estimated cost of the response based on its usage and model pricing.
+     */
+    public function cost(): Cost
+    {
+        return app(CostCalculator::class)->calculate(
+            $this->usage,
+            $this->meta->provider,
+            $this->meta->model,
+        );
     }
 
     /**

--- a/tests/Feature/BudgetTest.php
+++ b/tests/Feature/BudgetTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Laravel\Ai\Exceptions\BudgetExceededException;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TextResponse;
+use Tests\Fixtures\Agents\BudgetedAgent;
+
+test('an agent with a MaxCost budget throws once its budget is exhausted', function () {
+    config(['ai.pricing.models' => [
+        'openai' => ['budget-test-model' => ['input' => 0.006]],
+    ]]);
+
+    // Each call costs $0.006 (1M prompt tokens * $0.006/1M); the agent's budget is $0.005.
+    BudgetedAgent::fake(fn () => new TextResponse(
+        'ok',
+        new Usage(promptTokens: 1_000_000),
+        new Meta('openai', 'budget-test-model'),
+    ));
+
+    // First call is under budget and succeeds...
+    expect((new BudgetedAgent)->prompt('first')->text)->toBe('ok');
+
+    // Accumulated $0.006 now exceeds the $0.005 budget, so the next call is blocked.
+    expect(fn () => (new BudgetedAgent)->prompt('second'))
+        ->toThrow(BudgetExceededException::class);
+});
+
+test('budget does not trip for models without known pricing', function () {
+    BudgetedAgent::fake(fn () => new TextResponse(
+        'ok',
+        new Usage(promptTokens: 1_000_000),
+        new Meta('openai', 'unpriced-model'),
+    ));
+
+    expect((new BudgetedAgent)->prompt('first')->text)->toBe('ok')
+        ->and((new BudgetedAgent)->prompt('second')->text)->toBe('ok');
+});

--- a/tests/Feature/CostTest.php
+++ b/tests/Feature/CostTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TextResponse;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+test('response exposes its dollar cost from usage and model pricing', function () {
+    config(['ai.pricing.models' => [
+        'openai' => ['cost-test-model' => ['input' => 2.0, 'output' => 8.0]],
+    ]]);
+
+    AssistantAgent::fake(fn () => new TextResponse(
+        'Hello',
+        new Usage(promptTokens: 1_000_000, completionTokens: 500_000),
+        new Meta('openai', 'cost-test-model'),
+    ));
+
+    $cost = (new AssistantAgent)->prompt('Hi')->cost();
+
+    expect($cost->input)->toBe(2.0)
+        ->and($cost->output)->toBe(4.0)
+        ->and($cost->total())->toBe(6.0)
+        ->and($cost->isKnown())->toBeTrue()
+        ->and($cost->format(2))->toBe('$6.00');
+});
+
+test('response cost is unknown when the model has no pricing', function () {
+    AssistantAgent::fake(fn () => new TextResponse(
+        'Hello',
+        new Usage(promptTokens: 1_000),
+        new Meta('openai', 'totally-unknown-model'),
+    ));
+
+    $cost = (new AssistantAgent)->prompt('Hi')->cost();
+
+    expect($cost->isKnown())->toBeFalse()
+        ->and($cost->total())->toBe(0.0);
+});

--- a/tests/Fixtures/Agents/BudgetedAgent.php
+++ b/tests/Fixtures/Agents/BudgetedAgent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\MaxCost;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[MaxCost(0.005)]
+class BudgetedAgent implements Agent
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a budgeted assistant.';
+    }
+}

--- a/tests/Unit/Pricing/BudgetMeterTest.php
+++ b/tests/Unit/Pricing/BudgetMeterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Laravel\Ai\Pricing\BudgetMeter;
+use Laravel\Ai\Responses\Data\Cost;
+
+test('records and accumulates spend per bucket', function () {
+    $meter = new BudgetMeter;
+
+    $meter->record('a', new Cost(input: 0.01));
+    $meter->record('a', new Cost(output: 0.02));
+    $meter->record('b', new Cost(input: 0.05));
+
+    expect($meter->spent('a'))->toBe(0.03)
+        ->and($meter->spent('b'))->toBe(0.05)
+        ->and($meter->spent('missing'))->toBe(0.0)
+        ->and($meter->total())->toBe(0.08);
+});
+
+test('reset clears a single bucket or everything', function () {
+    $meter = new BudgetMeter;
+    $meter->record('a', new Cost(input: 0.01));
+    $meter->record('b', new Cost(input: 0.02));
+
+    $meter->reset('a');
+    expect($meter->spent('a'))->toBe(0.0)
+        ->and($meter->spent('b'))->toBe(0.02);
+
+    $meter->reset();
+    expect($meter->total())->toBe(0.0);
+});

--- a/tests/Unit/Pricing/CostCalculatorTest.php
+++ b/tests/Unit/Pricing/CostCalculatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Laravel\Ai\Pricing\CostCalculator;
+use Laravel\Ai\Pricing\PriceList;
+use Laravel\Ai\Responses\Data\Usage;
+
+function calculatorFor(array $overrides = []): CostCalculator
+{
+    return new CostCalculator(new PriceList($overrides));
+}
+
+test('calculates input and output cost from per-million rates', function () {
+    $calc = calculatorFor(['openai' => ['m' => ['input' => 2.00, 'output' => 8.00]]]);
+
+    $cost = $calc->calculate(new Usage(promptTokens: 1_000_000, completionTokens: 500_000), 'openai', 'm');
+
+    expect($cost->input)->toBe(2.0)
+        ->and($cost->output)->toBe(4.0)
+        ->and($cost->total())->toBe(6.0)
+        ->and($cost->isKnown())->toBeTrue();
+});
+
+test('cache and reasoning tokens cost nothing unless rates are configured', function () {
+    $calc = calculatorFor(['openai' => ['m' => ['input' => 2.00, 'output' => 8.00]]]);
+
+    $cost = $calc->calculate(new Usage(
+        promptTokens: 0,
+        completionTokens: 0,
+        cacheWriteInputTokens: 1_000_000,
+        cacheReadInputTokens: 1_000_000,
+        reasoningTokens: 1_000_000,
+    ), 'openai', 'm');
+
+    expect($cost->total())->toBe(0.0);
+});
+
+test('cache and reasoning rates are applied when configured', function () {
+    $calc = calculatorFor(['anthropic' => ['m' => [
+        'input' => 3.00, 'output' => 15.00, 'cache_read' => 0.30, 'cache_write' => 3.75, 'reasoning' => 15.00,
+    ]]]);
+
+    $cost = $calc->calculate(new Usage(
+        promptTokens: 1_000_000,
+        completionTokens: 1_000_000,
+        cacheWriteInputTokens: 1_000_000,
+        cacheReadInputTokens: 1_000_000,
+        reasoningTokens: 1_000_000,
+    ), 'anthropic', 'm');
+
+    expect($cost->cacheRead)->toBe(0.30)
+        ->and($cost->cacheWrite)->toBe(3.75)
+        ->and($cost->reasoning)->toBe(15.00)
+        ->and($cost->total())->toBe(37.05);
+});
+
+test('returns an unknown cost when pricing is missing', function () {
+    $cost = calculatorFor()->calculate(new Usage(promptTokens: 1000), 'openai', 'no-such-model');
+
+    expect($cost->isKnown())->toBeFalse()
+        ->and($cost->total())->toBe(0.0);
+});

--- a/tests/Unit/Pricing/CostTest.php
+++ b/tests/Unit/Pricing/CostTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Laravel\Ai\Responses\Data\Cost;
+
+test('total sums every component', function () {
+    $cost = new Cost(input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0.003, reasoning: 0.005);
+
+    expect($cost->total())->toBe(0.039)
+        ->and($cost->isKnown())->toBeTrue();
+});
+
+test('unknown cost has zero total and is flagged', function () {
+    $cost = Cost::unknown();
+
+    expect($cost->total())->toBe(0.0)
+        ->and($cost->isKnown())->toBeFalse();
+});
+
+test('breakdown exposes each component', function () {
+    $cost = new Cost(input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0.003, reasoning: 0.005);
+
+    expect($cost->breakdown())->toBe([
+        'input' => 0.01,
+        'output' => 0.02,
+        'cache_read' => 0.001,
+        'cache_write' => 0.003,
+        'reasoning' => 0.005,
+    ]);
+});
+
+test('format renders USD with a dollar sign and other currencies with a suffix', function () {
+    expect((new Cost(input: 1.5))->format(2))->toBe('$1.50')
+        ->and((new Cost(input: 1.5, currency: 'EUR'))->format(2))->toBe('1.50 EUR');
+});
+
+test('add combines two costs and degrades known when either is unknown', function () {
+    $a = new Cost(input: 0.01, output: 0.02);
+    $b = new Cost(input: 0.03, output: 0.04);
+
+    $sum = $a->add($b);
+
+    expect($sum->input)->toBe(0.04)
+        ->and($sum->output)->toBe(0.06)
+        ->and($sum->isKnown())->toBeTrue()
+        ->and($a->add(Cost::unknown())->isKnown())->toBeFalse();
+});
+
+test('serializes to an array with total and breakdown', function () {
+    $cost = new Cost(input: 0.01, output: 0.02);
+
+    expect($cost->toArray())->toMatchArray([
+        'total' => 0.03,
+        'currency' => 'USD',
+        'known' => true,
+        'input' => 0.01,
+        'output' => 0.02,
+    ])->and($cost->jsonSerialize())->toBe($cost->toArray());
+});

--- a/tests/Unit/Pricing/PriceListTest.php
+++ b/tests/Unit/Pricing/PriceListTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Laravel\Ai\Pricing\ModelPricing;
+use Laravel\Ai\Pricing\PriceList;
+
+test('resolves a built-in default model', function () {
+    $pricing = (new PriceList)->for('openai', 'gpt-4o');
+
+    expect($pricing)->toBeInstanceOf(ModelPricing::class)
+        ->and($pricing->input)->toBe(2.50)
+        ->and($pricing->output)->toBe(10.00);
+});
+
+test('resolves a versioned model id by longest contained key', function () {
+    $pricing = (new PriceList)->for('anthropic', 'claude-sonnet-4-6');
+
+    expect($pricing->input)->toBe(3.00)
+        ->and($pricing->output)->toBe(15.00);
+});
+
+test('prefers the longest matching key', function () {
+    // "gpt-4o-mini" contains both "gpt-4o" and "gpt-4o-mini"; the longer wins.
+    $pricing = (new PriceList)->for('openai', 'gpt-4o-mini-2026');
+
+    expect($pricing->input)->toBe(0.15)
+        ->and($pricing->output)->toBe(0.60);
+});
+
+test('returns null for an unknown provider or model', function () {
+    $prices = new PriceList;
+
+    expect($prices->for('openai', 'nonexistent-model'))->toBeNull()
+        ->and($prices->for('made-up-provider', 'whatever'))->toBeNull()
+        ->and($prices->for(null, null))->toBeNull();
+});
+
+test('config overrides win over defaults', function () {
+    $prices = new PriceList([
+        'openai' => ['gpt-4o' => ['input' => 99.0, 'output' => 100.0]],
+    ]);
+
+    $pricing = $prices->for('openai', 'gpt-4o');
+
+    expect($pricing->input)->toBe(99.0)
+        ->and($pricing->output)->toBe(100.0);
+});
+
+test('config can add a brand new model', function () {
+    $prices = new PriceList([
+        'custom' => ['my-model' => ['input' => 1.0, 'output' => 2.0]],
+    ]);
+
+    expect($prices->for('custom', 'my-model')->input)->toBe(1.0);
+});
+
+test('runtime registration wins over everything', function () {
+    $prices = (new PriceList([
+        'openai' => ['gpt-4o' => ['input' => 99.0, 'output' => 100.0]],
+    ]))->register('openai', 'gpt-4o', new ModelPricing(input: 1.0, output: 2.0));
+
+    expect($prices->for('openai', 'gpt-4o')->input)->toBe(1.0);
+});


### PR DESCRIPTION
Adds a cost layer to the SDK. Every response can now tell you what it actually cost in dollars, and agents can carry a hard spend budget that stops them before they blow past it.

Today the SDK surfaces raw token counts on `$response->usage`, but nothing turns those into money, and there's no way to cap what an agent or a runaway tool loop is allowed to spend. This adds both, computed entirely from data that already comes back on every response (the `usage` plus the `provider` and `model` on `meta`), so it works across every provider with no gateway changes.

<img width="3200" height="1800" alt="cost-card" src="https://github.com/user-attachments/assets/1a8afa5d-6ad1-49b7-94d2-6e3a5c4903e0" />


**The cost API**

`$response->cost()` returns a `Cost` value object built from the response usage and a per-model price table:

```php
$response = (new ResearchAgent)->prompt('Summarize Q3 earnings');

$response->cost()->total();      // 0.0032
$response->cost()->format();     // "$0.0032"
$response->cost()->breakdown();  // ['input' => 0.000174, 'output' => 0.00303, ...]
```

Pricing is config driven. The SDK ships a small default table (USD per 1M tokens) that you can override or extend in `config/ai.php`, or at runtime with `PriceList::register()`. A model with no known price returns an unknown cost (`isKnown()` is false, total `0`) instead of throwing, so cost reporting is always safe. Cost also rides every `Step`, so `$response->steps->sum(fn ($s) => $s->cost()->total())` just works.

**Budgets**

Tag an agent with `#[MaxCost]` and it stops once it has spent its budget within the process, throwing `BudgetExceededException` before the next call:

```php
#[MaxCost(0.50)]
class ResearchAgent implements Agent
{
    use Promptable;
}
```

<img width="3200" height="2000" alt="cost-dashboard" src="https://github.com/user-attachments/assets/99434042-29b6-4c19-8b97-eefb56b937fb" />


The figures above are real. They come from running three live Claude calls (opus, sonnet, haiku) through the SDK and pricing the actual token usage that came back.

**Why this doesn't break anything**

It is purely additive. No existing signature, response shape, or behavior changes:

- new classes only: `Cost`, `Pricing\{ModelPricing, PriceList, CostCalculator, BudgetMeter}`, the `EnforceBudget` middleware, the `MaxCost` attribute, and `BudgetExceededException`
- two new methods (`cost()`) on `TextResponse` and `Step`
- three singleton bindings, plus one additive `#[MaxCost]` branch in `gatherMiddlewareFor()` that only fires for agents that opt in
- a new `pricing` config key, merged via `mergeConfigFrom` so already published configs keep working Gateways, providers, events, and the tool loop are untouched.

**Scope**

v1 covers cost reporting and per-process / per-conversation budgets, enforced pre-flight through the existing middleware pipeline. _A hard mid-run abort (stopping inside a single multi-step tool loop) would need a small hook in the gateway loop, so it is left for a follow-up._

**Tests**

Added unit coverage for the cost math, price resolution (exact match, versioned-id matching, and config/runtime overrides), and the budget meter, plus feature tests that assert `$response->cost()` on a real response and the `#[MaxCost]` tripwire firing once the budget is spent. Full suite passes, Pint and PHPStan clean.