### PR TITLE
Fix empty Bedrock stream content blocks

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -8,3 +8,5 @@ permissions:
 jobs:
   lint:
     uses: laravel/.github/.github/workflows/coding-standards.yml@9c15e86fffce728fb6c50ebeae24fd63e98f4d1d # main
+    with:
+      php: "8.3"

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -298,7 +298,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                 $index = $event['contentBlockDelta']['contentBlockIndex'] ?? $currentBlockIndex;
                 $delta = $event['contentBlockDelta']['delta'] ?? [];
 
-                if (isset($delta['text'])) {
+                if (isset($delta['text']) && $delta['text'] !== '') {
                     $currentBlockType = 'text';
 
                     if ($emittedEvent = $emitTextStart()) {
@@ -314,7 +314,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                         $delta['text'],
                         $timestamp,
                     ))->withInvocationId($invocationId);
-                } elseif (isset($delta['reasoningContent']['text'])) {
+                } elseif (isset($delta['reasoningContent']['text']) && $delta['reasoningContent']['text'] !== '') {
                     $currentBlockType = 'reasoning';
 
                     if ($emittedEvent = $emitReasoningStart()) {
@@ -329,7 +329,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                         $delta['reasoningContent']['text'],
                         $timestamp,
                     ))->withInvocationId($invocationId);
-                } elseif (isset($delta['reasoningContent']['signature'])) {
+                } elseif (isset($delta['reasoningContent']['signature']) && $delta['reasoningContent']['signature'] !== '') {
                     $currentBlockType = 'reasoning';
 
                     if ($emittedEvent = $emitReasoningStart()) {
@@ -337,7 +337,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                     }
 
                     $currentReasoningSignature .= $delta['reasoningContent']['signature'];
-                } elseif (isset($delta['reasoningContent']['redactedContent'])) {
+                } elseif (isset($delta['reasoningContent']['redactedContent']) && $delta['reasoningContent']['redactedContent'] !== '') {
                     $currentBlockType = 'reasoning';
 
                     if ($emittedEvent = $emitReasoningStart()) {
@@ -363,12 +363,15 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                             ],
                         ];
                     } else {
+                        $reasoningText = ['text' => $currentReasoningText];
+
+                        if ($currentReasoningSignature !== '') {
+                            $reasoningText['signature'] = $currentReasoningSignature;
+                        }
+
                         $responseContent[$index] = [
                             'reasoningContent' => [
-                                'reasoningText' => [
-                                    'text' => $currentReasoningText,
-                                    'signature' => $currentReasoningSignature,
-                                ],
+                                'reasoningText' => $reasoningText,
                             ],
                         ];
                     }

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -247,6 +247,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
         $currentReasoningText = '';
         $currentReasoningSignature = '';
         $currentReasoningRedacted = '';
+        $hasReasoningBlocks = false;
         $stopReason = 'stop';
 
         $emitTextStart = function () use (&$textId, $invocationId, $timestamp) {
@@ -298,24 +299,27 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                 $index = $event['contentBlockDelta']['contentBlockIndex'] ?? $currentBlockIndex;
                 $delta = $event['contentBlockDelta']['delta'] ?? [];
 
-                if (isset($delta['text']) && $delta['text'] !== '') {
+                if (isset($delta['text'])) {
                     $currentBlockType = 'text';
 
-                    if ($emittedEvent = $emitTextStart()) {
-                        yield $emittedEvent;
+                    if ($delta['text'] !== '') {
+                        if ($emittedEvent = $emitTextStart()) {
+                            yield $emittedEvent;
+                        }
+
+                        $assistantText .= $delta['text'];
+                        $currentText .= $delta['text'];
+
+                        yield (new TextDelta(
+                            (string) Str::uuid(),
+                            $textId,
+                            $delta['text'],
+                            $timestamp,
+                        ))->withInvocationId($invocationId);
                     }
-
-                    $assistantText .= $delta['text'];
-                    $currentText .= $delta['text'];
-
-                    yield (new TextDelta(
-                        (string) Str::uuid(),
-                        $textId,
-                        $delta['text'],
-                        $timestamp,
-                    ))->withInvocationId($invocationId);
                 } elseif (isset($delta['reasoningContent']['text']) && $delta['reasoningContent']['text'] !== '') {
                     $currentBlockType = 'reasoning';
+                    $hasReasoningBlocks = true;
 
                     if ($emittedEvent = $emitReasoningStart()) {
                         yield $emittedEvent;
@@ -331,6 +335,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                     ))->withInvocationId($invocationId);
                 } elseif (isset($delta['reasoningContent']['signature']) && $delta['reasoningContent']['signature'] !== '') {
                     $currentBlockType = 'reasoning';
+                    $hasReasoningBlocks = true;
 
                     if ($emittedEvent = $emitReasoningStart()) {
                         yield $emittedEvent;
@@ -339,6 +344,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                     $currentReasoningSignature .= $delta['reasoningContent']['signature'];
                 } elseif (isset($delta['reasoningContent']['redactedContent']) && $delta['reasoningContent']['redactedContent'] !== '') {
                     $currentBlockType = 'reasoning';
+                    $hasReasoningBlocks = true;
 
                     if ($emittedEvent = $emitReasoningStart()) {
                         yield $emittedEvent;
@@ -386,14 +392,16 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
                     $currentReasoningSignature = '';
                     $currentReasoningRedacted = '';
                     $reasoningId = '';
-                } elseif ($currentBlockType === 'text' && $textId !== '') {
+                } elseif ($currentBlockType === 'text') {
                     $responseContent[$index] = ['text' => $currentText];
 
-                    yield (new TextEnd(
-                        (string) Str::uuid(),
-                        $textId,
-                        $timestamp,
-                    ))->withInvocationId($invocationId);
+                    if ($textId !== '') {
+                        yield (new TextEnd(
+                            (string) Str::uuid(),
+                            $textId,
+                            $timestamp,
+                        ))->withInvocationId($invocationId);
+                    }
 
                     $currentText = '';
                     $textId = '';
@@ -460,6 +468,15 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
             $finishReason = FinishReason::Stop;
         }
 
+        $providerContentBlocks = array_values($responseContent);
+
+        if (! $hasReasoningBlocks) {
+            $providerContentBlocks = array_values(array_filter(
+                $providerContentBlocks,
+                fn (array $block) => ! isset($block['text']) || $block['text'] !== '',
+            ));
+        }
+
         return new StepResponse(
             text: $assistantText,
             toolCalls: $toolCalls,
@@ -467,7 +484,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
             usage: $totalUsage,
             meta: new Meta($provider->name(), $model),
             structured: $structuredOutput !== null ? $this->decodeStructuredOutput($structuredOutput) : null,
-            providerContentBlocks: array_values($responseContent),
+            providerContentBlocks: $providerContentBlocks,
         );
     }
 

--- a/tests/Feature/Providers/Bedrock/StreamingTest.php
+++ b/tests/Feature/Providers/Bedrock/StreamingTest.php
@@ -158,6 +158,102 @@ describe('text streaming', function () {
             ->and($assistantTurn['content'][0])->toHaveKey('toolUse');
     });
 
+    test('streaming preserves empty text blocks between reasoning blocks on follow-up tool step', function () {
+        $mock = new MockHandler([
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['reasoningContent' => ['text' => 'I should call the tool']]),
+                $this->contentBlockDelta(0, ['reasoningContent' => ['signature' => 'sig-1']]),
+                $this->contentBlockStop(0),
+                $this->contentBlockStart(1),
+                $this->contentBlockDelta(1, ['text' => '']),
+                $this->contentBlockStop(1),
+                $this->contentBlockStart(2),
+                $this->contentBlockDelta(2, ['reasoningContent' => ['text' => 'I need the result']]),
+                $this->contentBlockDelta(2, ['reasoningContent' => ['signature' => 'sig-2']]),
+                $this->contentBlockStop(2),
+                $this->contentBlockStart(3, ['toolUse' => ['toolUseId' => 't1', 'name' => 'FixedNumberGenerator']]),
+                $this->contentBlockDelta(3, ['toolUse' => ['input' => '{}']]),
+                $this->contentBlockStop(3),
+                $this->messageStop('tool_use'),
+            ]]),
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['text' => 'Done']),
+                $this->contentBlockStop(0),
+                $this->messageStop('end_turn'),
+            ]]),
+        ]);
+
+        $gateway = $this->gatewayWithClient($this->bedrockClient($mock));
+
+        iterator_to_array(
+            (new TextGenerationLoop($gateway))->stream(
+                'inv-1',
+                $this->bedrockProvider(),
+                'anthropic.claude-sonnet-5',
+                null,
+                tools: [new FixedNumberGenerator],
+            ),
+            preserve_keys: false,
+        );
+
+        $assistantTurn = $mock->getLastCommand()->toArray()['messages'][0];
+
+        expect($assistantTurn['content'])->toHaveCount(4)
+            ->and($assistantTurn['content'][0])->toBe([
+                'reasoningContent' => ['reasoningText' => ['text' => 'I should call the tool', 'signature' => 'sig-1']],
+            ])
+            ->and($assistantTurn['content'][1])->toBe(['text' => ''])
+            ->and($assistantTurn['content'][2])->toBe([
+                'reasoningContent' => ['reasoningText' => ['text' => 'I need the result', 'signature' => 'sig-2']],
+            ])
+            ->and($assistantTurn['content'][3]['toolUse']['toolUseId'])->toBe('t1')
+            ->and($assistantTurn['content'][3]['toolUse']['name'])->toBe('FixedNumberGenerator');
+    });
+
+    test('streaming does not round-trip an empty reasoning block on follow-up tool step', function (array $delta) {
+        $mock = new MockHandler([
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, $delta),
+                $this->contentBlockStop(0),
+                $this->contentBlockStart(1, ['toolUse' => ['toolUseId' => 't1', 'name' => 'FixedNumberGenerator']]),
+                $this->contentBlockDelta(1, ['toolUse' => ['input' => '{}']]),
+                $this->contentBlockStop(1),
+                $this->messageStop('tool_use'),
+            ]]),
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['text' => 'Done']),
+                $this->contentBlockStop(0),
+                $this->messageStop('end_turn'),
+            ]]),
+        ]);
+
+        $gateway = $this->gatewayWithClient($this->bedrockClient($mock));
+
+        iterator_to_array(
+            (new TextGenerationLoop($gateway))->stream(
+                'inv-1',
+                $this->bedrockProvider(),
+                'anthropic.claude-sonnet-5',
+                null,
+                tools: [new FixedNumberGenerator],
+            ),
+            preserve_keys: false,
+        );
+
+        $assistantTurn = $mock->getLastCommand()->toArray()['messages'][0];
+
+        expect($assistantTurn['content'])->toHaveCount(1)
+            ->and($assistantTurn['content'][0])->toHaveKey('toolUse');
+    })->with([
+        'text' => [['reasoningContent' => ['text' => '']]],
+        'signature' => [['reasoningContent' => ['signature' => '']]],
+        'redacted content' => [['reasoningContent' => ['redactedContent' => '']]],
+    ]);
+
     test('streaming omits an empty reasoning signature on follow-up tool step', function () {
         $mock = new MockHandler([
             new Result(['stream' => [

--- a/tests/Feature/Providers/Bedrock/StreamingTest.php
+++ b/tests/Feature/Providers/Bedrock/StreamingTest.php
@@ -120,6 +120,85 @@ describe('text streaming', function () {
             ->and($assistantTurn['content'][1]['toolUse']['name'])->toBe('FixedNumberGenerator');
     });
 
+    test('streaming does not round-trip an empty text block on follow-up tool step', function () {
+        $mock = new MockHandler([
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['text' => '']),
+                $this->contentBlockStop(0),
+                $this->contentBlockStart(1, ['toolUse' => ['toolUseId' => 't1', 'name' => 'FixedNumberGenerator']]),
+                $this->contentBlockDelta(1, ['toolUse' => ['input' => '{}']]),
+                $this->contentBlockStop(1),
+                $this->messageStop('tool_use'),
+            ]]),
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['text' => 'Done']),
+                $this->contentBlockStop(0),
+                $this->messageStop('end_turn'),
+            ]]),
+        ]);
+
+        $gateway = $this->gatewayWithClient($this->bedrockClient($mock));
+
+        iterator_to_array(
+            (new TextGenerationLoop($gateway))->stream(
+                'inv-1',
+                $this->bedrockProvider(),
+                'anthropic.claude-sonnet-5',
+                null,
+                tools: [new FixedNumberGenerator],
+            ),
+            preserve_keys: false,
+        );
+
+        $assistantTurn = $mock->getLastCommand()->toArray()['messages'][0];
+
+        expect($assistantTurn['content'])->toHaveCount(1)
+            ->and($assistantTurn['content'][0])->toHaveKey('toolUse');
+    });
+
+    test('streaming omits an empty reasoning signature on follow-up tool step', function () {
+        $mock = new MockHandler([
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['reasoningContent' => ['text' => 'I should call the tool']]),
+                $this->contentBlockStop(0),
+                $this->contentBlockStart(1, ['toolUse' => ['toolUseId' => 't1', 'name' => 'FixedNumberGenerator']]),
+                $this->contentBlockDelta(1, ['toolUse' => ['input' => '{}']]),
+                $this->contentBlockStop(1),
+                $this->messageStop('tool_use'),
+            ]]),
+            new Result(['stream' => [
+                $this->contentBlockStart(0),
+                $this->contentBlockDelta(0, ['text' => 'Done']),
+                $this->contentBlockStop(0),
+                $this->messageStop('end_turn'),
+            ]]),
+        ]);
+
+        $gateway = $this->gatewayWithClient($this->bedrockClient($mock));
+
+        iterator_to_array(
+            (new TextGenerationLoop($gateway))->stream(
+                'inv-1',
+                $this->bedrockProvider(),
+                'openai.gpt-oss-120b-1:0',
+                null,
+                tools: [new FixedNumberGenerator],
+            ),
+            preserve_keys: false,
+        );
+
+        $assistantTurn = $mock->getLastCommand()->toArray()['messages'][0];
+
+        expect($assistantTurn['content'][0])->toBe([
+            'reasoningContent' => [
+                'reasoningText' => ['text' => 'I should call the tool'],
+            ],
+        ]);
+    });
+
     test('streaming round-trips redacted reasoning block', function () {
         $mock = new MockHandler([
             new Result(['stream' => [


### PR DESCRIPTION
## Summary

- ignore empty optional text and reasoning deltas while reconstructing Bedrock streamed content blocks
- omit `reasoningText.signature` when a model does not provide one
- add multi-step tool-call regressions for empty text blocks and unsigned reasoning blocks

Sonnet 5 can emit an empty text delta before a tool call. Replaying that delta on the next request produces an invalid empty text content block. GPT-OSS 120B can emit reasoning text without a signature, and replaying an empty signature is also rejected by Bedrock.

## Testing

- `composer test -- --compact` (1,713 passed, 257 skipped)
- Bedrock provider tests (89 passed)
- Pint on changed files
- PHPStan on `BedrockTextGateway`
- live multi-step tool calls with Bedrock Sonnet 5 and GPT-OSS 120B