### PR TITLE
Fix OpenRouter test for new provider options API

### DIFF
--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -118,7 +118,7 @@ test('web search tool sends allowed_domains', function () {
 test('web search tool forwards provider options into parameters', function () {
     Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
-    $search = (new WebSearch)->withProviderOptions('openrouter', [
+    $search = (new WebSearch)->withProviderOptions([
         'engine' => 'exa',
         'max_total_results' => 20,
         'search_context_size' => 'medium',


### PR DESCRIPTION
#738 landed a test using the two-argument
withProviderOptions('openrouter', [...]) signature that #753 (merged later) replaced with withProviderOptions(array|Closure), so the suite fails on 0.x with a TypeError. Update the call to the flat-array form, matching how #753 migrated the equivalent Anthropic and OpenAI web search tests.