### PR TITLE
Add collection generics to streamed agent response events

### DIFF
--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -10,6 +10,7 @@ use IteratorAggregate;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Symfony\Component\HttpFoundation\Response;
 use Traversable;
@@ -22,6 +23,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
     public ?Usage $usage;
 
+    /** @var Collection<int, StreamEvent> */
     public Collection $events;
 
     public ?string $conversationId = null;

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -5,14 +5,19 @@ namespace Laravel\Ai\Responses;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
 
 class StreamedAgentResponse extends AgentResponse
 {
+    /** @var Collection<int, StreamEvent> */
     public Collection $events;
 
+    /**
+     * @param  Collection<int, StreamEvent>  $events
+     */
     public function __construct(string $invocationId, Collection $events, Meta $meta)
     {
         parent::__construct(


### PR DESCRIPTION
Types the streamed agent `$events` collections, which were previously a bare  `Collection`:                                                                                                                                                                                                                                                                                                                                                                                                                                                           
  - `StreamedAgentResponse::$events` - `Collection<int, StreamEvent>`                                                                                                                                                                    
  - `StreamableAgentResponse::$events` - `Collection<int, StreamEvent>`                                                                                                                                                                  
                                                                                                                                                                                                                                   
`StreamEvent` is the abstract base of every streamed event (`TextDelta`, `StreamEnd`, `ToolCall`, `ToolResult`), so the annotation reflects exactly what is collected and yielded. 

Type-level only, no runtime or behaviour change.     