### PR TITLE
Trigger failover when a provider connection fails

### DIFF
--- a/src/Exceptions/ProviderConnectionException.php
+++ b/src/Exceptions/ProviderConnectionException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+use Throwable;
+
+class ProviderConnectionException extends AiException implements FailoverableException
+{
+    public static function forProvider(string $provider, int $code = 0, ?Throwable $previous = null): self
+    {
+        return new self(
+            'Could not connect to AI provider ['.$provider.'].',
+            $code,
+            $previous,
+        );
+    }
+}

--- a/src/Gateway/Concerns/HandlesFailoverErrors.php
+++ b/src/Gateway/Concerns/HandlesFailoverErrors.php
@@ -3,8 +3,10 @@
 namespace Laravel\Ai\Gateway\Concerns;
 
 use Closure;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Laravel\Ai\Exceptions\InsufficientCreditsException;
+use Laravel\Ai\Exceptions\ProviderConnectionException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 
@@ -22,6 +24,10 @@ trait HandlesFailoverErrors
     {
         try {
             return $callback();
+        } catch (ConnectionException $e) {
+            throw ProviderConnectionException::forProvider(
+                $providerName, $e->getCode(), $e
+            );
         } catch (RequestException $e) {
             if ($e->response !== null) {
                 $status = $e->response->status();

--- a/tests/Feature/Providers/Gemini/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Gemini/ErrorHandlingTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\ProviderConnectionException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Tests\Fixtures\Agents\AssistantAgent;
@@ -73,3 +75,37 @@ test('error in 200 response throws ai exception', function () {
         provider: 'gemini',
     );
 })->throws(AiException::class, 'Gemini Error');
+
+test('connection failure throws a failoverable provider connection exception', function () {
+    Http::fake(fn () => throw new ConnectionException('Connection refused'));
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'gemini',
+    );
+})->throws(ProviderConnectionException::class);
+
+test('connection failure fails over to the next provider', function () {
+    config([
+        'ai.providers.primary' => ['driver' => 'gemini', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'gemini', 'key' => 'test-key'],
+    ]);
+
+    $backup = $this->fakeTextResponse('Recovered on the backup provider');
+
+    $attempts = 0;
+
+    Http::fake(function () use (&$attempts, $backup) {
+        $attempts++;
+
+        if ($attempts === 1) {
+            throw new ConnectionException('Connection refused');
+        }
+
+        return $backup;
+    });
+
+    $response = (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']);
+
+    expect($response->text)->toBe('Recovered on the backup provider');
+});


### PR DESCRIPTION
Currently, automatic failover doesn't trigger when the primary provider is completely unreachable (host down, connection refused, an offline Ollama instance). In that case Laravel's HTTP client throws an `Illuminate\Http\Client\ConnectionException`, but `HandlesFailoverErrors` only catches `RequestException`. Since `ConnectionException` is a separate branch of the client exception hierarchy (it does not extend `RequestException`), it slips past the handler and bubbles up as a fatal error instead of failing over to the next provider.

This PR catches `ConnectionException` in `withErrorHandling` and rethrows it as a new `ProviderConnectionException`, which implements `FailoverableException` like the existing `RateLimitedException` and `ProviderOverloadedException`. The fix lives in the shared `HandlesFailoverErrors` trait that every gateway uses, so it applies to all providers at once, for both `prompt()` and `stream()`.

A single provider still surfaces the failure, now as a clear `ProviderConnectionException` instead of a raw `ConnectionException`, and the rest of the handler (429, 402, 503, quota patterns) is untouched, so nothing changes for existing code.

Fixes #775
