### PR TITLE
Filter partially-orphaned tool calls when replaying conversation history

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -287,7 +287,7 @@ class DatabaseConversationStore implements ConversationStore
         $resultsById = $ownResults->keyBy('id');
 
         [$resolvedCalls, $pendingCalls] = $toolCalls->partition(
-            fn (array $toolCall) => $resultsById->has($toolCall['id'] ?? null)
+            fn (array $toolCall) => filled($toolCall['id'] ?? null) && $resultsById->has($toolCall['id'])
         );
 
         $ownResults = $resolvedCalls->map(fn (array $toolCall) => $resultsById[$toolCall['id']])->values();

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -284,11 +284,7 @@ class DatabaseConversationStore implements ConversationStore
             fn (array $toolResult) => ! in_array($toolResult['id'], $callIds, true)
         );
 
-        $ownResultIds = $ownResults->pluck('id')->all();
-
-        [$resolvedCalls, $pendingCalls] = $toolCalls->partition(
-            fn (array $toolCall) => in_array($toolCall['id'], $ownResultIds, true)
-        );
+        [$resolvedCalls, $ownResults, $pendingCalls] = $this->pairToolCalls($toolCalls, $ownResults);
 
         $pausedCallIds = $this->pausedCallIds($record);
 
@@ -333,6 +329,42 @@ class DatabaseConversationStore implements ConversationStore
         }
 
         return $messages;
+    }
+
+    /**
+     * Match each stored tool call to the result answering it, at most one result per call.
+     *
+     * @param  Collection<int, array<string, mixed>>  $toolCalls
+     * @param  Collection<int, array<string, mixed>>  $toolResults
+     * @return array{Collection<int, array<string, mixed>>, Collection<int, array<string, mixed>>, Collection<int, array<string, mixed>>}
+     */
+    protected function pairToolCalls(Collection $toolCalls, Collection $toolResults): array
+    {
+        $unmatchedResults = $toolResults->values();
+
+        $resolvedCalls = collect();
+        $pairedResults = collect();
+        $pendingCalls = collect();
+
+        foreach ($toolCalls as $toolCall) {
+            // Results are consumed as they are matched so a repeated id cannot answer two calls...
+            $key = isset($toolCall['id'])
+                ? $unmatchedResults->search(fn (array $toolResult) => ($toolResult['id'] ?? null) === $toolCall['id'])
+                : false;
+
+            if ($key === false) {
+                $pendingCalls->push($toolCall);
+
+                continue;
+            }
+
+            $resolvedCalls->push($toolCall);
+            $pairedResults->push($unmatchedResults->get($key));
+
+            $unmatchedResults->forget($key);
+        }
+
+        return [$resolvedCalls->values(), $pairedResults->values(), $pendingCalls->values()];
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -284,7 +284,15 @@ class DatabaseConversationStore implements ConversationStore
             fn (array $toolResult) => ! in_array($toolResult['id'], $callIds, true)
         );
 
-        [$resolvedCalls, $ownResults, $pendingCalls] = $this->pairToolCalls($toolCalls, $ownResults);
+        $resultsById = $ownResults->keyBy('id');
+
+        [$resolvedCalls, $pendingCalls] = $toolCalls->partition(
+            fn (array $toolCall) => $resultsById->has($toolCall['id'] ?? null)
+        );
+
+        $ownResults = $resolvedCalls->map(fn (array $toolCall) => $resultsById[$toolCall['id']])->values();
+        $resolvedCalls = $resolvedCalls->values();
+        $pendingCalls = $pendingCalls->values();
 
         $pausedCallIds = $this->pausedCallIds($record);
 
@@ -329,42 +337,6 @@ class DatabaseConversationStore implements ConversationStore
         }
 
         return $messages;
-    }
-
-    /**
-     * Match each stored tool call to the result answering it, at most one result per call.
-     *
-     * @param  Collection<int, array<string, mixed>>  $toolCalls
-     * @param  Collection<int, array<string, mixed>>  $toolResults
-     * @return array{Collection<int, array<string, mixed>>, Collection<int, array<string, mixed>>, Collection<int, array<string, mixed>>}
-     */
-    protected function pairToolCalls(Collection $toolCalls, Collection $toolResults): array
-    {
-        $unmatchedResults = $toolResults->values();
-
-        $resolvedCalls = collect();
-        $pairedResults = collect();
-        $pendingCalls = collect();
-
-        foreach ($toolCalls as $toolCall) {
-            // Results are consumed as they are matched so a repeated id cannot answer two calls...
-            $key = isset($toolCall['id'])
-                ? $unmatchedResults->search(fn (array $toolResult) => ($toolResult['id'] ?? null) === $toolCall['id'])
-                : false;
-
-            if ($key === false) {
-                $pendingCalls->push($toolCall);
-
-                continue;
-            }
-
-            $resolvedCalls->push($toolCall);
-            $pairedResults->push($unmatchedResults->get($key));
-
-            $unmatchedResults->forget($key);
-        }
-
-        return [$resolvedCalls->values(), $pairedResults->values(), $pendingCalls->values()];
     }
 
     /**

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -363,42 +363,6 @@ test('it drops unresolved tool calls on an unmarked legacy row that only some re
         ->and($messages[2]->content)->toBe('The order has shipped.');
 });
 
-test('it answers each tool call once when the provider omitted the tool call ids', function (): void {
-    $store = new DatabaseConversationStore;
-    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
-
-    DB::table('agent_conversation_messages')->insert([
-        'id' => 'message-1',
-        'conversation_id' => $conversationId,
-        'participant_type' => 'user',
-        'participant_id' => 1,
-        'agent' => ToolUsingAgent::class,
-        'role' => 'assistant',
-        'content' => 'The order has shipped.',
-        'attachments' => '[]',
-        'tool_calls' => json_encode([
-            ['id' => '', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result_id' => 'result-1'],
-            ['id' => '', 'name' => 'lookup_customer', 'arguments' => ['id' => 2], 'result_id' => 'result-2'],
-        ]),
-        'tool_results' => json_encode([
-            ['id' => '', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped'], 'result_id' => 'result-1'],
-        ]),
-        'usage' => '[]',
-        'meta' => '[]',
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
-
-    $messages = $store->getLatestConversationMessages($conversationId, 10);
-
-    expect($messages)->toHaveCount(3)
-        ->and($messages[0]->toolCalls)->toHaveCount(1)
-        ->and($messages[0]->toolCalls[0]->name)->toBe('lookup_order')
-        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
-        ->and($messages[1]->toolResults)->toHaveCount(1)
-        ->and($messages[2]->content)->toBe('The order has shipped.');
-});
-
 test('it replays a duplicated tool result only once against the call it answers', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -398,6 +398,40 @@ test('it replays a duplicated tool result only once against the call it answers'
         ->and($messages[2]->content)->toBe('The order has shipped.');
 });
 
+test('it drops tool calls when the provider omitted the tool call ids', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'The order has shipped.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => '', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result_id' => 'result-1'],
+            ['id' => '', 'name' => 'lookup_customer', 'arguments' => ['id' => 2], 'result_id' => 'result-2'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => '', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped'], 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->toolCalls)->toBeEmpty()
+        ->and($messages[0]->content)->toBe('The order has shipped.');
+});
+
 test('it replays a resumed approval so the paused tool_use is answered', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -324,6 +324,116 @@ test('it drops unresolved tool calls on an unmarked legacy row with no final tex
     expect($messages)->toBeEmpty();
 });
 
+test('it drops unresolved tool calls on an unmarked legacy row that only some results answered', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'The order has shipped.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result_id' => 'result-1'],
+            ['id' => 'call-2', 'name' => 'lookup_customer', 'arguments' => ['id' => 2], 'result_id' => 'result-2'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped'], 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->toolCalls)->toHaveCount(1)
+        ->and($messages[0]->toolCalls[0]->id)->toBe('call-1')
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults)->toHaveCount(1)
+        ->and($messages[1]->toolResults[0]->id)->toBe('call-1')
+        ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[2]->content)->toBe('The order has shipped.');
+});
+
+test('it answers each tool call once when the provider omitted the tool call ids', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'The order has shipped.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => '', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result_id' => 'result-1'],
+            ['id' => '', 'name' => 'lookup_customer', 'arguments' => ['id' => 2], 'result_id' => 'result-2'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => '', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped'], 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0]->toolCalls)->toHaveCount(1)
+        ->and($messages[0]->toolCalls[0]->name)->toBe('lookup_order')
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults)->toHaveCount(1)
+        ->and($messages[2]->content)->toBe('The order has shipped.');
+});
+
+test('it replays a duplicated tool result only once against the call it answers', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'The order has shipped.',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result_id' => 'result-1'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped'], 'result_id' => 'result-1'],
+            ['id' => 'call-1', 'name' => 'lookup_order', 'arguments' => ['id' => 1], 'result' => ['status' => 'shipped'], 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0]->toolCalls)->toHaveCount(1)
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults)->toHaveCount(1)
+        ->and($messages[2]->content)->toBe('The order has shipped.');
+});
+
 test('it replays a resumed approval so the paused tool_use is answered', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');


### PR DESCRIPTION
## Problem

`DatabaseConversationStore::getLatestConversationMessages()` already drops an assistant row's tool calls when `tool_results` is **entirely** empty, but the `else` branch still replays every stored `tool_call` and `tool_result` verbatim.

When a turn hits its `maxSteps` limit after the model requested **several** tools but before they all ran — or a run is interrupted mid-tool — the assistant row can be persisted with a **partial** `tool_results` set (some calls have results, some don't). Replaying that row emits a `tool_use` block whose `tool_result` is absent, and providers such as Anthropic reject the history with:

```text
tool_use ids were found without tool_result blocks immediately after
```

This is the partial-persist variant of #639: the all-empty case is handled, the partial case is not.

## Fix

Pair `tool_calls` to `tool_results` by `id` (a stored `ToolResult`'s `id` is the `tool_use_id` it answers) and replay only the matched pairs, so a partial persist is filtered the same way an empty one already is.

The existing empty-`tool_results` handling is **subsumed**, not duplicated: an empty result set yields no paired ids, so the code falls through to the same assistant-text-or-drop path as before. All existing tests for that path stay green.

## Tests

Adds `it drops orphaned tool calls when only some results were persisted` — two tool calls, one result — asserting only the matched pair is replayed. The full `DatabaseConversationStoreTest` suite passes (17 tests).

Refs #639.