### PR TITLE
Add collection generics to ToolResultMessage toolResults

### DIFF
--- a/src/Messages/ToolResultMessage.php
+++ b/src/Messages/ToolResultMessage.php
@@ -3,13 +3,17 @@
 namespace Laravel\Ai\Messages;
 
 use Illuminate\Support\Collection;
+use Laravel\Ai\Responses\Data\ToolResult;
 
 class ToolResultMessage extends Message
 {
+    /** @var Collection<int, ToolResult> */
     public Collection $toolResults;
 
     /**
      * Create a new text conversation message instance.
+     *
+     * @param  Collection<int, ToolResult>  $toolResults
      */
     public function __construct(Collection $toolResults)
     {


### PR DESCRIPTION
Adds `Collection<int, ToolResult>` generics to `ToolResultMessage::$toolResults` and its constructor `@param`. 
The element type is already enforced throughout the codebase:                                                                                                                                                                                                                                                                                                                                                                                                                    
  - `TextResponse::withMessages()` annotates `$message->toolResults` as `Collection<int, ToolResult>`.                                                                                                                                   
  - `DatabaseConversationStore` constructs the message from `ToolResult::fromArray(...)`.                                                                                                                                                    
                                                                                                                                                                                                                                         
Type-only, no behavior change.       