### PR TITLE
Use the original request model for tool-loop follow-up requests

### DIFF
--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -50,6 +50,7 @@ trait ParsesTextResponses
         ?string $instructions = null,
         array $originalMessages = [],
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -64,6 +65,7 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            requestModel: $requestModel,
         );
     }
 
@@ -88,6 +90,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -146,7 +149,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $model,
+                $requestModel ?? $model,
                 $provider,
                 $structured,
                 $tools,
@@ -305,6 +308,7 @@ trait ParsesTextResponses
             $maxSteps,
             $options,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/DeepSeek/DeepSeekGateway.php
+++ b/src/Gateway/DeepSeek/DeepSeekGateway.php
@@ -72,6 +72,7 @@ class DeepSeekGateway implements TextGateway
             $instructions,
             $messages,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -50,6 +50,7 @@ trait ParsesTextResponses
         ?string $instructions = null,
         array $originalMessages = [],
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -64,6 +65,7 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            requestModel: $requestModel,
         );
     }
 
@@ -84,6 +86,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -137,7 +140,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $model,
+                $requestModel ?? $model,
                 $provider,
                 $structured,
                 $tools,
@@ -314,6 +317,7 @@ trait ParsesTextResponses
             $maxSteps,
             $options,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -72,6 +72,7 @@ class GroqGateway implements TextGateway
             $instructions,
             $messages,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -49,6 +49,7 @@ trait ParsesTextResponses
         ?string $instructions = null,
         array $originalMessages = [],
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -63,6 +64,7 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            requestModel: $requestModel,
         );
     }
 
@@ -83,6 +85,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -136,7 +139,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $model,
+                $requestModel ?? $model,
                 $provider,
                 $structured,
                 $tools,
@@ -282,6 +285,7 @@ trait ParsesTextResponses
             $maxSteps,
             $options,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -83,6 +83,7 @@ class MistralGateway implements EmbeddingGateway, TextGateway, TranscriptionGate
             $instructions,
             $messages,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
@@ -49,6 +49,7 @@ trait ParsesTextResponses
         ?string $instructions = null,
         array $originalMessages = [],
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -63,6 +64,7 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            requestModel: $requestModel,
         );
     }
 
@@ -83,6 +85,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         $message = $data['message'] ?? [];
         $model = $data['model'] ?? '';
@@ -138,7 +141,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $model,
+                $requestModel ?? $model,
                 $provider,
                 $structured,
                 $tools,
@@ -299,6 +302,7 @@ trait ParsesTextResponses
             $maxSteps,
             $options,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -75,6 +75,7 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
             $instructions,
             $messages,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -50,6 +50,7 @@ trait ParsesTextResponses
         ?string $instructions = null,
         array $originalMessages = [],
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -64,6 +65,7 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            requestModel: $requestModel,
         );
     }
 
@@ -84,6 +86,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
@@ -137,7 +140,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $model,
+                $requestModel ?? $model,
                 $provider,
                 $structured,
                 $tools,
@@ -311,6 +314,7 @@ trait ParsesTextResponses
             $maxSteps,
             $options,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -91,6 +91,7 @@ class OpenRouterGateway implements Gateway
             $instructions,
             $messages,
             $timeout,
+            requestModel: $model,
         );
     }
 

--- a/src/Gateway/Xai/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Xai/Concerns/ParsesTextResponses.php
@@ -59,6 +59,7 @@ trait ParsesTextResponses
         ?array $schema = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         return $this->processResponse(
             $data,
@@ -71,6 +72,7 @@ trait ParsesTextResponses
             maxSteps: $options?->maxSteps,
             options: $options,
             timeout: $timeout,
+            requestModel: $requestModel,
         );
     }
 
@@ -89,6 +91,7 @@ trait ParsesTextResponses
         ?int $maxSteps = null,
         ?TextGenerationOptions $options = null,
         ?int $timeout = null,
+        ?string $requestModel = null,
     ): TextResponse {
         $responseId = $data['id'] ?? '';
         $output = $data['output'] ?? [];
@@ -137,7 +140,7 @@ trait ParsesTextResponses
             $messages->push($toolResultMessage);
 
             return $this->continueWithToolResults(
-                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options, $timeout,
+                $responseId, $requestModel ?? $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options, $timeout,
             );
         }
 
@@ -250,7 +253,7 @@ trait ParsesTextResponses
 
         $this->validateTextResponse($data);
 
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
+        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout, requestModel: $model);
     }
 
     /**

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -56,7 +56,7 @@ class XaiGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout, $model);
     }
 
     /**

--- a/tests/Feature/Providers/DeepSeek/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/DeepSeek/ToolCallLoopTest.php
@@ -11,6 +11,31 @@ beforeEach(function () {
     ]]);
 });
 
+test('tool-loop follow-up uses the original request model, not the response model', function () {
+    Http::fake([
+        'api.deepseek.com/*' => Http::sequence([
+            fakeUniqueDeepSeekToolCallResponse(),
+            fakeDeepSeekResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'deepseek',
+        model: 'deepseek-reasoner',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp['model'])->toBe('deepseek-reasoner')
+        ->and($followUp['model'])->not->toBe('deepseek-chat')
+        ->and($response->meta->model)->toBe('deepseek-chat');
+});
+
 test('tool calls trigger follow up request', function () {
     Http::fake([
         'api.deepseek.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Groq/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Groq/ToolCallLoopTest.php
@@ -11,6 +11,31 @@ beforeEach(function () {
     ]]);
 });
 
+test('tool-loop follow-up uses the original request model, not the response model', function () {
+    Http::fake([
+        'api.groq.com/*' => Http::sequence([
+            fakeUniqueGroqToolCallResponse(),
+            fakeGroqResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'groq',
+        model: 'llama-3.3-70b',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp['model'])->toBe('llama-3.3-70b')
+        ->and($followUp['model'])->not->toBe('openai/gpt-oss-20b')
+        ->and($response->meta->model)->toBe('openai/gpt-oss-20b');
+});
+
 test('tool calls trigger follow up request', function () {
     Http::fake([
         'api.groq.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Mistral/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Mistral/ToolCallLoopTest.php
@@ -10,6 +10,31 @@ beforeEach(function () {
     ]]);
 });
 
+test('tool-loop follow-up uses the original request model, not the response model', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'mistral',
+        model: 'mistral-medium',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp['model'])->toBe('mistral-medium')
+        ->and($followUp['model'])->not->toBe('mistral-medium-latest')
+        ->and($response->meta->model)->toBe('mistral-medium-latest');
+});
+
 test('tool calls trigger follow up request', function () {
     Http::fake([
         '*' => Http::sequence([

--- a/tests/Feature/Providers/Ollama/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Ollama/ToolCallLoopTest.php
@@ -11,6 +11,31 @@ beforeEach(function () {
     ]]);
 });
 
+test('tool-loop follow-up uses the original request model, not the response model', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeUniqueOllamaToolCallResponse(),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'ollama',
+        model: 'llama3.1',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp['model'])->toBe('llama3.1')
+        ->and($followUp['model'])->not->toBe('llama3.1:8b')
+        ->and($response->meta->model)->toBe('llama3.1:8b');
+});
+
 test('tool calls trigger follow up request', function () {
     Http::fake([
         '*' => Http::sequence([

--- a/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
@@ -17,6 +17,31 @@ beforeEach(function () {
     ]]);
 });
 
+test('tool-loop follow-up uses the original request model, not the response model', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenRouterToolCallResponse(),
+            fakeOpenRouterResponse('Done'),
+        ]),
+    ]);
+
+    $response = agent(tools: [new FixedNumberGenerator])->prompt(
+        'Give me a number',
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp['model'])->toBe('anthropic/claude-sonnet-4')
+        ->and($followUp['model'])->not->toBe('anthropic/claude-sonnet-4.6')
+        ->and($response->meta->model)->toBe('anthropic/claude-sonnet-4.6');
+});
+
 test('tool calls trigger follow up request', function () {
     Http::fake([
         '*' => Http::sequence([

--- a/tests/Feature/Providers/Xai/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Xai/ToolCallLoopTest.php
@@ -10,6 +10,31 @@ beforeEach(function () {
     ]]);
 });
 
+test('tool-loop follow-up uses the original request model, not the response model', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            $this->fakeToolCallResponse(),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'xai',
+        model: 'grok-4-1',
+    );
+
+    $recorded = Http::recorded();
+
+    expect($recorded)->toHaveCount(2);
+
+    $followUp = json_decode($recorded[1][0]->body(), true);
+
+    expect($followUp['model'])->toBe('grok-4-1')
+        ->and($followUp['model'])->not->toBe('grok-4-1-fast-reasoning')
+        ->and($response->meta->model)->toBe('grok-4-1-fast-reasoning');
+});
+
 test('tool calls trigger follow up request', function () {
     Http::fake([
         '*' => Http::sequence([


### PR DESCRIPTION
Fixes #680

When `generateText` runs a multi-step tool loop, six gateways build the follow-up request after tool results using the model from the API response (`$data['model']`) instead of the original model the caller requested. When a provider resolves the requested alias to a different id in its response, the next tool-call request goes out with that resolved id and fails with `model_not_found`.

The original model is dropped at the parse boundary: `generateText` builds the first request with the caller's `$model` but never passes it into `parseTextResponse`, so the parser falls back to `$data['model']` and reuses it for the follow-up request body.

Affected: Xai, Mistral, DeepSeek, Groq, Ollama, OpenRouter. OpenAI and Anthropic already carry the original request body through the loop, and Gemini already threads the original model, so they are not affected. The streaming path was already correct everywhere (it threads the original model from `streamText`).

**The fix**

Thread the caller's model through as an optional `$requestModel` from `generateText` → `parseTextResponse` → `processResponse` → `continueWithToolResults`, and use it for the follow-up request body (`$requestModel ?? $model`). `Meta`/`Step` reporting is intentionally left on the response model, so `$response->meta->model` still reflects the model the provider actually used. The parameter is optional and falls back to the response model, so nothing else changes.

**Tests**

The reporter wasn't able to share a repro, so the added tests are the repro. Each affected gateway's `ToolCallLoopTest` gets a regression test that fakes a tool-call response whose `model` differs from the requested alias, then asserts the follow-up request uses the original alias (and that `meta->model` still reports the response model). Every one of them fails on `0.x` today and passes with this change. Full suite, Pint, and PHPStan all pass.
