### PR TITLE
feat: add token counting support for text providers

### DIFF
--- a/src/Contracts/Gateway/Gateway.php
+++ b/src/Contracts/Gateway/Gateway.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Ai\Contracts\Gateway;
 
-interface Gateway extends AudioGateway, EmbeddingGateway, ImageGateway, TextGateway, TranscriptionGateway
+interface Gateway extends AudioGateway, EmbeddingGateway, ImageGateway, TextGateway, TokenCountingGateway, TranscriptionGateway
 {
     //
 }

--- a/src/Contracts/Gateway/TokenCountingGateway.php
+++ b/src/Contracts/Gateway/TokenCountingGateway.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Gateway;
+
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\Message;
+
+interface TokenCountingGateway
+{
+    /**
+     * Count tokens for a text generation request.
+     *
+     * @param  Message[]  $messages
+     * @param  Tool[]  $tools
+     * @param  array<string, Type>|null  $schema
+     */
+    public function countTokens(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+    ): int;
+}

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -27,6 +27,7 @@ use LogicException;
 class AnthropicGateway implements Gateway, StepTextGateway
 {
     use Concerns\BuildsTextRequests;
+    use Concerns\CountsTokens;
     use Concerns\CreatesAnthropicClient;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;

--- a/src/Gateway/Anthropic/Concerns/CountsTokens.php
+++ b/src/Gateway/Anthropic/Concerns/CountsTokens.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic\Concerns;
+
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\Message;
+
+trait CountsTokens
+{
+    /**
+     * Count tokens for an Anthropic text generation request.
+     *
+     * @param  Message[]  $messages
+     * @param  Tool[]  $tools
+     * @param  array<string, Type>|null  $schema
+     */
+    public function countTokens(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+    ): int {
+        $body = $this->buildTokenCountingBody(
+            $provider,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+        );
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post('messages/count_tokens', $body),
+        );
+
+        $data = $response->json();
+
+        return $data['input_tokens'] ?? 0;
+    }
+
+    /**
+     * Build the request body for token counting.
+     */
+    protected function buildTokenCountingBody(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+        ?array $schema,
+    ): array {
+        $body = [
+            'model' => $model,
+            'messages' => $this->mapMessages($messages),
+        ];
+
+        if (filled($instructions)) {
+            $body['system'] = $instructions;
+        }
+
+        $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
+
+        if (filled($schema)) {
+            $mappedTools[] = $this->buildStructuredOutputTool($schema);
+        }
+
+        if (filled($mappedTools)) {
+            $body['tools'] = $mappedTools;
+        }
+
+        return $body;
+    }
+}

--- a/src/Gateway/Concerns/EstimatesTokenCounts.php
+++ b/src/Gateway/Concerns/EstimatesTokenCounts.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\Message;
+
+trait EstimatesTokenCounts
+{
+    /**
+     * Estimate tokens for a text generation request.
+     *
+     * Uses character-based heuristics for providers without native token counting.
+     * Approximate: 1 token per 4 characters, with 30% overhead for formatting/metadata.
+     *
+     * @param  Message[]  $messages
+     * @param  Tool[]  $tools
+     * @param  array<string, Type>|null  $schema
+     */
+    public function countTokens(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+    ): int {
+        $tokenCount = 0;
+
+        if (filled($instructions)) {
+            $tokenCount += $this->estimateTokens($instructions);
+        }
+
+        foreach ($messages as $message) {
+            $tokenCount += $this->estimateTokens($message->content ?? '');
+        }
+
+        foreach ($tools as $tool) {
+            $tokenCount += $this->estimateTokens(json_encode($tool));
+        }
+
+        if (filled($schema)) {
+            $tokenCount += $this->estimateTokens(json_encode($schema));
+        }
+
+        return max(1, (int) ($tokenCount * 1.3));
+    }
+
+    /**
+     * Estimate tokens from text content.
+     *
+     * Uses simple heuristic: approximately 1 token per 4 characters.
+     */
+    protected function estimateTokens(string $content): int
+    {
+        $charCount = mb_strlen($content);
+
+        return (int) ceil($charCount / 4);
+    }
+}

--- a/src/Gateway/Gemini/Concerns/CountsTokens.php
+++ b/src/Gateway/Gemini/Concerns/CountsTokens.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Gemini\Concerns;
+
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\Message;
+
+trait CountsTokens
+{
+    /**
+     * Count tokens for a Gemini text generation request.
+     *
+     * @param  Message[]  $messages
+     * @param  Tool[]  $tools
+     * @param  array<string, Type>|null  $schema
+     */
+    public function countTokens(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+    ): int {
+        $body = $this->buildTokenCountingBody(
+            $provider,
+            $instructions,
+            $messages,
+            $tools,
+        );
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->post("models/{$model}:countTokens", $body),
+        );
+
+        $data = $response->json();
+
+        return $data['totalTokens'] ?? 0;
+    }
+
+    /**
+     * Build the request body for token counting.
+     */
+    protected function buildTokenCountingBody(
+        TextProvider $provider,
+        ?string $instructions,
+        array $messages,
+        array $tools,
+    ): array {
+        $body = [
+            'contents' => $this->mapMessages($messages),
+        ];
+
+        if (filled($instructions)) {
+            $body['system_instruction'] = [
+                'parts' => [
+                    ['text' => $instructions],
+                ],
+            ];
+        }
+
+        $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
+
+        if (filled($mappedTools)) {
+            $body['tools'] = $mappedTools;
+        }
+
+        return $body;
+    }
+}

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -34,6 +34,7 @@ use RuntimeException;
 class GeminiGateway implements Gateway, StepTextGateway
 {
     use Concerns\BuildsTextRequests;
+    use Concerns\CountsTokens;
     use Concerns\CreatesGeminiClient;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;

--- a/src/Gateway/OpenAi/Concerns/CountsTokens.php
+++ b/src/Gateway/OpenAi/Concerns/CountsTokens.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi\Concerns;
+
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\Message;
+
+trait CountsTokens
+{
+    /**
+     * Count tokens for an OpenAI text generation request.
+     *
+     * OpenAI doesn't provide a dedicated token counting endpoint, so we estimate
+     * based on message content. Actual token counts are returned with API responses.
+     *
+     * @param  Message[]  $messages
+     * @param  Tool[]  $tools
+     * @param  array<string, Type>|null  $schema
+     */
+    public function countTokens(
+        TextProvider $provider,
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+    ): int {
+        $tokenCount = 0;
+
+        if (filled($instructions)) {
+            $tokenCount += $this->estimateTokens($instructions);
+        }
+
+        foreach ($messages as $message) {
+            $tokenCount += $this->estimateTokens($message->content ?? '');
+        }
+
+        foreach ($tools as $tool) {
+            $tokenCount += $this->estimateTokens(json_encode($tool));
+        }
+
+        if (filled($schema)) {
+            $tokenCount += $this->estimateTokens(json_encode($schema));
+        }
+
+        return max(1, (int) ($tokenCount * 1.3));
+    }
+
+    /**
+     * Estimate tokens from text content.
+     *
+     * Uses simple heuristic: approximately 1 token per 4 characters.
+     */
+    protected function estimateTokens(string $content): int
+    {
+        $charCount = mb_strlen($content);
+
+        return (int) ceil($charCount / 4);
+    }
+}

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -35,6 +35,7 @@ use LogicException;
 class OpenAiGateway implements Gateway, StepTextGateway
 {
     use Concerns\BuildsTextRequests;
+    use Concerns\CountsTokens;
     use Concerns\CreatesOpenAiClient;
     use Concerns\HandlesTextGeneration;
     use Concerns\HandlesTextSteps;

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -17,6 +17,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
+use Laravel\Ai\Gateway\Concerns\EstimatesTokenCounts;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
@@ -42,10 +43,10 @@ class OpenRouterGateway implements Gateway, StepTextGateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use DelegatesToTextGenerationLoop;
+    use EstimatesTokenCounts;
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
     use WrapsPcmAudio;
-    use \Laravel\Ai\Gateway\Concerns\EstimatesTokenCounts;
 
     public function __construct(protected Dispatcher $events)
     {

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -45,6 +45,7 @@ class OpenRouterGateway implements Gateway, StepTextGateway
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
     use WrapsPcmAudio;
+    use \Laravel\Ai\Gateway\Concerns\EstimatesTokenCounts;
 
     public function __construct(protected Dispatcher $events)
     {

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -13,6 +13,7 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
+use Laravel\Ai\Gateway\Concerns\EstimatesTokenCounts;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\StepContext;
@@ -34,9 +35,9 @@ class XaiGateway implements Gateway, StepTextGateway
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
     use DelegatesToTextGenerationLoop;
+    use EstimatesTokenCounts;
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
-    use \Laravel\Ai\Gateway\Concerns\EstimatesTokenCounts;
 
     public function __construct(protected Dispatcher $events) {}
 

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -36,6 +36,7 @@ class XaiGateway implements Gateway, StepTextGateway
     use DelegatesToTextGenerationLoop;
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
+    use \Laravel\Ai\Gateway\Concerns\EstimatesTokenCounts;
 
     public function __construct(protected Dispatcher $events) {}
 

--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Providers\Tools\WebSearch;
 
 class AnthropicProvider extends Provider implements FileProvider, SupportsWebFetch, SupportsWebSearch, TextProvider
 {
+    use Concerns\CountsTokens;
     use Concerns\GeneratesText;
     use Concerns\HasFileGateway;
     use Concerns\HasTextGateway;

--- a/src/Providers/Concerns/CountsTokens.php
+++ b/src/Providers/Concerns/CountsTokens.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Messages\Message;
+
+trait CountsTokens
+{
+    /**
+     * Count tokens for a text generation request.
+     *
+     * @param  Message[]  $messages
+     * @param  Tool[]  $tools
+     * @param  array<string, Type>|null  $schema
+     */
+    public function countTokens(
+        string $model,
+        ?string $instructions,
+        array $messages = [],
+        array $tools = [],
+        ?array $schema = null,
+    ): int {
+        return $this->gateway->countTokens(
+            $this,
+            $model,
+            $instructions,
+            $messages,
+            $tools,
+            $schema,
+        );
+    }
+}

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -23,6 +23,7 @@ use Laravel\Ai\Providers\Tools\WebSearch;
 
 class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsWebFetch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
+    use Concerns\CountsTokens;
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -22,6 +22,7 @@ use Laravel\Ai\Providers\Tools\WebSearch;
 
 class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
+    use Concerns\CountsTokens;
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -17,6 +17,7 @@ use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
 
 class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, TextProvider, TranscriptionProvider
 {
+    use Concerns\CountsTokens;
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -12,6 +12,7 @@ use Laravel\Ai\Gateway\Xai\XaiImageGateway;
 
 class XaiProvider extends Provider implements ImageProvider, TextProvider
 {
+    use Concerns\CountsTokens;
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
     use Concerns\HasImageGateway;

--- a/tests/Integration/TokenCountingTest.php
+++ b/tests/Integration/TokenCountingTest.php
@@ -11,7 +11,7 @@ test('token counting works with anthropic provider', function (string $provider,
     requiresApiKey($apiKey);
 
     $agent = new AssistantAgent;
-    $provider = \Ai::textProvider($provider);
+    $provider = Ai::textProvider($provider);
 
     $tokens = $provider->countTokens(
         model: $model,
@@ -32,7 +32,7 @@ test('token counting works with openai provider', function (string $provider, st
 
     requiresApiKey($apiKey);
 
-    $textProvider = \Ai::textProvider($provider);
+    $textProvider = Ai::textProvider($provider);
 
     $tokens = $textProvider->countTokens(
         model: $model,
@@ -53,7 +53,7 @@ test('token counting works with gemini provider', function (string $provider, st
 
     requiresApiKey($apiKey);
 
-    $textProvider = \Ai::textProvider($provider);
+    $textProvider = Ai::textProvider($provider);
 
     $tokens = $textProvider->countTokens(
         model: $model,

--- a/tests/Integration/TokenCountingTest.php
+++ b/tests/Integration/TokenCountingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Laravel\Ai\Messages\UserMessage;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+test('token counting works with anthropic provider', function (string $provider, string $apiKey, string $model) {
+    if ($provider !== 'anthropic') {
+        $this->markTestSkipped('Anthropic provider required');
+    }
+
+    requiresApiKey($apiKey);
+
+    $agent = new AssistantAgent;
+    $provider = \Ai::textProvider($provider);
+
+    $tokens = $provider->countTokens(
+        model: $model,
+        instructions: 'You are a helpful assistant.',
+        messages: [
+            new UserMessage('What is PHP?'),
+        ],
+    );
+
+    expect($tokens)->toBeGreaterThan(0)
+        ->and($tokens)->toBeLessThan(1000);
+})->with('agent-providers');
+
+test('token counting works with openai provider', function (string $provider, string $apiKey, string $model) {
+    if ($provider !== 'openai') {
+        $this->markTestSkipped('OpenAI provider required');
+    }
+
+    requiresApiKey($apiKey);
+
+    $textProvider = \Ai::textProvider($provider);
+
+    $tokens = $textProvider->countTokens(
+        model: $model,
+        instructions: 'You are a helpful assistant.',
+        messages: [
+            new UserMessage('What is PHP?'),
+        ],
+    );
+
+    expect($tokens)->toBeGreaterThan(0)
+        ->and($tokens)->toBeLessThan(1000);
+})->with('agent-providers');
+
+test('token counting works with gemini provider', function (string $provider, string $apiKey, string $model) {
+    if ($provider !== 'gemini') {
+        $this->markTestSkipped('Gemini provider required');
+    }
+
+    requiresApiKey($apiKey);
+
+    $textProvider = \Ai::textProvider($provider);
+
+    $tokens = $textProvider->countTokens(
+        model: $model,
+        instructions: 'You are a helpful assistant.',
+        messages: [
+            new UserMessage('What is PHP?'),
+        ],
+    );
+
+    expect($tokens)->toBeGreaterThan(0)
+        ->and($tokens)->toBeLessThan(1000);
+})->with('agent-providers');


### PR DESCRIPTION
## Summary

Implement token counting capability across all text providers, addressing issue #704.

## Implementation Details

- **New Contract**: `TokenCountingGateway` defines the token counting interface
- **Native Endpoints**:
  - Anthropic: Uses `/v1/messages/count_tokens` endpoint
  - Gemini: Uses `:countTokens` endpoint
- **Estimation Fallback**: OpenAI and OpenAI-compatible providers use character-based heuristics (1 token per 4 characters, with 30% overhead)
- **Provider Integration**: All `TextProvider` implementations now support `countTokens()`

## API Usage

```php
$provider = Ai::textProvider('anthropic');

$tokenCount = $provider->countTokens(
    model: 'claude-3-5-sonnet',
    instructions: 'You are a helpful assistant.',
    messages: [
        new UserMessage('What is PHP?'),
    ],
);
```

## Supported Providers

- ✅ Anthropic (native)
- ✅ Gemini (native)
- ✅ OpenAI (estimation)
- ✅ OpenRouter (estimation)
- ✅ xAI (estimation)

## Testing

Added integration tests for token counting across multiple providers.

Closes #704