### PR TITLE
[0.x] Validate blank base64 input consistently across file classes

### DIFF
--- a/src/Files/Base64Document.php
+++ b/src/Files/Base64Document.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\UploadedFile;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -14,6 +15,10 @@ class Base64Document extends Document implements Arrayable, JsonSerializable, St
 
     public function __construct(public string $base64, ?string $mimeType = null)
     {
+        if (blank($base64)) {
+            throw new InvalidArgumentException('Base64 document content cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/src/Files/Base64Image.php
+++ b/src/Files/Base64Image.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Files;
 
 use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
@@ -13,6 +14,10 @@ class Base64Image extends Image implements Arrayable, JsonSerializable, Storable
 
     public function __construct(public string $base64, ?string $mimeType = null)
     {
+        if (blank($base64)) {
+            throw new InvalidArgumentException('Base64 image content cannot be empty.');
+        }
+
         $this->mime = $mimeType;
     }
 

--- a/tests/Unit/Files/Base64DocumentTest.php
+++ b/tests/Unit/Files/Base64DocumentTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use Laravel\Ai\Files\Base64Document;
+
+test('base64 document rejects empty content', function () {
+    new Base64Document('');
+})->throws(InvalidArgumentException::class, 'Base64 document content cannot be empty.');

--- a/tests/Unit/Files/Base64ImageTest.php
+++ b/tests/Unit/Files/Base64ImageTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use Laravel\Ai\Files\Base64Image;
+
+test('base64 image rejects empty content', function () {
+    new Base64Image('');
+})->throws(InvalidArgumentException::class, 'Base64 image content cannot be empty.');

--- a/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
+++ b/tests/Unit/Gateway/Bedrock/BedrockTextGatewayTest.php
@@ -311,17 +311,17 @@ test('s3 document content throws unsupported exception', function () {
 test('document format maps common mime types', function () {
     $gateway = textGateway();
 
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'application/pdf')))->toBe('pdf');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'text/csv')))->toBe('csv');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'application/msword')))->toBe('doc');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')))->toBe('docx');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'application/vnd.ms-excel')))->toBe('xls');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')))->toBe('xlsx');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'text/html')))->toBe('html');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'text/markdown')))->toBe('md');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'text/x-markdown')))->toBe('md');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', 'text/plain; charset=utf-8')))->toBe('txt');
-    expect($gateway->callGetDocumentFormat(new Base64Document('', null)))->toBeNull();
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'application/pdf')))->toBe('pdf');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'text/csv')))->toBe('csv');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'application/msword')))->toBe('doc');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')))->toBe('docx');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'application/vnd.ms-excel')))->toBe('xls');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')))->toBe('xlsx');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'text/html')))->toBe('html');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'text/markdown')))->toBe('md');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'text/x-markdown')))->toBe('md');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), 'text/plain; charset=utf-8')))->toBe('txt');
+    expect($gateway->callGetDocumentFormat(new Base64Document(base64_encode('doc-bytes'), null)))->toBeNull();
 });
 
 test('user message with base64 image attachment produces image block', function () {
@@ -380,20 +380,20 @@ test('uploaded file attachment is rejected as unsupported', function () {
 test('image format maps common image mime types', function () {
     $gateway = textGateway();
 
-    expect($gateway->callGetImageFormat(new Base64Image('', 'image/png')))->toBe('png');
-    expect($gateway->callGetImageFormat(new Base64Image('', 'image/jpeg')))->toBe('jpeg');
-    expect($gateway->callGetImageFormat(new Base64Image('', 'image/jpg')))->toBe('jpeg');
-    expect($gateway->callGetImageFormat(new Base64Image('', 'image/gif')))->toBe('gif');
-    expect($gateway->callGetImageFormat(new Base64Image('', 'image/webp')))->toBe('webp');
+    expect($gateway->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), 'image/png')))->toBe('png');
+    expect($gateway->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), 'image/jpeg')))->toBe('jpeg');
+    expect($gateway->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), 'image/jpg')))->toBe('jpeg');
+    expect($gateway->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), 'image/gif')))->toBe('gif');
+    expect($gateway->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), 'image/webp')))->toBe('webp');
 });
 
 test('image format throws when mime type is unsupported', function () {
-    expect(fn () => textGateway()->callGetImageFormat(new Base64Image('', 'image/unsupported')))
+    expect(fn () => textGateway()->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), 'image/unsupported')))
         ->toThrow(InvalidArgumentException::class, 'Unsupported image MIME type [image/unsupported]');
 });
 
 test('image format throws when mime type is missing', function () {
-    expect(fn () => textGateway()->callGetImageFormat(new Base64Image('', null)))
+    expect(fn () => textGateway()->callGetImageFormat(new Base64Image(base64_encode('image-bytes'), null)))
         ->toThrow(InvalidArgumentException::class, 'Unable to determine MIME type');
 });
 


### PR DESCRIPTION
Add blank input validation to `Base64Image` & `Base64Document` constructors to match `Base64Audio`. All three constructors now throw `InvalidArgumentException` on empty input. 

Also, I updated the `BedrockTextGatewayTest` to use non empty base64 payloads where the tests are asserting MIME format behavior.