### PR TITLE
Add collection generics to image, transcription, and meta responses

### DIFF
--- a/src/Responses/Data/Meta.php
+++ b/src/Responses/Data/Meta.php
@@ -8,8 +8,12 @@ use JsonSerializable;
 
 class Meta implements Arrayable, JsonSerializable
 {
+    /** @var Collection<int, Citation> */
     public Collection $citations;
 
+    /**
+     * @param  Collection<int, Citation>|null  $citations
+     */
     public function __construct(
         public ?string $provider = null,
         public ?string $model = null,

--- a/src/Responses/ImageResponse.php
+++ b/src/Responses/ImageResponse.php
@@ -12,6 +12,9 @@ use RuntimeException;
 
 class ImageResponse implements Countable, Htmlable
 {
+    /**
+     * @param  Collection<int, GeneratedImage>  $images
+     */
     public function __construct(
         public Collection $images,
         public Usage $usage,

--- a/src/Responses/TranscriptionResponse.php
+++ b/src/Responses/TranscriptionResponse.php
@@ -4,18 +4,23 @@ namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 
 class TranscriptionResponse
 {
     public string $text;
 
+    /** @var Collection<int, TranscriptionSegment> */
     public Collection $segments;
 
     public Usage $usage;
 
     public Meta $meta;
 
+    /**
+     * @param  Collection<int, TranscriptionSegment>  $segments
+     */
     public function __construct(
         string $text,
         Collection $segments,


### PR DESCRIPTION
 Adds `Collection<int, T>` generics to the remaining response data classes that still typed their collection properties as a bare `Collection`:                                                                                                                                                                                                                                                                                                                                                    
  - `ImageResponse::$images` - `Collection<int, GeneratedImage>`                                                                                                                                                                         
  - `TranscriptionResponse::$segments` - `Collection<int, TranscriptionSegment>`                                                                                                                                                         
  - `Responses\Data\Meta::$citations` - `Collection<int, Citation>`                                                                                                                                                                      
                                                                                                                                                                                                                                         
  The element types match how the gateways already build these collections (`->map(fn () => new GeneratedImage(...))`, `new TranscriptionSegment(...)`, `->push(new UrlCitation(...))`), so static analysis now knows what each item is.                                                                                                                                                       
                                                                                                                                                                                                                                         
  Type-level only, no runtime or behaviour change.   