### PR TITLE
Remove dead dall-e-3 image integration dataset

### DIFF
--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -32,7 +32,6 @@ dataset('diarization-providers', [
 ]);
 
 dataset('image-providers', [
-    'openai-dall-e-3' => ['openai', 'OPENAI_API_KEY', 'dall-e-3'],
     'openai-gpt-image-2' => ['openai', 'OPENAI_API_KEY', 'gpt-image-2'],
     'xai' => ['xai', 'XAI_API_KEY', 'grok-imagine-image'],
     'gemini-2.5-flash-image' => ['gemini', 'GEMINI_API_KEY', 'gemini-2.5-flash-image'],


### PR DESCRIPTION
`Tests\Integration\ImageTest` has been failing against the live OpenAI API: the `openai-dall-e-3` case in the `image-providers` dataset can't run anymore, because OpenAI [retired DALL·E 2 and 3](https://developers.openai.com/api/docs/deprecations#2025-11-14-dalle-model-snapshots) on May 12, 2026.

The 400 you get back is a little misleading — `Unknown parameter: 'response_format'` — because that parameter was removed from the images endpoint along with DALL·E and is validated before the model name. Drop `response_format` from a bare request and the API gives you the real story: `dall-e-3` doesn't exist anymore.

```
Tests:    2 failed, 4 skipped, 2 passed   # before
Tests:    4 skipped, 2 passed             # after
```

This removes only the dead dataset row. OpenAI image coverage stays intact through `openai-gpt-image-2` — which is exactly the replacement OpenAI points you to — and it still passes.

I deliberately left the rest alone: the product-side `response_format` branch in `OpenAiGateway` and the mocked `ImageGenerationTest` cases still reference DALL·E, but they don't touch the network and pass fine. Fully retiring DALL·E support felt like a maintainer decision, so I scoped this to just the broken live dataset — happy to follow up on the rest if you'd like.
