### PR TITLE
Fix Anthropic native structured output rejecting JSON Schema value constraints

### DIFF
--- a/src/Exceptions/StructuredOutputValidationException.php
+++ b/src/Exceptions/StructuredOutputValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+class StructuredOutputValidationException extends AiException
+{
+    /**
+     * @param  array<int, string>  $violations
+     * @param  array<string, mixed>  $data
+     */
+    public function __construct(public readonly array $violations, public readonly array $data)
+    {
+        parent::__construct(
+            "Structured output does not satisfy the schema's value constraints: ".implode(' ', $violations)
+        );
+    }
+}

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -12,12 +12,14 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Exceptions\StructuredOutputValidationException;
 use Laravel\Ai\Gateway\Concerns\DelegatesToTextGenerationLoop;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\ImageResponse;
@@ -72,7 +74,34 @@ class AnthropicGateway implements Gateway, StepTextGateway
 
         $this->validateTextResponse($data);
 
-        return $this->parseTextResponse($data, $provider, filled($schema));
+        $result = $this->parseTextResponse($data, $provider, filled($schema));
+
+        if (filled($schema) && $this->supportsNativeStructuredOutput($provider) && $result->structured !== null) {
+            $this->validateStructuredOutput($result->structured, $schema);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Validate structured output against the full schema, including the value constraints
+     * that Anthropic's native structured output accepts but does not enforce on its own.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $schema
+     *
+     * @throws StructuredOutputValidationException
+     */
+    protected function validateStructuredOutput(array $data, array $schema): void
+    {
+        $violations = AnthropicStructuredOutputValidator::violations(
+            $data,
+            (new ObjectSchema($schema))->toSchema(),
+        );
+
+        if (filled($violations)) {
+            throw new StructuredOutputValidationException($violations, $data);
+        }
     }
 
     /**

--- a/src/Gateway/Anthropic/AnthropicSchemaSanitizer.php
+++ b/src/Gateway/Anthropic/AnthropicSchemaSanitizer.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic;
+
+class AnthropicSchemaSanitizer
+{
+    /**
+     * Numeric constraint keywords rejected by Anthropic's native structured output.
+     */
+    protected const NUMERIC_KEYWORDS = ['minimum', 'maximum', 'multipleOf'];
+
+    /**
+     * String length constraint keywords rejected by Anthropic's native structured output.
+     */
+    protected const STRING_LENGTH_KEYWORDS = ['minLength', 'maxLength'];
+
+    /**
+     * String formats accepted by Anthropic's native structured output.
+     */
+    protected const SUPPORTED_FORMATS = [
+        'date-time', 'time', 'date', 'duration',
+        'email', 'hostname', 'uri', 'ipv4', 'ipv6', 'uuid',
+    ];
+
+    /**
+     * Strip JSON Schema keywords unsupported by Anthropic's native structured output, folding
+     * each removed constraint into the node's description so the model still honors it.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    public static function sanitize(array $schema): array
+    {
+        return static::node($schema);
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    protected static function node(array $schema): array
+    {
+        $notes = [];
+
+        foreach (static::NUMERIC_KEYWORDS as $keyword) {
+            if (array_key_exists($keyword, $schema)) {
+                $notes[] = static::numericNote($keyword, $schema[$keyword]);
+                unset($schema[$keyword]);
+            }
+        }
+
+        foreach (static::STRING_LENGTH_KEYWORDS as $keyword) {
+            if (array_key_exists($keyword, $schema)) {
+                $notes[] = static::lengthNote($keyword, $schema[$keyword]);
+                unset($schema[$keyword]);
+            }
+        }
+
+        if (array_key_exists('maxItems', $schema)) {
+            $notes[] = "Must contain at most {$schema['maxItems']} item(s).";
+            unset($schema['maxItems']);
+        }
+
+        // Anthropic's native structured output only accepts minItems of 0 or 1.
+        if (array_key_exists('minItems', $schema) && $schema['minItems'] > 1) {
+            $notes[] = "Must contain at least {$schema['minItems']} item(s).";
+            $schema['minItems'] = 1;
+        }
+
+        if (array_key_exists('uniqueItems', $schema)) {
+            if ($schema['uniqueItems'] === true) {
+                $notes[] = 'All items must be unique.';
+            }
+
+            unset($schema['uniqueItems']);
+        }
+
+        if (array_key_exists('format', $schema) && ! in_array($schema['format'], static::SUPPORTED_FORMATS, true)) {
+            $notes[] = "Format: {$schema['format']}.";
+            unset($schema['format']);
+        }
+
+        if (filled($notes)) {
+            $schema['description'] = trim(($schema['description'] ?? '').' '.implode(' ', $notes));
+        }
+
+        if (isset($schema['properties']) && is_array($schema['properties'])) {
+            foreach ($schema['properties'] as $name => $property) {
+                if (is_array($property)) {
+                    $schema['properties'][$name] = static::node($property);
+                }
+            }
+        }
+
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            $schema['items'] = static::node($schema['items']);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Format a natural-language note describing a stripped numeric constraint.
+     */
+    protected static function numericNote(string $keyword, int|float $value): string
+    {
+        return match ($keyword) {
+            'minimum' => "Must be at least {$value}.",
+            'maximum' => "Must be at most {$value}.",
+            'multipleOf' => "Must be a multiple of {$value}.",
+        };
+    }
+
+    /**
+     * Format a natural-language note describing a stripped string-length constraint.
+     */
+    protected static function lengthNote(string $keyword, int $value): string
+    {
+        $unit = $value === 1 ? 'character' : 'characters';
+
+        return $keyword === 'minLength'
+            ? "Must be at least {$value} {$unit}."
+            : "Must be at most {$value} {$unit}.";
+    }
+}

--- a/src/Gateway/Anthropic/AnthropicStructuredOutputValidator.php
+++ b/src/Gateway/Anthropic/AnthropicStructuredOutputValidator.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Anthropic;
+
+class AnthropicStructuredOutputValidator
+{
+    /**
+     * Validate structured output data against the value constraints (minimum/maximum, string
+     * length, array bounds, etc.) that Anthropic's native structured output accepts but does
+     * not enforce on the model's behalf. The structural contract -- types, required properties,
+     * enums -- is already guaranteed by the API itself, so it is intentionally not re-checked here.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $schema
+     * @return array<int, string> Human-readable violation messages; empty when the data is valid.
+     */
+    public static function violations(array $data, array $schema): array
+    {
+        return static::node($data, $schema, '');
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<int, string>
+     */
+    protected static function node(mixed $value, array $schema, string $path): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        return match (true) {
+            is_int($value), is_float($value) => static::numericViolations($value, $schema, $path),
+            is_string($value) => static::stringViolations($value, $schema, $path),
+            is_array($value) && array_is_list($value) => static::arrayViolations($value, $schema, $path),
+            is_array($value) => static::objectViolations($value, $schema, $path),
+            default => [],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<int, string>
+     */
+    protected static function numericViolations(int|float $value, array $schema, string $path): array
+    {
+        $violations = [];
+
+        if (isset($schema['minimum']) && $value < $schema['minimum']) {
+            $violations[] = static::describe($path, "must be at least {$schema['minimum']} (got {$value})");
+        }
+
+        if (isset($schema['maximum']) && $value > $schema['maximum']) {
+            $violations[] = static::describe($path, "must be at most {$schema['maximum']} (got {$value})");
+        }
+
+        if (isset($schema['multipleOf']) && (float) $schema['multipleOf'] !== 0.0
+            && abs(fmod($value, $schema['multipleOf'])) > 1e-9) {
+            $violations[] = static::describe($path, "must be a multiple of {$schema['multipleOf']} (got {$value})");
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<int, string>
+     */
+    protected static function stringViolations(string $value, array $schema, string $path): array
+    {
+        $violations = [];
+        $length = mb_strlen($value);
+
+        if (isset($schema['minLength']) && $length < $schema['minLength']) {
+            $violations[] = static::describe($path, "must be at least {$schema['minLength']} character(s) (got {$length})");
+        }
+
+        if (isset($schema['maxLength']) && $length > $schema['maxLength']) {
+            $violations[] = static::describe($path, "must be at most {$schema['maxLength']} character(s) (got {$length})");
+        }
+
+        if (isset($schema['pattern']) && is_string($schema['pattern']) && static::failsPattern($value, $schema['pattern'])) {
+            $violations[] = static::describe($path, "must match the pattern: {$schema['pattern']}");
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param  array<int, mixed>  $value
+     * @param  array<string, mixed>  $schema
+     * @return array<int, string>
+     */
+    protected static function arrayViolations(array $value, array $schema, string $path): array
+    {
+        $violations = [];
+        $count = count($value);
+
+        if (isset($schema['minItems']) && $count < $schema['minItems']) {
+            $violations[] = static::describe($path, "must contain at least {$schema['minItems']} item(s) (got {$count})");
+        }
+
+        if (isset($schema['maxItems']) && $count > $schema['maxItems']) {
+            $violations[] = static::describe($path, "must contain at most {$schema['maxItems']} item(s) (got {$count})");
+        }
+
+        if (($schema['uniqueItems'] ?? false) === true) {
+            $serialized = array_map(fn ($item) => json_encode($item), $value);
+
+            if (count($serialized) !== count(array_unique($serialized))) {
+                $violations[] = static::describe($path, 'items must be unique');
+            }
+        }
+
+        if (isset($schema['items']) && is_array($schema['items'])) {
+            foreach ($value as $index => $item) {
+                array_push($violations, ...static::node($item, $schema['items'], "{$path}[{$index}]"));
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @param  array<string, mixed>  $schema
+     * @return array<int, string>
+     */
+    protected static function objectViolations(array $value, array $schema, string $path): array
+    {
+        $violations = [];
+
+        foreach ($schema['properties'] ?? [] as $key => $propertySchema) {
+            if (array_key_exists($key, $value) && is_array($propertySchema)) {
+                array_push($violations, ...static::node($value[$key], $propertySchema, static::join($path, $key)));
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Determine if the string value fails to match the given JSON Schema pattern.
+     *
+     * Invalid or unsupported regex syntax is treated as non-blocking rather than a violation.
+     */
+    protected static function failsPattern(string $value, string $pattern): bool
+    {
+        $result = @preg_match('/'.str_replace('/', '\/', $pattern).'/u', $value);
+
+        return $result === 0;
+    }
+
+    /**
+     * Join a property key onto a dotted path.
+     */
+    protected static function join(string $path, string $key): string
+    {
+        return $path === '' ? $key : "{$path}.{$key}";
+    }
+
+    /**
+     * Prefix a violation message with its schema path, when known.
+     */
+    protected static function describe(string $path, string $message): string
+    {
+        return $path === '' ? $message : "`{$path}` {$message}";
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Gateway\Anthropic\AnthropicSchemaSanitizer;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
@@ -39,7 +40,7 @@ trait BuildsTextRequests
             $body['output_config'] = [
                 'format' => [
                     'type' => 'json_schema',
-                    'schema' => (new ObjectSchema($schema))->toSchema(),
+                    'schema' => AnthropicSchemaSanitizer::sanitize((new ObjectSchema($schema))->toSchema()),
                 ],
             ];
 

--- a/tests/Feature/Providers/Anthropic/RequestMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/RequestMappingTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StructuredOutputValidationException;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
+use Tests\Fixtures\Agents\ConstrainedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\StructuredWithThinkingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -298,6 +300,75 @@ describe('structured output', function () {
         );
         expect($response->structured)->toMatchArray(['name' => 'Taylor', 'age' => 30]);
     });
+
+    test('native structured output strips unsupported constraints and folds them into descriptions', function () {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeStructuredResponse([
+                'score' => 5,
+                'summary' => 'Solid work overall.',
+                'tags' => ['clean'],
+            ]),
+        ]);
+
+        (new ConstrainedStructuredAgent)->prompt(
+            'Review this code',
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request) {
+            $schema = $request->data()['output_config']['format']['schema'];
+
+            $score = $schema['properties']['score'];
+            $summary = $schema['properties']['summary'];
+            $tags = $schema['properties']['tags'];
+
+            return ! isset($score['minimum']) && ! isset($score['maximum'])
+                && str_contains($score['description'], 'Must be at least 1.')
+                && str_contains($score['description'], 'Must be at most 10.')
+                && ! isset($summary['minLength']) && ! isset($summary['maxLength'])
+                && ! isset($tags['maxItems'])
+                && str_contains($tags['description'], 'Must contain at most 5 item(s).');
+        });
+    });
+
+    test('native structured output response satisfying its constraints is returned as-is', function () {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeStructuredResponse([
+                'score' => 5,
+                'summary' => 'Solid work overall.',
+                'tags' => ['clean'],
+            ]),
+        ]);
+
+        $response = (new ConstrainedStructuredAgent)->prompt(
+            'Review this code',
+            provider: 'anthropic',
+        );
+
+        expect($response->structured)->toMatchArray([
+            'score' => 5,
+            'summary' => 'Solid work overall.',
+            'tags' => ['clean'],
+        ]);
+    });
+
+    test('native structured output response violating a value constraint throws', function () {
+        Http::fake([
+            'api.anthropic.com/*' => $this->fakeStructuredResponse([
+                'score' => 42,
+                'summary' => 'Solid work overall.',
+                'tags' => ['clean'],
+            ]),
+        ]);
+
+        (new ConstrainedStructuredAgent)->prompt(
+            'Review this code',
+            provider: 'anthropic',
+        );
+    })->throws(
+        StructuredOutputValidationException::class,
+        "Structured output does not satisfy the schema's value constraints: `score` must be at most 10 (got 42)"
+    );
 });
 
 describe('response parsing', function () {

--- a/tests/Fixtures/Agents/ConstrainedStructuredAgent.php
+++ b/tests/Fixtures/Agents/ConstrainedStructuredAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+
+class ConstrainedStructuredAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that reviews code.';
+    }
+
+    /**
+     * Get the structured output's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'score' => $schema->integer()->required()->min(1)->max(10),
+            'summary' => $schema->string()->required()->min(1)->max(280),
+            'tags' => $schema->array()->required()->items($schema->string())->min(1)->max(5),
+        ];
+    }
+}

--- a/tests/Unit/Gateway/Anthropic/AnthropicSchemaSanitizerTest.php
+++ b/tests/Unit/Gateway/Anthropic/AnthropicSchemaSanitizerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use Illuminate\JsonSchema\JsonSchema;
+use Laravel\Ai\Gateway\Anthropic\AnthropicSchemaSanitizer;
+use Laravel\Ai\ObjectSchema;
+
+test('strips numeric constraints and folds them into the description', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'integer',
+        'minimum' => 1,
+        'maximum' => 10,
+    ]);
+
+    expect($result)->not->toHaveKeys(['minimum', 'maximum'])
+        ->and($result['type'])->toBe('integer')
+        ->and($result['description'])->toBe('Must be at least 1. Must be at most 10.');
+});
+
+test('strips multipleOf', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'number',
+        'multipleOf' => 5,
+    ]);
+
+    expect($result)->not->toHaveKey('multipleOf')
+        ->and($result['description'])->toBe('Must be a multiple of 5.');
+});
+
+test('strips string length constraints with correct pluralization', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'string',
+        'minLength' => 1,
+        'maxLength' => 255,
+    ]);
+
+    expect($result)->not->toHaveKeys(['minLength', 'maxLength'])
+        ->and($result['description'])->toBe('Must be at least 1 character. Must be at most 255 characters.');
+});
+
+test('strips maxItems and folds it into the description', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'array',
+        'maxItems' => 5,
+        'items' => ['type' => 'string'],
+    ]);
+
+    expect($result)->not->toHaveKey('maxItems')
+        ->and($result['description'])->toBe('Must contain at most 5 item(s).');
+});
+
+test('clamps minItems greater than one down to one', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'array',
+        'minItems' => 3,
+        'items' => ['type' => 'string'],
+    ]);
+
+    expect($result['minItems'])->toBe(1)
+        ->and($result['description'])->toBe('Must contain at least 3 item(s).');
+});
+
+test('leaves supported minItems values of 0 or 1 untouched', function () {
+    foreach ([0, 1] as $value) {
+        $result = AnthropicSchemaSanitizer::sanitize([
+            'type' => 'array',
+            'minItems' => $value,
+            'items' => ['type' => 'string'],
+        ]);
+
+        expect($result['minItems'])->toBe($value)
+            ->and($result)->not->toHaveKey('description');
+    }
+});
+
+test('strips uniqueItems and notes it only when true', function () {
+    $withUnique = AnthropicSchemaSanitizer::sanitize(['type' => 'array', 'uniqueItems' => true]);
+
+    expect($withUnique)->not->toHaveKey('uniqueItems')
+        ->and($withUnique['description'])->toBe('All items must be unique.');
+
+    $withoutUnique = AnthropicSchemaSanitizer::sanitize(['type' => 'array', 'uniqueItems' => false]);
+
+    expect($withoutUnique)->not->toHaveKey('uniqueItems')
+        ->and($withoutUnique)->not->toHaveKey('description');
+});
+
+test('strips unsupported string formats but keeps supported ones', function () {
+    $unsupported = AnthropicSchemaSanitizer::sanitize(['type' => 'string', 'format' => 'phone']);
+
+    expect($unsupported)->not->toHaveKey('format')
+        ->and($unsupported['description'])->toBe('Format: phone.');
+
+    $supported = AnthropicSchemaSanitizer::sanitize(['type' => 'string', 'format' => 'email']);
+
+    expect($supported['format'])->toBe('email')
+        ->and($supported)->not->toHaveKey('description');
+});
+
+test('appends constraint notes to an existing description', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'integer',
+        'description' => 'The score.',
+        'minimum' => 1,
+    ]);
+
+    expect($result['description'])->toBe('The score. Must be at least 1.');
+});
+
+test('leaves schemas without unsupported keywords untouched', function () {
+    $schema = [
+        'type' => 'object',
+        'properties' => [
+            'status' => ['type' => 'string', 'enum' => ['active', 'inactive']],
+            'slug' => ['type' => 'string', 'pattern' => '^[a-z]+$'],
+        ],
+        'required' => ['status'],
+        'additionalProperties' => false,
+    ];
+
+    expect(AnthropicSchemaSanitizer::sanitize($schema))->toBe($schema);
+});
+
+test('recurses into nested properties and array items', function () {
+    $result = AnthropicSchemaSanitizer::sanitize([
+        'type' => 'object',
+        'properties' => [
+            'tags' => [
+                'type' => 'array',
+                'maxItems' => 3,
+                'items' => ['type' => 'string', 'maxLength' => 20],
+            ],
+            'score' => ['type' => 'integer', 'minimum' => 0],
+        ],
+        'additionalProperties' => false,
+    ]);
+
+    expect($result['properties']['tags'])->not->toHaveKey('maxItems')
+        ->and($result['properties']['tags']['description'])->toBe('Must contain at most 3 item(s).')
+        ->and($result['properties']['tags']['items'])->not->toHaveKey('maxLength')
+        ->and($result['properties']['tags']['items']['description'])->toBe('Must be at most 20 characters.')
+        ->and($result['properties']['score'])->not->toHaveKey('minimum')
+        ->and($result['properties']['score']['description'])->toBe('Must be at least 0.');
+});
+
+test('sanitizes a schema produced by the Illuminate JsonSchema builder', function () {
+    $sanitized = AnthropicSchemaSanitizer::sanitize(
+        (new ObjectSchema([
+            'score' => JsonSchema::integer()->required()->min(1)->max(10),
+            'name' => JsonSchema::string()->required()->min(2)->max(50),
+            'tags' => JsonSchema::array()->items(JsonSchema::string())->min(1)->max(5),
+        ]))->toSchema()
+    );
+
+    expect(json_encode($sanitized))
+        ->not->toContain('minimum')
+        ->not->toContain('maximum')
+        ->not->toContain('minLength')
+        ->not->toContain('maxLength')
+        ->not->toContain('maxItems')
+        ->and($sanitized['additionalProperties'])->toBeFalse()
+        ->and($sanitized['properties']['score']['description'])->toContain('Must be at least 1.')
+        ->and($sanitized['properties']['name']['description'])->toContain('Must be at most 50 characters.')
+        ->and($sanitized['properties']['tags']['description'])->toContain('Must contain at most 5 item(s).')
+        ->and($sanitized['properties']['tags']['minItems'])->toBe(1);
+});

--- a/tests/Unit/Gateway/Anthropic/AnthropicStructuredOutputValidatorTest.php
+++ b/tests/Unit/Gateway/Anthropic/AnthropicStructuredOutputValidatorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\JsonSchema\JsonSchema;
+use Laravel\Ai\Gateway\Anthropic\AnthropicStructuredOutputValidator;
+use Laravel\Ai\ObjectSchema;
+
+function anthropicStructuredOutputSchema(array $properties): array
+{
+    return (new ObjectSchema($properties))->toSchema();
+}
+
+test('passes when every value satisfies its constraints', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'score' => JsonSchema::integer()->required()->min(1)->max(10),
+        'summary' => JsonSchema::string()->required()->min(1)->max(280),
+    ]);
+
+    $violations = AnthropicStructuredOutputValidator::violations(
+        ['score' => 5, 'summary' => 'A fine review.'],
+        $schema,
+    );
+
+    expect($violations)->toBe([]);
+});
+
+test('flags a number below the minimum or above the maximum', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'score' => JsonSchema::integer()->required()->min(1)->max(10),
+    ]);
+
+    $tooLow = AnthropicStructuredOutputValidator::violations(['score' => 0], $schema);
+    $tooHigh = AnthropicStructuredOutputValidator::violations(['score' => 11], $schema);
+
+    expect($tooLow)->toHaveCount(1)
+        ->and($tooLow[0])->toContain('score')->toContain('at least 1')
+        ->and($tooHigh)->toHaveCount(1)
+        ->and($tooHigh[0])->toContain('score')->toContain('at most 10');
+});
+
+test('flags a value that is not a multiple of the required factor', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'quantity' => JsonSchema::integer()->required()->multipleOf(5),
+    ]);
+
+    expect(AnthropicStructuredOutputValidator::violations(['quantity' => 7], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['quantity' => 10], $schema))
+        ->toBe([]);
+});
+
+test('flags a string shorter or longer than its length bounds', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'summary' => JsonSchema::string()->required()->min(5)->max(10),
+    ]);
+
+    expect(AnthropicStructuredOutputValidator::violations(['summary' => 'hi'], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['summary' => 'way too long a summary'], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['summary' => 'just ok'], $schema))
+        ->toBe([]);
+});
+
+test('flags a string that does not match the required pattern', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'slug' => JsonSchema::string()->required()->pattern('^[a-z]+$'),
+    ]);
+
+    expect(AnthropicStructuredOutputValidator::violations(['slug' => 'Not-A-Slug'], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['slug' => 'validslug'], $schema))
+        ->toBe([]);
+});
+
+test('flags an array with too few or too many items', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'tags' => JsonSchema::array()->required()->items(JsonSchema::string())->min(1)->max(3),
+    ]);
+
+    expect(AnthropicStructuredOutputValidator::violations(['tags' => []], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['tags' => ['a', 'b', 'c', 'd']], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['tags' => ['a', 'b']], $schema))
+        ->toBe([]);
+});
+
+test('flags duplicate items when uniqueItems is required', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'tags' => JsonSchema::array()->required()->items(JsonSchema::string())->unique(),
+    ]);
+
+    expect(AnthropicStructuredOutputValidator::violations(['tags' => ['a', 'a']], $schema))
+        ->toHaveCount(1)
+        ->and(AnthropicStructuredOutputValidator::violations(['tags' => ['a', 'b']], $schema))
+        ->toBe([]);
+});
+
+test('recurses into array item constraints', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'tags' => JsonSchema::array()->required()->items(JsonSchema::string()->max(3)),
+    ]);
+
+    $violations = AnthropicStructuredOutputValidator::violations(
+        ['tags' => ['ok', 'way too long']],
+        $schema,
+    );
+
+    expect($violations)->toHaveCount(1)
+        ->and($violations[0])->toContain('tags[1]');
+});
+
+test('recurses into nested object properties', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'author' => JsonSchema::object([
+            'age' => JsonSchema::integer()->required()->min(0)->max(120),
+        ])->required(),
+    ]);
+
+    $violations = AnthropicStructuredOutputValidator::violations(
+        ['author' => ['age' => 200]],
+        $schema,
+    );
+
+    expect($violations)->toHaveCount(1)
+        ->and($violations[0])->toContain('author.age');
+});
+
+test('does not flag a missing required property or a mismatched type', function () {
+    $schema = anthropicStructuredOutputSchema([
+        'score' => JsonSchema::integer()->required()->min(1)->max(10),
+    ]);
+
+    expect(AnthropicStructuredOutputValidator::violations([], $schema))->toBe([]);
+});


### PR DESCRIPTION
Fixes #715

## Problem

Anthropic's native structured output (`output_config.format` with `type: json_schema`) only accepts a strict subset of JSON Schema. When an agent's `schema()` uses value-constraint methods like `->min()`, `->max()`, `->items()`, etc., they compile to `minimum`/`maximum`/`minLength`/`maxLength`/`minItems`/`maxItems`/`multipleOf`/`uniqueItems` — keywords Anthropic's native structured output rejects with a `400` before the model even runs.

## Fix

This mirrors the transform that Anthropic's own official SDKs (Python, TypeScript, Ruby, PHP) apply, per [the structured outputs docs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs):

1. **`AnthropicSchemaSanitizer`** strips the unsupported keywords from the schema sent on the native `output_config` path and folds each one into the node's `description`, so the model still receives the constraint as a natural-language hint:

   ```php
   $schema->integer()->required()->min(1)->max(10);
   // sent as { "type": "integer", "description": "Must be at least 1. Must be at most 10." }
   ```

   `minItems` greater than 1 is clamped to 1 (Anthropic only allows `0`/`1`), and unsupported string `format`s are filtered to Anthropic's supported list. The synthetic-tool fallback (`use_native_structured_output => false`) is untouched, since tool `input_schema` already accepts these keywords as hints.

2. **`AnthropicStructuredOutputValidator`** then validates the *parsed response* against the original, constraint-bearing schema. Anthropic's native structured output already guarantees the structural contract (types, required properties, enums), so this only re-checks the value constraints that were stripped from the wire schema in step 1. If the model's output doesn't actually satisfy them, `AnthropicGateway` throws a new `StructuredOutputValidationException` with the specific violations, rather than silently returning an out-of-range value.

   This closes the "guarantee gap" called out in the issue (and related to #189): when a caller writes `->min(1)->max(10)`, they get either data that's actually within range, or an explicit exception — never a silent violation.

Note: I considered adding an automatic re-prompt-and-retry loop on validation failure (as sketched in the issue's "proposed direction"), but Anthropic's own SDKs don't do this — they validate and raise, leaving retry to the caller. I matched that behavior instead, since it's simpler, avoids touching the shared `TextGenerationLoop`, and is the actual reference behavior the issue asks to mirror.

## Testing

- New unit tests for `AnthropicSchemaSanitizer` (every stripped keyword + recursion into nested properties/items) and `AnthropicStructuredOutputValidator` (every constraint type + nested arrays/objects).
- New feature tests in `RequestMappingTest` verifying: constraints are stripped from the outgoing request body and folded into descriptions, a conforming response is returned normally, and a violating response throws `StructuredOutputValidationException`.
- Full existing test suite passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)