### PR TITLE
Add web fetch tool coverage for the Anthropic provider

### DIFF
--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Providers\Tools\FileSearch;
+use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Agents\NamedToolAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -90,6 +91,50 @@ test('web search tool forwards anthropic provider options into the tool payload'
         $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_search');
 
         return data_get($tool, 'blocked_domains') === ['spam.com'];
+    });
+});
+
+test('web fetch tool sends allowed_domains', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [(new WebFetch)->allow(['laravel.com', 'php.net'])])
+        ->prompt('Fetch', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_fetch');
+
+        return data_get($tool, 'type') === 'web_fetch_20250910'
+            && data_get($tool, 'allowed_domains') === ['laravel.com', 'php.net'];
+    });
+});
+
+test('web fetch tool defaults max_uses to ten', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [new WebFetch])->prompt('Fetch', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_fetch');
+
+        return data_get($tool, 'max_uses') === 10;
+    });
+});
+
+test('web fetch tool forwards a custom max_uses', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [(new WebFetch)->max(3)])->prompt('Fetch', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_fetch');
+
+        return data_get($tool, 'max_uses') === 3;
     });
 });
 


### PR DESCRIPTION
The `WebFetch` provider tool had almost no coverage, the only reference in the test suite was OpenRouter asserting it's unsupported, while its sibling `WebSearch` is well covered in the Anthropic `ToolMappingTest`. 

This adds tests for how the Anthropic provider maps a `WebFetch` tool, verifying it:                                                                                                                                                                                                                               
  - sends `allowed_domains` and the `web_fetch_20250910` type                                                                                                                                                                            
  - defaults `max_uses` to 10                                                                                                                                                                                                            
  - forwards a custom `max_uses` set via `->max()`        