### PR TITLE
Convert Ollama text gateway to TextGenerationLoop

### DIFF
--- a/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
 use Illuminate\Support\Arr;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -11,6 +12,8 @@ use Laravel\Ai\Providers\Provider;
 
 trait BuildsTextRequests
 {
+    use ComposesSchemaInstructions;
+
     /**
      * Build the request body for the current text generation step.
      */
@@ -42,7 +45,7 @@ trait BuildsTextRequests
         return $this->buildChatRequestBody(
             $provider,
             $model,
-            $this->mapMessagesToChat($messages, $instructions),
+            $this->mapMessagesToChat($messages, $this->composeInstructions($instructions, $schema)),
             $tools,
             $schema,
             $options,

--- a/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
@@ -3,12 +3,30 @@
 namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 
 trait BuildsTextRequests
 {
+    /**
+     * Build the request body for the current text generation step.
+     */
+    protected function buildStepBody(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        StepContext $stepContext,
+    ): array {
+        return $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+    }
+
     /**
      * Build the request body for the Ollama Chat API.
      */

--- a/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
@@ -4,46 +4,38 @@ namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
-use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
      * Process an Ollama NDJSON streaming response and yield Laravel stream events.
+     *
+     * @return Generator<int, StreamEvent, mixed, StepResponse|null>
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $streamStartEmitted = false;
         $textStartEmitted = false;
         $currentText = '';
+        $toolCalls = [];
         $pendingToolCalls = [];
         $usage = null;
         $lastData = [];
@@ -61,7 +53,7 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
 
-                return;
+                return null;
             }
 
             if (! $streamStartEmitted) {
@@ -160,7 +152,7 @@ trait HandlesTextStreaming
         }
 
         if (filled($pendingToolCalls)) {
-            $mappedToolCalls = array_map(function (array $toolCall) {
+            $toolCalls = array_map(function (array $toolCall) {
                 $arguments = $toolCall['arguments'];
 
                 if ($toolCall['argumentsBuffer'] !== '') {
@@ -176,153 +168,22 @@ trait HandlesTextStreaming
                 return new ToolCall($id, $toolCall['name'], $arguments, $id);
             }, array_values($pendingToolCalls));
 
-            foreach ($mappedToolCalls as $toolCall) {
+            foreach ($toolCalls as $toolCall) {
                 yield (new ToolCallEvent(
                     $this->generateEventId(),
                     $toolCall,
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-            );
-
-            return;
         }
 
-        yield (new StreamEnd(
-            $this->generateEventId(),
-            $this->extractFinishReason($lastData)->value,
-            $usage ?? new Usage(0, 0),
-            time(),
-        ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = [
-                'role' => 'assistant',
-                'content' => $currentText,
-                'tool_calls' => array_map(
-                    fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-                ),
-            ];
-
-            $toolResultMessages = array_map(fn (ToolResult $toolResult) => [
-                'role' => 'tool',
-                'tool_name' => $toolResult->name,
-                'content' => $this->serializeToolResultOutput($toolResult->result),
-            ], $toolResults);
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat($originalMessages, $instructions),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = $this->buildChatRequestBody(
-                $provider,
-                $model,
-                $chatMessages,
-                $tools,
-                $schema,
-                $options,
-                stream: true,
-            );
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('api/chat', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
+        return new StepResponse(
+            text: $currentText,
+            toolCalls: $toolCalls,
+            finishReason: filled($toolCalls) ? FinishReason::ToolCalls : $this->extractFinishReason($lastData),
+            usage: $usage ?? new Usage(0, 0),
+            meta: new Meta($provider->name(), $lastData['model'] ?? $model),
+        );
     }
 
     /**

--- a/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
@@ -2,22 +2,14 @@
 
 namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -37,60 +29,18 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Ollama response data into a TextResponse.
+     * Parse the Ollama response data into a single step response.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): StepResponse {
         $message = $data['message'] ?? [];
         $model = $data['model'] ?? '';
 
         $text = $message['content'] ?? '';
         $rawToolCalls = $message['tool_calls'] ?? [];
-        $usage = $this->extractUsage($data);
-        $finishReason = $this->extractFinishReason($data);
 
         $mappedToolCalls = array_map(function (array $toolCall) {
             $id = $toolCall['id'] ?? (string) Str::uuid7();
@@ -103,79 +53,14 @@ trait ParsesTextResponses
             );
         }, $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
+        return new StepResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: filled($mappedToolCalls) ? FinishReason::ToolCalls : $this->extractFinishReason($data),
+            usage: $this->extractUsage($data),
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
         );
-
-        $steps->push($step);
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-
-        $messages->push($assistantMessage);
-
-        if (filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
     }
 
     /**
@@ -188,118 +73,6 @@ trait ParsesTextResponses
         }
 
         return json_decode($arguments ?? '{}', true) ?? [];
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat($originalMessages, $instructions);
-
-        foreach ($messages as $msg) {
-            if ($msg instanceof AssistantMessage) {
-                $mapped = [
-                    'role' => 'assistant',
-                    'content' => $msg->content ?? '',
-                ];
-
-                if ($msg->toolCalls->isNotEmpty()) {
-                    $mapped['tool_calls'] = $msg->toolCalls->map(
-                        fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall)
-                    )->all();
-                }
-
-                $chatMessages[] = $mapped;
-            } elseif ($msg instanceof ToolResultMessage) {
-                foreach ($msg->toolResults as $toolResult) {
-                    $chatMessages[] = [
-                        'role' => 'tool',
-                        'tool_name' => $toolResult->name,
-                        'content' => $this->serializeToolResultOutput($toolResult->result),
-                    ];
-                }
-            }
-        }
-
-        $body = $this->buildChatRequestBody(
-            $provider,
-            $model,
-            $chatMessages,
-            $tools,
-            $schema,
-            $options,
-        );
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('api/chat', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
-        );
     }
 
     /**
@@ -324,16 +97,5 @@ trait ParsesTextResponses
             'length' => FinishReason::Length,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -5,18 +5,20 @@ namespace Laravel\Ai\Gateway\Ollama;
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
-use Laravel\Ai\Responses\TextResponse;
 
-class OllamaGateway implements EmbeddingGateway, TextGateway
+class OllamaGateway implements EmbeddingGateway, StepTextGateway, TextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesOllamaClient;
@@ -25,36 +27,29 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use DelegatesToTextGenerationLoop;
     use HandlesFailoverErrors;
-    use InvokesTools;
 
     public function __construct(protected Dispatcher $events)
     {
-        $this->initializeToolCallbacks();
+        //
     }
 
     /**
-     * {@inheritdoc}
+     * Generate text for a single Ollama Chat API step.
      */
-    public function generateText(
+    public function generateTextStep(
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
+    ): StepResponse {
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -65,43 +60,25 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
-     * {@inheritdoc}
+     * Stream text for a single Ollama Chat API step.
      */
-    public function streamText(
+    public function generateStreamStep(
         string $invocationId,
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
-
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
         $body['stream'] = true;
 
         $response = $this->withErrorHandling(
@@ -111,21 +88,7 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
                 ->post('api/chat', $body),
         );
 
-        yield from $this->processTextStream(
-            $invocationId,
-            $provider,
-            $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
-        );
+        return yield from $this->processTextStream($invocationId, $provider, $model, $response->getBody());
     }
 
     /**

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -68,6 +68,7 @@ dataset('agent-providers', [
     'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite'],
     'groq' => ['groq', 'GROQ_API_KEY', 'openai/gpt-oss-20b'],
     'mistral' => ['mistral', 'MISTRAL_API_KEY', 'mistral-small-latest'],
+    'ollama' => ['ollama', 'OLLAMA_API_KEY', 'gpt-oss:20b'],
     'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4-nano'],
     'openrouter' => ['openrouter', 'OPENROUTER_API_KEY', 'anthropic/claude-haiku-4.5'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-4-1-fast-reasoning'],

--- a/tests/Feature/Providers/Ollama/EmbeddingTest.php
+++ b/tests/Feature/Providers/Ollama/EmbeddingTest.php
@@ -11,6 +11,7 @@ beforeEach(function () {
     config(['ai.providers.ollama' => [
         ...config('ai.providers.ollama'),
         'key' => '',
+        'url' => 'http://localhost:11434',
     ]]);
 });
 

--- a/tests/Feature/Providers/Ollama/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Ollama/ErrorHandlingTest.php
@@ -11,6 +11,7 @@ beforeEach(function () {
     config(['ai.providers.ollama' => [
         ...config('ai.providers.ollama'),
         'key' => '',
+        'url' => 'http://localhost:11434',
     ]]);
 });
 

--- a/tests/Feature/Providers/Ollama/RequestMappingTest.php
+++ b/tests/Feature/Providers/Ollama/RequestMappingTest.php
@@ -109,6 +109,21 @@ test('structured output includes format field', function () {
     });
 });
 
+test('structured output appends json schema instruction to system message', function () {
+    Http::fake(['*' => $this->fakeStructuredResponse('{"symbol": "Au"}')]);
+
+    (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $systemMessage = collect($body['messages'])->firstWhere('role', 'system');
+
+        return $systemMessage !== null
+            && str_contains($systemMessage['content'], 'You MUST respond EXCLUSIVELY with a JSON object that strictly adheres to the following schema')
+            && str_contains($systemMessage['content'], '"symbol"');
+    });
+});
+
 test('request without schema excludes format field', function () {
     Http::fake(['*' => $this->fakeTextResponse('Hello')]);
 

--- a/tests/Feature/Providers/Ollama/StreamingTest.php
+++ b/tests/Feature/Providers/Ollama/StreamingTest.php
@@ -262,6 +262,38 @@ test('streaming captures usage from final chunk', function () {
         ->and($streamEnd->usage->completionTokens)->toBe(10);
 });
 
+test('streaming emits exactly one stream end across a tool loop', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            Http::response(
+                body: $this->ndjsonPayload([
+                    $this->chatChunkWithToolCalls([
+                        $this->toolCallChunk('call_1', 'FixedNumberGenerator'),
+                    ]),
+                ]),
+                status: 200,
+            ),
+            Http::response(
+                body: $this->ndjsonPayload([
+                    $this->chatChunk('The number is 72019'),
+                    $this->chatChunk('', true, 'stop', ['prompt_eval_count' => 20, 'eval_count' => 10]),
+                ]),
+                status: 200,
+            ),
+        ]),
+    ]);
+
+    $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+    $streamEnds = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd));
+
+    expect($streamEnds)->toHaveCount(1)
+        ->and($streamEnds[0])->toBe($events[count($events) - 1])
+        ->and($streamEnds[0]->reason)->toBe(FinishReason::Stop->value)
+        ->and($streamEnds[0]->usage->promptTokens)->toBe(30)
+        ->and($streamEnds[0]->usage->completionTokens)->toBe(15);
+});
+
 test('streaming finish reason maps correctly', function (string $doneReason, $expected) {
     Http::fake([
         '*' => Http::response(

--- a/tests/Feature/Providers/Ollama/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Ollama/ToolCallLoopTest.php
@@ -2,6 +2,8 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\NoSuchToolException;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
 beforeEach(function () {
@@ -156,6 +158,57 @@ test('tool calls are executed even when done_reason is stop', function () {
 
     expect($recorded)->toHaveCount(2)
         ->and($response->text)->toBe('The number is 72019');
+});
+
+test('multi step tool loop returns accumulated response shape', function () {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeUniqueOllamaToolCallResponse(),
+            fakeUniqueOllamaToolCallResponse(),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new MultiStepToolAgent)->prompt(
+        'Generate numbers',
+        provider: 'ollama',
+    );
+
+    expect((string) $response)->toBe('Done')
+        ->and($response->messages)->toHaveCount(5)
+        ->and($response->steps)->toHaveCount(3)
+        ->and($response->toolCalls)->toHaveCount(2)
+        ->and($response->toolResults)->toHaveCount(2)
+        ->and($response->usage->promptTokens)->toBe(21)
+        ->and($response->usage->completionTokens)->toBe(11);
+});
+
+test('unregistered tool call throws NoSuchToolException', function () {
+    Http::fake([
+        '*' => Http::response([
+            'model' => 'llama3.1:8b',
+            'message' => [
+                'role' => 'assistant',
+                'content' => '',
+                'tool_calls' => [[
+                    'id' => 'call_123',
+                    'function' => [
+                        'name' => 'UnregisteredTool',
+                        'arguments' => (object) [],
+                    ],
+                ]],
+            ],
+            'done_reason' => 'tool_calls',
+            'done' => true,
+            'prompt_eval_count' => 10,
+            'eval_count' => 5,
+        ]),
+    ]);
+
+    expect(fn () => (new MultiStepToolAgent)->prompt(
+        'Generate a number',
+        provider: 'ollama',
+    ))->toThrow(NoSuchToolException::class);
 });
 
 function fakeUniqueOllamaToolCallResponse(): PromiseInterface


### PR DESCRIPTION
Follows #652, which extracted the recursive multi-step tool loop into the shared TextGenerationLoop and converted OpenAI. This does the same for Ollama: the gateway now implements StepTextGateway and produces exactly one provider turn per step, while the loop owns tool dispatch, the step budget, message accumulation, usage totalling, and the terminal StreamEnd.

Ollama is a stateless (family B) provider, so continuationToken stays null and each step rebuilds the full request from the loop-accumulated messages. mapMessagesToChat already serializes the accumulated AssistantMessage and ToolResultMessage into the exact body the old inline continueWithToolResults built, so no message-mapping changes were needed.

One Ollama quirk worth flagging: it can report `done_reason: "stop"` even when tool_calls are populated. The old code looped on the presence of tool calls regardless of done_reason, so to preserve that, parseTextResponse and processTextStream now force FinishReason::ToolCalls whenever tool calls are present (the loop only continues on ToolCalls). This is the one deliberate divergence from OpenAI's parse, which trusts the provider's finish reason.

Carries the two intentional behaviour changes from #652: unknown tool calls now throw NoSuchToolException instead of being silently dropped, and a single StreamEnd is emitted by the loop. Tests updated accordingly; full suite green.