### PR TITLE
Forward attachment provider options to OpenAI text generation requests

### DIFF
--- a/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAi/Concerns/BuildsTextRequests.php
@@ -25,7 +25,7 @@ trait BuildsTextRequests
     ): array {
         $body = [
             'model' => $model,
-            'input' => $this->mapMessagesToInput($messages, $instructions),
+            'input' => $this->mapMessagesToInput($messages, $instructions, $provider),
         ];
 
         return $this->mergeSharedResponsesRequestOptions($body, $tools, $schema, $options, $provider);

--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -6,6 +6,8 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\File;
@@ -17,22 +19,25 @@ use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
 use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Providers\Provider;
 
 trait MapsAttachments
 {
     /**
      * Map the given Laravel attachments to OpenAI content parts.
      */
-    protected function mapAttachments(Collection $attachments): array
+    protected function mapAttachments(Collection $attachments, Provider $provider): array
     {
-        return $attachments->map(function ($attachment) {
+        $providerKey = Lab::tryFrom($provider->driver()) ?? $provider->driver();
+
+        return $attachments->map(function ($attachment) use ($providerKey) {
             if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
                 throw new InvalidArgumentException(
                     'Unsupported attachment type ['.get_class($attachment).']'
                 );
             }
 
-            return match (true) {
+            $part = match (true) {
                 $attachment instanceof ProviderImage => [
                     'type' => 'input_image',
                     'file_id' => $attachment->id,
@@ -92,6 +97,10 @@ trait MapsAttachments
                 ],
                 default => throw new InvalidArgumentException('Unsupported attachment type ['.get_class($attachment).']'),
             };
+
+            return $attachment instanceof HasProviderOptions
+                ? array_merge($part, $attachment->providerOptions($providerKey))
+                : $part;
         })->all();
     }
 

--- a/src/Gateway/OpenAi/Concerns/MapsAttachments.php
+++ b/src/Gateway/OpenAi/Concerns/MapsAttachments.php
@@ -99,7 +99,7 @@ trait MapsAttachments
             };
 
             return $attachment instanceof HasProviderOptions
-                ? array_merge($part, $attachment->providerOptions($providerKey))
+                ? array_merge($attachment->providerOptions($providerKey), $part)
                 : $part;
         })->all();
     }

--- a/src/Gateway/OpenAi/Concerns/MapsMessages.php
+++ b/src/Gateway/OpenAi/Concerns/MapsMessages.php
@@ -8,13 +8,14 @@ use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\MessageRole;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Providers\Provider;
 
 trait MapsMessages
 {
     /**
      * Map the given Laravel messages to OpenAI Responses API input format.
      */
-    protected function mapMessagesToInput(array $messages, ?string $instructions = null): array
+    protected function mapMessagesToInput(array $messages, ?string $instructions, Provider $provider): array
     {
         $input = [];
 
@@ -29,7 +30,7 @@ trait MapsMessages
             $message = Message::tryFrom($message);
 
             match ($message->role) {
-                MessageRole::User => $this->mapUserMessage($message, $input),
+                MessageRole::User => $this->mapUserMessage($message, $input, $provider),
                 MessageRole::Assistant => $this->mapAssistantMessage($message, $input),
                 MessageRole::ToolResult => $this->mapToolResultMessage($message, $input),
             };
@@ -41,14 +42,14 @@ trait MapsMessages
     /**
      * Map a user message to OpenAI format.
      */
-    protected function mapUserMessage(UserMessage|Message $message, array &$input): void
+    protected function mapUserMessage(UserMessage|Message $message, array &$input, Provider $provider): void
     {
         $content = [
             ['type' => 'input_text', 'text' => $message->content],
         ];
 
         if ($message instanceof UserMessage && $message->attachments->isNotEmpty()) {
-            $content = array_merge($content, $this->mapAttachments($message->attachments));
+            $content = array_merge($content, $this->mapAttachments($message->attachments, $provider));
         }
 
         $input[] = [

--- a/tests/Feature/Providers/AzureOpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/MessageMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
 use Tests\Fixtures\Agents\AssistantAgent;
@@ -121,6 +122,33 @@ test('image attachment maps to input_image content block', function () {
         return $imageBlock !== null
             && str_contains($imageBlock['image_url'], 'image/png')
             && str_contains($imageBlock['image_url'], base64_encode('fake-image-data'));
+    });
+});
+
+test('attachment provider options closure receives the azure provider', function () {
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => fakeAzureResponse('I see an image'),
+    ]);
+
+    $image = (new Base64Image(base64_encode('fake-image-data'), 'image/png'))
+        ->withProviderOptions(fn (Lab $provider) => match ($provider) {
+            Lab::Azure => ['detail' => 'low'],
+            default => ['detail' => 'high'],
+        });
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [$image],
+        provider: 'azure',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+        return $imageBlock !== null
+            && ($imageBlock['detail'] ?? null) === 'low';
     });
 });
 

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\LocalImage;
@@ -317,6 +318,104 @@ test('reasoning blocks are interleaved with associated tool calls on assistant r
             && $call2Index !== false
             && $rs2Index + 1 === $call2Index
             && $call3Index !== false;
+    });
+});
+
+test('image attachment provider options are forwarded to the content part', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('I see an image'),
+    ]);
+
+    $image = (new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png'))
+        ->withProviderOptions(['detail' => 'low']);
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [$image],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+        return $imageBlock !== null
+            && ($imageBlock['detail'] ?? null) === 'low'
+            && str_starts_with($imageBlock['image_url'], 'data:image/png;base64,');
+    });
+});
+
+test('document attachment provider options are forwarded to the content part', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('I see a document'),
+    ]);
+
+    $document = Files\Document::fromString('hello world', 'text/plain')
+        ->withProviderOptions(['detail' => 'high']);
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [$document],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $fileBlock = collect($userMessage['content'])->firstWhere('type', 'input_file');
+
+        return $fileBlock !== null
+            && ($fileBlock['detail'] ?? null) === 'high'
+            && str_contains($fileBlock['file_data'], base64_encode('hello world'));
+    });
+});
+
+test('attachment provider options resolve from a closure scoped to the provider', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('I see an image'),
+    ]);
+
+    $image = (new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png'))
+        ->withProviderOptions(fn (Lab $provider) => match ($provider) {
+            Lab::OpenAI => ['detail' => 'low'],
+            default => [],
+        });
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [$image],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+        return $imageBlock !== null
+            && ($imageBlock['detail'] ?? null) === 'low';
+    });
+});
+
+test('attachments without provider options map unchanged', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('I see an image'),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png')],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+        return $imageBlock !== null
+            && ! array_key_exists('detail', $imageBlock);
     });
 });
 

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -419,6 +419,32 @@ test('attachments without provider options map unchanged', function () {
     });
 });
 
+test('provider options cannot overwrite the mapped structural keys', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('I see an image'),
+    ]);
+
+    $image = (new LocalImage(__DIR__.'/../../../Fixtures/Images/red.png'))
+        ->withProviderOptions(['type' => 'input_text', 'detail' => 'low']);
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [$image],
+        provider: 'openai',
+    );
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $userMessage = collect($body['input'])->firstWhere('role', 'user');
+        $imageBlock = collect($userMessage['content'])->firstWhere('type', 'input_image');
+
+        return $imageBlock !== null
+            && $imageBlock['type'] === 'input_image'
+            && ($imageBlock['detail'] ?? null) === 'low'
+            && str_starts_with($imageBlock['image_url'], 'data:image/png;base64,');
+    });
+});
+
 test('system instructions are in input array as system role', function () {
     Http::fake([
         'api.openai.com/*' => fakeOpenAiResponse(),


### PR DESCRIPTION

I noticed that since #717 / #753, provider options on files are honored when uploading via `Files::put()`, but silently dropped when the same file is attached to a text prompt — `MapsAttachments` never reads them. This PR closes that gap for the OpenAI and Azure OpenAI text gateways:

```php
$response = $agent->prompt(
    'What is in this image?',
    attachments: [
        (new LocalImage($path))->withProviderOptions(['detail' => 'low']),
    ],
);
```

Previously the `detail` option never reached the request body. Now it's merged into the attachment's content part (`input_image` / `input_file`).

This matters because `detail` directly controls vision token billing. Same 1536×1024 image, measured against the live API:

| model | `detail: low` | `detail: high` |
|---|---|---|
| gpt-4o-mini | 2,849 tokens | 36,851 tokens (**13×**) |
| gpt-5.1 | 85 tokens | 925 tokens (**11×**) |

Before this change every request went out as `auto` no matter what the user configured.

The implementation follows the existing `mapTools` pattern: `Provider` is threaded down to `mapAttachments`, and the options are merged into the wire part with user options winning on conflicts. Closures work the same way they do on the upload path — `fn (Lab $provider) => match ($provider) { ... }` — which is also how you scope options in multi-provider or failover setups. Azure gets the feature automatically through the shared concerns, with `Lab::Azure` as the closure key. Heads-up: `mapMessagesToInput()` / `mapUserMessage()` are protected trait methods and gained a required `Provider` parameter.

One pre-existing limitation worth noting: provider options don't survive conversation persistence (`File::toArray()` doesn't round-trip them) — happy to address that in a follow-up.

I started with OpenAI as the reference implementation; the same pattern applies to the other attachment mappers (Anthropic `cache_control`, Gemini `video_metadata`, chat-completions `detail`). Happy to follow up with those too.

Includes five feature tests in the existing `MessageMappingTest` style: array options on image and document parts, closure options, a no-options regression, and an Azure test pinning `Lab::Azure` as the closure key.