### PR TITLE
Add coverage for iterating the embeddings response

### DIFF
--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -68,6 +68,28 @@ describe('generating embeddings', function () {
         expect($response)->toHaveCount(3);
     });
 
+    test('can iterate over response', function () {
+        Embeddings::fake([
+            [
+                array_fill(0, 3, 0.1),
+                array_fill(0, 3, 0.2),
+            ],
+        ]);
+
+        $response = Embeddings::for(['Hello', 'World'])->dimensions(3)->generate();
+
+        $embeddings = [];
+
+        foreach ($response as $embedding) {
+            $embeddings[] = $embedding;
+        }
+
+        expect($embeddings)->toEqual([
+            array_fill(0, 3, 0.1),
+            array_fill(0, 3, 0.2),
+        ]);
+    });
+
     test('can fake embeddings with custom response', function () {
         $customEmbedding = array_fill(0, 100, 0.5);
 


### PR DESCRIPTION
`EmbeddingsResponse` implements `IteratorAggregate`, but its `getIterator()` had no test coverage, while the sibling `RerankingResponse` already has a `can iterate over response` test in `RerankingFakeTest`. This adds a matching test to `EmbeddingsFakeTest` so iterating an embeddings response is verified.   