### PR TITLE
[0.x] Fix user_id columns to support UUID users

### DIFF
--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -16,7 +16,7 @@ return new class extends AiMigration
 
         Schema::create($conversationsTable, function (Blueprint $table) {
             $table->string('id', 36)->primary();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('title');
             $table->timestamps();
 
@@ -26,7 +26,7 @@ return new class extends AiMigration
         Schema::create($messagesTable, function (Blueprint $table) {
             $table->string('id', 36)->primary();
             $table->string('conversation_id', 36)->index();
-            $table->foreignId('user_id')->nullable();
+            $table->string('user_id')->nullable();
             $table->string('agent');
             $table->string('role', 25);
             $table->text('content');


### PR DESCRIPTION
Changed `user_id` columns from `foreignId()` to `string()` to match the `ConversationStore` contract, which accepts `string|int` user IDs.
