### PR TITLE
Fix`TextDelta::combine` glues multi-step streamed text together mid-sentence

### DIFF
--- a/src/Streaming/Events/TextDelta.php
+++ b/src/Streaming/Events/TextDelta.php
@@ -17,14 +17,22 @@ class TextDelta extends StreamEvent
 
     /**
      * Combine the text deltas in the given collection of events into a single string.
+     *
+     * Deltas from a multi-step generation carry a distinct message ID per step,
+     * and each step's text is a self-contained utterance (typically narration
+     * around a tool call). Steps are therefore joined with a blank line instead
+     * of being run together mid-sentence.
      */
     public static function combine(Collection|array $events): string
     {
         $events = is_array($events) ? new Collection($events) : $events;
 
         return $events->whereInstanceOf(TextDelta::class)
-            ->map(fn (TextDelta $event) => $event->delta)
-            ->join('');
+            ->groupBy(fn (TextDelta $event) => $event->messageId)
+            ->map(fn (Collection $deltas) => $deltas->map(fn (TextDelta $event) => $event->delta)->join(''))
+            ->filter(fn (string $text) => trim($text) !== '')
+            ->values()
+            ->join("\n\n");
     }
 
     /**

--- a/tests/Unit/Streaming/TextDeltaTest.php
+++ b/tests/Unit/Streaming/TextDeltaTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Laravel\Ai\Responses\Data;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+
+function textDelta(string $messageId, string $delta): TextDelta
+{
+    return new TextDelta(uniqid(), $messageId, $delta, time());
+}
+
+test('combine joins deltas of a single message without separators', function () {
+    $events = [
+        textDelta('message-1', 'Hello'),
+        textDelta('message-1', ' there'),
+        textDelta('message-1', '!'),
+    ];
+
+    expect(TextDelta::combine($events))->toBe('Hello there!');
+});
+
+test('combine separates text from different messages with a blank line', function () {
+    $events = [
+        textDelta('message-1', 'Let me look that up.'),
+        new ToolCall(uniqid(), new Data\ToolCall('call-1', 'get_weather', ['city' => 'Copenhagen']), time()),
+        new ToolResult(uniqid(), new Data\ToolResult('call-1', 'get_weather', ['city' => 'Copenhagen'], '12°C'), true, null, time()),
+        textDelta('message-2', 'It is '),
+        textDelta('message-2', '12°C in Copenhagen.'),
+    ];
+
+    expect(TextDelta::combine($events))->toBe("Let me look that up.\n\nIt is 12°C in Copenhagen.");
+});
+
+test('combine drops whitespace-only messages', function () {
+    $events = [
+        textDelta('message-1', 'First.'),
+        textDelta('message-2', "\n"),
+        textDelta('message-3', 'Second.'),
+    ];
+
+    expect(TextDelta::combine($events))->toBe("First.\n\nSecond.");
+});
+
+test('combine ignores events that are not text deltas', function () {
+    $events = [
+        new StreamStart(uniqid(), 'fake', 'fake-model', time()),
+        textDelta('message-1', 'Only text.'),
+    ];
+
+    expect(TextDelta::combine($events))->toBe('Only text.');
+});
+
+test('combine returns an empty string when there are no text deltas', function () {
+    expect(TextDelta::combine([]))->toBe('');
+});


### PR DESCRIPTION

We run a multi-tool agent (using `gemini-3.5-flash`) that streams its replies over broadcast and persists conversations with the database store.

We noticed that whenever a reply spanned multiple generation steps — narration, a tool call, then more narration — the *persisted* message glued the step texts together mid-sentence:

> `…you can see this in the other guides too.Let's do that!Now that we are back in the editor…`

Live rendering was fine (the client sees the tool-call events between the deltas), but the _stored_ transcript reads as run-on self-talk.

Once a few of those turns accumulate in a conversation, the rehydrated history itself becomes a repetition attractor for the LLM, often causing verbatim phrase loops that only stop at the output-token cap:

<img width="373" height="372" alt="image" src="https://github.com/user-attachments/assets/d35df972-f8db-48d4-a8ed-c54f02bd7cc6" />

## The problem

The cause is in `TextDelta::combine()`: it joins every text delta of the whole run with an empty string, blind to step boundaries.

## The fix

Every gateway mints a fresh `messageId` per stream call (i.e. per generation step), and each `TextDelta` carries it. `combine()` now groups deltas by `messageId`, joins each step's deltas exactly as before, drops whitespace-only steps, and joins the steps with a blank line — so the persisted text matches what the user actually saw: separate utterances.
