### PR TITLE
Add stateless transcript prompting to the agent API

### DIFF
--- a/src/Concerns/InteractsWithFakeAgents.php
+++ b/src/Concerns/InteractsWithFakeAgents.php
@@ -84,7 +84,7 @@ trait InteractsWithFakeAgents
         ?string $message = null): self
     {
         $callback = is_string($callback)
-            ? fn ($prompt) => $prompt->prompt === $callback
+            ? fn ($prompt) => $prompt->text() === $callback
             : $callback;
 
         PHPUnit::assertTrue(
@@ -120,7 +120,7 @@ trait InteractsWithFakeAgents
         ?string $message = null): self
     {
         $callback = is_string($callback)
-            ? fn ($prompt) => $prompt->prompt === $callback
+            ? fn ($prompt) => $prompt->text() === $callback
             : $callback;
 
         PHPUnit::assertTrue(

--- a/src/Jobs/BroadcastAgent.php
+++ b/src/Jobs/BroadcastAgent.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Throwable;
@@ -25,10 +26,12 @@ class BroadcastAgent implements ShouldQueue
 
     /**
      * Create a new job instance.
+     *
+     * @param  Message[]|string  $prompt
      */
     public function __construct(
         public Agent $agent,
-        public string $prompt,
+        public array|string $prompt,
         public Channel|array $channels,
         public array $attachments = [],
         public Lab|array|string|null $provider = null,

--- a/src/Jobs/InvokeAgent.php
+++ b/src/Jobs/InvokeAgent.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Messages\Message;
 
 class InvokeAgent implements ShouldQueue
 {
@@ -13,10 +14,12 @@ class InvokeAgent implements ShouldQueue
 
     /**
      * Create a new job instance.
+     *
+     * @param  Message[]|string  $prompt
      */
     public function __construct(
         public Agent $agent,
-        public string $prompt,
+        public array|string $prompt,
         public array $attachments = [],
         public Lab|array|string|null $provider = null,
         public ?string $model = null) {}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -15,13 +15,17 @@ use Laravel\Ai\Attributes\Timeout as TimeoutAttribute;
 use Laravel\Ai\Attributes\UseCheapestModel;
 use Laravel\Ai\Attributes\UseSmartestModel;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Gateway\FakeTextGateway;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Jobs\InvokeAgent;
+use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AgentResponse;
@@ -30,6 +34,7 @@ use Laravel\Ai\Responses\QueuedAgentResponse;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
+use LogicException;
 use ReflectionClass;
 use RuntimeException;
 
@@ -51,14 +56,18 @@ trait Promptable
 
     /**
      * Invoke the agent with a given prompt.
+     *
+     * @param  Message[]|string  $prompt
      */
     public function prompt(
-        string $prompt,
+        array|string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
         ?string $model = null,
         ?int $timeout = null): AgentResponse
     {
+        $this->ensureTranscriptCanBePrompted($prompt);
+
         return $this->withModelFailover(
             fn (TextProvider $provider, string $model) => $provider->prompt(
                 new AgentPrompt($this, $prompt, $attachments, $provider, $model, $this->getTimeout($timeout))
@@ -70,14 +79,18 @@ trait Promptable
 
     /**
      * Invoke the agent with a given prompt and return a streamable response.
+     *
+     * @param  Message[]|string  $prompt
      */
     public function stream(
-        string $prompt,
+        array|string $prompt,
         array $attachments = [],
         Lab|array|string|null $provider = null,
         ?string $model = null,
         ?int $timeout = null): StreamableAgentResponse
     {
+        $this->ensureTranscriptCanBePrompted($prompt);
+
         $providers = $this->getProvidersAndModelsForFailover($provider, $model);
         $resolvedTimeout = $this->getTimeout($timeout);
 
@@ -135,9 +148,13 @@ trait Promptable
 
     /**
      * Invoke the agent in a queued job.
+     *
+     * @param  Message[]|string  $prompt
      */
-    public function queue(string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(array|string $prompt, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
+        $this->ensureTranscriptCanBePrompted($prompt);
+
         if (static::isFaked()) {
             Ai::recordPrompt(
                 new QueuedAgentPrompt($this, $prompt, $attachments, $provider, $model),
@@ -153,8 +170,10 @@ trait Promptable
 
     /**
      * Invoke the agent with a given prompt and broadcast the streamed events.
+     *
+     * @param  Message[]|string  $prompt
      */
-    public function broadcast(string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(array|string $prompt, Channel|array $channels, array $attachments = [], bool $now = false, Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         $without = WithoutBroadcasting::eventsFor($this);
 
@@ -170,17 +189,23 @@ trait Promptable
 
     /**
      * Invoke the agent with a given prompt and broadcast the streamed events immediately.
+     *
+     * @param  Message[]|string  $prompt
      */
-    public function broadcastNow(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(array|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
     {
         return $this->broadcast($prompt, $channels, $attachments, now: true, provider: $provider, model: $model);
     }
 
     /**
      * Invoke the agent with a given prompt and broadcast the streamed events.
+     *
+     * @param  Message[]|string  $prompt
      */
-    public function broadcastOnQueue(string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(array|string $prompt, Channel|array $channels, array $attachments = [], Lab|array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
     {
+        $this->ensureTranscriptCanBePrompted($prompt);
+
         if (static::isFaked()) {
             Ai::recordPrompt(
                 new QueuedAgentPrompt($this, $prompt, $attachments, $provider, $model),
@@ -192,6 +217,37 @@ trait Promptable
         return new QueuedAgentResponse(
             BroadcastAgent::dispatch($this, $prompt, $channels, $attachments, $provider, $model)
         );
+    }
+
+    /**
+     * Ensure a transcript prompt is not combined with an agent's own conversation history.
+     *
+     * @param  Message[]|string  $prompt
+     */
+    private function ensureTranscriptCanBePrompted(array|string $prompt): void
+    {
+        if (! is_array($prompt)) {
+            return;
+        }
+
+        $this->ensureNoActiveConversation($this);
+    }
+
+    /**
+     * Throw if the given agent uses RemembersConversations and has an active conversation.
+     */
+    private function ensureNoActiveConversation(Agent $agent): void
+    {
+        if (! in_array(RemembersConversations::class, class_uses_recursive($agent))) {
+            return;
+        }
+
+        /** @var Agent&RemembersConversationsContract $agent */
+        if ($agent->hasConversationParticipant()) {
+            throw new LogicException(
+                'A transcript cannot be prompted while the agent has an active RemembersConversations conversation. Drop forUser()/continue() to replay the transcript statelessly.'
+            );
+        }
     }
 
     /**

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\UserMessage;
 
 class AgentPrompt extends Prompt
 {
@@ -17,9 +19,12 @@ class AgentPrompt extends Prompt
 
     public readonly ?string $invocationId;
 
+    /**
+     * @param  Message[]|string  $prompt
+     */
     public function __construct(
         Agent $agent,
-        string $prompt,
+        array|string $prompt,
         Collection|array $attachments,
         TextProvider $provider,
         string $model,
@@ -39,7 +44,7 @@ class AgentPrompt extends Prompt
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->prompt, $string);
+        return Str::contains($this->text(), $string);
     }
 
     /**
@@ -47,7 +52,7 @@ class AgentPrompt extends Prompt
      */
     public function prepend(string $prompt): AgentPrompt
     {
-        return $this->revise($prompt.PHP_EOL.PHP_EOL.$this->prompt);
+        return $this->revise($prompt.PHP_EOL.PHP_EOL.$this->text());
     }
 
     /**
@@ -55,11 +60,11 @@ class AgentPrompt extends Prompt
      */
     public function append(string $prompt): AgentPrompt
     {
-        return $this->revise($this->prompt.PHP_EOL.PHP_EOL.$prompt);
+        return $this->revise($this->text().PHP_EOL.PHP_EOL.$prompt);
     }
 
     /**
-     * Revise the prompt and return a new prompt instance.
+     * Revise the trailing prompt message and return a new prompt instance.
      */
     public function revise(string $prompt, Collection|array|null $attachments = null): AgentPrompt
     {
@@ -67,9 +72,15 @@ class AgentPrompt extends Prompt
             $attachments = new Collection($attachments);
         }
 
+        $trailing = $this->trailingMessage();
+
+        $revised = $this->hasTranscript()
+            ? [...$this->history(), new UserMessage($prompt, $trailing instanceof UserMessage ? $trailing->attachments : [])]
+            : $prompt;
+
         return new self(
             $this->agent,
-            $prompt,
+            $revised,
             $attachments ?? $this->attachments,
             $this->provider,
             $this->model,
@@ -83,7 +94,7 @@ class AgentPrompt extends Prompt
      */
     public function withAttachments(Collection|array $attachments): AgentPrompt
     {
-        return $this->revise($this->prompt, $attachments);
+        return $this->revise($this->text(), $attachments);
     }
 
     /**

--- a/src/Prompts/Concerns/HasTranscript.php
+++ b/src/Prompts/Concerns/HasTranscript.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Ai\Prompts\Concerns;
+
+use Laravel\Ai\Messages\Message;
+
+trait HasTranscript
+{
+    /**
+     * Determine if the prompt was given as a full transcript rather than a plain string.
+     */
+    public function hasTranscript(): bool
+    {
+        return is_array($this->prompt);
+    }
+
+    /**
+     * Get the trailing message of the transcript, if a transcript was given.
+     */
+    public function trailingMessage(): ?Message
+    {
+        return $this->hasTranscript() ? $this->prompt[array_key_last($this->prompt)] : null;
+    }
+
+    /**
+     * Get the text of the prompt: the string itself, or the trailing user message's content.
+     */
+    public function text(): string
+    {
+        return $this->trailingMessage()?->content ?? (is_string($this->prompt) ? $this->prompt : '');
+    }
+}

--- a/src/Prompts/Prompt.php
+++ b/src/Prompts/Prompt.php
@@ -3,12 +3,34 @@
 namespace Laravel\Ai\Prompts;
 
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Prompts\Concerns\HasTranscript;
 
 abstract class Prompt
 {
+    use HasTranscript;
+
+    /** @var Message[]|string */
+    public readonly array|string $prompt;
+
+    /**
+     * @param  Message[]|string  $prompt
+     */
     public function __construct(
-        public readonly string $prompt,
+        array|string $prompt,
         public readonly TextProvider $provider,
         public readonly string $model
-    ) {}
+    ) {
+        $this->prompt = is_array($prompt) ? Transcript::normalize($prompt) : $prompt;
+    }
+
+    /**
+     * Get the transcript history preceding the trailing user message.
+     *
+     * @return Message[]
+     */
+    public function history(): array
+    {
+        return $this->hasTranscript() ? array_slice($this->prompt, 0, -1) : [];
+    }
 }

--- a/src/Prompts/Transcript.php
+++ b/src/Prompts/Transcript.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Laravel\Ai\Prompts;
+
+use InvalidArgumentException;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\MessageRole;
+use Laravel\Ai\Messages\ToolResultMessage;
+
+class Transcript
+{
+    /**
+     * Normalize and validate a client-supplied transcript into a canonical Message[] array.
+     *
+     * @return Message[]
+     */
+    public static function normalize(array $messages): array
+    {
+        $messages = array_map(fn ($message) => Message::tryFrom($message), array_values($messages));
+
+        $messages = static::mergeAdjacentToolResults($messages);
+
+        $messages = static::pairToolCalls($messages);
+
+        $trailing = $messages[array_key_last($messages)] ?? null;
+
+        if (! $trailing instanceof Message || $trailing->role !== MessageRole::User) {
+            throw new InvalidArgumentException('A transcript must end with a user message.');
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Merge consecutive tool result messages into one, since providers require them grouped.
+     *
+     * @param  Message[]  $messages
+     * @return Message[]
+     */
+    protected static function mergeAdjacentToolResults(array $messages): array
+    {
+        $merged = [];
+
+        foreach ($messages as $message) {
+            $previous = $merged[count($merged) - 1] ?? null;
+
+            if ($message instanceof ToolResultMessage && $previous instanceof ToolResultMessage) {
+                $merged[count($merged) - 1] = new ToolResultMessage(
+                    $previous->toolResults->merge($message->toolResults)
+                );
+
+                continue;
+            }
+
+            $merged[] = $message;
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Strip tool calls/results that have no matching counterpart, since providers reject dangling pairs.
+     *
+     * @param  Message[]  $messages
+     * @return Message[]
+     */
+    protected static function pairToolCalls(array $messages): array
+    {
+        $result = [];
+
+        foreach ($messages as $index => $message) {
+            if ($message instanceof ToolResultMessage) {
+                $previous = $result[count($result) - 1] ?? null;
+
+                $callIds = $previous instanceof AssistantMessage
+                    ? $previous->toolCalls->pluck('id')->all()
+                    : [];
+
+                $matched = $message->toolResults
+                    ->filter(fn ($toolResult) => in_array($toolResult->id, $callIds, true))
+                    ->values();
+
+                if ($matched->isNotEmpty()) {
+                    $result[] = new ToolResultMessage($matched);
+                }
+
+                continue;
+            }
+
+            if ($message instanceof AssistantMessage && $message->toolCalls->isNotEmpty()) {
+                $next = $messages[$index + 1] ?? null;
+
+                $resultIds = $next instanceof ToolResultMessage
+                    ? $next->toolResults->pluck('id')->all()
+                    : [];
+
+                $matchedCalls = $message->toolCalls
+                    ->filter(fn ($toolCall) => in_array($toolCall->id, $resultIds, true))
+                    ->values();
+
+                if ($matchedCalls->count() < $message->toolCalls->count()) {
+                    if ($matchedCalls->isEmpty() && blank($message->content)) {
+                        continue;
+                    }
+
+                    $message = new AssistantMessage($message->content, $matchedCalls);
+                }
+            }
+
+            $result[] = $message;
+        }
+
+        return $result;
+    }
+}

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Providers\Concerns;
 
 use Closure;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Concerns\RemembersConversations;
@@ -55,10 +56,7 @@ trait GeneratesText
 
                 $agent = $prompt->agent;
 
-                $messages = [
-                    ...($agent instanceof Conversational ? $agent->messages() : []),
-                    new UserMessage($prompt->prompt, $prompt->attachments->all()),
-                ];
+                $messages = $this->buildMessages($prompt, $agent);
 
                 $this->listenForToolInvocations($invocationId, $agent);
 
@@ -90,6 +88,31 @@ trait GeneratesText
         );
 
         return $response;
+    }
+
+    /**
+     * Build the messages to send for the given prompt: transcript history, conversation history, then the trailing user message.
+     */
+    protected function buildMessages(AgentPrompt $prompt, Agent $agent): array
+    {
+        return [
+            ...$prompt->history(),
+            ...($agent instanceof Conversational && ! $prompt->hasTranscript() ? $agent->messages() : []),
+            new UserMessage($prompt->text(), $this->trailingAttachmentsFor($prompt)->all()),
+        ];
+    }
+
+    /**
+     * Get the attachments for the trailing user message, merging any transcript-embedded
+     * attachments with the ones passed at the call site (call-site attachments last).
+     */
+    protected function trailingAttachmentsFor(AgentPrompt $prompt): Collection
+    {
+        $trailing = $prompt->trailingMessage();
+
+        return $trailing instanceof UserMessage
+            ? $trailing->attachments->merge($prompt->attachments)
+            : $prompt->attachments;
     }
 
     /**

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -4,12 +4,10 @@ namespace Laravel\Ai\Providers\Concerns;
 
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Gateway\TextGenerationOptions;
-use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
@@ -47,10 +45,7 @@ trait StreamsText
                     function () use ($invocationId, $prompt, $agent) {
                         $this->events->dispatch(new StreamingAgent($invocationId, $prompt));
 
-                        $messages = [
-                            ...($agent instanceof Conversational ? $agent->messages() : []),
-                            new UserMessage($prompt->prompt, $prompt->attachments->all()),
-                        ];
+                        $messages = $this->buildMessages($prompt, $agent);
 
                         $this->listenForToolInvocations($invocationId, $agent);
 

--- a/src/QueuedAgentPrompt.php
+++ b/src/QueuedAgentPrompt.php
@@ -6,22 +6,35 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Prompts\Concerns\HasTranscript;
+use Laravel\Ai\Prompts\Transcript;
 
 class QueuedAgentPrompt
 {
+    use HasTranscript;
+
+    /** @var Message[]|string */
+    public readonly array|string $prompt;
+
+    /**
+     * @param  Message[]|string  $prompt
+     */
     public function __construct(
         public Agent $agent,
-        public string $prompt,
+        array|string $prompt,
         public Collection|array $attachments,
         public Lab|array|string|null $provider,
         public ?string $model
-    ) {}
+    ) {
+        $this->prompt = is_array($prompt) ? Transcript::normalize($prompt) : $prompt;
+    }
 
     /**
      * Determine if the prompt contains the given string.
      */
     public function contains(string $string): bool
     {
-        return Str::contains($this->prompt, $string);
+        return Str::contains($this->text(), $string);
     }
 }

--- a/tests/Feature/AgentTranscriptPromptingTest.php
+++ b/tests/Feature/AgentTranscriptPromptingTest.php
@@ -1,0 +1,418 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Jobs\InvokeAgent;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Prompts\Transcript;
+use Laravel\Ai\QueuedAgentPrompt;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\ConversationalAgent;
+use Tests\Fixtures\Agents\RememberingAssistantAgent;
+use Tests\Fixtures\FakeConversationStore;
+
+describe('prompting with a transcript', function () {
+    test('a transcript of message objects is accepted', function () {
+        AssistantAgent::fake([
+            fn (string $prompt) => "Echo: {$prompt}",
+        ]);
+
+        $response = (new AssistantAgent)->prompt([
+            new UserMessage('What is our refund policy?'),
+            new AssistantMessage('Returns within 30 days.'),
+            new UserMessage('What about digital products?'),
+        ]);
+
+        expect($response->text)->toEqual('Echo: What about digital products?');
+
+        AssistantAgent::assertPrompted('What about digital products?');
+    });
+
+    test('a transcript of plain array shapes is accepted', function () {
+        AssistantAgent::fake([
+            fn (string $prompt) => "Echo: {$prompt}",
+        ]);
+
+        $response = (new AssistantAgent)->prompt([
+            ['role' => 'user', 'content' => 'Hello'],
+            ['role' => 'assistant', 'content' => 'Hi there.'],
+            ['role' => 'user', 'content' => 'How are you?'],
+        ]);
+
+        expect($response->text)->toEqual('Echo: How are you?');
+    });
+
+    test('a transcript mixing message objects and array shapes is accepted', function () {
+        AssistantAgent::fake([
+            fn (string $prompt) => "Echo: {$prompt}",
+        ]);
+
+        $response = (new AssistantAgent)->prompt([
+            new UserMessage('Hello'),
+            ['role' => 'assistant', 'content' => 'Hi there.'],
+            new UserMessage('Follow up'),
+        ]);
+
+        expect($response->text)->toEqual('Echo: Follow up');
+    });
+
+    test('a transcript not ending in a user message is rejected', function () {
+        (new AssistantAgent)->prompt([
+            new UserMessage('Hello'),
+            new AssistantMessage('Hi there.'),
+        ]);
+    })->throws(InvalidArgumentException::class, 'A transcript must end with a user message.');
+
+    test('an empty transcript is rejected', function () {
+        (new AssistantAgent)->prompt([]);
+    })->throws(InvalidArgumentException::class, 'A transcript must end with a user message.');
+
+    test('call-site attachments merge with attachments already on the trailing message', function () {
+        $captured = null;
+
+        AssistantAgent::fake([
+            function (string $prompt, $attachments) use (&$captured) {
+                $captured = $attachments;
+
+                return 'Response';
+            },
+        ]);
+
+        (new AssistantAgent)->prompt(
+            [
+                new UserMessage('Look at this', ['from-transcript.png']),
+            ],
+            attachments: ['from-call-site.png'],
+        );
+
+        expect($captured->all())->toEqual(['from-transcript.png', 'from-call-site.png']);
+    });
+
+    test('an explicit transcript takes precedence over Conversational::messages', function () {
+        config(['ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+        Http::fake([
+            'api.groq.com/*' => Http::response([
+                'id' => 'chatcmpl-1',
+                'choices' => [['message' => ['role' => 'assistant', 'content' => 'Response'], 'finish_reason' => 'stop']],
+                'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+            ]),
+        ]);
+
+        (new ConversationalAgent)->prompt([
+            new UserMessage('Explicit transcript only'),
+        ], provider: 'primary');
+
+        Http::assertSent(function ($request) {
+            $contents = collect($request->data()['messages'])->pluck('content');
+
+            return $contents->contains('Explicit transcript only')
+                && $contents->doesntContain('My name is Taylor Otwell');
+        });
+    });
+
+    test('a transcript cannot be prompted while a RemembersConversations conversation is active', function () {
+        app()->instance(ConversationStore::class, new FakeConversationStore);
+
+        RememberingAssistantAgent::fake(['Fake response']);
+
+        $user = new class
+        {
+            public int $id = 1;
+        };
+
+        (new RememberingAssistantAgent)->forUser($user)->prompt([
+            new UserMessage('Hi'),
+        ]);
+    })->throws(LogicException::class);
+
+    test('a transcript cannot be streamed while a RemembersConversations conversation is active', function () {
+        app()->instance(ConversationStore::class, new FakeConversationStore);
+
+        RememberingAssistantAgent::fake(['Fake response']);
+
+        $user = new class
+        {
+            public int $id = 1;
+        };
+
+        (new RememberingAssistantAgent)->forUser($user)->stream([
+            new UserMessage('Hi'),
+        ]);
+    })->throws(LogicException::class);
+
+    test('withAttachments works on a transcript-based prompt', function () {
+        $prompt = new AgentPrompt(
+            new AssistantAgent,
+            [new UserMessage('History'), new UserMessage('Latest question')],
+            [],
+            Ai::textProviderFor(new AssistantAgent, 'groq'),
+            'test-model',
+        );
+
+        $revised = $prompt->withAttachments(['photo.png']);
+
+        expect($revised->hasTranscript())->toBeTrue()
+            ->and($revised->text())->toEqual('Latest question')
+            ->and($revised->attachments->all())->toEqual(['photo.png'])
+            ->and($revised->history())->toHaveCount(1);
+    });
+
+    test('revise preserves the trailing transcript message own attachments', function () {
+        $prompt = new AgentPrompt(
+            new AssistantAgent,
+            [
+                new UserMessage('History'),
+                new UserMessage('Latest question', ['from-transcript.png']),
+            ],
+            [],
+            Ai::textProviderFor(new AssistantAgent, 'groq'),
+            'test-model',
+        );
+
+        $revised = $prompt->append('one more thing');
+
+        expect($revised->trailingMessage())->toBeInstanceOf(UserMessage::class)
+            ->and($revised->trailingMessage()->attachments->all())->toEqual(['from-transcript.png']);
+
+        $withCallSiteAttachment = $prompt->withAttachments(['from-call-site.png']);
+
+        expect($withCallSiteAttachment->trailingMessage()->attachments->all())->toEqual(['from-transcript.png'])
+            ->and($withCallSiteAttachment->attachments->all())->toEqual(['from-call-site.png']);
+    });
+
+    test('a transcript is allowed for a RemembersConversations agent without an active conversation', function () {
+        RememberingAssistantAgent::fake([
+            fn (string $prompt) => "Echo: {$prompt}",
+        ]);
+
+        $response = (new RememberingAssistantAgent)->prompt([
+            new UserMessage('Hi'),
+        ]);
+
+        expect($response->text)->toEqual('Echo: Hi');
+    });
+});
+
+describe('assertions with a transcript prompt', function () {
+    test('assertPrompted matches the trailing user message text', function () {
+        AssistantAgent::fake(['Fake response']);
+
+        (new AssistantAgent)->prompt([
+            new UserMessage('History line'),
+            new UserMessage('Latest question'),
+        ]);
+
+        AssistantAgent::assertPrompted('Latest question');
+        AssistantAgent::assertNotPrompted('History line');
+
+        AssistantAgent::assertPrompted(function (AgentPrompt $prompt) {
+            return $prompt->hasTranscript() && $prompt->text() === 'Latest question';
+        });
+    });
+
+    test('assertQueued matches the trailing user message text for a transcript', function () {
+        AssistantAgent::fake();
+
+        (new AssistantAgent)->queue([
+            new UserMessage('History line'),
+            new UserMessage('Latest question'),
+        ]);
+
+        AssistantAgent::assertQueued('Latest question');
+        AssistantAgent::assertNotQueued('History line');
+
+        AssistantAgent::assertQueued(function (QueuedAgentPrompt $prompt) {
+            return $prompt->hasTranscript();
+        });
+    });
+});
+
+describe('queue serialization with a transcript', function () {
+    test('a transcript prompt survives queue serialization round-trip', function () {
+        AssistantAgent::fake([
+            fn (string $prompt) => "Echo: {$prompt}",
+        ]);
+
+        $job = new InvokeAgent(new AssistantAgent, [
+            new UserMessage('History line'),
+            new AssistantMessage('Ack.', collect([
+                new ToolCall(id: 'call_1', name: 'demo', arguments: []),
+            ])),
+            new ToolResultMessage(collect([
+                new ToolResult(id: 'call_1', name: 'demo', arguments: [], result: 'ok'),
+            ])),
+            new UserMessage('Latest question'),
+        ]);
+
+        $restored = unserialize(serialize($job));
+
+        expect($restored->prompt)->toBeArray();
+
+        $restored->handle();
+
+        AssistantAgent::assertPrompted('Latest question');
+    });
+});
+
+describe('transcript normalization', function () {
+    test('adjacent tool result messages are merged into one', function () {
+        $normalized = Transcript::normalize([
+            new UserMessage('Go'),
+            new AssistantMessage('Working.', collect([
+                new ToolCall(id: 'call_1', name: 'one', arguments: []),
+                new ToolCall(id: 'call_2', name: 'two', arguments: []),
+            ])),
+            new ToolResultMessage(collect([
+                new ToolResult(id: 'call_1', name: 'one', arguments: [], result: 'a'),
+            ])),
+            new ToolResultMessage(collect([
+                new ToolResult(id: 'call_2', name: 'two', arguments: [], result: 'b'),
+            ])),
+            new UserMessage('Thanks'),
+        ]);
+
+        $toolResultMessages = array_values(array_filter(
+            $normalized, fn (Message $message) => $message instanceof ToolResultMessage
+        ));
+
+        expect($toolResultMessages)->toHaveCount(1)
+            ->and($toolResultMessages[0]->toolResults)->toHaveCount(2);
+    });
+
+    test('an assistant tool call with no matching result is stripped but the text is kept', function () {
+        $normalized = Transcript::normalize([
+            new UserMessage('Go'),
+            new AssistantMessage('Here is some text.', collect([
+                new ToolCall(id: 'call_missing', name: 'one', arguments: []),
+            ])),
+            new UserMessage('Continue'),
+        ]);
+
+        $assistant = $normalized[1];
+
+        expect($assistant)->toBeInstanceOf(AssistantMessage::class)
+            ->and($assistant->content)->toEqual('Here is some text.')
+            ->and($assistant->toolCalls)->toHaveCount(0);
+    });
+
+    test('an assistant message that is only unmatched tool calls is dropped entirely', function () {
+        $normalized = Transcript::normalize([
+            new UserMessage('Go'),
+            new AssistantMessage('', collect([
+                new ToolCall(id: 'call_missing', name: 'one', arguments: []),
+            ])),
+            new UserMessage('Continue'),
+        ]);
+
+        expect($normalized)->toHaveCount(2)
+            ->and($normalized[0])->toBeInstanceOf(UserMessage::class)
+            ->and($normalized[0]->content)->toEqual('Go')
+            ->and($normalized[1]->content)->toEqual('Continue');
+    });
+
+    test('an orphaned tool result message with no preceding call is dropped', function () {
+        $normalized = Transcript::normalize([
+            new UserMessage('Go'),
+            new AssistantMessage('Just text, no tool calls.'),
+            new ToolResultMessage(collect([
+                new ToolResult(id: 'call_orphan', name: 'one', arguments: [], result: 'a'),
+            ])),
+            new UserMessage('Continue'),
+        ]);
+
+        $toolResultMessages = array_filter($normalized, fn (Message $message) => $message instanceof ToolResultMessage);
+
+        expect($toolResultMessages)->toBeEmpty();
+    });
+
+    test('a transcript ending in unresolved assistant tool calls is rejected', function () {
+        Transcript::normalize([
+            new UserMessage('Go'),
+            new AssistantMessage('Working.', collect([
+                new ToolCall(id: 'call_1', name: 'one', arguments: []),
+            ])),
+        ]);
+    })->throws(InvalidArgumentException::class, 'A transcript must end with a user message.');
+
+    test('matched tool calls and results are preserved as-is', function () {
+        $normalized = Transcript::normalize([
+            new UserMessage('Go'),
+            new AssistantMessage('Working.', collect([
+                new ToolCall(id: 'call_1', name: 'one', arguments: []),
+            ])),
+            new ToolResultMessage(collect([
+                new ToolResult(id: 'call_1', name: 'one', arguments: [], result: 'a'),
+            ])),
+            new UserMessage('Thanks'),
+        ]);
+
+        expect($normalized)->toHaveCount(4);
+
+        $assistant = $normalized[1];
+        $toolResult = $normalized[2];
+
+        expect($assistant->toolCalls)->toHaveCount(1)
+            ->and($toolResult->toolResults)->toHaveCount(1);
+    });
+});
+
+describe('streaming a transcript with failover', function () {
+    test('a transcript threads through provider failover on stream', function () {
+        config([
+            'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+            'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+        ]);
+
+        Http::preventStrayRequests();
+
+        Http::fakeSequence()
+            ->push(status: 429)
+            ->push(fakeGroqStreamBodyForTranscriptFailover(), 200);
+
+        $response = (new AssistantAgent)->stream(
+            [
+                new UserMessage('History line'),
+                new UserMessage('Latest question'),
+            ],
+            provider: ['primary', 'backup'],
+        );
+
+        foreach ($response as $_) {
+        }
+
+        expect($response->text)->toBe('Hello');
+
+        $recorded = Http::recorded();
+
+        expect($recorded)->toHaveCount(2);
+
+        $body = json_decode($recorded[1][0]->body(), true);
+
+        expect(collect($body['messages'])->pluck('content'))->toContain('Latest question');
+    });
+});
+
+function fakeGroqStreamBodyForTranscriptFailover(): string
+{
+    $chunks = [
+        '{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}',
+        '{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}',
+        '{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}',
+    ];
+
+    $body = '';
+
+    foreach ($chunks as $chunk) {
+        $body .= "data: {$chunk}\n\n";
+    }
+
+    return $body."data: [DONE]\n\n";
+}

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -8,7 +8,10 @@ use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
 use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -471,6 +474,40 @@ test('thinking and redacted_thinking blocks are preserved on replay', function (
     $mapped = $method->invoke($gateway, [$assistant]);
 
     expect($mapped[0]['content'])->toBe($contentBlocks);
+});
+
+test('a client-supplied transcript with a tool call/result pair maps to anthropic format', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('Sure thing.'),
+    ]);
+
+    (new AssistantAgent)->prompt([
+        new UserMessage('Generate a number'),
+        new AssistantMessage('Rolling.', collect([
+            new ToolCall(id: 'toolu_1', name: 'FixedNumberGenerator', arguments: []),
+        ])),
+        new ToolResultMessage(collect([
+            new ToolResult(id: 'toolu_1', name: 'FixedNumberGenerator', arguments: [], result: '72019'),
+        ])),
+        new UserMessage('Thanks, what does that mean?'),
+    ], provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $messages = $request->data()['messages'];
+
+        $toolUseBlock = collect($messages[1]['content'])->firstWhere('type', 'tool_use');
+        $toolResultBlock = collect($messages[2]['content'])->firstWhere('type', 'tool_result');
+
+        return $messages[0]['role'] === 'user'
+            && $messages[0]['content'][0]['text'] === 'Generate a number'
+            && $messages[1]['role'] === 'assistant'
+            && $toolUseBlock['id'] === 'toolu_1'
+            && $toolUseBlock['name'] === 'FixedNumberGenerator'
+            && $messages[2]['role'] === 'user'
+            && $toolResultBlock['tool_use_id'] === 'toolu_1'
+            && $messages[3]['role'] === 'user'
+            && $messages[3]['content'][0]['text'] === 'Thanks, what does that mean?';
+    });
 });
 
 test('system instructions are not in messages array', function () {

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -214,6 +214,39 @@ test('empty tool arguments serialize as object string on assistant replay', func
     });
 });
 
+test('a client-supplied transcript with a tool call/result pair maps to openai format', function () {
+    Http::fake([
+        'api.openai.com/*' => fakeOpenAiResponse('Sure thing.'),
+    ]);
+
+    (new AssistantAgent)->prompt([
+        new UserMessage('Generate a number'),
+        new AssistantMessage('Rolling.', collect([
+            new ToolCall(id: 'call_1', name: 'FixedNumberGenerator', arguments: [], resultId: 'call_1'),
+        ])),
+        new ToolResultMessage(collect([
+            new ToolResult(id: 'call_1', name: 'FixedNumberGenerator', arguments: [], result: '72019', resultId: 'call_1'),
+        ])),
+        new UserMessage('Thanks, what does that mean?'),
+    ], provider: 'openai');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+        $input = $body['input'];
+
+        $firstUser = collect($input)->firstWhere('role', 'user');
+        $functionCall = collect($input)->firstWhere('type', 'function_call');
+        $functionCallOutput = collect($input)->firstWhere('type', 'function_call_output');
+        $lastUser = collect($input)->where('role', 'user')->last();
+
+        return $firstUser['content'][0]['text'] === 'Generate a number'
+            && $functionCall['call_id'] === 'call_1'
+            && $functionCall['name'] === 'FixedNumberGenerator'
+            && $functionCallOutput['call_id'] === 'call_1'
+            && $lastUser['content'][0]['text'] === 'Thanks, what does that mean?';
+    });
+});
+
 test('non-empty tool arguments preserve shape on assistant replay', function () {
     Http::fake([
         'api.openai.com/*' => fakeOpenAiResponse('hi'),


### PR DESCRIPTION
Currently there's no way to hand an agent a client-supplied conversation history at call time. `Conversational::messages()` is class-level only and conflicts with `RemembersConversations`, so a stateless backend (client posts the full transcript every request, like Vercel's `useChat`) has nowhere to plug in except the anonymous `agent()` helper.

This widens the `Promptable` verbs (`prompt`, `stream`, `queue`, `broadcast`, `broadcastNow`, `broadcastOnQueue`) to accept a full transcript in addition to a plain string:

```php
// before: no call-time transcript support on a named agent
$response = (new SalesCoach)->prompt('What about digital products?');

// after
$response = (new SalesCoach)->prompt([
    new UserMessage('What is our refund policy?'),
    new AssistantMessage('Our refund policy allows returns within 30 days...'),
    new UserMessage('What about digital products?'),
]);

// the plain array shape Message::tryFrom() already understands works too
$response = (new SalesCoach)->prompt($request->input('messages'));
```

The trailing user message is treated as "the prompt", everything before it is history. An explicit transcript overrides `Conversational::messages()` for that call, and throws a `LogicException` if the agent has an active `RemembersConversations` conversation (two owners of history is a footgun).
