### PR TITLE
Add web search and citation support to OpenRouterProvider

### DIFF
--- a/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
@@ -27,7 +27,7 @@ trait BuildsTextRequests
         ];
 
         if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
+            $mappedTools = $this->mapTools($tools, $provider);
 
             if (filled($mappedTools)) {
                 $body['tool_choice'] = 'auto';

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -280,7 +280,7 @@ trait HandlesTextStreaming
             ];
 
             if (filled($tools)) {
-                $mappedTools = $this->mapTools($tools);
+                $mappedTools = $this->mapTools($tools, $provider);
 
                 if (filled($mappedTools)) {
                     $body['tool_choice'] = 'auto';

--- a/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/OpenRouter/Concerns/HandlesTextStreaming.php
@@ -9,7 +9,9 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
@@ -135,6 +137,26 @@ trait HandlesTextStreaming
 
                     if (isset($tcDelta['function']['arguments'])) {
                         $pendingToolCalls[$idx]['arguments'] .= $tcDelta['function']['arguments'];
+                    }
+                }
+            }
+
+            if (isset($delta['annotations'])) {
+                foreach ($delta['annotations'] as $annotation) {
+                    if (($annotation['type'] ?? '') === 'url_citation') {
+                        $urlCitation = $annotation['url_citation'] ?? [];
+
+                        yield (new CitationEvent(
+                            $this->generateEventId(),
+                            $messageId,
+                            new UrlCitation(
+                                $urlCitation['url'] ?? '',
+                                $urlCitation['title'] ?? null,
+                                isset($urlCitation['start_index']) ? (int) $urlCitation['start_index'] : null,
+                                isset($urlCitation['end_index']) ? (int) $urlCitation['end_index'] : null,
+                            ),
+                            time(),
+                        ))->withInvocationId($invocationId);
                     }
                 }
             }

--- a/src/Gateway/OpenRouter/Concerns/MapsTools.php
+++ b/src/Gateway/OpenRouter/Concerns/MapsTools.php
@@ -3,9 +3,12 @@
 namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
+use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Tools\ToolNameResolver;
 use RuntimeException;
 
@@ -14,21 +17,36 @@ trait MapsTools
     /**
      * Map the given tools to Chat Completions function definitions.
      */
-    protected function mapTools(array $tools): array
+    protected function mapTools(array $tools, Provider $provider): array
     {
         $mapped = [];
 
         foreach ($tools as $tool) {
-            if ($tool instanceof ProviderTool) {
+            if ($tool instanceof WebSearch) {
+                $mapped[] = $this->mapWebSearchTool($tool, $provider);
+            } elseif ($tool instanceof ProviderTool) {
                 throw new RuntimeException('OpenRouter does not support ['.class_basename($tool).'] provider tools.');
-            }
-
-            if ($tool instanceof Tool) {
+            } elseif ($tool instanceof Tool) {
                 $mapped[] = $this->mapTool($tool);
             }
         }
 
         return $mapped;
+    }
+
+    /**
+     * Map a web search tool to an OpenRouter web search definition.
+     */
+    protected function mapWebSearchTool(WebSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
+        }
+
+        return [
+            'type' => 'openrouter:web_search',
+            ...$provider->webSearchToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -261,7 +261,7 @@ trait ParsesTextResponses
         ];
 
         if (filled($tools)) {
-            $mappedTools = $this->mapTools($tools);
+            $mappedTools = $this->mapTools($tools, $provider);
 
             if (filled($mappedTools)) {
                 $body['tool_choice'] = 'auto';

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
@@ -91,6 +92,7 @@ trait ParsesTextResponses
 
         $text = $message['content'] ?? '';
         $rawToolCalls = $message['tool_calls'] ?? [];
+        $citations = $this->extractCitations($message);
         $usage = $this->extractUsage($data);
         $finishReason = $this->extractFinishReason($choice);
 
@@ -107,7 +109,7 @@ trait ParsesTextResponses
             [],
             $finishReason,
             $usage,
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, $citations),
         );
 
         $steps->push($step);
@@ -129,7 +131,7 @@ trait ParsesTextResponses
                 $toolResults,
                 $finishReason,
                 $usage,
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, $citations),
             ));
 
             $toolResultMessage = new ToolResultMessage(collect($toolResults));
@@ -163,7 +165,7 @@ trait ParsesTextResponses
                 $structuredData,
                 $text,
                 $this->combineUsage($steps),
-                new Meta($provider->name(), $model),
+                new Meta($provider->name(), $model, $citations),
             ))->withToolCallsAndResults(
                 toolCalls: $allToolCalls,
                 toolResults: $allToolResults,
@@ -173,7 +175,7 @@ trait ParsesTextResponses
         return (new TextResponse(
             $text,
             $this->combineUsage($steps),
-            new Meta($provider->name(), $model),
+            new Meta($provider->name(), $model, $citations),
         ))->withMessages($messages)->withSteps($steps);
     }
 
@@ -312,6 +314,29 @@ trait ParsesTextResponses
             $options,
             $timeout,
         );
+    }
+
+    /**
+     * Extract URL citations from the message annotations array.
+     */
+    protected function extractCitations(array $message): Collection
+    {
+        $citations = new Collection;
+
+        foreach ($message['annotations'] ?? [] as $annotation) {
+            if (($annotation['type'] ?? '') === 'url_citation') {
+                $urlCitation = $annotation['url_citation'] ?? [];
+
+                $citations->push(new UrlCitation(
+                    $urlCitation['url'] ?? '',
+                    $urlCitation['title'] ?? null,
+                    isset($urlCitation['start_index']) ? (int) $urlCitation['start_index'] : null,
+                    isset($urlCitation['end_index']) ? (int) $urlCitation['end_index'] : null,
+                ));
+            }
+        }
+
+        return $citations->values();
     }
 
     /**

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\Concerns\DecodesStructuredOutput;
 use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
@@ -14,6 +15,8 @@ use Laravel\Ai\Responses\Data\Usage;
 
 trait ParsesTextResponses
 {
+    use DecodesStructuredOutput;
+
     /**
      * Validate the OpenRouter response data.
      *
@@ -58,7 +61,7 @@ trait ParsesTextResponses
             finishReason: $this->extractFinishReason($choice),
             usage: $this->extractUsage($data),
             meta: new Meta($provider->name(), $model, $citations),
-            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            structured: $structured ? $this->decodeStructuredOutput($text) : null,
         );
     }
 

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -15,8 +15,8 @@ use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
-use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
+use Laravel\Ai\Providers\Tools\WebSearch;
 
 class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, SupportsWebSearch, TextProvider, TranscriptionProvider
 {

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
 
@@ -41,7 +42,16 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
      */
     public function webSearchToolOptions(WebSearch $search): array
     {
-        return [];
+        $options = $search->providerOptions(Lab::OpenRouter);
+
+        $parameters = array_filter([
+            'max_results' => $search->maxSearches,
+            'allowed_domains' => filled($search->allowedDomains) ? $search->allowedDomains : null,
+        ]) + $options;
+
+        return array_filter([
+            'parameters' => filled($parameters) ? $parameters : null,
+        ]);
     }
 
     /**

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -11,11 +11,13 @@ use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
 
-class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, TextProvider, TranscriptionProvider
+class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
@@ -32,6 +34,14 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
     public function __construct(protected array $config, protected Dispatcher $events)
     {
         //
+    }
+
+    /**
+     * Get the web search tool options for the provider.
+     */
+    public function webSearchToolOptions(WebSearch $search): array
+    {
+        return [];
     }
 
     /**

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -236,3 +236,91 @@ test('structured response is correctly parsed', function () {
 
     expect($response->structured['symbol'])->toBe('Au');
 });
+
+test('web search citations are extracted from message annotations', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => 'Paris is the capital of France.',
+                'annotations' => [
+                    [
+                        'type' => 'url_citation',
+                        'url_citation' => [
+                            'url' => 'https://example.com/paris',
+                            'title' => 'Paris - Wikipedia',
+                            'start_index' => 0,
+                            'end_index' => 30,
+                        ],
+                    ],
+                    [
+                        'type' => 'url_citation',
+                        'url_citation' => [
+                            'url' => 'https://example.com/france',
+                            'title' => 'France - Wikipedia',
+                            'start_index' => 31,
+                            'end_index' => 50,
+                        ],
+                    ],
+                ],
+            ],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5],
+    ])]);
+
+    $response = agent()->prompt('What is the capital of France?', provider: 'openrouter');
+
+    expect($response->meta->citations)->toHaveCount(2)
+        ->and($response->meta->citations[0]->url)->toBe('https://example.com/paris')
+        ->and($response->meta->citations[0]->title)->toBe('Paris - Wikipedia')
+        ->and($response->meta->citations[0]->startIndex)->toBe(0)
+        ->and($response->meta->citations[0]->endIndex)->toBe(30)
+        ->and($response->meta->citations[1]->url)->toBe('https://example.com/france')
+        ->and($response->meta->citations[1]->title)->toBe('France - Wikipedia')
+        ->and($response->meta->citations[1]->startIndex)->toBe(31)
+        ->and($response->meta->citations[1]->endIndex)->toBe(50);
+});
+
+test('web search citations omit span indices when not provided', function () {
+    Http::fake(['*' => Http::response([
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'model' => 'anthropic/claude-sonnet-4.6',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => 'Some answer.',
+                'annotations' => [[
+                    'type' => 'url_citation',
+                    'url_citation' => [
+                        'url' => 'https://example.com/source',
+                        'title' => 'Source',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'stop',
+        ]],
+        'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 3],
+    ])]);
+
+    $response = agent()->prompt('Question', provider: 'openrouter');
+
+    expect($response->meta->citations)->toHaveCount(1)
+        ->and($response->meta->citations[0]->url)->toBe('https://example.com/source')
+        ->and($response->meta->citations[0]->startIndex)->toBeNull()
+        ->and($response->meta->citations[0]->endIndex)->toBeNull();
+});
+
+test('response with no annotations has empty citations collection', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('Hello')]);
+
+    $response = agent()->prompt('Hi', provider: 'openrouter');
+
+    expect($response->meta->citations)->toHaveCount(0);
+});

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
@@ -154,3 +155,87 @@ test('streaming finish reason maps correctly', function (string $apiReason, $exp
     'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
     'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);
+
+test('streaming emits citation events for web search annotations', function () {
+    Http::fake([
+        '*' => Http::response($this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Paris is the capital']),
+            $this->chatChunk(['content' => ' of France.', 'annotations' => [
+                [
+                    'type' => 'url_citation',
+                    'url_citation' => [
+                        'url' => 'https://example.com/paris',
+                        'title' => 'Paris - Wikipedia',
+                        'start_index' => 0,
+                        'end_index' => 30,
+                    ],
+                ],
+            ]]),
+            $this->chatChunkFinish('stop', ['prompt_tokens' => 10, 'completion_tokens' => 5]),
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('What is the capital of France?', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $citations = array_values(array_filter($events, fn ($e) => $e instanceof CitationEvent));
+
+    expect($citations)->toHaveCount(1)
+        ->and($citations[0]->citation->url)->toBe('https://example.com/paris')
+        ->and($citations[0]->citation->title)->toBe('Paris - Wikipedia')
+        ->and($citations[0]->citation->startIndex)->toBe(0)
+        ->and($citations[0]->citation->endIndex)->toBe(30);
+});
+
+test('streaming emits multiple citation events across chunks', function () {
+    Http::fake([
+        '*' => Http::response($this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Answer', 'annotations' => [
+                [
+                    'type' => 'url_citation',
+                    'url_citation' => ['url' => 'https://example.com/one', 'title' => 'One'],
+                ],
+            ]]),
+            $this->chatChunk(['content' => ' more', 'annotations' => [
+                [
+                    'type' => 'url_citation',
+                    'url_citation' => ['url' => 'https://example.com/two', 'title' => 'Two'],
+                ],
+            ]]),
+            $this->chatChunkFinish('stop', ['prompt_tokens' => 5, 'completion_tokens' => 2]),
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Question', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $citations = array_values(array_filter($events, fn ($e) => $e instanceof CitationEvent));
+
+    expect($citations)->toHaveCount(2)
+        ->and($citations[0]->citation->url)->toBe('https://example.com/one')
+        ->and($citations[1]->citation->url)->toBe('https://example.com/two');
+});
+
+test('streaming ignores non-url-citation annotation types', function () {
+    Http::fake([
+        '*' => Http::response($this->ssePayload([
+            $this->chatChunk(['role' => 'assistant', 'content' => 'Answer', 'annotations' => [
+                ['type' => 'other_type', 'data' => 'something'],
+            ]]),
+            $this->chatChunkFinish('stop', ['prompt_tokens' => 5, 'completion_tokens' => 2]),
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Question', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $citations = array_values(array_filter($events, fn ($e) => $e instanceof CitationEvent));
+
+    expect($citations)->toHaveCount(0);
+});

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
@@ -68,11 +69,24 @@ test('tool parameters are not wrapped in schema definition', function () {
     });
 });
 
-test('provider tools throw runtime exception', function () {
+test('unsupported provider tools throw runtime exception', function () {
     Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
-    expect(fn () => agent(tools: [new WebSearch])->prompt('Search', provider: 'openrouter'))
-        ->toThrow(RuntimeException::class, 'OpenRouter does not support');
+    expect(fn () => agent(tools: [new WebFetch])->prompt('Search', provider: 'openrouter'))
+        ->toThrow(RuntimeException::class, 'OpenRouter does not support [WebFetch] provider tools.');
+});
+
+test('web search tool is sent as openrouter:web_search type', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [new WebSearch])->prompt('Search the web', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
+
+        return $tool !== null;
+    });
 });
 
 test('tool with a name() method emits the declared name', function () {

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -85,7 +85,56 @@ test('web search tool is sent as openrouter:web_search type', function () {
         $body = json_decode($request->body(), true);
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
 
-        return $tool !== null;
+        return $tool !== null && ! array_key_exists('parameters', $tool);
+    });
+});
+
+test('web search tool sends max_results when maxSearches is set', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [(new WebSearch)->max(5)])->prompt('Search the web', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
+
+        return data_get($tool, 'parameters.max_results') === 5;
+    });
+});
+
+test('web search tool sends allowed_domains', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [(new WebSearch)->allow(['example.com', 'laravel.com'])])->prompt('Search the web', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
+
+        return data_get($tool, 'parameters.allowed_domains') === ['example.com', 'laravel.com'];
+    });
+});
+
+test('web search tool forwards provider options into parameters', function () {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    $search = (new WebSearch)->withProviderOptions('openrouter', [
+        'engine' => 'exa',
+        'max_total_results' => 20,
+        'search_context_size' => 'medium',
+        'excluded_domains' => ['reddit.com'],
+    ]);
+
+    agent(tools: [$search])->prompt('Search the web', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
+
+        return data_get($tool, 'parameters.engine') === 'exa'
+            && data_get($tool, 'parameters.max_total_results') === 20
+            && data_get($tool, 'parameters.search_context_size') === 'medium'
+            && data_get($tool, 'parameters.excluded_domains') === ['reddit.com'];
     });
 });
 


### PR DESCRIPTION
Adds web search support to `OpenRouterProvider`, including handling of `url_citation` annotations from OpenRouter's response — both in streaming (via `CitationEvent`) and non-streaming (via `Meta`) responses.

See [OpenRouter web search docs](https://openrouter.ai/docs/guides/features/server-tools/web-search) for details on the annotations format.