### PR TITLE
Remove redundant global use statements in OpenRouter transcription test

### DIFF
--- a/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenRouter/TranscriptionTest.php
@@ -4,11 +4,9 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
-use InvalidArgumentException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Transcription;
-use LogicException;
 
 beforeEach(function () {
     config(['ai.providers.openrouter' => [


### PR DESCRIPTION
Running the test suite emitted PHP warnings because `TranscriptionTest.php` imports `InvalidArgumentException` and `LogicException` with `use` statements, but the file has no namespace so those imports have no effect. Removed them. The references resolve to the global classes either way.