### PR TITLE
Default Anthropic text model to Claude Sonnet 5

### DIFF
--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -59,7 +59,7 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsWebFet
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['text']['default'] ?? 'claude-sonnet-4-6';
+        return $this->config['models']['text']['default'] ?? 'claude-sonnet-5';
     }
 
     /**


### PR DESCRIPTION
The default Anthropic text model was still `claude-sonnet-4-6`. This bumps the fallback in `defaultTextModel()` to `claude-sonnet-5`, Anthropic's current Sonnet.

Only affects the fallback, so anyone setting `models.text.default` in their config is unchanged.