### PR TITLE
Add tests for the image portrait and custom size helpers

### DIFF
--- a/tests/Feature/ImageFakeTest.php
+++ b/tests/Feature/ImageFakeTest.php
@@ -105,6 +105,28 @@ test('image size and quality are recorded', function () {
     });
 });
 
+test('image portrait aspect ratio is recorded', function () {
+    Image::fake();
+
+    Image::of('A sunset')->portrait()->generate();
+
+    Image::assertGenerated(function (ImagePrompt $prompt) {
+        return $prompt->prompt === 'A sunset'
+            && $prompt->size === '2:3';
+    });
+});
+
+test('image custom size is recorded', function () {
+    Image::fake();
+
+    Image::of('A sunset')->size('16:9')->generate();
+
+    Image::assertGenerated(function (ImagePrompt $prompt) {
+        return $prompt->prompt === 'A sunset'
+            && $prompt->size === '16:9';
+    });
+});
+
 test('queued images can be faked', function () {
     Image::fake();
 


### PR DESCRIPTION
`PendingImageGeneration` exposes four ways to set the aspect ratio, but only two of them are covered. `square()` and `landscape()` are both asserted in the image tests, while `portrait()` and the underlying `size()` helper are never exercised — so the `'2:3'` ratio and any custom size string pass through untested.

This adds the two missing assertions, mirroring the existing `image size and quality are recorded` test.

Test-only change, no behavior is modified.