### PR TITLE
Convert Gemini gateway to the shared TextGenerationLoop

### DIFF
--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -12,9 +12,6 @@ trait BuildsTextRequests
 {
     /**
      * Build the request body for the Gemini generateContent API.
-     *
-     * Returns a tuple of [request body, contents array] so the contents
-     * can be tracked for tool loop history resending.
      */
     protected function buildTextRequestBody(
         Provider $provider,
@@ -26,20 +23,6 @@ trait BuildsTextRequests
     ): array {
         $contents = $this->mapMessagesToContents($messages);
 
-        return [$this->assembleRequestBody($contents, $instructions, $tools, $schema, $options, $provider), $contents];
-    }
-
-    /**
-     * Rebuild the request body for a tool-loop continuation.
-     */
-    protected function rebuildContinuationBody(
-        array $contents,
-        ?string $instructions,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        Provider $provider,
-    ): array {
         return $this->assembleRequestBody($contents, $instructions, $tools, $schema, $options, $provider);
     }
 

--- a/src/Gateway/Gemini/Concerns/HandlesTextSteps.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextSteps.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Gemini\Concerns;
+
+use Generator;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\StepResponse;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+
+trait HandlesTextSteps
+{
+    /**
+     * Generate text for a single generateContent step.
+     */
+    public function generateTextStep(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
+    ): StepResponse {
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return $this->parseTextResponse($data, $provider, $model, filled($schema));
+    }
+
+    /**
+     * Stream text for a single streamGenerateContent step.
+     */
+    public function generateStreamStep(
+        string $invocationId,
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        ?int $timeout,
+        StepContext $stepContext,
+    ): Generator {
+        $body = $this->buildStepBody($provider, $model, $instructions, $messages, $tools, $schema, $options, $stepContext);
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->withOptions(['stream' => true])
+                ->post("models/{$model}:streamGenerateContent?alt=sse", $body),
+        );
+
+        return yield from $this->processTextStream($invocationId, $provider, $model, $response->getBody());
+    }
+
+    /**
+     * Build the request body for the current text generation step.
+     */
+    protected function buildStepBody(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+        ?TextGenerationOptions $options,
+        StepContext $stepContext,
+    ): array {
+        return $this->buildTextRequestBody($provider, $instructions, $messages, $tools, $schema, $options);
+    }
+}

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -4,43 +4,34 @@ namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Generator;
 use Illuminate\Support\Str;
-use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
-use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
-use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
-use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
 
 trait HandlesTextStreaming
 {
     /**
      * Process a Gemini streaming response and yield Laravel stream events.
+     *
+     * @return Generator<int, StreamEvent, mixed, StepResponse|null>
      */
     protected function processTextStream(
         string $invocationId,
         Provider $provider,
         string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
         $streamBody,
-        array $contents = [],
-        ?string $instructions = null,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
     ): Generator {
-        $maxSteps ??= $options?->maxSteps;
-
         $messageId = $this->generateEventId();
         $reasoningId = '';
         $streamStartEmitted = false;
@@ -179,129 +170,29 @@ trait HandlesTextStreaming
             ))->withInvocationId($invocationId);
         }
 
-        // Handle pending tool calls...
+        // Map and emit any pending tool calls...
+        $toolCalls = [];
+
         if (filled($pendingToolCalls)) {
-            yield from $this->handleStreamingToolCalls(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $pendingToolCalls,
-                $contents,
-                $instructions,
-                $modelParts,
-                $depth,
-                $maxSteps,
-                $timeout,
-            );
+            $toolCalls = $this->mapToolCalls($pendingToolCalls);
 
-            return;
-        }
-
-        yield (new StreamEnd(
-            $this->generateEventId(),
-            $this->extractFinishReason($data, $pendingToolCalls)->value,
-            $usage ?? new Usage(0, 0),
-            time(),
-        ))->withInvocationId($invocationId);
-    }
-
-    /**
-     * Handle tool calls detected during streaming.
-     */
-    protected function handleStreamingToolCalls(
-        string $invocationId,
-        Provider $provider,
-        string $model,
-        array $tools,
-        ?array $schema,
-        ?TextGenerationOptions $options,
-        array $pendingToolCalls,
-        array $contents,
-        ?string $instructions,
-        array $modelParts,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): Generator {
-        $mappedToolCalls = $this->mapToolCalls($pendingToolCalls);
-
-        // Emit tool call events...
-        foreach ($mappedToolCalls as $toolCall) {
-            yield (new ToolCallEvent(
-                $this->generateEventId(),
-                $toolCall,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
-
-        $toolResults = [];
-
-        foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
+            foreach ($toolCalls as $toolCall) {
+                yield (new ToolCallEvent(
+                    $this->generateEventId(),
+                    $toolCall,
+                    time(),
+                ))->withInvocationId($invocationId);
             }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $toolResult = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-
-            $toolResults[] = $toolResult;
-
-            yield (new ToolResultEvent(
-                $this->generateEventId(),
-                $toolResult,
-                true,
-                null,
-                time(),
-            ))->withInvocationId($invocationId);
         }
 
-        if ($depth + 1 < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $contents[] = ['role' => 'model', 'parts' => $this->sanitizeRequestParts($this->excludeThinkingParts($modelParts))];
-            $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
-
-            $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);
-
-            $response = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)
-                    ->withOptions(['stream' => true])
-                    ->post("models/{$model}:streamGenerateContent?alt=sse", $body),
-            );
-
-            yield from $this->processTextStream(
-                $invocationId,
-                $provider,
-                $model,
-                $tools,
-                $schema,
-                $options,
-                $response->getBody(),
-                $contents,
-                $instructions,
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        } else {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                'stop',
-                new Usage(0, 0),
-                time(),
-            ))->withInvocationId($invocationId);
-        }
+        return new StepResponse(
+            text: $currentText,
+            toolCalls: $toolCalls,
+            finishReason: $this->extractFinishReason($data, $pendingToolCalls),
+            usage: $usage ?? new Usage(0, 0),
+            meta: new Meta($provider->name(), $model),
+            providerContentBlocks: $this->sanitizeRequestParts($this->excludeThinkingParts($modelParts)),
+        );
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/MapsMessages.php
+++ b/src/Gateway/Gemini/Concerns/MapsMessages.php
@@ -52,6 +52,15 @@ trait MapsMessages
      */
     protected function mapAssistantMessage(AssistantMessage|Message $message, array &$contents): void
     {
+        if ($message instanceof AssistantMessage && filled($message->providerContentBlocks)) {
+            $contents[] = [
+                'role' => 'model',
+                'parts' => $message->providerContentBlocks,
+            ];
+
+            return;
+        }
+
         $parts = [];
 
         if (filled($message->content)) {

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -4,21 +4,14 @@ namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\AiException;
-use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\AssistantMessage;
-use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
-use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
-use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
-use Laravel\Ai\Responses\StructuredTextResponse;
-use Laravel\Ai\Responses\TextResponse;
 
 trait ParsesTextResponses
 {
@@ -39,201 +32,28 @@ trait ParsesTextResponses
     }
 
     /**
-     * Parse the Gemini response data into a TextResponse.
+     * Parse the Gemini response data into a single step response.
      */
     protected function parseTextResponse(
         array $data,
         Provider $provider,
         string $model,
         bool $structured,
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        array $contents = [],
-        ?string $instructions = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        return $this->processResponse(
-            $data,
-            $provider,
-            $model,
-            $structured,
-            $tools,
-            $schema,
-            new Collection,
-            new Collection,
-            $contents,
-            $instructions,
-            $options,
-            maxSteps: $options?->maxSteps,
-            timeout: $timeout,
-        );
-    }
-
-    /**
-     * Process a single response, handling tool loops recursively.
-     */
-    protected function processResponse(
-        array $data,
-        Provider $provider,
-        string $model,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $contents,
-        ?string $instructions,
-        ?TextGenerationOptions $options,
-        int $depth = 0,
-        ?int $maxSteps = null,
-        ?int $timeout = null,
-    ): TextResponse {
+    ): StepResponse {
         $candidate = $data['candidates'][0] ?? [];
         $parts = $candidate['content']['parts'] ?? [];
 
         $text = $this->extractText($parts);
         $rawToolCalls = $this->extractRawToolCalls($parts);
-        $citations = $this->extractCitations($data);
-        $usage = $this->extractUsage($data);
-        $finishReason = $this->extractFinishReason($data, $rawToolCalls);
 
-        $mappedToolCalls = $this->mapToolCalls($rawToolCalls);
-        $meta = new Meta($provider->name(), $model, $citations);
-        $toolResults = [];
-
-        $assistantMessage = new AssistantMessage($text, collect($mappedToolCalls));
-        $messages->push($assistantMessage);
-
-        if ($finishReason === FinishReason::ToolCalls &&
-            filled($mappedToolCalls) &&
-            $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
-        }
-
-        $steps->push(new Step($text, $mappedToolCalls, $toolResults, $finishReason, $usage, $meta));
-
-        if (filled($toolResults)) {
-            $messages->push(new ToolResultMessage(collect($toolResults)));
-
-            $contents[] = ['role' => 'model', 'parts' => $this->sanitizeRequestParts($this->excludeThinkingParts($parts))];
-            $contents[] = ['role' => 'user', 'parts' => $this->buildFunctionResponseParts($toolResults)];
-
-            return $this->continueWithToolResults(
-                $model,
-                $provider,
-                $structured,
-                $tools,
-                $schema,
-                $steps,
-                $messages,
-                $contents,
-                $instructions,
-                $options,
-                $depth + 1,
-                $maxSteps,
-                $timeout,
-            );
-        }
-
-        $allToolCalls = $steps->flatMap(fn (Step $s) => $s->toolCalls);
-        $allToolResults = $steps->flatMap(fn (Step $s) => $s->toolResults);
-
-        if ($structured) {
-            return (new StructuredTextResponse(
-                json_decode($text, true) ?? [],
-                $text,
-                $this->combineUsage($steps),
-                $meta,
-            ))->withToolCallsAndResults(
-                toolCalls: $allToolCalls,
-                toolResults: $allToolResults,
-            )->withSteps($steps);
-        }
-
-        return (new TextResponse(
-            $text,
-            $this->combineUsage($steps),
-            $meta,
-        ))->withMessages($messages)->withSteps($steps);
-    }
-
-    /**
-     * Execute tool calls and return tool results.
-     *
-     * @param  array<ToolCall>  $toolCalls
-     * @param  array<Tool>  $tools
-     * @return array<ToolResult>
-     */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
-    {
-        $results = [];
-
-        foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
-
-            if ($tool === null) {
-                continue;
-            }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
-
-            $results[] = new ToolResult(
-                $toolCall->id,
-                $toolCall->name,
-                $toolCall->arguments,
-                $result,
-                $toolCall->resultId,
-            );
-        }
-
-        return $results;
-    }
-
-    /**
-     * Continue the conversation with tool results by resending the full history.
-     */
-    protected function continueWithToolResults(
-        string $model,
-        Provider $provider,
-        bool $structured,
-        array $tools,
-        ?array $schema,
-        Collection $steps,
-        Collection $messages,
-        array $contents,
-        ?string $instructions,
-        ?TextGenerationOptions $options,
-        int $depth,
-        ?int $maxSteps,
-        ?int $timeout = null,
-    ): TextResponse {
-        $body = $this->rebuildContinuationBody($contents, $instructions, $tools, $schema, $options, $provider);
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->processResponse(
-            $data,
-            $provider,
-            $model,
-            $structured,
-            $tools,
-            $schema,
-            $steps,
-            $messages,
-            $contents,
-            $instructions,
-            $options,
-            $depth,
-            $maxSteps,
-            $timeout,
+        return new StepResponse(
+            text: $text,
+            toolCalls: $this->mapToolCalls($rawToolCalls),
+            finishReason: $this->extractFinishReason($data, $rawToolCalls),
+            usage: $this->extractUsage($data),
+            meta: new Meta($provider->name(), $model, $this->extractCitations($data)),
+            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            providerContentBlocks: $this->sanitizeRequestParts($this->excludeThinkingParts($parts)),
         );
     }
 
@@ -412,16 +232,5 @@ trait ParsesTextResponses
             'SAFETY', 'RECITATION', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'MALFORMED_FUNCTION_CALL' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
-    }
-
-    /**
-     * Combine usage across all steps.
-     */
-    protected function combineUsage(Collection $steps): Usage
-    {
-        return $steps->reduce(
-            fn (Usage $carry, Step $step) => $carry->add($step->usage),
-            new Usage(0, 0)
-        );
     }
 }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -2,22 +2,20 @@
 
 namespace Laravel\Ai\Gateway\Gemini;
 
-use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
+use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
-use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
+use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
-use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
-use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
@@ -25,108 +23,27 @@ use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
-use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use RuntimeException;
 
-class GeminiGateway implements Gateway
+class GeminiGateway implements Gateway, StepTextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesGeminiClient;
+    use Concerns\HandlesTextSteps;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
+    use DelegatesToTextGenerationLoop;
     use HandlesFailoverErrors;
-    use InvokesTools;
     use ParsesServerSentEvents;
     use WrapsPcmAudio;
 
     public function __construct(protected Dispatcher $events)
     {
-        $this->initializeToolCallbacks();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function generateText(
-        TextProvider $provider,
-        string $model,
-        ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): TextResponse {
-        [$body, $contents] = $this->buildTextRequestBody(
-            $provider, $instructions, $messages, $tools, $schema, $options,
-        );
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", $body),
-        );
-
-        $data = $response->json();
-
-        $this->validateTextResponse($data);
-
-        return $this->parseTextResponse(
-            $data,
-            $provider,
-            $model,
-            filled($schema),
-            $tools,
-            $schema,
-            $options,
-            $contents,
-            $instructions,
-            $timeout,
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function streamText(
-        string $invocationId,
-        TextProvider $provider,
-        string $model,
-        ?string $instructions,
-        array $messages = [],
-        array $tools = [],
-        ?array $schema = null,
-        ?TextGenerationOptions $options = null,
-        ?int $timeout = null,
-    ): Generator {
-        [$body, $contents] = $this->buildTextRequestBody(
-            $provider, $instructions, $messages, $tools, $schema, $options,
-        );
-
-        $response = $this->withErrorHandling(
-            $provider->name(),
-            fn () => $this->client($provider, $timeout)
-                ->withOptions(['stream' => true])
-                ->post("models/{$model}:streamGenerateContent?alt=sse", $body),
-        );
-
-        yield from $this->processTextStream(
-            $invocationId,
-            $provider,
-            $model,
-            $tools,
-            $schema,
-            $options,
-            $response->getBody(),
-            $contents,
-            $instructions,
-            0,
-            null,
-            $timeout,
-        );
+        //
     }
 
     /**

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -92,6 +92,43 @@ describe('tool calls', function () {
             ->and($toolCallEvents[0]->toolCall->name)->toBe('FixedNumberGenerator');
     });
 
+    test('streaming tool loop emits a single stream end with accumulated usage', function () {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([[
+                            'functionCall' => [
+                                'id' => 'call_1',
+                                'name' => 'FixedNumberGenerator',
+                                'args' => (object) [],
+                            ],
+                        ]], 10, 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([['text' => 'The number is 72019']], 20, 10),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $events = $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $streamEnds = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd));
+
+        expect($streamEnds)->toHaveCount(1)
+            ->and($streamEnds[0]->reason)->toBe(FinishReason::Stop->value)
+            ->and($streamEnds[0]->usage)
+            ->promptTokens->toBe(30)
+            ->completionTokens->toBe(15);
+    });
+
     test('streaming thinking parts are excluded from tool call continuation', function () {
         Http::fake([
             'generativelanguage.googleapis.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\NoSuchToolException;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\NamedToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -68,6 +70,41 @@ test('max steps limits tool call depth', function () {
     $recorded = Http::recorded();
 
     expect(count($recorded))->toBeLessThanOrEqual(3);
+});
+
+test('multi step tool loop returns accumulated response shape', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            $this->fakeUniqueToolCallResponse(),
+            $this->fakeUniqueToolCallResponse(),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    $response = (new MultiStepToolAgent)->prompt(
+        'Generate numbers',
+        provider: 'gemini',
+    );
+
+    expect((string) $response)->toBe('Done')
+        ->and($response->messages)->toHaveCount(5)
+        ->and($response->steps)->toHaveCount(3)
+        ->and($response->toolCalls)->toHaveCount(2)
+        ->and($response->toolResults)->toHaveCount(2)
+        ->and($response->usage->promptTokens)->toBe(30)
+        ->and($response->usage->completionTokens)->toBe(15);
+});
+
+test('unregistered tool call throws', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            $this->fakeToolCallResponse('NonExistentTool', 'call_missing'),
+            $this->fakeTextResponse('Done'),
+        ]),
+    ]);
+
+    expect(fn () => (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini'))
+        ->toThrow(NoSuchToolException::class);
 });
 
 test('function response includes id for gemini 3', function () {


### PR DESCRIPTION
#652 extracted the recursive multi-step tool loop into the shared `TextGenerationLoop` and moved OpenAI (and Azure) onto the `StepTextGateway` contract. This applies the same migration to Gemini: the gateway now produces a single provider turn as a `StepResponse` and the loop owns tool dispatch, the step budget, message accumulation, usage totalling, and final-response assembly.

Gemini is a stateless "full replay" provider (unlike OpenAI's stateful `previous_response_id`), so `continuationToken` stays null and each step rebuilds the request from the loop-accumulated messages. The delicate part is replaying the assistant turn identically to the old inline code: `StepResponse::providerContentBlocks` carries the sanitized, thinking-stripped parts, and `mapAssistantMessage` now replays those blocks so the follow-up request body is byte-for-byte what it was before.

Three intentional behaviour changes carried over from #652:
- An unregistered tool call now throws `NoSuchToolException` instead of being silently dropped.
- `StreamEnd` is emitted once by the loop with accumulated finish reason and usage (previously emitted per recursion with a zeroed `Usage`).
- When streaming hits the step budget with a pending tool call, the final `StreamEnd` now reports the model's actual finish reason (`tool_calls`) instead of being forced to `stop`. This matches what the non-streaming path already reported, so both paths are now consistent.

Pure refactor, no wire-format changes. Existing Gemini tests pass unchanged; added coverage for multi-step accumulation, the no-such-tool throw, and the single streaming `StreamEnd`.
