### PR TITLE
Route top-level Ollama provider options out of the options object

### DIFF
--- a/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
@@ -69,6 +69,17 @@ trait BuildsTextRequests
 
         $providerOptions = $options?->providerOptions($provider->driver()) ?? [];
 
+        // Hoist keys that belong at the top level, as everything else is passed in options.
+        $topLevelKeys = ['format', 'keep_alive', 'think', 'logprobs', 'top_logprobs'];
+
+        foreach ($topLevelKeys as $key) {
+            if (array_key_exists($key, $providerOptions)) {
+                // A schema-driven format already on the body wins.
+                $body[$key] ??= $providerOptions[$key];
+                unset($providerOptions[$key]);
+            }
+        }
+
         $mergedOptions = array_merge($ollamaOptions, $providerOptions);
 
         if (filled($mergedOptions)) {

--- a/tests/Feature/Providers/Ollama/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Ollama/ProviderOptionsTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\OllamaStructuredProviderOptionsAgent;
+use Tests\Fixtures\Agents\OllamaTopLevelOptionsAgent;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 
@@ -59,4 +61,47 @@ test('provider options are persisted in tool call follow up requests', function 
     $followUpBody = json_decode($requests[1][0]->body(), true);
 
     expect(array_key_exists('options', $followUpBody))->toBeTrue();
+});
+
+test('top-level provider options are placed at the body root, not inside options', function () {
+    Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+    (new OllamaTopLevelOptionsAgent)->prompt('Hello', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['format'] ?? null) === 'json'
+            && ($body['keep_alive'] ?? null) === '10m'
+            && ($body['logprobs'] ?? null) === true
+            && ! array_key_exists('format', $body['options'] ?? [])
+            && ! array_key_exists('keep_alive', $body['options'] ?? [])
+            && ! array_key_exists('logprobs', $body['options'] ?? []);
+    });
+});
+
+test('model parameters from provider options remain inside the options object', function () {
+    Http::fake(['*' => $this->fakeTextResponse('Hello')]);
+
+    (new OllamaTopLevelOptionsAgent)->prompt('Hello', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['options']['num_ctx'] ?? null) === 8192
+            && ! array_key_exists('num_ctx', $body);
+    });
+});
+
+test('structured output schema is not overwritten by a provider options format', function () {
+    Http::fake(['*' => $this->fakeStructuredResponse('{"symbol": "Au"}')]);
+
+    (new OllamaStructuredProviderOptionsAgent)->prompt('What is the symbol for Gold?', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return array_key_exists('format', $body)
+            && is_array($body['format']);
+    });
 });

--- a/tests/Fixtures/Agents/OllamaStructuredProviderOptionsAgent.php
+++ b/tests/Fixtures/Agents/OllamaStructuredProviderOptionsAgent.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+#[Strict]
+class OllamaStructuredProviderOptionsAgent implements Agent, HasProviderOptions, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that uses structured output and knows about periodic table element symbols.';
+    }
+
+    /**
+     * Get the structured output's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'symbol' => $schema->string()->required(),
+        ];
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Ollama => [
+                'format' => 'json',
+            ],
+            default => [],
+        };
+    }
+}

--- a/tests/Fixtures/Agents/OllamaTopLevelOptionsAgent.php
+++ b/tests/Fixtures/Agents/OllamaTopLevelOptionsAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+class OllamaTopLevelOptionsAgent implements Agent, HasProviderOptions
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Ollama => [
+                'format' => 'json',
+                'keep_alive' => '10m',
+                'logprobs' => true,
+                'num_ctx' => 8192,
+            ],
+            default => [],
+        };
+    }
+}


### PR DESCRIPTION
Currently, provider options set for Ollama via `HasProviderOptions` (`providerOptions(Lab::Ollama)`) are all merged into the request body's `options` object - Ollama's *model-parameters* bag (`temperature`, `top_p`, `num_ctx`, `seed`, …). 

But a few Ollama request fields are top-level rather than model parameters, notably `format` (Ollama's JSON-mode / structured-output switch) and `keep_alive`. 

Ollama ignores them under `options`, so there's currently no way to set `format` through provider options - you're pushed into the full schema path even when all you want is `"format": "json"`:

```jsonc
// providerOptions(Lab::Ollama) => ['format' => 'json'] today:
{ "model": "…", "messages": […], "stream": false, "options": { "format": "json" } }
// Ollama ignores options.format, so JSON mode never engages.
```

`buildChatRequestBody()` now hoists the keys Ollama documents at the top level of `POST /api/chat` (`format`, `keep_alive`, `think`, `logprobs`, `top_logprobs`) to the body root and keeps everything else under `options`:


```jsonc
{ "model": "…", "messages": […], "stream": false, "format": "json" }
```

Genuine model parameters (`top_k`, `repeat_penalty`, `num_ctx`, `seed`, …) are untouched and still sent under `options`, and a schema-driven `format` (structured output) still wins over a provider-options `format`. This mirrors how the Gemini gateway already hoists top-level keys out of `generationConfig`. Tests added.