### PR TITLE
Migrate Groq gateway to StepTextGateway via TextGenerationLoop

### DIFF
--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Groq\Concerns;
 
 use Illuminate\Support\Arr;
 use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
@@ -11,6 +12,22 @@ use Laravel\Ai\Providers\Provider;
 trait BuildsTextRequests
 {
     use ComposesSchemaInstructions;
+
+    /**
+     * Build the request body for the current text generation step.
+     */
+    protected function buildStepBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        StepContext $stepContext,
+    ): array {
+        return $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+    }
 
     /**
      * Build the request body for the Chat Completions API.

--- a/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Groq/Concerns/HandlesTextStreaming.php
@@ -3,51 +3,39 @@
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
-use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
-     * Process a Chat Completions streaming response and yield Laravel stream events.
+     * Process a Chat Completions streaming response for a single turn and yield Laravel stream events.
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $streamStartEmitted = false;
         $textStartEmitted = false;
         $currentText = '';
+        $toolCalls = [];
         $pendingToolCalls = [];
         $usage = null;
         $finishReason = null;
+        $responseModel = $model;
 
         foreach ($this->parseServerSentEvents($streamBody) as $data) {
             if (isset($data['error'])) {
@@ -59,7 +47,7 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
 
-                return;
+                return null;
             }
 
             $choice = $data['choices'][0] ?? null;
@@ -76,6 +64,7 @@ trait HandlesTextStreaming
 
             if (! $streamStartEmitted) {
                 $streamStartEmitted = true;
+                $responseModel = $data['model'] ?? $model;
 
                 yield (new StreamStart(
                     $this->generateEventId(),
@@ -142,189 +131,24 @@ trait HandlesTextStreaming
         }
 
         if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
-            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+            $toolCalls = $this->mapStreamToolCalls($pendingToolCalls);
 
-            foreach ($mappedToolCalls as $toolCall) {
+            foreach ($toolCalls as $toolCall) {
                 yield (new ToolCallEvent(
                     $this->generateEventId(),
                     $toolCall,
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-            );
-
-            return;
         }
 
-        yield (new StreamEnd(
-            $this->generateEventId(),
-            $this->extractFinishReason(['finish_reason' => $finishReason ?? ''])->value,
-            $usage ?? new Usage(0, 0),
-            time(),
-        ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = ['role' => 'assistant'];
-
-            if (filled($currentText)) {
-                $assistantMsg['content'] = $currentText;
-            }
-
-            $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-            );
-
-            $toolResultMessages = [];
-
-            foreach ($toolResults as $toolResult) {
-                $toolResultMessages[] = [
-                    'role' => 'tool',
-                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                    'content' => $this->serializeToolResultOutput($toolResult->result),
-                ];
-            }
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
-            $hasTools = filled($mappedTools);
-            $inlineSchema = $hasTools && filled($schema);
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat(
-                    $originalMessages,
-                    $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
-                ),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = [
-                'model' => $model,
-                'messages' => $chatMessages,
-                'stream' => true,
-                'stream_options' => ['include_usage' => true],
-            ];
-
-            if ($hasTools) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
-
-            if (filled($schema) && ! $inlineSchema) {
-                $body['response_format'] = $this->buildResponseFormat($schema);
-            }
-
-            if (! is_null($options?->maxTokens)) {
-                $body['max_completion_tokens'] = $options->maxTokens;
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('chat/completions', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
+        return new StepResponse(
+            text: $currentText,
+            toolCalls: $toolCalls,
+            finishReason: $this->extractFinishReason(['finish_reason' => $finishReason ?? '']),
+            usage: $usage ?? new Usage(0, 0),
+            meta: new Meta($provider->name(), $responseModel),
+        );
     }
 
     /**

--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -2,22 +2,13 @@
 
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -38,53 +29,13 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Groq response data into a TextResponse.
+     * Parse a single Groq response into a StepResponse.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): StepResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
@@ -101,219 +52,13 @@ trait ParsesTextResponses
             $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
-        );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $mappedTools = filled($tools) ? $this->mapTools($tools) : [];
-        $hasTools = filled($mappedTools);
-        $inlineSchema = $hasTools && filled($schema);
-
-        $chatMessages = $this->mapMessagesToChat(
-            $originalMessages,
-            $inlineSchema ? $this->composeInstructions($instructions, $schema) : $instructions,
-        );
-
-        foreach ($messages as $msg) {
-            if ($msg instanceof AssistantMessage) {
-                $mapped = ['role' => 'assistant'];
-
-                if (filled($msg->content)) {
-                    $mapped['content'] = $msg->content;
-                }
-
-                if ($msg->toolCalls->isNotEmpty()) {
-                    $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
-                    )->all();
-                }
-
-                $chatMessages[] = $mapped;
-            } elseif ($msg instanceof ToolResultMessage) {
-                foreach ($msg->toolResults as $toolResult) {
-                    $chatMessages[] = [
-                        'role' => 'tool',
-                        'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                        'content' => $this->serializeToolResultOutput($toolResult->result),
-                    ];
-                }
-            }
-        }
-
-        $body = [
-            'model' => $model,
-            'messages' => $chatMessages,
-        ];
-
-        if ($hasTools) {
-            $body['tool_choice'] = 'auto';
-            $body['tools'] = $mappedTools;
-        }
-
-        if (filled($schema) && ! $inlineSchema) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
-        }
-
-        if (! is_null($options?->maxTokens)) {
-            $body['max_completion_tokens'] = $options->maxTokens;
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
+        return new StepResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $finishReason,
+            usage: $usage,
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
         );
     }
 
@@ -346,16 +91,5 @@ trait ParsesTextResponses
             'content_filter' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -4,15 +4,17 @@ namespace Laravel\Ai\Gateway\Groq;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Responses\TextResponse;
 
-class GroqGateway implements TextGateway
+class GroqGateway implements StepTextGateway, TextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesGroqClient;
@@ -21,37 +23,27 @@ class GroqGateway implements TextGateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use DelegatesToTextGenerationLoop;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
-    public function __construct(protected Dispatcher $events)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected Dispatcher $events) {}
 
     /**
      * {@inheritdoc}
      */
-    public function generateText(
+    public function generateTextStep(
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
+    ): StepResponse {
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -62,42 +54,25 @@ class GroqGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function streamText(
+    public function generateStreamStep(
         string $invocationId,
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $body['stream'] = true;
         $body['stream_options'] = ['include_usage' => true];
@@ -109,20 +84,6 @@ class GroqGateway implements TextGateway
                 ->post('chat/completions', $body),
         );
 
-        yield from $this->processTextStream(
-            $invocationId,
-            $provider,
-            $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
-        );
+        return yield from $this->processTextStream($invocationId, $provider, $model, $response->getBody());
     }
 }

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -76,6 +76,41 @@ test('streaming handles tool calls', function () {
         ->and($toolCallEvents[0]->toolCall->id)->toBe('call_1');
 });
 
+test('streaming tool call loop emits a single accumulated stream end', function () {
+    Http::fake([
+        'api.groq.com/*' => Http::sequence([
+            Http::response(
+                body: $this->ssePayload([
+                    $this->chatChunkToolCallStart(0, 'call_1', 'FixedNumberGenerator'),
+                    $this->chatChunkToolCallDelta(0, '{}'),
+                    $this->chatChunkFinish('tool_calls', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+                    '[DONE]',
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+            Http::response(
+                body: $this->ssePayload([
+                    $this->chatChunk(['role' => 'assistant', 'content' => 'The number is 72019']),
+                    $this->chatChunkFinish('stop', ['prompt_tokens' => 20, 'completion_tokens' => 10]),
+                    '[DONE]',
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]),
+    ]);
+
+    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+    $streamEnds = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd));
+
+    expect($streamEnds)->toHaveCount(1)
+        ->and($streamEnds[0]->reason)->toBe(FinishReason::Stop->value)
+        ->and($streamEnds[0]->usage->promptTokens)->toBe(30)
+        ->and($streamEnds[0]->usage->completionTokens)->toBe(15);
+});
+
 test('streaming error event stops stream', function () {
     Http::fake([
         'api.groq.com/*' => Http::response(

--- a/tests/Feature/Providers/Groq/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Groq/ToolCallLoopTest.php
@@ -2,6 +2,8 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\NoSuchToolException;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
 beforeEach(function () {
@@ -65,6 +67,64 @@ test('max steps limits tool call depth', function () {
     $recorded = Http::recorded();
 
     expect(count($recorded))->toBeLessThanOrEqual(3);
+});
+
+test('multi step tool loop returns accumulated response shape', function () {
+    Http::fake([
+        'api.groq.com/*' => Http::sequence([
+            fakeUniqueGroqToolCallResponse(),
+            fakeUniqueGroqToolCallResponse(),
+            fakeGroqResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new MultiStepToolAgent)->prompt(
+        'Generate numbers',
+        provider: 'groq',
+    );
+
+    expect((string) $response)->toBe('Done')
+        ->and($response->messages)->toHaveCount(5)
+        ->and($response->steps)->toHaveCount(3)
+        ->and($response->toolCalls)->toHaveCount(2)
+        ->and($response->toolResults)->toHaveCount(2)
+        ->and($response->usage->promptTokens)->toBe(21)
+        ->and($response->usage->completionTokens)->toBe(11);
+});
+
+test('unknown tool call throws', function () {
+    Http::fake([
+        'api.groq.com/*' => Http::response([
+            'id' => 'chatcmpl-missing',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_missing',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'MissingTool',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]),
+    ]);
+
+    expect(fn () => (new MultiStepToolAgent)->prompt(
+        'Generate numbers',
+        provider: 'groq',
+    ))->toThrow(NoSuchToolException::class);
 });
 
 function fakeUniqueGroqToolCallResponse(): PromiseInterface


### PR DESCRIPTION
Groq still drives its own recursive multi-step tool loop inside the gateway, duplicating the orchestration that #652 extracted into `TextGenerationLoop`. This migrates Groq onto the shared loop via `StepTextGateway`, the same way OpenAI, Azure, and xAI now work.

Groq is a stateless chat-completions provider (family B), so each step just replays the loop-accumulated `$messages` through the existing `MapsMessages` layer, no `previous_response_id` continuation. The gateway now produces one turn as a `StepResponse` and the loop owns tool dispatch, the step budget, usage totalling, and final-response assembly.

Two intentional behaviour changes inherited from #652:
- unknown tool calls now throw `NoSuchToolException` instead of being silently skipped
- streaming emits a single terminal `StreamEnd` (with accumulated usage and finish reason) from the loop

Tests updated accordingly (multi-step accumulation, no-such-tool, single accumulated `StreamEnd`). Full faked suite green, Pint and PHPStan clean. Integration tests pending a `GROQ_API_KEY`.