### PR TITLE
Document TextGateway removal in upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,13 +34,69 @@ $tool->withProviderOptions(fn (Lab|string $provider) => match ($provider) {
 });
 ```
 
+### The `TextGateway` Contract Was Removed
+
+**Likelihood Of Impact: Low**
+
+`Laravel\Ai\Contracts\Gateway\TextGateway` has been removed. Provider gateways
+now implement only `StepTextGateway`, and the multi-step API lives entirely on
+the provider's `TextGenerationLoop`. Most applications are unaffected.
+
+If you wrote or type-hinted a custom gateway, swap the contract:
+
+```php
+// Before...
+use Laravel\Ai\Contracts\Gateway\TextGateway;
+
+class MyGateway implements TextGateway { /* generateText, streamText, onToolInvocation */ }
+
+// After...
+use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+
+class MyGateway implements StepTextGateway { /* generateTextStep, generateStreamStep */ }
+```
+
+The multi-step methods you used to call on the gateway now live on the loop:
+
+```php
+// Before...
+$provider->textGateway()->generateText(...);
+$provider->textGateway()->onToolInvocation(...);
+
+// After...
+$provider->textGenerationLoop()->generate(...);
+$provider->textGenerationLoop()->onToolInvocation(...);
+```
+
+If you implement `TextProvider` directly instead of extending the base
+`Provider`, add a `textGenerationLoop(): TextGenerationLoop` method. Anything
+extending `Provider` gets it for free.
+
+### Faked Responses Now Run Through The Real Loop
+
+**Likelihood Of Impact: Low**
+
+`Agent::fake()` responses now flow through the same `TextGenerationLoop` as real
+providers. Existing tests keep passing, but if you assert on exact messages or
+streamed events, four behaviors are now more realistic:
+
+- Faking a tool call for a tool the agent has not registered throws
+  `NoSuchToolException` instead of being silently skipped. Register the tool.
+- After a faked tool call, `$response->messages` includes the final assistant
+  reply (one extra message). `text`, `toolCalls`, `toolResults`, and `steps`
+  are unchanged.
+- Faking an empty string no longer emits `TextStart` / `TextEnd` events while
+  streaming.
+- Faked tool calls now emit a `ToolCall` event while streaming. If you count
+  streamed events, expect one extra per tool call.
+
 ### Native Anthropic Structured Outputs
 
 **Likelihood Of Impact: Low**
 
 Anthropic structured outputs now use the native `output_config.format` API by
 default instead of the synthetic tool approach. To restore the previous
-behavior, disable it in your provider configuration:
+behavior, disable it in your provider config:
 
 ```php
 'anthropic' => [

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -96,7 +96,7 @@ streamed events, four behaviors are now more realistic:
 
 Anthropic structured outputs now use the native `output_config.format` API by
 default instead of the synthetic tool approach. To restore the previous
-behavior, disable it in your provider config:
+behavior, disable it in your provider configuration:
 
 ```php
 'anthropic' => [


### PR DESCRIPTION
#743 removed the `TextGateway` contract but the upgrade guide didn't cover it. This adds sections for the contract swap (`TextGateway` to `StepTextGateway`, with multi-step calls moving to `textGenerationLoop()`) and the faked-response behavior changes from that PR.