### PR TITLE
Add support for custom agent names via the #[Name] attribute

### DIFF
--- a/src/Attributes/Name.php
+++ b/src/Attributes/Name.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Name
+{
+    public function __construct(public string $value)
+    {
+        //
+    }
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Attributes\Model as ModelAttribute;
+use Laravel\Ai\Attributes\Name as NameAttribute;
 use Laravel\Ai\Attributes\Provider as ProviderAttribute;
 use Laravel\Ai\Attributes\Timeout as TimeoutAttribute;
 use Laravel\Ai\Attributes\UseCheapestModel;
@@ -301,6 +302,20 @@ trait Promptable
         }
 
         return $provider->defaultTextModel();
+    }
+
+    /**
+     * Get the display name for this agent.
+     */
+    public function agentName(): string
+    {
+        $attributes = (new ReflectionClass($this))->getAttributes(NameAttribute::class);
+
+        if (! empty($attributes)) {
+            return $attributes[0]->newInstance()->value;
+        }
+
+        return static::class;
     }
 
     /**

--- a/tests/Feature/AgentAttributeTest.php
+++ b/tests/Feature/AgentAttributeTest.php
@@ -1,14 +1,18 @@
 <?php
 
+use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Promptable;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\IncompatibleMethodsAgent;
 use Tests\Fixtures\Agents\MethodOptionsAgent;
 use Tests\Fixtures\Agents\MethodOverridesAttributeAgent;
+use Tests\Fixtures\Agents\NamedAgent;
 use Tests\Fixtures\Agents\NullableMethodOptionsAgent;
+use Tests\Fixtures\Agents\ResearchAgent;
 
 test('text generation options can be created from agent attributes', function () {
     $options = TextGenerationOptions::forAgent(new AttributeAgent);
@@ -58,6 +62,37 @@ test('non-public or parameterized option methods are ignored', function () {
     expect($options->maxSteps)->toBe(8)
         ->and($options->maxTokens)->toBe(1024)
         ->and($options->temperature)->toBe(0.9);
+});
+
+test('agent name defaults to class name', function () {
+    expect((new AssistantAgent)->agentName())->toBe(AssistantAgent::class);
+});
+
+test('agent name can be set via the Name attribute', function () {
+    expect((new NamedAgent)->agentName())->toBe('My Custom Agent');
+});
+
+test('agent name ignores the CanActAsTool name method', function () {
+    expect((new ResearchAgent)->agentName())->toBe(ResearchAgent::class);
+});
+
+test('agent name can be overridden directly', function () {
+    $agent = new class implements Agent
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function agentName(): string
+        {
+            return 'Dynamic Agent';
+        }
+    };
+
+    expect($agent->agentName())->toBe('Dynamic Agent');
 });
 
 test('provider attribute is used when prompting', function () {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -19,8 +19,43 @@ use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Tests\Fixtures\Agents\NamedAgent;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
+
+test('it persists the agent class name', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Hello');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Hello',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $store->storeUserMessage($conversationId, 1, $prompt);
+
+    expect(DB::table('agent_conversation_messages')->first()->agent)->toBe(ToolUsingAgent::class);
+});
+
+test('it persists the agent class name even when a custom name is defined', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Hello');
+
+    $prompt = new AgentPrompt(
+        new NamedAgent,
+        'Hello',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $store->storeUserMessage($conversationId, 1, $prompt);
+
+    expect(DB::table('agent_conversation_messages')->first()->agent)->toBe(NamedAgent::class);
+});
 
 test('it writes conversations to the default tables', function () {
     $store = new DatabaseConversationStore;

--- a/tests/Fixtures/Agents/NamedAgent.php
+++ b/tests/Fixtures/Agents/NamedAgent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Attributes\Name;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[Name('My Custom Agent')]
+class NamedAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+}


### PR DESCRIPTION
Adds an `agentName()` accessor to `Promptable`, resolved from a `#[Name]` class attribute and falling back to the class name. Dynamic names can be provided by overriding `agentName()` directly.

The conversation `agent` column continues to store the FQCN so it remains a stable identifier; `agentName()` is a runtime accessor apps can use to render a display name for stored messages. The accessor intentionally ignores `CanActAsTool::name()`, which is the machine-facing tool name for sub-agents.