### PR TITLE
Add client-side tool support

### DIFF
--- a/src/Attributes/ClientSideTool.php
+++ b/src/Attributes/ClientSideTool.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Ai\Attributes;
+
+use Attribute;
+use ReflectionClass;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class ClientSideTool
+{
+    public static function isAppliedTo(?object $target): bool
+    {
+        return $target !== null
+            && (new ReflectionClass($target))->getAttributes(self::class) !== [];
+    }
+}

--- a/src/Contracts/ConversationStore.php
+++ b/src/Contracts/ConversationStore.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\ToolResult;
 
 interface ConversationStore
 {
@@ -28,6 +29,13 @@ interface ConversationStore
      * Store a new assistant message for the given conversation and return its ID.
      */
     public function storeAssistantMessage(string $conversationId, string|int|null $userId, AgentPrompt $prompt, AgentResponse $response): string;
+
+    /**
+     * Store tool results for the most recent assistant message in the given conversation.
+     *
+     * @param  ToolResult[]  $toolResults
+     */
+    public function storeToolResults(string $conversationId, array $toolResults): void;
 
     /**
      * Get the latest messages for the given conversation.

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway;
 use Generator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Laravel\Ai\Attributes\ClientSideTool;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
@@ -92,7 +93,9 @@ class TextGenerationLoop
                 $tools
             );
 
-            $shouldContinue = filled($toolResults);
+            $hasPendingClientTools = $this->hasPendingClientSideTools($lastResult->toolCalls, $tools);
+
+            $shouldContinue = filled($toolResults) && ! $hasPendingClientTools;
 
             $steps->push($this->buildStep($lastResult, $toolResults));
 
@@ -187,18 +190,18 @@ class TextGenerationLoop
                 ? $this->continuationToolResults($result->finishReason, $result->toolCalls, $stepContext->isFinalStep, $tools)
                 : [];
 
-            $shouldContinue = filled($toolResults);
+            $hasPendingClientTools = $this->hasPendingClientSideTools($result?->toolCalls ?? [], $tools);
 
-            if ($shouldContinue) {
-                foreach ($toolResults as $toolResult) {
-                    yield (new ToolResultEvent(
-                        strtolower((string) Str::uuid7()),
-                        $toolResult,
-                        true,
-                        null,
-                        time(),
-                    ))->withInvocationId($invocationId);
-                }
+            $shouldContinue = filled($toolResults) && ! $hasPendingClientTools;
+
+            foreach ($toolResults as $toolResult) {
+                yield (new ToolResultEvent(
+                    strtolower((string) Str::uuid7()),
+                    $toolResult,
+                    true,
+                    null,
+                    time(),
+                ))->withInvocationId($invocationId);
             }
 
             $allMessages[] = new AssistantMessage(
@@ -263,21 +266,56 @@ class TextGenerationLoop
      */
     protected function executeToolCalls(array $toolCalls, array $tools): array
     {
-        return array_map(function (ToolCall $toolCall) use ($tools) {
+        $results = [];
+
+        foreach ($toolCalls as $toolCall) {
             $tool = $this->findTool($toolCall->name, $tools);
 
             if ($tool === null) {
                 throw new NoSuchToolException($toolCall->name);
             }
 
-            return new ToolResult(
+            if ($this->isClientSideTool($tool)) {
+                continue;
+            }
+
+            $results[] = new ToolResult(
                 $toolCall->id,
                 $toolCall->name,
                 $toolCall->arguments,
                 $this->executeTool($tool, $toolCall->arguments),
                 $toolCall->resultId,
             );
-        }, $toolCalls);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Determine whether any of the given tool calls resolve to a client-side tool.
+     *
+     * @param  ToolCall[]  $toolCalls
+     * @param  Tool[]  $tools
+     */
+    protected function hasPendingClientSideTools(array $toolCalls, array $tools): bool
+    {
+        foreach ($toolCalls as $toolCall) {
+            $tool = $this->findTool($toolCall->name, $tools);
+
+            if ($this->isClientSideTool($tool)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether the given tool is marked as client-side.
+     */
+    protected function isClientSideTool(?Tool $tool): bool
+    {
+        return ClientSideTool::isAppliedTo($tool);
     }
 
     /**
@@ -329,6 +367,11 @@ class TextGenerationLoop
             $finalStep->text,
             $totalUsage,
             $finalStep->meta,
-        ))->withMessages($newMessages)->withSteps($steps);
+        ))->withMessages($newMessages)
+            ->withToolCallsAndResults(
+                $steps->flatMap(fn (Step $s) => collect($s->toolCalls)),
+                $steps->flatMap(fn (Step $s) => collect($s->toolResults)),
+            )
+            ->withSteps($steps);
     }
 }

--- a/src/Responses/TextResponse.php
+++ b/src/Responses/TextResponse.php
@@ -91,6 +91,15 @@ class TextResponse
     }
 
     /**
+     * Determine whether the response contains tool calls that were not executed server-side
+     * and are awaiting client-side execution before the conversation can continue.
+     */
+    public function hasPendingClientSideToolCalls(): bool
+    {
+        return $this->toolCalls->count() > $this->toolResults->count();
+    }
+
+    /**
      * Get the string representation of the object.
      */
     public function __toString(): string

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -128,6 +128,21 @@ class DatabaseConversationStore implements ConversationStore
     }
 
     /**
+     * Store tool results for the most recent assistant message in the given conversation.
+     *
+     * @param  ToolResult[]  $toolResults
+     */
+    public function storeToolResults(string $conversationId, array $toolResults): void
+    {
+        $this->table($this->messagesTable())
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'assistant')
+            ->orderByDesc('id')
+            ->limit(1)
+            ->update(['tool_results' => json_encode(collect($toolResults)->values())]);
+    }
+
+    /**
      * Get the latest messages for the given conversation.
      *
      * @return Collection<int, Message>

--- a/tests/Feature/Providers/Anthropic/ClientSideToolTest.php
+++ b/tests/Feature/Providers/Anthropic/ClientSideToolTest.php
@@ -1,0 +1,158 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
+use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
+use Tests\Fixtures\Agents\ClientSideToolAgent;
+
+test('client-side tool stops the loop without a follow-up request', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_client_tool_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_client_123',
+                'name' => 'ClientLocationTool',
+                'input' => (object) [],
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = (new ClientSideToolAgent)->prompt('Where am I?', provider: 'anthropic');
+
+    expect(Http::recorded())->toHaveCount(1);
+    expect($response->toolCalls)->toHaveCount(1);
+    expect($response->toolCalls->first())->toBeInstanceOf(ToolCall::class)
+        ->and($response->toolCalls->first()->name)->toBe('ClientLocationTool');
+    expect($response->toolResults)->toHaveCount(0);
+});
+
+test('client-side tool is not executed server-side', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_client_tool_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_client_123',
+                'name' => 'ClientLocationTool',
+                'input' => (object) [],
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    expect(fn () => (new ClientSideToolAgent)->prompt('Where am I?', provider: 'anthropic'))
+        ->not->toThrow(BadMethodCallException::class);
+});
+
+test('assistant message with client-side tool call is included in response messages', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_client_tool_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [[
+                'type' => 'tool_use',
+                'id' => 'toolu_client_123',
+                'name' => 'ClientLocationTool',
+                'input' => (object) [],
+            ]],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = (new ClientSideToolAgent)->prompt('Where am I?', provider: 'anthropic');
+
+    $assistantMessage = $response->messages
+        ->first(fn ($m) => $m instanceof AssistantMessage);
+
+    expect($assistantMessage)->not->toBeNull();
+    expect($assistantMessage->toolCalls)->toHaveCount(1);
+    expect($assistantMessage->toolCalls->first()->name)->toBe('ClientLocationTool');
+});
+
+test('streaming emits server tool result event when mixed with client-side tools', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->messageStart(),
+                $this->contentBlockStart(0, ['type' => 'tool_use', 'id' => 'toolu_server_123', 'name' => 'FixedNumberGenerator', 'input' => '']),
+                $this->contentBlockDelta(0, ['type' => 'input_json_delta', 'partial_json' => '{}']),
+                $this->contentBlockStop(0),
+                $this->contentBlockStart(1, ['type' => 'tool_use', 'id' => 'toolu_client_123', 'name' => 'ClientLocationTool', 'input' => '']),
+                $this->contentBlockDelta(1, ['type' => 'input_json_delta', 'partial_json' => '{}']),
+                $this->contentBlockStop(1),
+                $this->messageDelta('tool_use', 5),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents(agent: new ClientSideToolAgent(withServerTool: true));
+
+    $toolCallEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolCallEvent));
+    $toolResultEvents = array_values(array_filter($events, fn ($e) => $e instanceof ToolResultEvent));
+
+    // Both tool calls are streamed
+    expect($toolCallEvents)->toHaveCount(2);
+
+    // Server tool result is streamed so the client can reconstruct history for the next turn
+    expect($toolResultEvents)->toHaveCount(1);
+    expect($toolResultEvents[0]->toolResult->name)->toBe('FixedNumberGenerator');
+});
+
+test('server tools are executed before client-side tool ends the turn', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_mixed_123',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [
+                [
+                    'type' => 'tool_use',
+                    'id' => 'toolu_server_123',
+                    'name' => 'FixedNumberGenerator',
+                    'input' => (object) [],
+                ],
+                [
+                    'type' => 'tool_use',
+                    'id' => 'toolu_client_123',
+                    'name' => 'ClientLocationTool',
+                    'input' => (object) [],
+                ],
+            ],
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = (new ClientSideToolAgent(withServerTool: true))->prompt(
+        'Get a number and my location',
+        provider: 'anthropic',
+    );
+
+    // Only one HTTP request — no follow-up despite server tool executing
+    expect(Http::recorded())->toHaveCount(1);
+
+    // Both tool calls present
+    expect($response->toolCalls)->toHaveCount(2);
+
+    // Only the server tool has a result
+    expect($response->toolResults)->toHaveCount(1);
+    expect($response->toolResults->first()->name)->toBe('FixedNumberGenerator');
+});

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -386,6 +386,79 @@ test('malformed known stored attachments fail loudly', function () {
         ->toThrow(InvalidArgumentException::class, 'Cannot reconstruct [remote-image] attachment because [url] is missing or invalid.');
 });
 
+test('storeToolResults backfills client tool results onto the last assistant message', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Client tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'msg-assistant-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'toolu_client_123', 'name' => 'ClientLocationTool', 'arguments' => []],
+        ]),
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $store->storeToolResults($conversationId, [
+        new ToolResult('toolu_client_123', 'ClientLocationTool', [], '37.7749° N, 122.4194° W'),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(2)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->first()->result)->toBe('37.7749° N, 122.4194° W');
+});
+
+test('storeToolResults merges server and client results for mixed tool turns', function () {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation(1, 'Mixed tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'msg-assistant-1',
+        'conversation_id' => $conversationId,
+        'user_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'toolu_server_123', 'name' => 'FixedNumberGenerator', 'arguments' => []],
+            ['id' => 'toolu_client_123', 'name' => 'ClientLocationTool', 'arguments' => []],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'toolu_server_123', 'name' => 'FixedNumberGenerator', 'arguments' => [], 'result' => '42'],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $store->storeToolResults($conversationId, [
+        new ToolResult('toolu_server_123', 'FixedNumberGenerator', [], '42'),
+        new ToolResult('toolu_client_123', 'ClientLocationTool', [], '37.7749° N, 122.4194° W'),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(2)
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults)->toHaveCount(2)
+        ->and($messages[1]->toolResults[0]->name)->toBe('FixedNumberGenerator')
+        ->and($messages[1]->toolResults[1]->name)->toBe('ClientLocationTool');
+});
+
 function createConversationSchema(?string $connection = null): void
 {
     $schema = Schema::connection($connection);

--- a/tests/Fixtures/Agents/ClientSideToolAgent.php
+++ b/tests/Fixtures/Agents/ClientSideToolAgent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\ClientLocationTool;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+class ClientSideToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function __construct(public bool $withServerTool = false) {}
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     */
+    public function tools(): iterable
+    {
+        $tools = [new ClientLocationTool];
+
+        if ($this->withServerTool) {
+            $tools[] = new FixedNumberGenerator;
+        }
+
+        return $tools;
+    }
+}

--- a/tests/Fixtures/ConversationStores/InMemoryConversationStore.php
+++ b/tests/Fixtures/ConversationStores/InMemoryConversationStore.php
@@ -59,6 +59,18 @@ class InMemoryConversationStore implements ConversationStore
         return $id;
     }
 
+    public function storeToolResults(string $conversationId, array $toolResults): void
+    {
+        $index = collect($this->messages)
+            ->keys()
+            ->last(fn ($key) => $this->messages[$key]['conversation_id'] === $conversationId
+                && $this->messages[$key]['role'] === 'assistant');
+
+        if ($index !== null) {
+            $this->messages[$index]['tool_results'] = $toolResults;
+        }
+    }
+
     public function getLatestConversationMessages(string $conversationId, int $limit): Collection
     {
         return collect($this->messages)

--- a/tests/Fixtures/FakeConversationStore.php
+++ b/tests/Fixtures/FakeConversationStore.php
@@ -29,6 +29,11 @@ class FakeConversationStore implements ConversationStore
         return 'assistant-message-123';
     }
 
+    public function storeToolResults(string $conversationId, array $toolResults): void
+    {
+        //
+    }
+
     public function getLatestConversationMessages(string $conversationId, int $limit): Collection
     {
         return new Collection;

--- a/tests/Fixtures/Tools/ClientLocationTool.php
+++ b/tests/Fixtures/Tools/ClientLocationTool.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Attributes\ClientSideTool;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+#[ClientSideTool]
+class ClientLocationTool implements Tool
+{
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'Returns the user\'s current geographic location from the browser.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        return '';
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Closes laravel/ai#770

Adds #[ClientSideTool] — a marker attribute for tools that must execute in the browser (geolocation, clipboard, interactive forms, confirmations, etc.) rather than on the server.

When the LLM calls a client-side tool, TextGenerationLoop skips execution and stops the loop. The caller checks $response->hasPendingClientSideToolCalls(), ships the pending tool call to the frontend, executes it there, and resumes the conversation on the next request via ConversationStore::storeToolResults(). Mixed turns (server tools + client-side tools in the same step) are supported — server tools execute immediately, the loop stops only when a client-side tool is encountered.

New API surface

- #[ClientSideTool] attribute
- TextResponse::hasPendingClientSideToolCalls(): bool
- ConversationStore::storeToolResults(string $conversationId, ToolResult[] $toolResults): void