### PR TITLE
Let sub-agents continue the parent conversation

### DIFF
--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -125,7 +125,7 @@ trait GeneratesText
         }
 
         return array_map(
-            fn ($tool) => $this->resolveTool($tool),
+            fn ($tool) => $this->resolveTool($tool, $agent),
             [...$agent->tools()],
         );
     }
@@ -133,10 +133,10 @@ trait GeneratesText
     /**
      * Resolve a tool returned by the agent into a native tool instance when needed.
      */
-    protected function resolveTool(mixed $tool): mixed
+    protected function resolveTool(mixed $tool, Agent $parent): mixed
     {
         return match (true) {
-            $tool instanceof Agent => new AgentTool($tool),
+            $tool instanceof Agent => new AgentTool($tool, $parent),
             $tool instanceof Tool => $tool,
             McpTool::supports($tool) => new McpTool($tool),
             McpServerTool::supports($tool) => new McpServerTool($tool),

--- a/src/Tools/AgentTool.php
+++ b/src/Tools/AgentTool.php
@@ -5,13 +5,14 @@ namespace Laravel\Ai\Tools;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\RemembersConversations;
 use Laravel\Ai\Contracts\Tool;
 use Stringable;
 use Throwable;
 
 class AgentTool implements Tool
 {
-    public function __construct(protected Agent $agent)
+    public function __construct(protected Agent $agent, protected ?Agent $parent = null)
     {
         //
     }
@@ -31,8 +32,15 @@ class AgentTool implements Tool
      */
     public function description(): Stringable|string
     {
-        return $this->agent instanceof CanActAsTool
-            ? $this->agent->description()
+        if ($this->agent instanceof CanActAsTool) {
+            return $this->agent->description();
+        }
+
+        return $this->agent instanceof RemembersConversations
+            ? sprintf(
+                'Delegates a task to the %s sub-agent and returns its response. The sub-agent continues the parent conversation, so it can see the history when handling the task.',
+                $this->name(),
+            )
             : sprintf(
                 'Delegates a task to the %s sub-agent and returns its response. Pass a clear, self-contained task description as the sub-agent runs in isolation and has no access to the parent conversation history.',
                 $this->name(),
@@ -45,10 +53,36 @@ class AgentTool implements Tool
     public function handle(Request $request): string
     {
         try {
+            $this->continueParentConversation();
+
             return $this->agent->prompt((string) $request['task'])->text;
         } catch (Throwable $e) {
             return 'Agent failed: '.$e->getMessage();
         }
+    }
+
+    /**
+     * Continue the parent's conversation so the sub-agent shares its history.
+     *
+     * Only applies when both the parent and the sub-agent remember conversations
+     * and the parent is already participating in one; otherwise the sub-agent
+     * runs in isolation, preserving the default behavior.
+     */
+    protected function continueParentConversation(): void
+    {
+        if (! $this->agent instanceof RemembersConversations ||
+            ! $this->parent instanceof RemembersConversations) {
+            return;
+        }
+
+        $conversationId = $this->parent->currentConversation();
+        $participant = $this->parent->conversationParticipant();
+
+        if ($conversationId === null || $participant === null) {
+            return;
+        }
+
+        $this->agent->continue($conversationId, $participant);
     }
 
     /**

--- a/tests/Feature/SubAgentTest.php
+++ b/tests/Feature/SubAgentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -8,7 +9,10 @@ use Laravel\Ai\Tools\AgentTool;
 use Tests\Fixtures\Agents\DelegatingAgent;
 use Tests\Fixtures\Agents\MiddleManagerAgent;
 use Tests\Fixtures\Agents\OrchestratorAgent;
+use Tests\Fixtures\Agents\RememberingDelegatingAgent;
+use Tests\Fixtures\Agents\RememberingSubAgent;
 use Tests\Fixtures\Agents\ResearchAgent;
+use Tests\Fixtures\ConversationStores\InMemoryConversationStore;
 
 test('agent returned from tools is invoked when called by parent agent', function () {
     DelegatingAgent::fake([
@@ -124,4 +128,52 @@ test('nested agent delegates through a middle manager to a research agent', func
         ->and($response->toolCalls->first()->name)->toBe('middle_manager')
         ->and($response->toolResults)->toHaveCount(1)
         ->and($response->toolResults->first()->result)->toBe('Research delegated.');
+});
+
+test('sub-agent continues the parent conversation when both remember conversations', function () {
+    $store = new InMemoryConversationStore;
+    app()->instance(ConversationStore::class, $store);
+
+    $user = (object) ['id' => 1];
+    $conversationId = $store->storeConversation($user->id, 'Existing conversation');
+
+    RememberingDelegatingAgent::fake([
+        new ToolCall('call_123', 'remembering_sub_agent', ['task' => 'Summarize the request']),
+        'Delegated.',
+    ]);
+
+    RememberingSubAgent::fake(['Sub-agent reply']);
+
+    (new RememberingDelegatingAgent)
+        ->continue($conversationId, $user)
+        ->prompt('What is the status?');
+
+    RememberingSubAgent::assertPrompted(function (AgentPrompt $prompt) use ($conversationId, $user) {
+        return $prompt->agent->currentConversation() === $conversationId
+            && $prompt->agent->conversationParticipant() === $user;
+    });
+});
+
+test('sub-agent stays isolated when the parent has no active conversation', function () {
+    $store = new InMemoryConversationStore;
+    app()->instance(ConversationStore::class, $store);
+
+    $user = (object) ['id' => 1];
+
+    RememberingDelegatingAgent::fake([
+        new ToolCall('call_123', 'remembering_sub_agent', ['task' => 'Do the work']),
+        'Delegated.',
+    ]);
+
+    RememberingSubAgent::fake(['Sub-agent reply']);
+
+    // forUser() starts a fresh conversation whose id is only persisted after the run,
+    // so there is nothing to share while the sub-agent is being delegated to.
+    (new RememberingDelegatingAgent)
+        ->forUser($user)
+        ->prompt('Start');
+
+    RememberingSubAgent::assertPrompted(function (AgentPrompt $prompt) {
+        return $prompt->agent->currentConversation() === null;
+    });
 });

--- a/tests/Fixtures/Agents/RememberingDelegatingAgent.php
+++ b/tests/Fixtures/Agents/RememberingDelegatingAgent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Promptable;
+
+class RememberingDelegatingAgent implements Agent, HasTools, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversations;
+
+    public function instructions(): string
+    {
+        return 'You are a manager that delegates tasks to your remembering_sub_agent sub-agent.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new RememberingSubAgent,
+        ];
+    }
+}

--- a/tests/Fixtures/Agents/RememberingSubAgent.php
+++ b/tests/Fixtures/Agents/RememberingSubAgent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Promptable;
+
+class RememberingSubAgent implements Agent, CanActAsTool, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversations;
+
+    public function name(): string
+    {
+        return 'remembering_sub_agent';
+    }
+
+    public function description(): string
+    {
+        return 'A specialist sub-agent that continues the parent conversation.';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a specialist that answers using the shared conversation history.';
+    }
+}


### PR DESCRIPTION
Currently `AgentTool` always runs a delegated agent in isolation. It calls `->prompt($task)` with just the task string, so a sub-agent never sees the conversation it was called from (the default tool description even says so). If you want the delegated agent to keep talking in the same thread, remembering who the user is and what was already said, you have to re-feed that context by hand on every call.

This PR lets a sub-agent continue the parent's conversation when both sides remember conversations:

```php
class OrchestratorAgent implements Agent, HasTools, RemembersConversations
{
    use Promptable, RemembersConversations;

    public function tools(): iterable
    {
        return [new SupportAgent]; // also implements RemembersConversations
    }
}
```

When the orchestrator is already in a conversation and delegates to `SupportAgent`, the sub-agent now continues that same conversation instead of starting cold, so it can read the history while handling its task.

Under the hood `AgentTool` takes the parent agent as an optional second argument, and the framework passes it in when it auto-wraps an agent returned from `tools()`. Right before the sub-agent runs, if both agents are `RemembersConversations` and the parent already has an active conversation, it calls `continue()` with the parent's conversation id and participant. Everything downstream already works: `GeneratesText` seeds `messages()` into the prompt and the `RememberConversation` middleware writes the sub-agent's turn back into the same conversation, so there's no new plumbing.

A sub-agent that doesn't remember conversations still runs in isolation, and `new AgentTool($agent)` keeps working, so nothing changes for existing code.

Went with an optional constructor arg on `AgentTool` rather than a new hook or contract change, so the wrapper stays the single place this behavior lives.

### Notes

* Sharing only kicks in when the parent already has a conversation with a participant. On a brand-new conversation the id isn't persisted until after the run, so on that first turn there's nothing to share yet and the sub-agent stays isolated.
* It's opt-in by capability: a sub-agent joins the parent thread only if it implements `RemembersConversations`, so history never leaks into agents meant to be stateless.
