### PR TITLE
Feature/citations and gemini config fix

### DIFF
--- a/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Gemini/Concerns/BuildsTextRequests.php
@@ -101,6 +101,30 @@ trait BuildsTextRequests
             $body['generationConfig'] = $generationConfig;
         }
 
+        return $this->postProcessRequestBody($body);
+    }
+
+    /**
+     * Flatten a nested `generationConfig` key and hoist `safetySettings` to the top level.
+     *
+     * Some provider option payloads nest an entire `generationConfig` object under the
+     * `generationConfig` key (e.g. when the caller passes raw Gemini config objects). This
+     * merges those inner keys into the outer config and moves `safetySettings` up to the
+     * request root where the Gemini API expects it.
+     */
+    private function postProcessRequestBody(array $body): array
+    {
+        if (isset($body['generationConfig']['generationConfig'])) {
+            $inner = $body['generationConfig']['generationConfig'];
+            unset($body['generationConfig']['generationConfig']);
+            $body['generationConfig'] = array_merge($body['generationConfig'], $inner);
+        }
+
+        if (isset($body['generationConfig']['safetySettings'])) {
+            $body['safetySettings'] = $body['generationConfig']['safetySettings'];
+            unset($body['generationConfig']['safetySettings']);
+        }
+
         return $body;
     }
 

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -8,6 +8,7 @@ use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
@@ -185,12 +186,24 @@ trait HandlesTextStreaming
             }
         }
 
+        // Emit any citations found in the final response chunk...
+        $citations = $this->extractCitations($data);
+
+        foreach ($citations as $citation) {
+            yield (new CitationEvent(
+                $this->generateEventId(),
+                $messageId,
+                $citation,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
         return new StepResponse(
             text: $currentText,
             toolCalls: $toolCalls,
             finishReason: $this->extractFinishReason($data, $pendingToolCalls),
             usage: $usage ?? new Usage(0, 0),
-            meta: new Meta($provider->name(), $model),
+            meta: new Meta($provider->name(), $model, $citations->isNotEmpty() ? $citations : null),
             providerContentBlocks: $this->sanitizeRequestParts($this->excludeThinkingParts($modelParts)),
         );
     }

--- a/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Gemini/Concerns/ParsesTextResponses.php
@@ -173,25 +173,28 @@ trait ParsesTextResponses
         }
 
         // Grounding metadata format (Google Search grounding)...
-        $groundingChunks = $candidate['groundingMetadata']['groundingChunks'] ?? [];
         $groundingSupports = $candidate['groundingMetadata']['groundingSupports'] ?? [];
-
-        $referencedIndices = [];
+        $groundingChunks = $candidate['groundingMetadata']['groundingChunks'] ?? [];
 
         foreach ($groundingSupports as $support) {
             foreach ($support['groundingChunkIndices'] ?? [] as $index) {
-                $referencedIndices[$index] = true;
-            }
-        }
+                $web = $groundingChunks[$index]['web'] ?? [];
 
-        foreach ($referencedIndices as $index => $_) {
-            $web = $groundingChunks[$index]['web'] ?? [];
+                if (! isset($web['uri'])) {
+                    continue;
+                }
 
-            if (isset($web['uri'])) {
-                $citations->push(new UrlCitation(
-                    $web['uri'],
-                    $web['title'] ?? null,
-                ));
+                $existing = $citations->first(fn (UrlCitation $c) => $c->url === $web['uri']);
+
+                if ($existing === null) {
+                    $existing = new UrlCitation($web['uri'], $web['title'] ?? null, isByteOffset: true);
+                    $citations->push($existing);
+                }
+
+                $existing->addRange(
+                    $support['segment']['startIndex'] ?? null,
+                    $support['segment']['endIndex'] ?? null,
+                );
             }
         }
 

--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -276,12 +277,24 @@ trait HandlesTextGeneration
             }
         }
 
+        // Emit any citations found in the completed response...
+        $citations = $this->extractCitations($responseData['output'] ?? []);
+
+        foreach ($citations as $citation) {
+            yield (new CitationEvent(
+                $this->generateEventId(),
+                $messageId,
+                $citation,
+                time(),
+            ))->withInvocationId($invocationId);
+        }
+
         return new StepResponse(
             text: $currentText,
             toolCalls: $toolCalls,
             finishReason: $this->extractFinishReason($responseData),
             usage: $usage ?? new Usage(0, 0),
-            meta: new Meta($provider->name(), $responseData['model'] ?? $model),
+            meta: new Meta($provider->name(), $responseData['model'] ?? $model, $citations->isNotEmpty() ? $citations : null),
             continuationToken: $responseId,
         );
     }

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -88,7 +88,7 @@ trait ParsesTextResponses
     }
 
     /**
-     * Extract citations from the output array.
+     * Extract citations from the output array, merging multiple text ranges per unique URL.
      */
     protected function extractCitations(array $output): Collection
     {
@@ -101,16 +101,22 @@ trait ParsesTextResponses
 
             foreach ($item['content'] ?? [] as $content) {
                 foreach ($content['annotations'] ?? [] as $annotation) {
-                    if (($annotation['type'] ?? '') !== 'url_citation') {
+                    if (($annotation['type'] ?? '') !== 'url_citation' || empty($annotation['url'])) {
                         continue;
                     }
 
-                    $citations->push(new UrlCitation(
-                        $annotation['url'] ?? '',
-                        $annotation['title'] ?? null,
+                    $url = $annotation['url'];
+                    $existing = $citations->first(fn (UrlCitation $c) => $c->url === $url);
+
+                    if ($existing === null) {
+                        $existing = new UrlCitation($url, $annotation['title'] ?? null);
+                        $citations->push($existing);
+                    }
+
+                    $existing->addRange(
                         isset($annotation['start_index']) ? (int) $annotation['start_index'] : null,
                         isset($annotation['end_index']) ? (int) $annotation['end_index'] : null,
-                    ));
+                    );
                 }
             }
         }

--- a/src/Responses/Data/UrlCitation.php
+++ b/src/Responses/Data/UrlCitation.php
@@ -3,17 +3,52 @@
 namespace Laravel\Ai\Responses\Data;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
 use JsonSerializable;
 
 class UrlCitation extends Citation implements Arrayable, JsonSerializable
 {
+    /** @var Collection<int, array{0: int, 1: int}> */
+    public Collection $ranges;
+
     public function __construct(
         public string $url,
         ?string $title = null,
         public ?int $startIndex = null,
         public ?int $endIndex = null,
+        /**
+         * Whether startIndex/endIndex are byte offsets rather than character offsets.
+         * Used by providers that report grounding positions in bytes (e.g. Gemini Search grounding).
+         */
+        public bool $isByteOffset = false,
     ) {
         parent::__construct($title);
+
+        $this->ranges = ($startIndex !== null && $endIndex !== null)
+            ? collect([[$startIndex, $endIndex]])
+            : collect();
+    }
+
+    /**
+     * Add a text range for this citation.
+     * Duplicate ranges are silently ignored.
+     */
+    public function addRange(?int $startIndex, ?int $endIndex): void
+    {
+        if ($startIndex === null || $endIndex === null) {
+            return;
+        }
+
+        if ($this->ranges->contains(fn ($r) => $r[0] === $startIndex && $r[1] === $endIndex)) {
+            return;
+        }
+
+        $this->ranges[] = [$startIndex, $endIndex];
+
+        if ($this->ranges->count() === 1) {
+            $this->startIndex = $startIndex;
+            $this->endIndex = $endIndex;
+        }
     }
 
     /**
@@ -26,6 +61,8 @@ class UrlCitation extends Citation implements Arrayable, JsonSerializable
             'title' => $this->title,
             'start_index' => $this->startIndex,
             'end_index' => $this->endIndex,
+            'ranges' => $this->ranges->values()->all(),
+            'byte_offset' => $this->isByteOffset,
         ];
     }
 

--- a/src/Streaming/Events/Citation.php
+++ b/src/Streaming/Events/Citation.php
@@ -30,6 +30,8 @@ class Citation extends StreamEvent
                 $this->citation instanceof UrlCitation => [
                     'title' => $this->citation->title,
                     'url' => $this->citation->url,
+                    'ranges' => $this->citation->ranges->values()->all(),
+                    'byte_offset' => $this->citation->isByteOffset,
                 ],
             },
             'timestamp' => $this->timestamp,

--- a/tests/Feature/Providers/Gemini/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Gemini/ProviderOptionsTest.php
@@ -72,6 +72,77 @@ test('provider options are persisted in tool call follow up requests', function 
         ->and($secondConfig['thinkingConfig']['thinkingBudget'])->toBe(10000);
 });
 
+test('nested generationConfig inside providerOptions is flattened into the top-level generationConfig', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $agent = new class implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return match ($provider) {
+                Lab::Gemini => ['generationConfig' => ['temperature' => 0.5, 'topP' => 0.9]],
+                default => [],
+            };
+        }
+    };
+
+    $agent->prompt('Hi', provider: 'gemini');
+
+    Http::assertSent(function ($request) {
+        $config = $request->data()['generationConfig'] ?? [];
+
+        return ($config['temperature'] ?? null) === 0.5
+            && ($config['topP'] ?? null) === 0.9
+            && ! isset($config['generationConfig']);
+    });
+});
+
+test('safetySettings inside providerOptions generationConfig is hoisted to request root', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $safetySettings = [['category' => 'HARM_CATEGORY_HATE_SPEECH', 'threshold' => 'BLOCK_NONE']];
+
+    $agent = new class ($safetySettings) implements Agent, HasProviderOptions
+    {
+        use Promptable;
+
+        public function __construct(private array $safetySettings) {}
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function providerOptions(Lab|string $provider): array
+        {
+            return match ($provider) {
+                Lab::Gemini => ['safetySettings' => $this->safetySettings],
+                default => [],
+            };
+        }
+    };
+
+    $agent->prompt('Hi', provider: 'gemini');
+
+    Http::assertSent(function ($request) use ($safetySettings) {
+        $body = $request->data();
+
+        return ($body['safetySettings'] ?? null) === $safetySettings
+            && ! isset($body['generationConfig']['safetySettings']);
+    });
+});
+
 test('cachedContent is placed at top level of request body, not in generationConfig', function () {
     Http::fake([
         'generativelanguage.googleapis.com/*' => $this->fakeTextResponse(),

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
@@ -263,4 +264,95 @@ describe('usage tracking', function () {
         'MALFORMED_FUNCTION_CALL maps to ContentFilter' => ['MALFORMED_FUNCTION_CALL', FinishReason::ContentFilter],
         'RECITATION maps to ContentFilter' => ['RECITATION', FinishReason::ContentFilter],
     ]);
+});
+
+describe('citations', function () {
+    test('streaming emits citation events from grounding metadata in the final chunk', function () {
+        $finalChunk = $this->geminiChunkWithUsage([['text' => 'Spain won Euro 2024.']], 10, 5, finishReason: 'STOP');
+        $finalChunk['candidates'][0]['groundingMetadata'] = [
+            'groundingChunks' => [
+                ['web' => ['uri' => 'https://example.com/euro', 'title' => 'Euro 2024']],
+                ['web' => ['uri' => 'https://example.com/spain', 'title' => 'Spain Wins']],
+            ],
+            'groundingSupports' => [
+                ['segment' => ['startIndex' => 0, 'endIndex' => 20], 'groundingChunkIndices' => [0, 1]],
+            ],
+        ];
+
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->geminiChunk([['text' => 'Spain won']]),
+                    $finalChunk,
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $citationEvents = array_values(array_filter($events, fn ($e) => $e instanceof CitationEvent));
+
+        expect($citationEvents)->toHaveCount(2)
+            ->and($citationEvents[0]->citation->url)->toBe('https://example.com/euro')
+            ->and($citationEvents[0]->citation->isByteOffset)->toBeTrue()
+            ->and($citationEvents[0]->citation->ranges->all())->toBe([[0, 20]])
+            ->and($citationEvents[1]->citation->url)->toBe('https://example.com/spain');
+    });
+
+    test('streaming emits citation events from legacy citationMetadata', function () {
+        $finalChunk = $this->geminiChunkWithUsage([['text' => 'Some content.']], 10, 5, finishReason: 'STOP');
+        $finalChunk['candidates'][0]['citationMetadata'] = [
+            'citationSources' => [
+                ['uri' => 'https://example.com/source', 'title' => 'The Source'],
+            ],
+        ];
+
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response(
+                body: $this->ssePayload([$finalChunk]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $citationEvents = array_values(array_filter($events, fn ($e) => $e instanceof CitationEvent));
+
+        expect($citationEvents)->toHaveCount(1)
+            ->and($citationEvents[0]->citation->url)->toBe('https://example.com/source')
+            ->and($citationEvents[0]->citation->isByteOffset)->toBeFalse();
+    });
+
+    test('citation events appear after text events and before stream end', function () {
+        $finalChunk = $this->geminiChunkWithUsage([['text' => 'Answer.']], 10, 5, finishReason: 'STOP');
+        $finalChunk['candidates'][0]['groundingMetadata'] = [
+            'groundingChunks' => [
+                ['web' => ['uri' => 'https://example.com/ref', 'title' => 'Ref']],
+            ],
+            'groundingSupports' => [
+                ['segment' => ['startIndex' => 0, 'endIndex' => 7], 'groundingChunkIndices' => [0]],
+            ],
+        ];
+
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response(
+                body: $this->ssePayload([$finalChunk]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+        $types = array_map(fn ($e) => get_class($e), $events);
+
+        $textEndPos = array_search(\Laravel\Ai\Streaming\Events\TextEnd::class, $types);
+        $citationPos = array_search(CitationEvent::class, $types);
+        $streamEndPos = array_search(\Laravel\Ai\Streaming\Events\StreamEnd::class, $types);
+
+        expect($citationPos)->toBeGreaterThan($textEndPos)
+            ->and($citationPos)->toBeLessThan($streamEndPos);
+    });
 });

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -195,7 +195,7 @@ test('structured response is correctly parsed', function () {
     expect($response->structured['symbol'])->toBe('Au');
 });
 
-test('citations preserve every annotation with span indices', function () {
+test('citations deduplicate by url and accumulate ranges', function () {
     Http::fake(['*' => Http::response([
         'id' => 'resp_123',
         'status' => 'completed',
@@ -239,14 +239,14 @@ test('citations preserve every annotation with span indices', function () {
 
     $response = agent()->prompt('Give me sources', provider: 'openai');
 
-    expect($response->meta->citations)->toHaveCount(3)
+    expect($response->meta->citations)->toHaveCount(2)
         ->and($response->meta->citations[0]->url)->toBe('https://example.com/one')
         ->and($response->meta->citations[0]->startIndex)->toBe(0)
         ->and($response->meta->citations[0]->endIndex)->toBe(10)
+        ->and($response->meta->citations[0]->ranges->all())->toBe([[0, 10], [26, 40]])
         ->and($response->meta->citations[1]->url)->toBe('https://example.com/two')
         ->and($response->meta->citations[1]->startIndex)->toBe(11)
-        ->and($response->meta->citations[2]->url)->toBe('https://example.com/one')
-        ->and($response->meta->citations[2]->startIndex)->toBe(26);
+        ->and($response->meta->citations[1]->ranges->all())->toBe([[11, 25]]);
 });
 
 test('citations omit span indices when not provided by the api', function () {

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -193,3 +193,108 @@ test('streaming finish reason maps correctly', function (string $status, string 
     'unknown status maps to Unknown' => ['mystery_status', 'message', FinishReason::Unknown],
     'completed unknown type maps to Unknown' => ['completed', 'mystery_output', FinishReason::Unknown],
 ]);
+
+describe('citations', function () {
+    test('streaming emits citation events from url_citation annotations in response.completed', function () {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputTextDelta('Here are sources'),
+                    $this->outputTextDone('Here are sources'),
+                    $this->responseCompleted(10, 5, output: [[
+                        'type' => 'message',
+                        'status' => 'completed',
+                        'content' => [[
+                            'type' => 'output_text',
+                            'text' => 'Here are sources',
+                            'annotations' => [
+                                ['type' => 'url_citation', 'url' => 'https://example.com/a', 'title' => 'A', 'start_index' => 0, 'end_index' => 5],
+                                ['type' => 'url_citation', 'url' => 'https://example.com/b', 'title' => 'B', 'start_index' => 6, 'end_index' => 11],
+                            ],
+                        ]],
+                    ]]),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $citationEvents = array_values(array_filter($events, fn ($e) => $e instanceof \Laravel\Ai\Streaming\Events\Citation));
+
+        expect($citationEvents)->toHaveCount(2)
+            ->and($citationEvents[0]->citation->url)->toBe('https://example.com/a')
+            ->and($citationEvents[0]->citation->ranges->all())->toBe([[0, 5]])
+            ->and($citationEvents[1]->citation->url)->toBe('https://example.com/b');
+    });
+
+    test('streaming deduplicates citations by url and accumulates ranges', function () {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputTextDone('text'),
+                    $this->responseCompleted(10, 5, output: [[
+                        'type' => 'message',
+                        'status' => 'completed',
+                        'content' => [[
+                            'type' => 'output_text',
+                            'text' => 'text',
+                            'annotations' => [
+                                ['type' => 'url_citation', 'url' => 'https://example.com/same', 'title' => 'X', 'start_index' => 0, 'end_index' => 4],
+                                ['type' => 'url_citation', 'url' => 'https://example.com/same', 'title' => 'X', 'start_index' => 10, 'end_index' => 20],
+                            ],
+                        ]],
+                    ]]),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $citationEvents = array_values(array_filter($events, fn ($e) => $e instanceof \Laravel\Ai\Streaming\Events\Citation));
+
+        expect($citationEvents)->toHaveCount(1)
+            ->and($citationEvents[0]->citation->url)->toBe('https://example.com/same')
+            ->and($citationEvents[0]->citation->ranges->all())->toBe([[0, 4], [10, 20]]);
+    });
+
+    test('citation events appear after text events and before stream end', function () {
+        Http::fake([
+            'api.openai.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->responseCreated(),
+                    $this->outputTextDelta('Answer'),
+                    $this->outputTextDone('Answer'),
+                    $this->responseCompleted(10, 5, output: [[
+                        'type' => 'message',
+                        'status' => 'completed',
+                        'content' => [[
+                            'type' => 'output_text',
+                            'text' => 'Answer',
+                            'annotations' => [
+                                ['type' => 'url_citation', 'url' => 'https://example.com/ref', 'title' => 'Ref', 'start_index' => 0, 'end_index' => 6],
+                            ],
+                        ]],
+                    ]]),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+        $types = array_map(fn ($e) => get_class($e), $events);
+
+        $textEndPos  = array_search(\Laravel\Ai\Streaming\Events\TextEnd::class, $types);
+        $citationPos = array_search(\Laravel\Ai\Streaming\Events\Citation::class, $types);
+        $streamEndPos = array_search(\Laravel\Ai\Streaming\Events\StreamEnd::class, $types);
+
+        expect($citationPos)->toBeGreaterThan($textEndPos)
+            ->and($citationPos)->toBeLessThan($streamEndPos);
+    });
+});

--- a/tests/Unit/Responses/Data/UrlCitationTest.php
+++ b/tests/Unit/Responses/Data/UrlCitationTest.php
@@ -26,6 +26,8 @@ test('url citation to array returns all fields', function () {
         'title' => 'Laravel',
         'start_index' => 0,
         'end_index' => 7,
+        'ranges' => [[0, 7]],
+        'byte_offset' => false,
     ]);
 });
 
@@ -37,5 +39,74 @@ test('url citation json serialize returns to array', function () {
         'title' => null,
         'start_index' => null,
         'end_index' => null,
+        'ranges' => [],
+        'byte_offset' => false,
     ]);
+});
+
+test('url citation initializes ranges from constructor indices', function () {
+    $citation = new UrlCitation('https://example.com', startIndex: 5, endIndex: 15);
+
+    expect($citation->ranges->all())->toBe([[5, 15]]);
+});
+
+test('url citation has empty ranges when no indices given', function () {
+    $citation = new UrlCitation('https://example.com');
+
+    expect($citation->ranges->isEmpty())->toBeTrue();
+});
+
+test('url citation addRange adds a range and sets startIndex and endIndex on first call', function () {
+    $citation = new UrlCitation('https://example.com');
+
+    $citation->addRange(10, 20);
+
+    expect($citation->startIndex)->toBe(10)
+        ->and($citation->endIndex)->toBe(20)
+        ->and($citation->ranges->all())->toBe([[10, 20]]);
+});
+
+test('url citation addRange accumulates multiple ranges', function () {
+    $citation = new UrlCitation('https://example.com');
+
+    $citation->addRange(0, 10);
+    $citation->addRange(20, 30);
+
+    expect($citation->ranges->all())->toBe([[0, 10], [20, 30]])
+        ->and($citation->startIndex)->toBe(0)
+        ->and($citation->endIndex)->toBe(10);
+});
+
+test('url citation addRange ignores duplicate ranges', function () {
+    $citation = new UrlCitation('https://example.com');
+
+    $citation->addRange(5, 15);
+    $citation->addRange(5, 15);
+
+    expect($citation->ranges->count())->toBe(1);
+});
+
+test('url citation addRange ignores null indices', function () {
+    $citation = new UrlCitation('https://example.com');
+
+    $citation->addRange(null, 10);
+    $citation->addRange(5, null);
+    $citation->addRange(null, null);
+
+    expect($citation->ranges->isEmpty())->toBeTrue()
+        ->and($citation->startIndex)->toBeNull()
+        ->and($citation->endIndex)->toBeNull();
+});
+
+test('url citation isByteOffset defaults to false', function () {
+    $citation = new UrlCitation('https://example.com');
+
+    expect($citation->isByteOffset)->toBeFalse();
+});
+
+test('url citation isByteOffset can be set to true', function () {
+    $citation = new UrlCitation('https://example.com', isByteOffset: true);
+
+    expect($citation->isByteOffset)->toBeTrue()
+        ->and($citation->toArray()['byte_offset'])->toBeTrue();
 });


### PR DESCRIPTION
Hey there.

I recently added laravel/ai to [our project](https://github.com/hawk-digital-environments/HAWKI/tree/feature/v2.5.0).
It works like a charm, but I noticed a three inconsistencies, this PR tries to resolve.

1. The Gemini Gateway tries to be smart by building the `generationConfig` object, but by doing so it locks away some options to forward to the provider, like [safetySettings](https://github.com/hawk-digital-environments/HAWKI/blob/feature/v2.5.0/app/Services/Ai/Providers/Adapters/Implementations/GeminiAdapter.php#L64). Also I was quite confused at first why it told me that "generationConfig" was not a valid config key, until I saw the implementation. To resolve this issue, I added a lean preprocessor step that hoists both values into the correct layer. 

2. I noticed that citations were only extracted while "not streaming". Since we are using streaming everywhere I could not access the groundingMetadata (for Google) or annotations (for OpenAi). This PR provides support for both.

3. I extended the UrlCitation object, to handle more complex cases. It should be completely backward compatible.

3.1 groundingMetadata can contain citations that are relevant not for a single block of data, but for multiple. Therefore I extended UrlCitation globally to be able to hold more than one range, since I guess this can come handy in the future.

2.2 Google gives us indexes for the citations as byte offsets, openAi for character offsets. To allow the frontend to determine the difference there is also a new isByteOffset flag on the range.

P.S. The main code was written by hand. The tests were written by Claude and reviewed by human eyes ;) 