### PR TITLE
Add web search and web fetch support for Ollama

### DIFF
--- a/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Ollama/Concerns/BuildsTextRequests.php
@@ -50,7 +50,7 @@ trait BuildsTextRequests
         ];
 
         if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
+            $mappedTools = $this->mapTools($tools, $provider);
 
             if (filled($mappedTools)) {
                 $body['tools'] = $mappedTools;

--- a/src/Gateway/Ollama/Concerns/ExecutesWebTools.php
+++ b/src/Gateway/Ollama/Concerns/ExecutesWebTools.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Exceptions\AiException;
@@ -9,9 +10,26 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
+use Laravel\Ai\Responses\Data\ToolCall;
 
 trait ExecutesWebTools
 {
+    /**
+     * Resolve a tool call to its result, or null when no matching tool is registered.
+     */
+    protected function resolveToolResult(ToolCall $toolCall, array $tools, Provider $provider, ?int $timeout): ?string
+    {
+        if ($webTool = $this->findProviderWebTool($toolCall->name, $tools)) {
+            return $this->executeWebTool($webTool, $toolCall->arguments, $provider, $timeout);
+        }
+
+        $tool = $this->findTool($toolCall->name, $tools);
+
+        return $tool === null
+            ? null
+            : $this->executeTool($tool, $toolCall->arguments);
+    }
+
     /**
      * Find a provider web tool matching the given tool call name.
      */
@@ -48,14 +66,16 @@ trait ExecutesWebTools
 
         [$endpoint, $body] = $tool instanceof WebSearch
             ? ['api/web_search', $this->webSearchRequestBody($tool, $arguments, $provider)]
-            : ['api/web_fetch', array_filter(['url' => $arguments['url'] ?? null], fn ($value) => ! is_null($value))];
+            : ['api/web_fetch', $this->webFetchRequestBody($arguments)];
 
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $client->post($endpoint, $body),
         );
 
-        return json_encode($response->json()) ?: '{}';
+        $data = $response->json();
+
+        return $data === null ? '{}' : (json_encode($data) ?: '{}');
     }
 
     /**
@@ -67,10 +87,22 @@ trait ExecutesWebTools
             ? $provider->webSearchToolOptions($tool)
             : [];
 
-        return array_filter([
+        $maxResults = $options['max_results'] ?? $arguments['max_results'] ?? null;
+
+        return Arr::whereNotNull([
             'query' => $arguments['query'] ?? null,
-            'max_results' => $options['max_results'] ?? $arguments['max_results'] ?? null,
-        ], fn ($value) => ! is_null($value));
+            'max_results' => is_null($maxResults) ? null : min((int) $maxResults, 10),
+        ]);
+    }
+
+    /**
+     * Build the request body for an Ollama web fetch call.
+     */
+    protected function webFetchRequestBody(array $arguments): array
+    {
+        return Arr::whereNotNull([
+            'url' => $arguments['url'] ?? null,
+        ]);
     }
 
     /**

--- a/src/Gateway/Ollama/Concerns/ExecutesWebTools.php
+++ b/src/Gateway/Ollama/Concerns/ExecutesWebTools.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Ollama\Concerns;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebFetch;
+use Laravel\Ai\Providers\Tools\WebSearch;
+
+trait ExecutesWebTools
+{
+    /**
+     * Find a provider web tool matching the given tool call name.
+     */
+    protected function findProviderWebTool(string $name, array $tools): ?ProviderTool
+    {
+        foreach ($tools as $tool) {
+            if ($name === 'web_search' && $tool instanceof WebSearch) {
+                return $tool;
+            }
+
+            if ($name === 'web_fetch' && $tool instanceof WebFetch) {
+                return $tool;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Execute a web tool against Ollama's hosted web search API.
+     */
+    protected function executeWebTool(ProviderTool $tool, array $arguments, Provider $provider, ?int $timeout = null): string
+    {
+        $key = $provider->providerCredentials()['key'] ?? null;
+
+        if (blank($key)) {
+            throw new AiException('Ollama web search requires an API key. Set the "key" configuration value for the Ollama provider.');
+        }
+
+        $client = Http::baseUrl($this->webSearchBaseUrl($provider))
+            ->withToken($key)
+            ->timeout($timeout ?? 60)
+            ->throw();
+
+        [$endpoint, $body] = $tool instanceof WebSearch
+            ? ['api/web_search', $this->webSearchRequestBody($tool, $arguments, $provider)]
+            : ['api/web_fetch', array_filter(['url' => $arguments['url'] ?? null], fn ($value) => ! is_null($value))];
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $client->post($endpoint, $body),
+        );
+
+        return json_encode($response->json()) ?: '{}';
+    }
+
+    /**
+     * Build the request body for an Ollama web search call.
+     */
+    protected function webSearchRequestBody(WebSearch $tool, array $arguments, Provider $provider): array
+    {
+        $options = $provider instanceof SupportsWebSearch
+            ? $provider->webSearchToolOptions($tool)
+            : [];
+
+        return array_filter([
+            'query' => $arguments['query'] ?? null,
+            'max_results' => $options['max_results'] ?? $arguments['max_results'] ?? null,
+        ], fn ($value) => ! is_null($value));
+    }
+
+    /**
+     * Get the base URL for Ollama's hosted web search API.
+     */
+    protected function webSearchBaseUrl(Provider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['web_search_url'] ?? 'https://ollama.com', '/');
+    }
+}

--- a/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
@@ -234,13 +234,17 @@ trait HandlesTextStreaming
         $toolResults = [];
 
         foreach ($mappedToolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
+            if ($webTool = $this->findProviderWebTool($toolCall->name, $tools)) {
+                $result = $this->executeWebTool($webTool, $toolCall->arguments, $provider, $timeout);
+            } else {
+                $tool = $this->findTool($toolCall->name, $tools);
 
-            if ($tool === null) {
-                continue;
+                if ($tool === null) {
+                    continue;
+                }
+
+                $result = $this->executeTool($tool, $toolCall->arguments);
             }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
 
             $toolResult = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Ollama/Concerns/HandlesTextStreaming.php
@@ -234,16 +234,10 @@ trait HandlesTextStreaming
         $toolResults = [];
 
         foreach ($mappedToolCalls as $toolCall) {
-            if ($webTool = $this->findProviderWebTool($toolCall->name, $tools)) {
-                $result = $this->executeWebTool($webTool, $toolCall->arguments, $provider, $timeout);
-            } else {
-                $tool = $this->findTool($toolCall->name, $tools);
+            $result = $this->resolveToolResult($toolCall, $tools, $provider, $timeout);
 
-                if ($tool === null) {
-                    continue;
-                }
-
-                $result = $this->executeTool($tool, $toolCall->arguments);
+            if ($result === null) {
+                continue;
             }
 
             $toolResult = new ToolResult(

--- a/src/Gateway/Ollama/Concerns/MapsTools.php
+++ b/src/Gateway/Ollama/Concerns/MapsTools.php
@@ -58,6 +58,14 @@ trait MapsTools
             throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
         }
 
+        if (filled($tool->allowedDomains)) {
+            throw new RuntimeException('Ollama web search does not support restricting allowed domains.');
+        }
+
+        if ($tool->hasLocation()) {
+            throw new RuntimeException('Ollama web search does not support location-based results.');
+        }
+
         return [
             'type' => 'function',
             'function' => [
@@ -88,6 +96,10 @@ trait MapsTools
     {
         if (! $provider instanceof SupportsWebFetch) {
             throw new RuntimeException('Provider ['.$provider->name().'] does not support web fetch.');
+        }
+
+        if (filled($tool->allowedDomains)) {
+            throw new RuntimeException('Ollama web fetch does not support restricting allowed domains.');
         }
 
         return [

--- a/src/Gateway/Ollama/Concerns/MapsTools.php
+++ b/src/Gateway/Ollama/Concerns/MapsTools.php
@@ -3,9 +3,14 @@
 namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebFetch;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Tools\ToolNameResolver;
 use RuntimeException;
 
@@ -14,21 +19,94 @@ trait MapsTools
     /**
      * Map the given tools to Ollama function definitions.
      */
-    protected function mapTools(array $tools): array
+    protected function mapTools(array $tools, Provider $provider): array
     {
         $mapped = [];
 
         foreach ($tools as $tool) {
             if ($tool instanceof ProviderTool) {
-                throw new RuntimeException('Ollama does not support ['.class_basename($tool).'] provider tools.');
-            }
-
-            if ($tool instanceof Tool) {
+                $mapped[] = $this->mapProviderTool($tool, $provider);
+            } elseif ($tool instanceof Tool) {
                 $mapped[] = $this->mapTool($tool);
             }
         }
 
         return $mapped;
+    }
+
+    /**
+     * Map a provider tool to an Ollama function definition.
+     *
+     * Ollama exposes web search and web fetch as client-executed functions
+     * backed by its hosted API rather than as native server-side tools.
+     */
+    protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
+    {
+        return match (true) {
+            $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
+            $tool instanceof WebFetch => $this->mapWebFetchTool($tool, $provider),
+            default => throw new RuntimeException('Ollama does not support ['.class_basename($tool).'] provider tools.'),
+        };
+    }
+
+    /**
+     * Map a web search tool to an Ollama function definition.
+     */
+    protected function mapWebSearchTool(WebSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
+        }
+
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'web_search',
+                'description' => 'Search the web for current information. Returns a list of results with titles, URLs, and content snippets.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'query' => [
+                            'type' => 'string',
+                            'description' => 'The search query.',
+                        ],
+                        'max_results' => [
+                            'type' => 'integer',
+                            'description' => 'The maximum number of results to return.',
+                        ],
+                    ],
+                    'required' => ['query'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Map a web fetch tool to an Ollama function definition.
+     */
+    protected function mapWebFetchTool(WebFetch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebFetch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web fetch.');
+        }
+
+        return [
+            'type' => 'function',
+            'function' => [
+                'name' => 'web_fetch',
+                'description' => 'Fetch the contents of a web page by URL. Returns the page title, content, and links.',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'url' => [
+                            'type' => 'string',
+                            'description' => 'The URL of the web page to fetch.',
+                        ],
+                    ],
+                    'required' => ['url'],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
@@ -202,16 +202,10 @@ trait ParsesTextResponses
         $results = [];
 
         foreach ($toolCalls as $toolCall) {
-            if ($webTool = $this->findProviderWebTool($toolCall->name, $tools)) {
-                $result = $this->executeWebTool($webTool, $toolCall->arguments, $provider, $timeout);
-            } else {
-                $tool = $this->findTool($toolCall->name, $tools);
+            $result = $this->resolveToolResult($toolCall, $tools, $provider, $timeout);
 
-                if ($tool === null) {
-                    continue;
-                }
-
-                $result = $this->executeTool($tool, $toolCall->arguments);
+            if ($result === null) {
+                continue;
             }
 
             $results[] = new ToolResult(

--- a/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Ollama/Concerns/ParsesTextResponses.php
@@ -120,7 +120,7 @@ trait ParsesTextResponses
 
         if (filled($mappedToolCalls) &&
             $steps->count() < ($maxSteps ?? round(count($tools) * 1.5))) {
-            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools);
+            $toolResults = $this->executeToolCalls($mappedToolCalls, $tools, $provider, $timeout);
 
             $steps->pop();
 
@@ -197,18 +197,22 @@ trait ParsesTextResponses
      * @param  array<Tool>  $tools
      * @return array<ToolResult>
      */
-    protected function executeToolCalls(array $toolCalls, array $tools): array
+    protected function executeToolCalls(array $toolCalls, array $tools, Provider $provider, ?int $timeout = null): array
     {
         $results = [];
 
         foreach ($toolCalls as $toolCall) {
-            $tool = $this->findTool($toolCall->name, $tools);
+            if ($webTool = $this->findProviderWebTool($toolCall->name, $tools)) {
+                $result = $this->executeWebTool($webTool, $toolCall->arguments, $provider, $timeout);
+            } else {
+                $tool = $this->findTool($toolCall->name, $tools);
 
-            if ($tool === null) {
-                continue;
+                if ($tool === null) {
+                    continue;
+                }
+
+                $result = $this->executeTool($tool, $toolCall->arguments);
             }
-
-            $result = $this->executeTool($tool, $toolCall->arguments);
 
             $results[] = new ToolResult(
                 $toolCall->id,

--- a/src/Gateway/Ollama/OllamaGateway.php
+++ b/src/Gateway/Ollama/OllamaGateway.php
@@ -20,6 +20,7 @@ class OllamaGateway implements EmbeddingGateway, TextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesOllamaClient;
+    use Concerns\ExecutesWebTools;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;
     use Concerns\MapsMessages;

--- a/src/Providers/OllamaProvider.php
+++ b/src/Providers/OllamaProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
@@ -43,9 +44,9 @@ class OllamaProvider extends Provider implements EmbeddingProvider, SupportsWebF
      */
     public function webSearchToolOptions(WebSearch $search): array
     {
-        return array_filter([
+        return Arr::whereNotNull([
             'max_results' => $search->maxSearches,
-        ], fn ($value) => ! is_null($value));
+        ]);
     }
 
     /**

--- a/src/Providers/OllamaProvider.php
+++ b/src/Providers/OllamaProvider.php
@@ -6,10 +6,14 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\TextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\Ollama\OllamaGateway;
+use Laravel\Ai\Providers\Tools\WebFetch;
+use Laravel\Ai\Providers\Tools\WebSearch;
 
-class OllamaProvider extends Provider implements EmbeddingProvider, TextProvider
+class OllamaProvider extends Provider implements EmbeddingProvider, SupportsWebFetch, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
@@ -32,6 +36,24 @@ class OllamaProvider extends Provider implements EmbeddingProvider, TextProvider
         return [
             'key' => $this->config['key'] ?? '',
         ];
+    }
+
+    /**
+     * Get the web search tool options for the provider.
+     */
+    public function webSearchToolOptions(WebSearch $search): array
+    {
+        return array_filter([
+            'max_results' => $search->maxSearches,
+        ], fn ($value) => ! is_null($value));
+    }
+
+    /**
+     * Get the web fetch tool options for the provider.
+     */
+    public function webFetchToolOptions(WebFetch $fetch): array
+    {
+        return [];
     }
 
     /**

--- a/tests/Feature/Providers/Ollama/WebSearchTest.php
+++ b/tests/Feature/Providers/Ollama/WebSearchTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Providers\Tools\WebFetch;
+use Laravel\Ai\Providers\Tools\WebSearch;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function () {
+    config(['ai.providers.ollama' => [
+        ...config('ai.providers.ollama'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('web search tool is mapped to a function definition', function () {
+    Http::fake(['*' => $this->fakeTextResponse('done')]);
+
+    agent(tools: [new WebSearch])->prompt('Search the web', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('function.name', 'web_search');
+
+        return $tool['type'] === 'function'
+            && array_key_exists('query', $tool['function']['parameters']['properties'])
+            && in_array('query', $tool['function']['parameters']['required'], true);
+    });
+});
+
+test('web fetch tool is mapped to a function definition', function () {
+    Http::fake(['*' => $this->fakeTextResponse('done')]);
+
+    agent(tools: [new WebFetch])->prompt('Fetch a page', provider: 'ollama');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('function.name', 'web_fetch');
+
+        return $tool['type'] === 'function'
+            && array_key_exists('url', $tool['function']['parameters']['properties'])
+            && in_array('url', $tool['function']['parameters']['required'], true);
+    });
+});
+
+test('web search tool call is executed against the hosted API', function () {
+    Http::fake([
+        'https://ollama.com/api/web_search*' => Http::response([
+            'results' => [
+                ['title' => 'Laravel', 'url' => 'https://laravel.com', 'content' => 'The PHP framework.'],
+            ],
+        ]),
+        'http://localhost:11434/*' => Http::sequence([
+            fakeOllamaWebSearchToolCall(['query' => 'laravel']),
+            $this->fakeTextResponse('Laravel is a PHP framework.'),
+        ]),
+    ]);
+
+    $response = agent(tools: [new WebSearch])->prompt('What is Laravel?', provider: 'ollama');
+
+    expect($response->text)->toBe('Laravel is a PHP framework.');
+
+    Http::assertSent(function (Request $request) {
+        return str_contains($request->url(), 'ollama.com/api/web_search')
+            && $request['query'] === 'laravel'
+            && $request->hasHeader('Authorization', 'Bearer test-key');
+    });
+
+    $followUp = json_decode(Http::recorded()->last()[0]->body(), true);
+    $toolMsg = collect($followUp['messages'])->first(fn ($m) => $m['role'] === 'tool');
+
+    expect($toolMsg['tool_name'])->toBe('web_search')
+        ->and($toolMsg['content'])->toContain('laravel.com');
+});
+
+test('web fetch tool call is executed against the hosted API', function () {
+    Http::fake([
+        'https://ollama.com/api/web_fetch*' => Http::response([
+            'title' => 'Laravel',
+            'content' => 'The PHP framework for web artisans.',
+            'links' => ['https://laravel.com/docs'],
+        ]),
+        'http://localhost:11434/*' => Http::sequence([
+            fakeOllamaWebToolCall('web_fetch', ['url' => 'https://laravel.com']),
+            $this->fakeTextResponse('Fetched the page.'),
+        ]),
+    ]);
+
+    $response = agent(tools: [new WebFetch])->prompt('Read laravel.com', provider: 'ollama');
+
+    expect($response->text)->toBe('Fetched the page.');
+
+    Http::assertSent(function (Request $request) {
+        return str_contains($request->url(), 'ollama.com/api/web_fetch')
+            && $request['url'] === 'https://laravel.com';
+    });
+});
+
+test('web search without an API key throws', function () {
+    config(['ai.providers.ollama' => [
+        ...config('ai.providers.ollama'),
+        'key' => '',
+    ]]);
+
+    Http::fake([
+        'http://localhost:11434/*' => Http::sequence([
+            fakeOllamaWebSearchToolCall(['query' => 'laravel']),
+            $this->fakeTextResponse('Done.'),
+        ]),
+    ]);
+
+    expect(fn () => agent(tools: [new WebSearch])->prompt('Search', provider: 'ollama'))
+        ->toThrow(AiException::class);
+});
+
+test('streaming executes a web search tool call', function () {
+    Http::fake([
+        'https://ollama.com/api/web_search*' => Http::response([
+            'results' => [
+                ['title' => 'Laravel', 'url' => 'https://laravel.com', 'content' => 'The PHP framework.'],
+            ],
+        ]),
+        'http://localhost:11434/*' => Http::sequence([
+            Http::response(
+                body: $this->ndjsonPayload([
+                    $this->chatChunkWithToolCalls([
+                        $this->toolCallChunk('call_ws', 'web_search', ['query' => 'laravel']),
+                    ]),
+                ]),
+            ),
+            Http::response(
+                body: $this->ndjsonPayload([
+                    $this->chatChunk('Laravel is a PHP framework.'),
+                    $this->chatChunk('', true, 'stop', ['prompt_eval_count' => 20, 'eval_count' => 10]),
+                ]),
+            ),
+        ]),
+    ]);
+
+    $events = [];
+
+    foreach (agent(tools: [new WebSearch])->stream('What is Laravel?', provider: 'ollama') as $event) {
+        $events[] = $event;
+    }
+
+    $toolResults = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
+
+    expect($toolResults)->not->toBeEmpty()
+        ->and($toolResults[0]->toolResult->name)->toBe('web_search')
+        ->and($toolResults[0]->toolResult->result)->toContain('laravel.com');
+
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'ollama.com/api/web_search')
+        && $request['query'] === 'laravel');
+});
+
+function fakeOllamaWebToolCall(string $name, array $arguments): PromiseInterface
+{
+    return Http::response([
+        'model' => 'llama3.1:8b',
+        'message' => [
+            'role' => 'assistant',
+            'content' => '',
+            'tool_calls' => [[
+                'id' => 'call_'.$name,
+                'function' => ['name' => $name, 'arguments' => (object) $arguments],
+            ]],
+        ],
+        'done_reason' => 'tool_calls',
+        'done' => true,
+        'prompt_eval_count' => 10,
+        'eval_count' => 5,
+    ]);
+}
+
+function fakeOllamaWebSearchToolCall(array $arguments): PromiseInterface
+{
+    return fakeOllamaWebToolCall('web_search', $arguments);
+}

--- a/tests/Feature/Providers/Ollama/WebSearchTest.php
+++ b/tests/Feature/Providers/Ollama/WebSearchTest.php
@@ -117,6 +117,43 @@ test('web search without an API key throws', function () {
         ->toThrow(AiException::class);
 });
 
+test('web search with allowed domains throws', function () {
+    Http::fake(['*' => $this->fakeTextResponse('done')]);
+
+    expect(fn () => agent(tools: [(new WebSearch)->allow(['laravel.com'])])->prompt('Search', provider: 'ollama'))
+        ->toThrow(RuntimeException::class, 'Ollama web search does not support restricting allowed domains.');
+});
+
+test('web search with a location throws', function () {
+    Http::fake(['*' => $this->fakeTextResponse('done')]);
+
+    expect(fn () => agent(tools: [(new WebSearch)->location(city: 'Indore')])->prompt('Search', provider: 'ollama'))
+        ->toThrow(RuntimeException::class, 'Ollama web search does not support location-based results.');
+});
+
+test('web fetch with allowed domains throws', function () {
+    Http::fake(['*' => $this->fakeTextResponse('done')]);
+
+    expect(fn () => agent(tools: [(new WebFetch)->allow(['laravel.com'])])->prompt('Fetch', provider: 'ollama'))
+        ->toThrow(RuntimeException::class, 'Ollama web fetch does not support restricting allowed domains.');
+});
+
+test('web search max results is capped at ten', function () {
+    Http::fake([
+        'https://ollama.com/api/web_search*' => Http::response(['results' => []]),
+        'http://localhost:11434/*' => Http::sequence([
+            fakeOllamaWebSearchToolCall(['query' => 'laravel', 'max_results' => 50]),
+            $this->fakeTextResponse('Done.'),
+        ]),
+    ]);
+
+    agent(tools: [new WebSearch])->prompt('What is Laravel?', provider: 'ollama');
+
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'ollama.com/api/web_search')
+        ? $request['max_results'] === 10
+        : true);
+});
+
 test('streaming executes a web search tool call', function () {
     Http::fake([
         'https://ollama.com/api/web_search*' => Http::response([


### PR DESCRIPTION
Currently passing a provider tool to Ollama just throws ("Ollama does not support [WebSearch] provider tools"), even though Ollama ships a hosted web search API. So there's no way to give an Ollama model live web access.

This PR wires up WebSearch and WebFetch:

```php
$response = Agent::tools([new WebSearch])
    ->prompt('What shipped in the latest Laravel release?', provider: 'ollama');
```

Unlike OpenAI/Anthropic/Gemini, Ollama's web search isn't a native server-side tool. It's a separate hosted endpoint (ollama.com/api/web_search) that the client calls. So instead of baking it into the chat request, these map to regular function definitions and the gateway intercepts the model's web_search/web_fetch calls in the tool loop, runs them against the hosted API with your Ollama key, and feeds results back. Works in both streaming and non-streaming paths.

One thing worth a look: the provider key now reaches two hosts (your configured Ollama url and ollama.com). That's correct when the key is your ollama.com cloud key, but a self-hosted setup using key only for a local auth proxy would send it to ollama.com too. Happy to add a separate config value if you'd prefer.