### PR TITLE
Add WithoutBroadcasting attribute to skip oversized stream events

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -278,6 +278,20 @@ class MyAgent implements Agent
 
 The `#[UseCheapestModel]` and `#[UseSmartestModel]` attributes are also available for automatic model selection.
 
+The `#[WithoutBroadcasting]` attribute stops the given stream event types from broadcasting (e.g. data-heavy `ToolResult` payloads that exceed the WebSocket frame limit). The events are still streamed and persisted; they just never hit the channel:
+
+```php
+use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Streaming\Events\{ToolCall, ToolResult};
+
+#[WithoutBroadcasting(ToolResult::class, ToolCall::class)]
+class SearchAgent implements Agent, HasTools
+{
+    use Promptable;
+    // ...
+}
+```
+
 ### Tools
 
 Implement the `HasTools` interface and scaffold tools with `php artisan make:tool`:

--- a/src/Attributes/WithoutBroadcasting.php
+++ b/src/Attributes/WithoutBroadcasting.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use ReflectionClass;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class WithoutBroadcasting
+{
+    /**
+     * The stream event classes that should not be broadcast.
+     *
+     * @var array<int, class-string<StreamEvent>>
+     */
+    public array $events;
+
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  class-string<StreamEvent>  ...$events
+     */
+    public function __construct(string ...$events)
+    {
+        $this->events = $events;
+    }
+
+    /**
+     * Determine if the given stream event should be broadcast for the target agent.
+     */
+    public static function allows(?object $target, StreamEvent $event): bool
+    {
+        if ($target === null) {
+            return true;
+        }
+
+        $attributes = (new ReflectionClass($target))->getAttributes(self::class);
+
+        if ($attributes === []) {
+            return true;
+        }
+
+        return ! in_array($event::class, $attributes[0]->newInstance()->events, true);
+    }
+}

--- a/src/Attributes/WithoutBroadcasting.php
+++ b/src/Attributes/WithoutBroadcasting.php
@@ -31,16 +31,26 @@ final class WithoutBroadcasting
      */
     public static function allows(?object $target, StreamEvent $event): bool
     {
+        return ! in_array($event::class, self::eventsFor($target), true);
+    }
+
+    /**
+     * Get the stream event classes that should not be broadcast for the target agent.
+     *
+     * @return array<int, class-string<StreamEvent>>
+     */
+    public static function eventsFor(?object $target): array
+    {
         if ($target === null) {
-            return true;
+            return [];
         }
 
         $attributes = (new ReflectionClass($target))->getAttributes(self::class);
 
         if ($attributes === []) {
-            return true;
+            return [];
         }
 
-        return ! in_array($event::class, $attributes[0]->newInstance()->events, true);
+        return $attributes[0]->newInstance()->events;
     }
 }

--- a/src/Attributes/WithoutBroadcasting.php
+++ b/src/Attributes/WithoutBroadcasting.php
@@ -27,14 +27,6 @@ final class WithoutBroadcasting
     }
 
     /**
-     * Determine if the given stream event should be broadcast for the target agent.
-     */
-    public static function allows(?object $target, StreamEvent $event): bool
-    {
-        return ! in_array($event::class, self::eventsFor($target), true);
-    }
-
-    /**
      * Get the stream event classes that should not be broadcast for the target agent.
      *
      * @return array<int, class-string<StreamEvent>>

--- a/src/Attributes/WithoutBroadcasting.php
+++ b/src/Attributes/WithoutBroadcasting.php
@@ -34,11 +34,11 @@ final class WithoutBroadcasting
     }
 
     /**
-     * Determine if the given event should be withheld from the resolved skip set.
+     * Determine if the given event is excluded by the resolved skip set.
      *
      * @param  array<int, class-string<StreamEvent>>  $events
      */
-    public static function withholds(array $events, StreamEvent $event): bool
+    public static function excludes(array $events, StreamEvent $event): bool
     {
         return in_array($event::class, $events, true);
     }

--- a/src/Attributes/WithoutBroadcasting.php
+++ b/src/Attributes/WithoutBroadcasting.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Attributes;
 
 use Attribute;
+use InvalidArgumentException;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use ReflectionClass;
 
@@ -23,7 +24,23 @@ final class WithoutBroadcasting
      */
     public function __construct(string ...$events)
     {
+        foreach ($events as $event) {
+            if (! is_subclass_of($event, StreamEvent::class)) {
+                throw new InvalidArgumentException("[{$event}] is not a valid ".StreamEvent::class.' to exclude from broadcasting.');
+            }
+        }
+
         $this->events = $events;
+    }
+
+    /**
+     * Determine if the given event should be withheld from the resolved skip set.
+     *
+     * @param  array<int, class-string<StreamEvent>>  $events
+     */
+    public static function withholds(array $events, StreamEvent $event): bool
+    {
+        return in_array($event::class, $events, true);
     }
 
     /**

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -48,7 +48,7 @@ class BroadcastAgent implements ShouldQueue
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
             ->each(function (StreamEvent $event) use ($without) {
-                if (WithoutBroadcasting::withholds($without, $event)) {
+                if (WithoutBroadcasting::excludes($without, $event)) {
                     return;
                 }
 

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -48,7 +48,7 @@ class BroadcastAgent implements ShouldQueue
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
             ->each(function (StreamEvent $event) use ($without) {
-                if (in_array($event::class, $without, true)) {
+                if (WithoutBroadcasting::withholds($without, $event)) {
                     return;
                 }
 

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -6,6 +6,7 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Str;
+use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Streaming\Events\Error;
@@ -45,6 +46,10 @@ class BroadcastAgent implements ShouldQueue
 
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
             ->each(function (StreamEvent $event) {
+                if (! WithoutBroadcasting::allows($this->agent, $event)) {
+                    return;
+                }
+
                 $event->withInvocationId($this->invocationId)->broadcastNow($this->channels);
             })
             ->then(function ($response) use (&$streamedResponse) {

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -44,9 +44,11 @@ class BroadcastAgent implements ShouldQueue
     {
         $streamedResponse = null;
 
+        $without = WithoutBroadcasting::eventsFor($this->agent);
+
         $this->agent->stream($this->prompt, $this->attachments, $this->provider, $this->model)
-            ->each(function (StreamEvent $event) {
-                if (! WithoutBroadcasting::allows($this->agent, $event)) {
+            ->each(function (StreamEvent $event) use ($without) {
+                if (in_array($event::class, $without, true)) {
                     return;
                 }
 

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -13,6 +13,7 @@ use Laravel\Ai\Attributes\Provider as ProviderAttribute;
 use Laravel\Ai\Attributes\Timeout as TimeoutAttribute;
 use Laravel\Ai\Attributes\UseCheapestModel;
 use Laravel\Ai\Attributes\UseSmartestModel;
+use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
@@ -155,6 +156,10 @@ trait Promptable
     {
         return $this->stream($prompt, $attachments, $provider, $model)
             ->each(function (StreamEvent $event) use ($channels, $now) {
+                if (! WithoutBroadcasting::allows($this, $event)) {
+                    return;
+                }
+
                 $event->{$now ? 'broadcastNow' : 'broadcast'}($channels);
             });
     }

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -154,9 +154,11 @@ trait Promptable
      */
     public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
+        $without = WithoutBroadcasting::eventsFor($this);
+
         return $this->stream($prompt, $attachments, $provider, $model)
-            ->each(function (StreamEvent $event) use ($channels, $now) {
-                if (! WithoutBroadcasting::allows($this, $event)) {
+            ->each(function (StreamEvent $event) use ($channels, $now, $without) {
+                if (in_array($event::class, $without, true)) {
                     return;
                 }
 

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -158,7 +158,7 @@ trait Promptable
 
         return $this->stream($prompt, $attachments, $provider, $model)
             ->each(function (StreamEvent $event) use ($channels, $now, $without) {
-                if (in_array($event::class, $without, true)) {
+                if (WithoutBroadcasting::withholds($without, $event)) {
                     return;
                 }
 

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -158,7 +158,7 @@ trait Promptable
 
         return $this->stream($prompt, $attachments, $provider, $model)
             ->each(function (StreamEvent $event) use ($channels, $now, $without) {
-                if (WithoutBroadcasting::withholds($without, $event)) {
+                if (WithoutBroadcasting::excludes($without, $event)) {
                     return;
                 }
 

--- a/src/Streaming/Events/StreamEvent.php
+++ b/src/Streaming/Events/StreamEvent.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Streaming\Events;
 
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Facades\Broadcast;
 
@@ -21,10 +22,14 @@ abstract class StreamEvent
      */
     public function broadcast(Channel|array $channels, bool $now = false): void
     {
-        Broadcast::on($channels)
-            ->as($this->type())
-            ->with($this->toArray())
-            ->{$now ? 'sendNow' : 'send'}();
+        try {
+            Broadcast::on($channels)
+                ->as($this->type())
+                ->with($this->toArray())
+                ->{$now ? 'sendNow' : 'send'}();
+        } catch (BroadcastException $e) {
+            report($e);
+        }
     }
 
     /**

--- a/tests/Feature/BroadcastAgentTest.php
+++ b/tests/Feature/BroadcastAgentTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Broadcasting\AnonymousEvent;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Responses\StreamedAgentResponse;
@@ -126,6 +128,35 @@ test('failed event shares the invocation id with broadcasts from handle', functi
     });
 
     expect(array_values(array_unique($broadcastIds)))->toBe([$invocationId]);
+});
+
+test('an oversized broadcast frame does not abort the stream and then still resolves', function () {
+    AssistantAgent::fake(['Hello world']);
+
+    $pending = Mockery::mock(AnonymousEvent::class);
+    $pending->shouldReceive('as')->andReturnSelf();
+    $pending->shouldReceive('with')->andReturnSelf();
+    $pending->shouldReceive('sendNow')->andThrow(new BroadcastException('Payload too large'));
+
+    Broadcast::shouldReceive('on')->andReturn($pending);
+
+    $received = null;
+
+    $job = new BroadcastAgent(
+        agent: new AssistantAgent,
+        prompt: 'Say hello',
+        channels: new Channel('test-channel'),
+    );
+
+    $job->then(function ($response) use (&$received) {
+        $received = $response;
+    });
+
+    $job->handle();
+
+    expect($received)->not->toBeNull('then() callback was never invoked despite a failed broadcast')
+        ->toBeInstanceOf(StreamedAgentResponse::class)
+        ->and($received->text)->toBe('Hello world');
 });
 
 test('streamed response passed to then is fully resolved', function () {

--- a/tests/Feature/WithoutBroadcastingTest.php
+++ b/tests/Feature/WithoutBroadcastingTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Responses\Data;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\NonBroadcastingToolAgent;
+
+function toolResultEvent(): ToolResult
+{
+    return new ToolResult(
+        id: 'event-id',
+        toolResult: new Data\ToolResult('tool-id', 'search', [], str_repeat('x', 15_000)),
+        successful: true,
+        error: null,
+        timestamp: time(),
+    );
+}
+
+function toolCallEvent(): ToolCall
+{
+    return new ToolCall(
+        id: 'event-id',
+        toolCall: new Data\ToolCall('tool-id', 'search', []),
+        timestamp: time(),
+    );
+}
+
+function textDeltaEvent(): TextDelta
+{
+    return new TextDelta('event-id', 'message-id', 'Hello', time());
+}
+
+test('all events are broadcast when the attribute is absent', function () {
+    $agent = new AssistantAgent;
+
+    expect(WithoutBroadcasting::allows($agent, toolResultEvent()))->toBeTrue()
+        ->and(WithoutBroadcasting::allows($agent, toolCallEvent()))->toBeTrue()
+        ->and(WithoutBroadcasting::allows($agent, textDeltaEvent()))->toBeTrue();
+});
+
+test('listed events are not broadcast when the attribute is present', function () {
+    $agent = new NonBroadcastingToolAgent;
+
+    expect(WithoutBroadcasting::allows($agent, toolResultEvent()))->toBeFalse()
+        ->and(WithoutBroadcasting::allows($agent, toolCallEvent()))->toBeFalse();
+});
+
+test('events not listed in the attribute are still broadcast', function () {
+    $agent = new NonBroadcastingToolAgent;
+
+    expect(WithoutBroadcasting::allows($agent, textDeltaEvent()))->toBeTrue();
+});
+
+test('a null target broadcasts all events', function () {
+    expect(WithoutBroadcasting::allows(null, toolResultEvent()))->toBeTrue();
+});

--- a/tests/Feature/WithoutBroadcastingTest.php
+++ b/tests/Feature/WithoutBroadcastingTest.php
@@ -5,7 +5,6 @@ use Illuminate\Broadcasting\Channel;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Laravel\Ai\Jobs\BroadcastAgent;
-use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
@@ -13,54 +12,23 @@ use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\NonBroadcastingTextAgent;
 use Tests\Fixtures\Agents\NonBroadcastingToolAgent;
 
-function toolResultEvent(): ToolResult
-{
-    return new ToolResult(
-        id: 'event-id',
-        toolResult: new Data\ToolResult('tool-id', 'search', [], str_repeat('x', 15_000)),
-        successful: true,
-        error: null,
-        timestamp: time(),
-    );
-}
-
-function toolCallEvent(): ToolCall
-{
-    return new ToolCall(
-        id: 'event-id',
-        toolCall: new Data\ToolCall('tool-id', 'search', []),
-        timestamp: time(),
-    );
-}
-
-function textDeltaEvent(): TextDelta
-{
-    return new TextDelta('event-id', 'message-id', 'Hello', time());
-}
-
-test('all events are broadcast when the attribute is absent', function () {
-    $agent = new AssistantAgent;
-
-    expect(WithoutBroadcasting::allows($agent, toolResultEvent()))->toBeTrue()
-        ->and(WithoutBroadcasting::allows($agent, toolCallEvent()))->toBeTrue()
-        ->and(WithoutBroadcasting::allows($agent, textDeltaEvent()))->toBeTrue();
+test('no events are withheld when the attribute is absent', function () {
+    expect(WithoutBroadcasting::eventsFor(new AssistantAgent))->toBe([]);
 });
 
-test('listed events are not broadcast when the attribute is present', function () {
-    $agent = new NonBroadcastingToolAgent;
-
-    expect(WithoutBroadcasting::allows($agent, toolResultEvent()))->toBeFalse()
-        ->and(WithoutBroadcasting::allows($agent, toolCallEvent()))->toBeFalse();
+test('listed events are withheld when the attribute is present', function () {
+    expect(WithoutBroadcasting::eventsFor(new NonBroadcastingToolAgent))
+        ->toContain(ToolResult::class)
+        ->toContain(ToolCall::class);
 });
 
-test('events not listed in the attribute are still broadcast', function () {
-    $agent = new NonBroadcastingToolAgent;
-
-    expect(WithoutBroadcasting::allows($agent, textDeltaEvent()))->toBeTrue();
+test('events not listed in the attribute are not withheld', function () {
+    expect(WithoutBroadcasting::eventsFor(new NonBroadcastingToolAgent))
+        ->not->toContain(TextDelta::class);
 });
 
-test('a null target broadcasts all events', function () {
-    expect(WithoutBroadcasting::allows(null, toolResultEvent()))->toBeTrue();
+test('a null target withholds nothing', function () {
+    expect(WithoutBroadcasting::eventsFor(null))->toBe([]);
 });
 
 test('broadcast withholds listed events from the channel but assembles the full response', function () {

--- a/tests/Feature/WithoutBroadcastingTest.php
+++ b/tests/Feature/WithoutBroadcastingTest.php
@@ -1,11 +1,16 @@
 <?php
 
+use Illuminate\Broadcasting\AnonymousEvent;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
 use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\NonBroadcastingTextAgent;
 use Tests\Fixtures\Agents\NonBroadcastingToolAgent;
 
 function toolResultEvent(): ToolResult
@@ -56,4 +61,48 @@ test('events not listed in the attribute are still broadcast', function () {
 
 test('a null target broadcasts all events', function () {
     expect(WithoutBroadcasting::allows(null, toolResultEvent()))->toBeTrue();
+});
+
+test('broadcast withholds listed events from the channel but assembles the full response', function () {
+    Event::fake();
+    NonBroadcastingTextAgent::fake(['Hello world']);
+
+    $received = null;
+
+    (new NonBroadcastingTextAgent)
+        ->broadcastNow('Say hello', new Channel('test-channel'))
+        ->then(function ($response) use (&$received) {
+            $received = $response;
+        });
+
+    Event::assertNotDispatched(AnonymousEvent::class, fn (AnonymousEvent $e) => $e->broadcastAs() === 'text_delta');
+    Event::assertDispatched(AnonymousEvent::class, fn (AnonymousEvent $e) => $e->broadcastAs() === 'stream_start');
+
+    expect($received)->not->toBeNull('then() callback was never invoked')
+        ->and($received->text)->toBe('Hello world');
+});
+
+test('broadcast agent withholds listed events from the channel but resolves the full response', function () {
+    Event::fake();
+    NonBroadcastingTextAgent::fake(['Hello world']);
+
+    $received = null;
+
+    $job = new BroadcastAgent(
+        agent: new NonBroadcastingTextAgent,
+        prompt: 'Say hello',
+        channels: new Channel('test-channel'),
+    );
+
+    $job->then(function ($response) use (&$received) {
+        $received = $response;
+    });
+
+    $job->handle();
+
+    Event::assertNotDispatched(AnonymousEvent::class, fn (AnonymousEvent $e) => $e->broadcastAs() === 'text_delta');
+    Event::assertDispatched(AnonymousEvent::class, fn (AnonymousEvent $e) => $e->broadcastAs() === 'stream_start');
+
+    expect($received)->not->toBeNull('then() callback was never invoked')
+        ->and($received->text)->toBe('Hello world');
 });

--- a/tests/Feature/WithoutBroadcastingTest.php
+++ b/tests/Feature/WithoutBroadcastingTest.php
@@ -12,6 +12,11 @@ use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\NonBroadcastingTextAgent;
 use Tests\Fixtures\Agents\NonBroadcastingToolAgent;
 
+test('it rejects event classes that are not stream events', function () {
+    expect(fn () => new WithoutBroadcasting('App\Events\Typo'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
 test('no events are withheld when the attribute is absent', function () {
     expect(WithoutBroadcasting::eventsFor(new AssistantAgent))->toBe([]);
 });

--- a/tests/Fixtures/Agents/NonBroadcastingTextAgent.php
+++ b/tests/Fixtures/Agents/NonBroadcastingTextAgent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Streaming\Events\TextDelta;
+
+#[WithoutBroadcasting(TextDelta::class)]
+class NonBroadcastingTextAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}

--- a/tests/Fixtures/Agents/NonBroadcastingToolAgent.php
+++ b/tests/Fixtures/Agents/NonBroadcastingToolAgent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+
+#[WithoutBroadcasting(ToolResult::class, ToolCall::class)]
+class NonBroadcastingToolAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}


### PR DESCRIPTION
Currently there isn't a clean way to stop `BroadcastAgent` from broadcasting every `StreamEvent`. Tool results from data-heavy tools (listing records, search, email bodies) routinely blow past the 10KB WebSocket frame limit on Reverb/Pusher, which throws a `BroadcastException` and fails the whole queued job. Folks have been working around it by subclassing the job and overriding `broadcastOnQueue` (see #174).

This PR adds a class attribute so an affected agent can opt out of broadcasting specific event types:

```php
#[WithoutBroadcasting(ToolResult::class, ToolCall::class)]
class SearchAgent implements Agent, HasTools
{
    use Promptable;
}
```

The named events simply never hit the websocket; the frontend loads tool data from `agent_conversation_messages` after the stream completes, same as the existing workaround. No attribute means everything broadcasts as before, so nothing changes for the majority who never hit the limit. It applies to both the queued (`broadcastOnQueue`) and synchronous (`broadcast`/`broadcastNow`) paths.

Went with an attribute to match the existing `#[MaxSteps]`/`#[Timeout]` style and avoid widening the `Agent` contract or threading a new param through three broadcast signatures. Open to renaming if you'd prefer something else.

Fixes #174