### PR TITLE
Convert DeepSeek to TextGenerationLoop and StepTextGateway

### DIFF
--- a/src/Gateway/DeepSeek/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/DeepSeek/Concerns/BuildsTextRequests.php
@@ -4,12 +4,29 @@ namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
 use Illuminate\Support\Arr;
 use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
+use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 
 trait BuildsTextRequests
 {
     use ComposesSchemaInstructions;
+
+    /**
+     * Build the request body for the current text generation step.
+     */
+    protected function buildStepBody(
+        Provider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        StepContext $stepContext,
+    ): array {
+        return $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+    }
 
     /**
      * Build the request body for the Chat Completions API.

--- a/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/DeepSeek/Concerns/HandlesTextStreaming.php
@@ -3,47 +3,36 @@
 namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
 use Generator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
-use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
      * Process a Chat Completions streaming response and yield Laravel stream events.
+     *
+     * @return Generator<int, StreamEvent, mixed, StepResponse|null>
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        array $priorChatMessages = [],
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $reasoningId = '';
         $inReasoning = false;
@@ -54,6 +43,7 @@ trait HandlesTextStreaming
         $pendingToolCalls = [];
         $usage = null;
         $finishReason = null;
+        $responseModel = $model;
 
         foreach ($this->parseServerSentEvents($streamBody) as $data) {
             if (isset($data['error'])) {
@@ -65,7 +55,7 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
 
-                return;
+                return null;
             }
 
             $choice = $data['choices'][0] ?? null;
@@ -82,11 +72,12 @@ trait HandlesTextStreaming
 
             if (! $streamStartEmitted) {
                 $streamStartEmitted = true;
+                $responseModel = $data['model'] ?? $model;
 
                 yield (new StreamStart(
                     $this->generateEventId(),
                     $provider->name(),
-                    $data['model'] ?? $model,
+                    $responseModel,
                     time(),
                 ))->withInvocationId($invocationId);
             }
@@ -189,196 +180,35 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
-            $mappedToolCalls = $this->mapStreamToolCalls($pendingToolCalls);
+        $toolCalls = [];
 
-            foreach ($mappedToolCalls as $toolCall) {
+        if (filled($pendingToolCalls) && $finishReason === 'tool_calls') {
+            foreach ($this->mapStreamToolCalls($pendingToolCalls) as $toolCall) {
+                $toolCalls[] = $toolCall;
+
                 yield (new ToolCallEvent(
                     $this->generateEventId(),
                     $toolCall,
                     time(),
                 ))->withInvocationId($invocationId);
             }
-
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $mappedToolCalls,
-                $currentText,
-                $instructions,
-                $originalMessages,
-                $depth,
-                $maxSteps,
-                $priorChatMessages,
-                $timeout,
-                $currentReasoning,
-            );
-
-            return;
         }
 
-        yield (new StreamEnd(
-            $this->generateEventId(),
-            $this->extractFinishReason(['finish_reason' => $finishReason ?? ''])->value,
-            $usage ?? new Usage(0, 0),
-            time(),
-        ))->withInvocationId($invocationId);
-    }
+        $providerContentBlocks = [];
 
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $mappedToolCalls,
-        string $currentText,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        array $priorChatMessages,
-        ?int $timeout = null,
-        string $currentReasoning = '',
-    ): Generator {
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
+        if (filled($currentReasoning)) {
+            $providerContentBlocks['reasoning_content'] = $currentReasoning;
         }
 
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $assistantMsg = ['role' => 'assistant'];
-
-            if (filled($currentText)) {
-                $assistantMsg['content'] = $currentText;
-            }
-
-            if (filled($currentReasoning)) {
-                $assistantMsg['reasoning_content'] = $currentReasoning;
-            }
-
-            $assistantMsg['tool_calls'] = array_map(
-                fn (ToolCall $toolCall) => $this->serializeToolCallToChat($toolCall), $mappedToolCalls
-            );
-
-            $toolResultMessages = [];
-
-            foreach ($toolResults as $toolResult) {
-                $toolResultMessages[] = [
-                    'role' => 'tool',
-                    'tool_call_id' => $toolResult->resultId ?? $toolResult->id,
-                    'content' => $this->serializeToolResultOutput($toolResult->result),
-                ];
-            }
-
-            $updatedPriorMessages = [...$priorChatMessages, $assistantMsg, ...$toolResultMessages];
-
-            $chatMessages = [
-                ...$this->mapMessagesToChat(
-                    $originalMessages,
-                    $this->composeInstructions($instructions, $schema),
-                ),
-                ...$updatedPriorMessages,
-            ];
-
-            $body = [
-                'model' => $model,
-                'messages' => $chatMessages,
-                'stream' => true,
-                'stream_options' => ['include_usage' => true],
-            ];
-
-            if (filled($tools)) {
-                $mappedTools = $this->mapTools($tools);
-
-                if (filled($mappedTools)) {
-                    $body['tool_choice'] = 'auto';
-                    $body['tools'] = $mappedTools;
-                }
-            }
-
-            if (filled($schema)) {
-                $body['response_format'] = $this->buildResponseFormat();
-            }
-
-            if (! is_null($options?->maxTokens)) {
-                $body['max_completion_tokens'] = $options->maxTokens;
-            }
-
-            $body = array_merge($body, Arr::whereNotNull([
-                'temperature' => $options?->temperature,
-                'top_p' => $options?->topP,
-            ]));
-
-            $providerOptions = $options?->providerOptions($provider->driver());
-
-            if (filled($providerOptions)) {
-                $body = array_merge($body, $providerOptions);
-            }
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post('chat/completions', $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $updatedPriorMessages,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
+        return new StepResponse(
+            text: $currentText,
+            toolCalls: $toolCalls,
+            finishReason: $this->extractFinishReason(['finish_reason' => $finishReason ?? '']),
+            usage: $usage ?? new Usage(0, 0),
+            meta: new Meta($provider->name(), $responseModel),
+            continuationToken: null,
+            providerContentBlocks: $providerContentBlocks,
+        );
     }
 
     /**

--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -2,22 +2,13 @@
 
 namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -38,65 +29,23 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the DeepSeek response data into a TextResponse.
-     */
-    protected function parseTextResponse(
-        array $data,
-        Provider $provider,
-        bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            instructions: $instructions,
-            originalMessages: $originalMessages,
-            maxSteps: $options?->maxSteps,
-            options: $options,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
+     * Parse the DeepSeek response data into a single step response.
      *
      * DeepSeek thinking-mode responses can include `reasoning_content` on each
      * choice's message. We capture it into `providerContentBlocks`; the message
      * mapper only replays it for assistant messages that include tool calls.
      */
-    protected function processResponse(
+    protected function parseTextResponse(
         array $data,
         Provider $provider,
         bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions = null,
-        array $originalMessages = [],
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): StepResponse {
         $choice = $data['choices'][0] ?? [];
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
 
         $text = $message['content'] ?? '';
         $rawToolCalls = $message['tool_calls'] ?? [];
-        $usage = $this->extractUsage($data);
-        $finishReason = $this->extractFinishReason($choice);
 
         $mappedToolCalls = array_map(fn (array $toolCall) => new ToolCall(
             $toolCall['id'] ?? '',
@@ -105,206 +54,21 @@ trait ParsesTextResponses
             $toolCall['id'] ?? null,
         ), $rawToolCalls);
 
-        $step = new Step(
-            $text,
-            $mappedToolCalls,
-            [],
-            $finishReason,
-            $usage,
-            new Meta($provider->name(), $model),
-        );
-
-        $steps->push($step);
-
         $providerContentBlocks = [];
+
         if (filled($message['reasoning_content'] ?? null)) {
             $providerContentBlocks['reasoning_content'] = $message['reasoning_content'];
         }
 
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls), $providerContentBlocks);
-
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-
-            $steps->pop();
-
-            $steps->push(new Step(
-                $text,
-                $mappedToolCalls,
-                $toolResults,
-                $finishReason,
-                $usage,
-                new Meta($provider->name(), $model),
-            ));
-
-            $toolResultMessage = new ToolResultMessage(collect($toolResults));
-
-            $messages->push($toolResultMessage);
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $instructions,
-                $originalMessages,
-                $depth + 1,
-                $maxSteps,
-                $options,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            $structuredData = json_decode($text, true) ?? [];
-
-            return (new StructuredTextResponse(
-                $structuredData,
-                $text,
-                $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by making a follow-up request.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        ?string $instructions,
-        array $originalMessages,
-        int $depth,
-        ?int $maxSteps,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $chatMessages = $this->mapMessagesToChat(
-            $originalMessages,
-            $this->composeInstructions($instructions, $schema),
-        );
-
-        foreach ($messages as $msg) {
-            match (true) {
-                $msg instanceof AssistantMessage => $this->mapAssistantMessage($msg, $chatMessages),
-                $msg instanceof ToolResultMessage => $this->mapToolResultMessage($msg, $chatMessages),
-                default => null,
-            };
-        }
-
-        $body = [
-            'model' => $model,
-            'messages' => $chatMessages,
-        ];
-
-        if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
-
-            if (filled($mappedTools)) {
-                $body['tool_choice'] = 'auto';
-                $body['tools'] = $mappedTools;
-            }
-        }
-
-        if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat();
-        }
-
-        if (! is_null($options?->maxTokens)) {
-            $body['max_completion_tokens'] = $options->maxTokens;
-        }
-
-        $body = array_merge($body, Arr::whereNotNull([
-            'temperature' => $options?->temperature,
-            'top_p' => $options?->topP,
-        ]));
-
-        $providerOptions = $options?->providerOptions($provider->driver());
-
-        if (filled($providerOptions)) {
-            $body = array_merge($body, $providerOptions);
-        }
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('chat/completions', $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $instructions,
-            $originalMessages,
-            $depth,
-            $maxSteps,
-            $options,
-            $timeout,
+        return new StepResponse(
+            text: $text,
+            toolCalls: $mappedToolCalls,
+            finishReason: $this->extractFinishReason($choice),
+            usage: $this->extractUsage($data),
+            meta: new Meta($provider->name(), $model),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            continuationToken: null,
+            providerContentBlocks: $providerContentBlocks,
         );
     }
 
@@ -336,16 +100,5 @@ trait ParsesTextResponses
             'content_filter' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/DeepSeek/DeepSeekGateway.php
+++ b/src/Gateway/DeepSeek/DeepSeekGateway.php
@@ -4,15 +4,17 @@ namespace Laravel\Ai\Gateway\DeepSeek;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Responses\TextResponse;
 
-class DeepSeekGateway implements TextGateway
+class DeepSeekGateway implements StepTextGateway, TextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesDeepSeekClient;
@@ -21,37 +23,30 @@ class DeepSeekGateway implements TextGateway
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use DelegatesToTextGenerationLoop;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
 
     public function __construct(protected Dispatcher $events)
     {
-        $this->initializeToolCallbacks();
+        //
     }
 
     /**
-     * {@inheritdoc}
+     * Generate text for a single Chat Completions step.
      */
-    public function generateText(
+    public function generateTextStep(
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
+    ): StepResponse {
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -62,42 +57,25 @@ class DeepSeekGateway implements TextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $instructions,
-            $messages,
-            $timeout,
-        );
+        return $this->parseTextResponse($data, $provider, filled($schema));
     }
 
     /**
-     * {@inheritdoc}
+     * Stream text for a single Chat Completions step.
      */
-    public function streamText(
+    public function generateStreamStep(
         string $invocationId,
         TextProvider $provider,
         string $model,
         ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
     ): Generator {
-        $body = $this->buildTextRequestBody(
-            $provider,
-            $model,
-            $instructions,
-            $messages,
-            $tools,
-            $schema,
-            $options,
-        );
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
 
         $body['stream'] = true;
         $body['stream_options'] = ['include_usage' => true];
@@ -109,20 +87,6 @@ class DeepSeekGateway implements TextGateway
                 ->post('chat/completions', $body),
         );
 
-        yield from $this->processTextStream(
-            $invocationId,
-            $provider,
-            $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
-            $instructions,
-            $messages,
-            0,
-            null,
-            [],
-            $timeout,
-        );
+        return yield from $this->processTextStream($invocationId, $provider, $model, $response->getBody());
     }
 }

--- a/tests/Feature/Providers/DeepSeek/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/DeepSeek/ToolCallLoopTest.php
@@ -2,6 +2,8 @@
 
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\NoSuchToolException;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
 beforeEach(function () {
@@ -65,6 +67,64 @@ test('max steps limits tool call depth', function () {
     $recorded = Http::recorded();
 
     expect(count($recorded))->toBeLessThanOrEqual(3);
+});
+
+test('multi step tool loop returns accumulated response shape', function () {
+    Http::fake([
+        'api.deepseek.com/*' => Http::sequence([
+            fakeUniqueDeepSeekToolCallResponse(),
+            fakeUniqueDeepSeekToolCallResponse(),
+            fakeDeepSeekResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new MultiStepToolAgent)->prompt(
+        'Generate numbers',
+        provider: 'deepseek',
+    );
+
+    expect((string) $response)->toBe('Done')
+        ->and($response->messages)->toHaveCount(5)
+        ->and($response->steps)->toHaveCount(3)
+        ->and($response->toolCalls)->toHaveCount(2)
+        ->and($response->toolResults)->toHaveCount(2)
+        ->and($response->usage->promptTokens)->toBe(21)
+        ->and($response->usage->completionTokens)->toBe(11);
+});
+
+test('unknown tool call throws no such tool exception', function () {
+    Http::fake([
+        'api.deepseek.com/*' => Http::response([
+            'id' => 'chatcmpl-tool-unknown',
+            'object' => 'chat.completion',
+            'model' => 'deepseek-chat',
+            'choices' => [[
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [[
+                        'id' => 'call_unknown',
+                        'type' => 'function',
+                        'function' => [
+                            'name' => 'UnregisteredTool',
+                            'arguments' => '{}',
+                        ],
+                    ]],
+                ],
+                'finish_reason' => 'tool_calls',
+            ]],
+            'usage' => [
+                'prompt_tokens' => 10,
+                'completion_tokens' => 5,
+            ],
+        ]),
+    ]);
+
+    expect(fn () => (new MultiStepToolAgent)->prompt(
+        'Generate numbers',
+        provider: 'deepseek',
+    ))->toThrow(NoSuchToolException::class);
 });
 
 function fakeUniqueDeepSeekToolCallResponse(): PromiseInterface


### PR DESCRIPTION
Continues the #652 migration (OpenAI is the gold standard there) by moving DeepSeek off its private recursive tool loop and onto the shared TextGenerationLoop via the StepTextGateway contract. Pure refactor: same request bodies, response parsing, streaming events, usage, and finish-reason mapping, just with multi-step orchestration owned by the loop instead of the gateway.

DeepSeek is a family B (stateless) provider, so it replays the full conversation each step rather than using a continuation token. The accumulated AssistantMessage (tool calls + reasoning_content) and ToolResultMessage are reconstructed through the existing MapsMessages layer, which already produced the identical follow-up body the old inline continuation built, so MapsMessages is untouched.

Two behaviour changes carry over from #652: unknown tool calls now throw NoSuchToolException instead of being silently dropped, and the single StreamEnd is emitted by the loop. Tests updated accordingly (added multi-step accumulation and no-such-tool cases).

Faked suite green (59 passing), Pint and PHPStan clean. Integration tests are pending a DEEPSEEK_API_KEY.