### PR TITLE
Migrate xAI gateway to StepTextGateway via TextGenerationLoop

### DIFF
--- a/src/Gateway/Xai/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Xai/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\ObjectSchema;
@@ -27,6 +28,24 @@ trait BuildsTextRequests
         $body = ['model' => $model, 'input' => $input];
 
         return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Build the request body for the current text generation step.
+     */
+    protected function buildStepBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        StepContext $stepContext,
+    ): array {
+        return $stepContext->continuationToken
+            ? $this->buildContinuationBody($stepContext->continuationToken, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Xai/Concerns/BuildsTextRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\Support\Arr;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 
@@ -25,6 +26,42 @@ trait BuildsTextRequests
 
         $body = ['model' => $model, 'input' => $input];
 
+        return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Build a lightweight continuation body using previous_response_id.
+     *
+     * Only sends tool results as input instead of replaying the full conversation.
+     */
+    protected function buildContinuationBody(
+        string $previousResponseId,
+        string $model,
+        array $messages,
+        array $tools,
+        Provider $provider,
+        ?array $schema,
+        ?TextGenerationOptions $options = null,
+    ): array {
+        $body = [
+            'model' => $model,
+            'previous_response_id' => $previousResponseId,
+            'input' => $this->extractToolResultsInput($messages),
+        ];
+
+        return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);
+    }
+
+    /**
+     * Apply options shared by full requests and previous_response_id continuations.
+     */
+    protected function mergeSharedResponsesRequestOptions(
+        array $body,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        Provider $provider,
+    ): array {
         if (filled($tools)) {
             $body['tool_choice'] = 'auto';
             $body['tools'] = $this->mapTools($tools, $provider);
@@ -50,6 +87,28 @@ trait BuildsTextRequests
         }
 
         return $body;
+    }
+
+    /**
+     * Extract tool result items from the trailing ToolResultMessage for a continuation request.
+     */
+    protected function extractToolResultsInput(array $messages): array
+    {
+        $input = [];
+
+        $lastMessage = end($messages);
+
+        if ($lastMessage instanceof ToolResultMessage) {
+            foreach ($lastMessage->toolResults as $toolResult) {
+                $input[] = [
+                    'type' => 'function_call_output',
+                    'call_id' => $toolResult->resultId,
+                    'output' => $this->serializeToolResultOutput($toolResult->result),
+                ];
+            }
+        }
+
+        return $input;
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -3,51 +3,41 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
-use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process an xAI streaming response and yield Laravel stream events.
+     * Process an xAI streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
-        $responseId = '';
+        $responseId = null;
         $reasoningId = '';
         $streamStartEmitted = false;
         $textStartEmitted = false;
         $currentText = '';
+        $toolCalls = [];
         $pendingToolCalls = [];
         $reasoningItems = [];
         $usage = null;
@@ -70,7 +60,7 @@ trait HandlesTextStreaming
 
             if ($type === 'response.created' && ! $streamStartEmitted) {
                 $streamStartEmitted = true;
-                $responseId = $data['response']['id'] ?? '';
+                $responseId = $data['response']['id'] ?? null;
 
                 yield (new StreamStart(
                     $this->generateEventId(),
@@ -243,16 +233,20 @@ trait HandlesTextStreaming
                             $call['arguments'] = $arguments;
                         }
 
+                        $toolCall = new ToolCall(
+                            $call['id'],
+                            $call['name'],
+                            json_decode($call['arguments'] ?? '{}', true) ?? [],
+                            $call['call_id'] ?? null,
+                            $call['reasoning_id'] ?? null,
+                            $call['reasoning_summary'] ?? null,
+                        );
+
+                        $toolCalls[] = $toolCall;
+
                         yield (new ToolCallEvent(
                             $this->generateEventId(),
-                            new ToolCall(
-                                $call['id'],
-                                $call['name'],
-                                json_decode($call['arguments'] ?? '{}', true) ?? [],
-                                $call['call_id'] ?? null,
-                                $call['reasoning_id'] ?? null,
-                                $call['reasoning_summary'] ?? null,
-                            ),
+                            $toolCall,
                             time(),
                         ))->withInvocationId($invocationId);
 
@@ -281,138 +275,14 @@ trait HandlesTextStreaming
             }
         }
 
-        if (filled($pendingToolCalls)) {
-            yield from $this->handleStreamingToolCalls(
-                $invocationId, $responseId, $provider, $model, $tools, $schema, $options,
-                $pendingToolCalls, $currentText, $reasoningItems,
-                $depth, $maxSteps, $timeout,
-            );
-
-            return;
-        }
-
-        yield (new StreamEnd(
-            $this->generateEventId(),
-            $this->extractFinishReason($responseData)->value,
-            $usage ?? new Usage(0, 0),
-            time(),
-        ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        string $responseId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $pendingToolCalls,
-        string $currentText,
-        array $reasoningItems,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
-
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $body = [
-                'model' => $model,
-                'previous_response_id' => $responseId,
-                'input' => $this->buildToolResultsInput($toolResults),
-                'stream' => true,
-            ];
-
-            if (filled($tools)) {
-                $body['tools'] = $this->mapTools($tools, $provider);
-            }
-
-            if (filled($schema)) {
-                $body['text'] = $this->buildSchemaFormat($schema);
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-                'max_output_tokens' => $options?->maxTokens,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('responses', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId, $provider, $model, $tools, $schema, $options,
-                $response->getBody(), $depth + 1, $maxSteps, $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-    }
-
-    /**
-     * Map raw streaming tool call data to ToolCall DTOs.
-     *
-     * @return array<ToolCall>
-     */
-    protected function mapStreamToolCalls(array $toolCalls): array
-    {
-        return array_map(fn (array $tc) => new ToolCall(
-            $tc['id'] ?? '',
-            $tc['name'] ?? '',
-            json_decode($tc['arguments'] ?? '{}', true) ?? [],
-            $tc['call_id'] ?? null,
-            $tc['reasoning_id'] ?? null,
-            $tc['reasoning_summary'] ?? null,
-        ), array_values($toolCalls));
+        return new StepResponse(
+            text: $currentText,
+            toolCalls: $toolCalls,
+            finishReason: $this->extractFinishReason($responseData),
+            usage: $usage ?? new Usage(0, 0),
+            meta: new Meta($provider->name(), $responseData['model'] ?? $model),
+            continuationToken: $responseId,
+        );
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/MapsMessages.php
+++ b/src/Gateway/Xai/Concerns/MapsMessages.php
@@ -128,4 +128,16 @@ trait MapsMessages
             ];
         }
     }
+
+    /**
+     * Serialize a tool result output value to a string suitable for the API.
+     */
+    protected function serializeToolResultOutput(mixed $output): string
+    {
+        if (is_string($output)) {
+            return $output;
+        }
+
+        return is_array($output) ? json_encode($output) : strval($output);
+    }
 }

--- a/src/Gateway/Xai/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Xai/Concerns/ParsesTextResponses.php
@@ -2,23 +2,15 @@
 
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -49,48 +41,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the xAI response data into a TextResponse.
+     * Parse a single xAI response into a StepResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $responseId = $data['id'] ?? '';
+    ): StepResponse {
         $output = $data['output'] ?? [];
         $model = $data['model'] ?? '';
 
@@ -101,188 +58,15 @@ trait ParsesTextResponses
 
         $mappedToolCalls = $this->mapToolCallsWithReasoning($output);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model, $citations),
+        return new StepResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model, $citations),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            continuationToken: $data['id'] ?? null,
         );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model, $citations),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $responseId, $model, $provider, $structured, $tools, $schema, $steps, $messages, $toolResults, $depth + 1, $maxSteps, $options, $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model, $citations),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model, $citations),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $responseId,
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $toolResults,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = [
-            'model' => $model,
-            'previous_response_id' => $responseId,
-            'input' => $this->buildToolResultsInput($toolResults),
-        ];
-
-        if (filled($tools)) {
-            $body['tools'] = $this->mapTools($tools, $provider);
-        }
-
-        if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema);
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-            'max_output_tokens' => $options?->maxTokens,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('responses', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse($data, $provider, $structured, $tools, $schema, $steps, $messages, $depth, $maxSteps, $options, $timeout);
-    }
-
-    /**
-     * Build the input array containing only tool results for a follow-up request.
-     *
-     * @param  array<ToolResult>  $toolResults
-     */
-    protected function buildToolResultsInput(array $toolResults): array
-    {
-        $input = [];
-
-        foreach ($toolResults as $result) {
-            $input[] = [
-                'type' => 'function_call_output',
-                'call_id' => $result->resultId,
-                'output' => $this->serializeToolResultOutput($result->result),
-            ];
-        }
-
-        return $input;
-    }
-
-    /**
-     * Serialize a tool result output value to a string.
-     */
-    protected function serializeToolResultOutput(mixed $output): string
-    {
-        if (is_string($output)) {
-            return $output;
-        }
-
-        return is_array($output) ? json_encode($output) : strval($output);
     }
 
     /**
@@ -399,16 +183,5 @@ trait ParsesTextResponses
         }
 
         return $toolCalls;
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -4,15 +4,27 @@ namespace Laravel\Ai\Gateway\Xai;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
-use Laravel\Ai\Contracts\Gateway\TextGateway;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\Gateway;
+use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\ImageResponse;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use LogicException;
 
-class XaiGateway implements TextGateway
+class XaiGateway implements Gateway, StepTextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesXaiClient;
@@ -21,31 +33,29 @@ class XaiGateway implements TextGateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use DelegatesToTextGenerationLoop;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
      */
-    public function generateText(
+    public function generateTextStep(
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
-        );
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
+    ): StepResponse {
+        $body = $stepContext->continuationToken
+            ? $this->buildContinuationBody($stepContext->continuationToken, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -56,26 +66,27 @@ class XaiGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema), $tools, $schema, $options, $timeout);
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function streamText(
+    public function generateStreamStep(
         string $invocationId,
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider, $model, $instructions, $messages, $tools, $schema, $options,
-        );
+        $body = $stepContext->continuationToken
+            ? $this->buildContinuationBody($stepContext->continuationToken, $model, $messages, $tools, $provider, $schema, $options)
+            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
 
         $body['stream'] = true;
 
@@ -86,10 +97,69 @@ class XaiGateway implements TextGateway
                 ->post('responses', $body),
         );
 
-        yield from $this->processTextStream(
-            $invocationId, $provider, $model, $tools, $schema, $options,
+        return yield from $this->processTextStream(
+            $invocationId,
+            $provider,
+            $model,
             $response->getBody(),
-            timeout: $timeout,
         );
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function generateImage(
+        ImageProvider $provider,
+        string $model,
+        string $prompt,
+        array $attachments = [],
+        ?string $size = null,
+        ?string $quality = null,
+        ?int $timeout = null,
+    ): ImageResponse {
+        throw new LogicException('Use XaiImageGateway for image generation.');
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        throw new LogicException('xAI does not support audio generation.');
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): TranscriptionResponse {
+        throw new LogicException('xAI does not support transcription generation.');
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): EmbeddingsResponse {
+        throw new LogicException('xAI does not support embedding generation.');
     }
 }

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -53,9 +53,7 @@ class XaiGateway implements Gateway, StepTextGateway
         ?int $timeout,
         StepContext $stepContext,
     ): StepResponse {
-        $body = $stepContext->continuationToken
-            ? $this->buildContinuationBody($stepContext->continuationToken, $model, $messages, $tools, $provider, $schema, $options)
-            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -84,9 +82,7 @@ class XaiGateway implements Gateway, StepTextGateway
         ?int $timeout,
         StepContext $stepContext,
     ): Generator {
-        $body = $stepContext->continuationToken
-            ? $this->buildContinuationBody($stepContext->continuationToken, $model, $messages, $tools, $provider, $schema, $options)
-            : $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $body['stream'] = true;
 

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -36,7 +36,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['text']['default'] ?? 'grok-4-1-fast-reasoning';
+        return $this->config['models']['text']['default'] ?? 'grok-4.20-non-reasoning';
     }
 
     /**
@@ -44,7 +44,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['text']['cheapest'] ?? 'grok-4-1-fast-reasoning';
+        return $this->config['models']['text']['cheapest'] ?? 'grok-4.20-non-reasoning';
     }
 
     /**
@@ -52,7 +52,7 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['text']['smartest'] ?? 'grok-4-1-fast-reasoning';
+        return $this->config['models']['text']['smartest'] ?? 'grok-4.3';
     }
 
     /**

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -70,7 +70,7 @@ dataset('agent-providers', [
     'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
     'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'anthropic/claude-haiku-4.5'],
-    'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
+    'xai' => ['xai', 'XAI_API_KEY', 'grok-4.20-non-reasoning'],
 ]);
 
 dataset('agent-document-providers', [
@@ -82,7 +82,7 @@ dataset('agent-document-providers', [
 dataset('agent-image-providers', [
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
     'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite'],
-    'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],
+    'xai' => ['xai', 'XAI_API_KEY', 'grok-4.20-non-reasoning'],
 ]);
 
 dataset('tool-replay-providers', [


### PR DESCRIPTION
Moves xAI's tool loop and structured output handling out of the gateway and into the shared `TextGenerationLoop` orchestrator. The gateway now executes one Responses API turn at a time and returns a `StepResponse`.

The response ID is carried as `continuationToken` so follow-up tool-call steps use `previous_response_id` instead of replaying the full conversation history.

`buildContinuationBody`, `buildStepBody`, and `extractToolResultsInput` are extracted into `BuildsTextRequests` to keep all request-body construction in one place and match the OpenAI gateway's structure. `serializeToolResultOutput` moves from `ParsesTextResponses` to `MapsMessages` where it is actually called.