### PR TITLE
Add cross-provider service tier support

### DIFF
--- a/src/Attributes/ServiceTier.php
+++ b/src/Attributes/ServiceTier.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+use BackedEnum;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ServiceTier
+{
+    public string $value;
+
+    /**
+     * Accepts a raw provider string (e.g. 'priority') or any provider service
+     * tier enum, normalizing it down to its string value.
+     */
+    public function __construct(string|BackedEnum $value)
+    {
+        $this->value = $value instanceof BackedEnum ? (string) $value->value : $value;
+    }
+}

--- a/src/Contracts/ServiceTier.php
+++ b/src/Contracts/ServiceTier.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use BackedEnum;
+
+/**
+ * Marker interface implemented by every provider's service tier enum.
+ *
+ * Service tiers let an agent opt into a faster (higher priority) or cheaper
+ * (lower priority) processing tier than the provider default. Each provider
+ * exposes its own native values, so the enums live under the provider's own
+ * namespace and resolve down to a plain string before reaching the gateway.
+ */
+interface ServiceTier extends BackedEnum
+{
+    //
+}

--- a/src/Enums/Anthropic/ServiceTier.php
+++ b/src/Enums/Anthropic/ServiceTier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Ai\Enums\Anthropic;
+
+use Laravel\Ai\Contracts\ServiceTier as ServiceTierContract;
+
+/**
+ * Service tiers supported by the Anthropic Messages API.
+ *
+ * Anthropic has no explicit "priority" request value: send "auto" to
+ * opportunistically use priority capacity when available, or "standard_only"
+ * to always use standard capacity.
+ *
+ * @see https://docs.anthropic.com/en/api/service-tiers
+ */
+enum ServiceTier: string implements ServiceTierContract
+{
+    case Auto = 'auto';
+    case StandardOnly = 'standard_only';
+}

--- a/src/Enums/Bedrock/ServiceTier.php
+++ b/src/Enums/Bedrock/ServiceTier.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Enums\Bedrock;
+
+use Laravel\Ai\Contracts\ServiceTier as ServiceTierContract;
+
+/**
+ * Service tiers supported by the Amazon Bedrock Converse API.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+ */
+enum ServiceTier: string implements ServiceTierContract
+{
+    case Priority = 'priority';
+    case Default = 'default';
+    case Flex = 'flex';
+    case Reserved = 'reserved';
+}

--- a/src/Enums/Groq/ServiceTier.php
+++ b/src/Enums/Groq/ServiceTier.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Enums\Groq;
+
+use Laravel\Ai\Contracts\ServiceTier as ServiceTierContract;
+
+/**
+ * Service tiers supported by the Groq API.
+ *
+ * @see https://console.groq.com/docs/service-tiers
+ */
+enum ServiceTier: string implements ServiceTierContract
+{
+    case Auto = 'auto';
+    case OnDemand = 'on_demand';
+    case Flex = 'flex';
+    case Performance = 'performance';
+}

--- a/src/Enums/OpenAi/ServiceTier.php
+++ b/src/Enums/OpenAi/ServiceTier.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Ai\Enums\OpenAi;
+
+use Laravel\Ai\Contracts\ServiceTier as ServiceTierContract;
+
+/**
+ * Service tiers supported by the OpenAI API.
+ *
+ * Also applies to Azure OpenAI, which reuses the OpenAI request builder.
+ *
+ * @see https://platform.openai.com/docs/api-reference/responses/create
+ */
+enum ServiceTier: string implements ServiceTierContract
+{
+    case Auto = 'auto';
+    case Default = 'default';
+    case Flex = 'flex';
+    case Priority = 'priority';
+}

--- a/src/Enums/OpenRouter/ServiceTier.php
+++ b/src/Enums/OpenRouter/ServiceTier.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ai\Enums\OpenRouter;
+
+use Laravel\Ai\Contracts\ServiceTier as ServiceTierContract;
+
+/**
+ * Service tiers supported by the OpenRouter API.
+ *
+ * @see https://openrouter.ai/docs/guides/features/service-tiers
+ */
+enum ServiceTier: string implements ServiceTierContract
+{
+    case Flex = 'flex';
+    case Priority = 'priority';
+}

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -61,6 +61,7 @@ trait BuildsTextRequests
         $body = array_merge($body, Arr::whereNotNull([
             'temperature' => $options?->temperature,
             'top_p' => $options?->topP,
+            'service_tier' => $options?->serviceTier,
         ]));
 
         return array_merge($body, $providerOptions);

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -672,6 +672,10 @@ class BedrockTextGateway implements EmbeddingGateway, TextGateway
             $parameters['inferenceConfig'] = $inferenceConfig;
         }
 
+        if ($options?->serviceTier !== null) {
+            $parameters['serviceTier'] = ['type' => $options->serviceTier];
+        }
+
         $providerOptions = $options?->providerOptions(Lab::Bedrock);
 
         if (! empty($providerOptions)) {

--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -56,6 +56,7 @@ trait BuildsTextRequests
         $body = array_merge($body, Arr::whereNotNull([
             'temperature' => $options?->temperature,
             'top_p' => $options?->topP,
+            'service_tier' => $options?->serviceTier,
         ]));
 
         $providerOptions = $options?->providerOptions($provider->driver());

--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -42,6 +42,7 @@ trait BuildsTextRequests
         $body = array_merge($body, Arr::whereNotNull([
             'temperature' => $options?->temperature,
             'top_p' => $options?->topP,
+            'service_tier' => $options?->serviceTier,
         ]));
 
         $providerOptions = $options?->providerOptions($provider->driver());

--- a/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
@@ -46,6 +46,7 @@ trait BuildsTextRequests
         $body = array_merge($body, Arr::whereNotNull([
             'temperature' => $options?->temperature,
             'top_p' => $options?->topP,
+            'service_tier' => $options?->serviceTier,
         ]));
 
         $providerOptions = $options?->providerOptions($provider->driver());

--- a/src/Gateway/TextGenerationOptions.php
+++ b/src/Gateway/TextGenerationOptions.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Ai\Gateway;
 
+use BackedEnum;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\ServiceTier;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Attributes\TopP;
 use Laravel\Ai\Contracts\Agent;
@@ -19,6 +21,7 @@ class TextGenerationOptions
         public readonly ?float $temperature = null,
         public readonly ?Agent $agent = null,
         public readonly ?float $topP = null,
+        public readonly ?string $serviceTier = null,
     ) {
         //
     }
@@ -47,20 +50,49 @@ class TextGenerationOptions
         $reflection = new ReflectionClass($agent);
 
         return new self(
-            maxSteps: self::resolve($agent, $reflection, 'maxSteps', MaxSteps::class),
-            maxTokens: self::resolve($agent, $reflection, 'maxTokens', MaxTokens::class),
-            temperature: self::resolve($agent, $reflection, 'temperature', Temperature::class),
+            maxSteps: self::resolveNumeric($agent, $reflection, 'maxSteps', MaxSteps::class),
+            maxTokens: self::resolveNumeric($agent, $reflection, 'maxTokens', MaxTokens::class),
+            temperature: self::resolveNumeric($agent, $reflection, 'temperature', Temperature::class),
             agent: $agent,
-            topP: self::resolve($agent, $reflection, 'topP', TopP::class),
+            topP: self::resolveNumeric($agent, $reflection, 'topP', TopP::class),
+            serviceTier: self::resolveString($agent, $reflection, 'serviceTier', ServiceTier::class),
         );
     }
 
     /**
-     * Resolve an option from the agent's method, falling back to the attribute.
+     * Resolve a numeric option from the agent's method, falling back to the attribute.
      *
      * @param  class-string  $attribute
      */
-    private static function resolve(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): int|float|null
+    private static function resolveNumeric(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): int|float|null
+    {
+        return self::resolveValue($agent, $reflection, $method, $attribute);
+    }
+
+    /**
+     * Resolve a string option from the agent's method, falling back to the attribute.
+     *
+     * The method or attribute may yield a raw string or any backed enum (e.g. a
+     * provider service tier enum); both normalize down to the string value. An
+     * empty string is treated as "unset" so it is never forwarded to a provider.
+     *
+     * @param  class-string  $attribute
+     */
+    private static function resolveString(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): ?string
+    {
+        $value = self::resolveValue($agent, $reflection, $method, $attribute);
+
+        $value = $value instanceof BackedEnum ? (string) $value->value : $value;
+
+        return $value ?: null;
+    }
+
+    /**
+     * Resolve a raw option value from the agent's method, falling back to the attribute.
+     *
+     * @param  class-string  $attribute
+     */
+    private static function resolveValue(Agent $agent, ReflectionClass $reflection, string $method, string $attribute): mixed
     {
         if (method_exists($agent, $method)) {
             try {

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Enums\Anthropic\ServiceTier;
+use Laravel\Ai\Promptable;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
@@ -27,6 +30,31 @@ describe('request structure', function () {
                 && $body['messages'][0]['role'] === 'user'
                 && $body['messages'][0]['content'][0]['text'] === 'What is Laravel?';
         });
+    });
+
+    test('service tier is included in the request body when set', function () {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeTextResponse(),
+        ]);
+
+        $agent = new class implements Agent
+        {
+            use Promptable;
+
+            public function instructions(): string
+            {
+                return 'test';
+            }
+
+            public function serviceTier(): ServiceTier
+            {
+                return ServiceTier::Auto;
+            }
+        };
+
+        $agent->prompt('Hi', provider: 'anthropic');
+
+        Http::assertSent(fn ($request) => ($request->data()['service_tier'] ?? null) === 'auto');
     });
 
     test('system instructions are sent as top level system field', function () {

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\ServiceTierAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
@@ -14,6 +15,16 @@ beforeEach(function () {
         ...config('ai.providers.groq'),
         'key' => 'test-key',
     ]]);
+});
+
+test('service tier is included in the request body when set', function () {
+    Http::fake(['*' => fakeGroqResponse('Hello')]);
+
+    (new ServiceTierAgent)->prompt('Hello', provider: 'groq');
+
+    Http::assertSent(function (Request $request) {
+        return data_get(json_decode($request->body(), true), 'service_tier') === 'flex';
+    });
 });
 
 test('request includes model and messages', function () {

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -2,9 +2,15 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Enums\OpenAi\ServiceTier;
+use Laravel\Ai\Promptable;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\NestedStructuredAgent;
+use Tests\Fixtures\Agents\ServiceTierAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
@@ -15,6 +21,56 @@ beforeEach(function () {
         ...config('ai.providers.openai'),
         'key' => 'test-key',
     ]]);
+});
+
+test('service tier is included in the request body when set', function () {
+    Http::fake(['*' => fakeOpenAiResponse('Hello')]);
+
+    (new ServiceTierAgent)->prompt('Hello', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        return data_get(json_decode($request->body(), true), 'service_tier') === 'flex';
+    });
+});
+
+test('service tier is excluded when not set', function () {
+    Http::fake(['*' => fakeOpenAiResponse('Hello')]);
+
+    agent()->prompt('Hello', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        return ! array_key_exists('service_tier', json_decode($request->body(), true));
+    });
+});
+
+test('raw provider options override the resolved service tier', function () {
+    Http::fake(['*' => fakeOpenAiResponse('Hello')]);
+
+    $agent = new class implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function serviceTier(): ServiceTier
+        {
+            return ServiceTier::Flex;
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return ['service_tier' => 'priority'];
+        }
+    };
+
+    $agent->prompt('Hello', provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        return data_get(json_decode($request->body(), true), 'service_tier') === 'priority';
+    });
 });
 
 test('request includes model and input', function () {

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\ServiceTierAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
@@ -14,6 +15,16 @@ beforeEach(function () {
         ...config('ai.providers.openrouter'),
         'key' => 'test-key',
     ]]);
+});
+
+test('service tier is included in the request body when set', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    (new ServiceTierAgent)->prompt('Hello', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        return data_get(json_decode($request->body(), true), 'service_tier') === 'flex';
+    });
 });
 
 test('request includes model and messages', function () {

--- a/tests/Fixtures/Agents/ServiceTierAgent.php
+++ b/tests/Fixtures/Agents/ServiceTierAgent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+class ServiceTierAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function serviceTier(): string
+    {
+        return 'flex';
+    }
+}

--- a/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
@@ -3,7 +3,11 @@
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Http\Testing\File as TestingFile;
 use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Bedrock\ServiceTier;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\Document;
@@ -18,6 +22,7 @@ use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Tools\Request;
@@ -619,4 +624,71 @@ test('build converse parameters omits provider options when agent has none', fun
 
     expect($params)->not->toHaveKey('additionalModelRequestFields')
         ->and($params)->not->toHaveKey('guardrailConfig');
+});
+
+test('build converse parameters includes the service tier as a typed object when set', function () {
+    $options = new TextGenerationOptions(serviceTier: 'priority');
+
+    $params = textGateway()->callBuildConverseParameters(
+        'claude-sonnet',
+        null,
+        [['role' => 'user', 'content' => [['text' => 'hi']]]],
+        null,
+        null,
+        true,
+        $options,
+        false,
+    );
+
+    expect($params['serviceTier'])->toEqual(['type' => 'priority']);
+});
+
+test('build converse parameters omits the service tier when not set', function () {
+    $params = textGateway()->callBuildConverseParameters(
+        'claude-sonnet',
+        null,
+        [['role' => 'user', 'content' => [['text' => 'hi']]]],
+        null,
+        null,
+        true,
+        new TextGenerationOptions,
+        false,
+    );
+
+    expect($params)->not->toHaveKey('serviceTier');
+});
+
+test('raw provider options win over the resolved service tier for bedrock', function () {
+    $agent = new class implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function serviceTier(): ServiceTier
+        {
+            return ServiceTier::Flex;
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return ['serviceTier' => ['type' => 'priority']];
+        }
+    };
+
+    $params = textGateway()->callBuildConverseParameters(
+        'claude-sonnet',
+        null,
+        [['role' => 'user', 'content' => [['text' => 'hi']]]],
+        null,
+        null,
+        true,
+        TextGenerationOptions::forAgent($agent),
+        false,
+    );
+
+    expect($params['serviceTier'])->toEqual(['type' => 'priority']);
 });

--- a/tests/Unit/Gateway/ServiceTierResolutionTest.php
+++ b/tests/Unit/Gateway/ServiceTierResolutionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Laravel\Ai\Attributes\ServiceTier;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Enums\Bedrock\ServiceTier as BedrockServiceTier;
+use Laravel\Ai\Enums\OpenAi\ServiceTier as OpenAiServiceTier;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Promptable;
+
+it('resolves the service tier from a string returned by the agent method', function () {
+    $agent = new class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function serviceTier(): string
+        {
+            return 'priority';
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBe('priority');
+});
+
+it('normalizes a provider enum returned by the agent method to its string value', function () {
+    $agent = new class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function serviceTier(): OpenAiServiceTier
+        {
+            return OpenAiServiceTier::Flex;
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBe('flex');
+});
+
+it('resolves the service tier from a string attribute', function () {
+    $agent = new #[ServiceTier('priority')] class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBe('priority');
+});
+
+it('normalizes a provider enum passed to the attribute', function () {
+    $agent = new #[ServiceTier(BedrockServiceTier::Reserved)] class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBe('reserved');
+});
+
+it('prefers the agent method over the attribute', function () {
+    $agent = new #[ServiceTier('flex')] class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function serviceTier(): string
+        {
+            return 'priority';
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBe('priority');
+});
+
+it('treats an empty string service tier as unset', function () {
+    $agent = new class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+
+        public function serviceTier(): string
+        {
+            return '';
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBeNull();
+});
+
+it('is null when the agent declares no service tier', function () {
+    $agent = new class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'test';
+        }
+    };
+
+    expect(TextGenerationOptions::forAgent($agent)->serviceTier)->toBeNull();
+});


### PR DESCRIPTION
## Summary

Most inference providers now expose a "service tier" knob to trade latency
against cost — priority/faster vs flex/cheaper than the default. There's
currently no way to set it through this package. This adds an optional,
opt-in service tier that an agent can declare once and have applied to
whichever provider it runs against.

## Usage

An agent declares a tier via a no-arg `serviceTier()` method or a
`#[ServiceTier]` attribute. Both accept a raw string or a provider-specific
enum:

```php
use Laravel\Ai\Enums\Bedrock\ServiceTier;

class SupportAgent implements Agent
{
    public function serviceTier(): ServiceTier|string|null
    {
        return ServiceTier::Priority; // or 'priority'
    }
}

// or, declaratively:
#[ServiceTier('priority')]
class SupportAgent implements Agent { /* ... */ }
```

## How it works

- Resolved onto `TextGenerationOptions::$serviceTier` (a plain `string`), so
  unknown/future provider values keep working without library changes. The
  per-provider string-backed enums (`Laravel\Ai\Enums\<Provider>\ServiceTier`)
  are optional sugar for discoverability and normalize to their value.
- Each gateway that has a native tier concept writes it into that provider's
  own field. Raw `providerOptions()` still take precedence, so they remain the
  escape hatch.
- An empty string is treated as "unset" and never forwarded.

| Provider | Field | Accepted values |
|---|---|---|
| Bedrock | `serviceTier: { type }` | `priority` / `default` / `flex` / `reserved` |
| OpenAI (and Azure) | `service_tier` | `auto` / `default` / `flex` / `priority` |
| Groq | `service_tier` | `auto` / `on_demand` / `flex` / `performance` |
| OpenRouter | `service_tier` | `flex` / `priority` |
| Anthropic | `service_tier` | `auto` / `standard_only` |

Providers without a request-level tier concept (DeepSeek, Mistral, xAI,
Gemini, Ollama) ignore it. Because the option defaults to `null`, nothing is
ever sent unless an agent opts in — this is fully backward compatible.

## Tests

- Resolution unit tests: method/attribute, raw string + provider enum,
  method-over-attribute precedence, empty-string-as-unset, null default.
- Per-provider request-mapping tests for all five wired gateways, including
  that `providerOptions` overrides the resolved tier.
- Full suite green; Pint and PHPStan clean.

---

Claude (Anthropic) assisted with this implementation. I have reviewed, tested,
and understand all of the code, and take responsibility for it as my own
contribution, per Laravel's AI-generated contributions guidance.
