### PR TITLE
Support multimodal for Gemini and VoyageAI

### DIFF
--- a/src/Contracts/Gateway/EmbeddingGateway.php
+++ b/src/Contracts/Gateway/EmbeddingGateway.php
@@ -3,6 +3,10 @@
 namespace Laravel\Ai\Contracts\Gateway;
 
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 
 interface EmbeddingGateway
@@ -10,7 +14,7 @@ interface EmbeddingGateway
     /**
      * Generate embedding vectors representing the given inputs.
      *
-     * @param  string[]  $inputs
+     * @param  array<int, string|Audio|Document|Image|Video>  $inputs
      * @param  array<string, mixed>  $providerOptions
      */
     public function generateEmbeddings(EmbeddingProvider $provider, string $model, array $inputs, int $dimensions, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse;

--- a/src/Contracts/Providers/EmbeddingProvider.php
+++ b/src/Contracts/Providers/EmbeddingProvider.php
@@ -3,6 +3,10 @@
 namespace Laravel\Ai\Contracts\Providers;
 
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 
 interface EmbeddingProvider extends Provider
@@ -10,7 +14,7 @@ interface EmbeddingProvider extends Provider
     /**
      * Get embedding vectors representing the given inputs.
      *
-     * @param  string[]  $inputs
+     * @param  array<int, string|Audio|Document|Image|Video>  $inputs
      * @param  array<string, mixed>  $providerOptions
      */
     public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse;

--- a/src/Embeddings.php
+++ b/src/Embeddings.php
@@ -4,6 +4,10 @@ namespace Laravel\Ai;
 
 use Closure;
 use InvalidArgumentException;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Gateway\FakeEmbeddingGateway;
 use Laravel\Ai\PendingResponses\PendingEmbeddingsGeneration;
 
@@ -12,9 +16,9 @@ class Embeddings
     /**
      * Get embedding vectors representing the given inputs.
      *
-     * @param  string[]  $inputs
+     * @param  array<int, string|Audio|Document|Image|Video>  $inputs
      *
-     * @throws InvalidArgumentException if the given inputs are not a list, are empty, are not strings, or contain only blank strings.
+     * @throws InvalidArgumentException if the given inputs are not a list, are empty, or contain an unsupported input type.
      */
     public static function for(array $inputs): PendingEmbeddingsGeneration
     {

--- a/src/Files/Base64Video.php
+++ b/src/Files/Base64Video.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Ai\Files;
+
+use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
+use JsonSerializable;
+use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
+
+class Base64Video extends Video implements Arrayable, JsonSerializable, StorableFile
+{
+    use CanBeUploadedToProvider;
+
+    public function __construct(public string $base64, ?string $mimeType = null)
+    {
+        if (blank($base64)) {
+            throw new InvalidArgumentException('Base64 video content cannot be empty.');
+        }
+
+        $this->mime = $mimeType;
+    }
+
+    /**
+     * Get the raw representation of the file.
+     */
+    public function content(): string
+    {
+        return base64_decode($this->base64);
+    }
+
+    /**
+     * Get the file's MIME type.
+     */
+    #[\Override]
+    public function mimeType(): ?string
+    {
+        return $this->mime;
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'base64-video',
+            'name' => $this->name(),
+            'base64' => $this->base64,
+            'mime' => $this->mime,
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return $this->content();
+    }
+}

--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -45,18 +45,6 @@ trait HasRemoteContent
     }
 
     /**
-     * Set the file's MIME type.
-     *
-     * @return $this
-     */
-    public function withMimeType(string $mimeType): static
-    {
-        $this->mime = $mimeType;
-
-        return $this;
-    }
-
-    /**
      * Get the HTTP response for the remote file.
      */
     protected function response(): Response

--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -37,6 +37,26 @@ trait HasRemoteContent
     }
 
     /**
+     * Get the declared MIME type without fetching the remote resource.
+     */
+    public function declaredMimeType(): ?string
+    {
+        return $this->mime;
+    }
+
+    /**
+     * Set the file's MIME type.
+     *
+     * @return $this
+     */
+    public function withMimeType(string $mimeType): static
+    {
+        $this->mime = $mimeType;
+
+        return $this;
+    }
+
+    /**
      * Get the HTTP response for the remote file.
      */
     protected function response(): Response

--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -44,6 +44,10 @@ abstract class File implements HasName, HasProviderOptions
             'local-audio' => new LocalAudio(self::value($data, 'path', $type), $data['mime'] ?? null),
             'stored-audio' => new StoredAudio(self::value($data, 'path', $type), $data['disk'] ?? null),
             'remote-audio' => new RemoteAudio(self::value($data, 'url', $type), $data['mime'] ?? null),
+            'base64-video' => new Base64Video(self::value($data, 'base64', $type), $data['mime'] ?? null),
+            'local-video' => new LocalVideo(self::value($data, 'path', $type), $data['mime'] ?? null),
+            'stored-video' => new StoredVideo(self::value($data, 'path', $type), $data['disk'] ?? null),
+            'remote-video' => new RemoteVideo(self::value($data, 'url', $type), $data['mime'] ?? null),
             default => null,
         };
 

--- a/src/Files/LocalVideo.php
+++ b/src/Files/LocalVideo.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Ai\Files;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
+use JsonSerializable;
+use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
+use RuntimeException;
+
+class LocalVideo extends Video implements Arrayable, JsonSerializable, StorableFile
+{
+    use CanBeUploadedToProvider;
+
+    public function __construct(public string $path, ?string $mimeType = null)
+    {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Video file path cannot be empty.');
+        }
+
+        $this->mime = $mimeType;
+    }
+
+    /**
+     * Get the raw representation of the file.
+     */
+    public function content(): string
+    {
+        $content = file_get_contents($this->path);
+
+        if ($content === false) {
+            throw new RuntimeException("File does not exist at path [{$this->path}]");
+        }
+
+        return $content;
+    }
+
+    /**
+     * Get the displayable name of the file.
+     */
+    #[\Override]
+    public function name(): ?string
+    {
+        return $this->name ?? basename($this->path);
+    }
+
+    /**
+     * Get the file's MIME type.
+     */
+    #[\Override]
+    public function mimeType(): ?string
+    {
+        return $this->mime ?? ((new Filesystem)->mimeType($this->path) ?: null);
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'local-video',
+            'name' => $this->name(),
+            'path' => $this->path,
+            'mime' => $this->mime,
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return $this->content();
+    }
+}

--- a/src/Files/RemoteVideo.php
+++ b/src/Files/RemoteVideo.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Ai\Files;
+
+use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
+use JsonSerializable;
+use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
+use Laravel\Ai\Files\Concerns\HasRemoteContent;
+
+class RemoteVideo extends Video implements Arrayable, JsonSerializable, StorableFile
+{
+    use CanBeUploadedToProvider, HasRemoteContent;
+
+    public function __construct(public string $url, ?string $mimeType = null)
+    {
+        if (blank($url)) {
+            throw new InvalidArgumentException('Remote video URL cannot be empty.');
+        }
+
+        $this->mime = $mimeType;
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'remote-video',
+            'name' => $this->name(),
+            'url' => $this->url,
+            'mime' => $this->mime,
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Files/StoredVideo.php
+++ b/src/Files/StoredVideo.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Laravel\Ai\Files;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use JsonSerializable;
+use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Files\Concerns\CanBeUploadedToProvider;
+use RuntimeException;
+
+class StoredVideo extends Video implements Arrayable, JsonSerializable, StorableFile
+{
+    use CanBeUploadedToProvider;
+
+    public function __construct(public string $path, public ?string $disk = null)
+    {
+        if (blank($path)) {
+            throw new InvalidArgumentException('Video file path cannot be empty.');
+        }
+    }
+
+    /**
+     * Get the raw representation of the file.
+     */
+    public function content(): string
+    {
+        return Storage::disk($this->disk)->get($this->path) ??
+            throw new RuntimeException('File ['.$this->path.'] does not exist on disk ['.$this->disk.'].');
+    }
+
+    /**
+     * Get the displayable name of the file.
+     */
+    #[\Override]
+    public function name(): ?string
+    {
+        return $this->name ?? basename($this->path);
+    }
+
+    /**
+     * Get the file's MIME type.
+     */
+    #[\Override]
+    public function mimeType(): ?string
+    {
+        /** @var FilesystemAdapter $disk */
+        $disk = Storage::disk($this->disk);
+
+        return $this->mime ?? ($disk->mimeType($this->path) ?: null);
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'stored-video',
+            'name' => $this->name(),
+            'path' => $this->path,
+            'disk' => $this->disk ?? config('filesystems.default'),
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return $this->content();
+    }
+}

--- a/src/Files/Video.php
+++ b/src/Files/Video.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Ai\Files;
+
+use Illuminate\Http\UploadedFile;
+
+abstract class Video extends File
+{
+    /**
+     * Create a new video from Base64 data.
+     */
+    public static function fromBase64(string $base64, ?string $mimeType = null): Base64Video
+    {
+        return new Base64Video($base64, $mimeType);
+    }
+
+    /**
+     * Create a new video using the video at the given path.
+     */
+    public static function fromPath(string $path, ?string $mimeType = null): LocalVideo
+    {
+        return new LocalVideo($path, $mimeType);
+    }
+
+    /**
+     * Create a new remote video using the video at the given URL.
+     */
+    public static function fromUrl(string $url, ?string $mimeType = null): RemoteVideo
+    {
+        return new RemoteVideo($url, $mimeType);
+    }
+
+    /**
+     * Create a new stored video using the video at the given path on the given disk.
+     */
+    public static function fromStorage(string $path, ?string $disk = null): StoredVideo
+    {
+        return new StoredVideo($path, $disk);
+    }
+
+    /**
+     * Create a new Base64 video using the given file upload.
+     */
+    public static function fromUpload(UploadedFile $file, ?string $mimeType = null): Base64Video
+    {
+        return (new Base64Video(
+            base64_encode($file->getContent()),
+            $mimeType ?? $file->getClientMimeType(),
+        ))->as($file->getClientOriginalName());
+    }
+}

--- a/src/Gateway/Gemini/Concerns/MapsAttachments.php
+++ b/src/Gateway/Gemini/Concerns/MapsAttachments.php
@@ -9,18 +9,22 @@ use InvalidArgumentException;
 use Laravel\Ai\Files\Base64Audio;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\Base64Video;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\LocalAudio;
 use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\LocalVideo;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Files\ProviderImage;
 use Laravel\Ai\Files\RemoteAudio;
 use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\RemoteVideo;
 use Laravel\Ai\Files\StoredAudio;
 use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Files\StoredVideo;
 
 trait MapsAttachments
 {
@@ -29,110 +33,142 @@ trait MapsAttachments
      */
     protected function mapAttachments(Collection $attachments): array
     {
-        return $attachments->map(function ($attachment): array {
-            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
-                throw new InvalidArgumentException(
-                    'Unsupported attachment type ['.$attachment::class.']'
-                );
-            }
+        return $attachments->map(fn ($attachment): array => $this->mapAttachment($attachment))->all();
+    }
 
-            return match (true) {
-                $attachment instanceof ProviderImage => [
-                    'fileData' => [
-                        'fileUri' => $attachment->id,
-                    ],
+    /**
+     * Map a Laravel attachment to a Gemini content part.
+     */
+    protected function mapAttachment(mixed $attachment): array
+    {
+        if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
+            throw new InvalidArgumentException(
+                'Unsupported attachment type ['.get_debug_type($attachment).']'
+            );
+        }
+
+        return match (true) {
+            $attachment instanceof ProviderImage => [
+                'fileData' => [
+                    'fileUri' => $attachment->id,
                 ],
-                $attachment instanceof Base64Image => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mime,
-                        'data' => $attachment->base64,
-                    ],
+            ],
+            $attachment instanceof Base64Image => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mime,
+                    'data' => $attachment->base64,
                 ],
-                $attachment instanceof RemoteImage => [
-                    'fileData' => array_filter([
-                        'mimeType' => $attachment->mime,
-                        'fileUri' => $attachment->url,
-                    ]),
+            ],
+            $attachment instanceof RemoteImage => [
+                'fileData' => array_filter([
+                    'mimeType' => $attachment->mime,
+                    'fileUri' => $attachment->url,
+                ]),
+            ],
+            $attachment instanceof LocalImage => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'image/png',
+                    'data' => base64_encode(file_get_contents($attachment->path)),
                 ],
-                $attachment instanceof LocalImage => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mimeType() ?? 'image/png',
-                        'data' => base64_encode(file_get_contents($attachment->path)),
-                    ],
+            ],
+            $attachment instanceof StoredImage => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'image/png',
+                    'data' => base64_encode(
+                        (string) Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
                 ],
-                $attachment instanceof StoredImage => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mimeType() ?? 'image/png',
-                        'data' => base64_encode(
-                            (string) Storage::disk($attachment->disk)->get($attachment->path)
-                        ),
-                    ],
+            ],
+            $attachment instanceof ProviderDocument => [
+                'fileData' => [
+                    'fileUri' => $attachment->id,
                 ],
-                $attachment instanceof ProviderDocument => [
-                    'fileData' => [
-                        'fileUri' => $attachment->id,
-                    ],
+            ],
+            $attachment instanceof Base64Document => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mime,
+                    'data' => $attachment->base64,
                 ],
-                $attachment instanceof Base64Document => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mime,
-                        'data' => $attachment->base64,
-                    ],
+            ],
+            $attachment instanceof LocalDocument => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
+                    'data' => base64_encode(file_get_contents($attachment->path)),
                 ],
-                $attachment instanceof LocalDocument => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
-                        'data' => base64_encode(file_get_contents($attachment->path)),
-                    ],
+            ],
+            $attachment instanceof RemoteDocument => [
+                'fileData' => array_filter([
+                    'mimeType' => $attachment->mime,
+                    'fileUri' => $attachment->url,
+                ]),
+            ],
+            $attachment instanceof StoredDocument => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
+                    'data' => base64_encode(
+                        (string) Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
                 ],
-                $attachment instanceof RemoteDocument => [
-                    'fileData' => array_filter([
-                        'mimeType' => $attachment->mime,
-                        'fileUri' => $attachment->url,
-                    ]),
+            ],
+            $attachment instanceof Base64Audio => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mime ?? 'audio/mp3',
+                    'data' => $attachment->base64,
                 ],
-                $attachment instanceof StoredDocument => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
-                        'data' => base64_encode(
-                            (string) Storage::disk($attachment->disk)->get($attachment->path)
-                        ),
-                    ],
+            ],
+            $attachment instanceof LocalAudio => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'audio/mp3',
+                    'data' => base64_encode(file_get_contents($attachment->path)),
                 ],
-                $attachment instanceof Base64Audio => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mime ?? 'audio/mp3',
-                        'data' => $attachment->base64,
-                    ],
+            ],
+            $attachment instanceof StoredAudio => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'audio/mp3',
+                    'data' => base64_encode(
+                        (string) Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
                 ],
-                $attachment instanceof LocalAudio => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mimeType() ?? 'audio/mp3',
-                        'data' => base64_encode(file_get_contents($attachment->path)),
-                    ],
+            ],
+            $attachment instanceof RemoteAudio => [
+                'fileData' => array_filter([
+                    'mimeType' => $attachment->mime,
+                    'fileUri' => $attachment->url,
+                ]),
+            ],
+            $attachment instanceof Base64Video => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mime ?? 'video/mp4',
+                    'data' => $attachment->base64,
                 ],
-                $attachment instanceof StoredAudio => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->mimeType() ?? 'audio/mp3',
-                        'data' => base64_encode(
-                            (string) Storage::disk($attachment->disk)->get($attachment->path)
-                        ),
-                    ],
+            ],
+            $attachment instanceof LocalVideo => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'video/mp4',
+                    'data' => base64_encode(file_get_contents($attachment->path)),
                 ],
-                $attachment instanceof RemoteAudio => [
-                    'fileData' => array_filter([
-                        'mimeType' => $attachment->mime,
-                        'fileUri' => $attachment->url,
-                    ]),
+            ],
+            $attachment instanceof StoredVideo => [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'video/mp4',
+                    'data' => base64_encode(
+                        (string) Storage::disk($attachment->disk)->get($attachment->path)
+                    ),
                 ],
-                $attachment instanceof UploadedFile => [
-                    'inlineData' => [
-                        'mimeType' => $attachment->getClientMimeType(),
-                        'data' => base64_encode($attachment->get()),
-                    ],
+            ],
+            $attachment instanceof RemoteVideo => [
+                'fileData' => array_filter([
+                    'mimeType' => $attachment->mime,
+                    'fileUri' => $attachment->url,
+                ]),
+            ],
+            $attachment instanceof UploadedFile => [
+                'inlineData' => [
+                    'mimeType' => $attachment->getClientMimeType(),
+                    'data' => base64_encode($attachment->get()),
                 ],
-                default => throw new InvalidArgumentException('Unsupported attachment type ['.$attachment::class.']'),
-            };
-        })->all();
+            ],
+            default => throw new InvalidArgumentException('Unsupported attachment type ['.get_debug_type($attachment).']'),
+        };
     }
 }

--- a/src/Gateway/Gemini/Concerns/MapsEmbeddingInputs.php
+++ b/src/Gateway/Gemini/Concerns/MapsEmbeddingInputs.php
@@ -2,22 +2,6 @@
 
 namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
-use Illuminate\Support\Collection;
-use InvalidArgumentException;
-use Laravel\Ai\Contracts\Files\StorableFile;
-use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
-use Laravel\Ai\Contracts\Providers\FileProvider;
-use Laravel\Ai\Files\Audio as AudioFile;
-use Laravel\Ai\Files\Document as DocumentFile;
-use Laravel\Ai\Files\Image as ImageFile;
-use Laravel\Ai\Files\ProviderDocument;
-use Laravel\Ai\Files\ProviderImage;
-use Laravel\Ai\Files\RemoteAudio;
-use Laravel\Ai\Files\RemoteDocument;
-use Laravel\Ai\Files\RemoteImage;
-use Laravel\Ai\Files\RemoteVideo;
-use Laravel\Ai\Files\Video as VideoFile;
-
 trait MapsEmbeddingInputs
 {
     /**
@@ -29,86 +13,10 @@ trait MapsEmbeddingInputs
     }
 
     /**
-     * Determine if the model uses Gemini's Embedding 2 API shape.
-     */
-    protected function isGeminiEmbedding2Model(string $model): bool
-    {
-        return in_array($this->normalizeEmbeddingModel($model), ['gemini-embedding-2', 'gemini-embedding-2-preview'], true);
-    }
-
-    /**
-     * Determine if any embeddings input requires Gemini's multimodal endpoint.
-     */
-    protected function hasMultimodalEmbeddingInputs(array $inputs): bool
-    {
-        return (new Collection($inputs))->contains(fn ($input) => ! is_string($input));
-    }
-
-    /**
      * Map a Laravel embeddings input to a Gemini content part.
      */
-    protected function mapEmbeddingInput(EmbeddingProvider $provider, mixed $input): array
+    protected function mapEmbeddingInput(mixed $input): array
     {
-        if (is_string($input)) {
-            return ['text' => $input];
-        }
-
-        if ($input instanceof ProviderImage || $input instanceof ProviderDocument) {
-            return ['fileData' => $this->resolveEmbeddingProviderFileData($provider, $input)];
-        }
-
-        if ($input instanceof RemoteAudio || $input instanceof RemoteDocument || $input instanceof RemoteImage || $input instanceof RemoteVideo) {
-            return [
-                'fileData' => array_filter([
-                    'mimeType' => $input->declaredMimeType(),
-                    'fileUri' => $input->url,
-                ]),
-            ];
-        }
-
-        if ($input instanceof StorableFile && ($input instanceof AudioFile || $input instanceof DocumentFile || $input instanceof ImageFile || $input instanceof VideoFile)) {
-            return [
-                'inlineData' => [
-                    'mimeType' => $input->mimeType() ?? $this->defaultEmbeddingMimeType($input),
-                    'data' => base64_encode($input->content()),
-                ],
-            ];
-        }
-
-        throw new InvalidArgumentException('Unsupported embeddings input type ['.get_debug_type($input).']');
-    }
-
-    /**
-     * Resolve a provider file ID to the URI Gemini expects in embedding parts.
-     */
-    protected function resolveEmbeddingProviderFileData(EmbeddingProvider $provider, ProviderImage|ProviderDocument $input): array
-    {
-        if (! $provider instanceof FileProvider) {
-            throw new InvalidArgumentException(
-                'Provider ['.$provider->driver().'] does not support retrieving files for embeddings.'
-            );
-        }
-
-        $file = $provider->getFile($input->id());
-
-        return array_filter([
-            'mimeType' => $file->mimeType(),
-            'fileUri' => $file->uri() ?? throw new InvalidArgumentException(
-                'Provider file ['.$input->id().'] is missing a URI required for Gemini embeddings.'
-            ),
-        ]);
-    }
-
-    /**
-     * Get a fallback MIME type for inline embeddings media.
-     */
-    protected function defaultEmbeddingMimeType(AudioFile|DocumentFile|ImageFile|VideoFile $input): string
-    {
-        return match (true) {
-            $input instanceof AudioFile => 'audio/mpeg',
-            $input instanceof ImageFile => 'image/png',
-            $input instanceof VideoFile => 'video/mp4',
-            default => 'application/octet-stream',
-        };
+        return is_string($input) ? ['text' => $input] : $this->mapAttachment($input);
     }
 }

--- a/src/Gateway/Gemini/Concerns/MapsEmbeddingInputs.php
+++ b/src/Gateway/Gemini/Concerns/MapsEmbeddingInputs.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Gemini\Concerns;
+
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\FileProvider;
+use Laravel\Ai\Files\Audio as AudioFile;
+use Laravel\Ai\Files\Document as DocumentFile;
+use Laravel\Ai\Files\Image as ImageFile;
+use Laravel\Ai\Files\ProviderDocument;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteAudio;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\RemoteVideo;
+use Laravel\Ai\Files\Video as VideoFile;
+
+trait MapsEmbeddingInputs
+{
+    /**
+     * Normalize model names accepted by the Gemini API.
+     */
+    protected function normalizeEmbeddingModel(string $model): string
+    {
+        return str_starts_with($model, 'models/') ? substr($model, 7) : $model;
+    }
+
+    /**
+     * Determine if the model uses Gemini's Embedding 2 API shape.
+     */
+    protected function isGeminiEmbedding2Model(string $model): bool
+    {
+        return in_array($this->normalizeEmbeddingModel($model), ['gemini-embedding-2', 'gemini-embedding-2-preview'], true);
+    }
+
+    /**
+     * Determine if any embeddings input requires Gemini's multimodal endpoint.
+     */
+    protected function hasMultimodalEmbeddingInputs(array $inputs): bool
+    {
+        return (new Collection($inputs))->contains(fn ($input) => ! is_string($input));
+    }
+
+    /**
+     * Map a Laravel embeddings input to a Gemini content part.
+     */
+    protected function mapEmbeddingInput(EmbeddingProvider $provider, mixed $input): array
+    {
+        if (is_string($input)) {
+            return ['text' => $input];
+        }
+
+        if ($input instanceof ProviderImage || $input instanceof ProviderDocument) {
+            return ['fileData' => $this->resolveEmbeddingProviderFileData($provider, $input)];
+        }
+
+        if ($input instanceof RemoteAudio || $input instanceof RemoteDocument || $input instanceof RemoteImage || $input instanceof RemoteVideo) {
+            return [
+                'fileData' => array_filter([
+                    'mimeType' => $input->declaredMimeType(),
+                    'fileUri' => $input->url,
+                ]),
+            ];
+        }
+
+        if ($input instanceof StorableFile && ($input instanceof AudioFile || $input instanceof DocumentFile || $input instanceof ImageFile || $input instanceof VideoFile)) {
+            return [
+                'inlineData' => [
+                    'mimeType' => $input->mimeType() ?? $this->defaultEmbeddingMimeType($input),
+                    'data' => base64_encode($input->content()),
+                ],
+            ];
+        }
+
+        throw new InvalidArgumentException('Unsupported embeddings input type ['.get_debug_type($input).']');
+    }
+
+    /**
+     * Resolve a provider file ID to the URI Gemini expects in embedding parts.
+     */
+    protected function resolveEmbeddingProviderFileData(EmbeddingProvider $provider, ProviderImage|ProviderDocument $input): array
+    {
+        if (! $provider instanceof FileProvider) {
+            throw new InvalidArgumentException(
+                'Provider ['.$provider->driver().'] does not support retrieving files for embeddings.'
+            );
+        }
+
+        $file = $provider->getFile($input->id());
+
+        return array_filter([
+            'mimeType' => $file->mimeType(),
+            'fileUri' => $file->uri() ?? throw new InvalidArgumentException(
+                'Provider file ['.$input->id().'] is missing a URI required for Gemini embeddings.'
+            ),
+        ]);
+    }
+
+    /**
+     * Get a fallback MIME type for inline embeddings media.
+     */
+    protected function defaultEmbeddingMimeType(AudioFile|DocumentFile|ImageFile|VideoFile $input): string
+    {
+        return match (true) {
+            $input instanceof AudioFile => 'audio/mpeg',
+            $input instanceof ImageFile => 'image/png',
+            $input instanceof VideoFile => 'video/mp4',
+            default => 'application/octet-stream',
+        };
+    }
+}

--- a/src/Gateway/Gemini/GeminiFileGateway.php
+++ b/src/Gateway/Gemini/GeminiFileGateway.php
@@ -32,6 +32,7 @@ class GeminiFileGateway implements FileGateway
         return new FileResponse(
             id: $response->json('name'),
             mimeType: $response->json('mimeType'),
+            uri: $response->json('uri'),
         );
     }
 

--- a/src/Gateway/Gemini/GeminiFileGateway.php
+++ b/src/Gateway/Gemini/GeminiFileGateway.php
@@ -32,7 +32,6 @@ class GeminiFileGateway implements FileGateway
         return new FileResponse(
             id: $response->json('name'),
             mimeType: $response->json('mimeType'),
-            uri: $response->json('uri'),
         );
     }
 

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -13,7 +13,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
-use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
@@ -36,6 +36,7 @@ class GeminiGateway implements Gateway, StepTextGateway
     use Concerns\CreatesGeminiClient;
     use Concerns\HandlesTextStreaming;
     use Concerns\MapsAttachments;
+    use Concerns\MapsEmbeddingInputs;
     use Concerns\MapsMessages;
     use Concerns\MapsTools;
     use Concerns\ParsesTextResponses;
@@ -106,7 +107,7 @@ class GeminiGateway implements Gateway, StepTextGateway
     /**
      * Generate an image.
      *
-     * @param  array<Image>  $attachments
+     * @param  array<ImageFile>  $attachments
      * @param  '3:2'|'2:3'|'1:1'|null  $size
      * @param  'low'|'medium'|'high'|null  $quality
      */
@@ -171,10 +172,16 @@ class GeminiGateway implements Gateway, StepTextGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        $requests = array_map(fn (string $input): array => array_merge($providerOptions, [
+        $model = $this->normalizeEmbeddingModel($model);
+
+        if ($this->usesEmbedContentEndpoint($model, $inputs)) {
+            return $this->generateEmbedContentEmbeddings($provider, $model, $inputs, $dimensions, $timeout, $providerOptions);
+        }
+
+        $requests = array_map(fn (mixed $input): array => array_merge($providerOptions, [
             'model' => "models/{$model}",
-            'content' => ['parts' => [['text' => $input]]],
-            'output_dimensionality' => $dimensions,
+            'content' => ['parts' => [$this->mapEmbeddingInput($provider, $input)]],
+            'outputDimensionality' => $dimensions,
         ]), $inputs);
 
         $response = $this->withErrorHandling(
@@ -187,10 +194,62 @@ class GeminiGateway implements Gateway, StepTextGateway
         $data = $response->json();
 
         return new EmbeddingsResponse(
-            (new Collection($data['embeddings'] ?? []))->pluck('values')->all(),
+            $this->parseEmbeddingValues($data),
             $data['usageMetadata']['promptTokenCount'] ?? 0,
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Determine if embeddings should be generated through Gemini's single content endpoint.
+     */
+    protected function usesEmbedContentEndpoint(string $model, array $inputs): bool
+    {
+        return $this->isGeminiEmbedding2Model($model) || $this->hasMultimodalEmbeddingInputs($inputs);
+    }
+
+    /**
+     * Generate embeddings through Gemini's single content endpoint.
+     */
+    protected function generateEmbedContentEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): EmbeddingsResponse {
+        $embeddings = [];
+        $tokens = 0;
+
+        foreach ($inputs as $input) {
+            $data = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)->post("models/{$model}:embedContent", array_merge($providerOptions, [
+                    'content' => ['parts' => [$this->mapEmbeddingInput($provider, $input)]],
+                    'outputDimensionality' => $dimensions,
+                ])),
+            )->json();
+
+            $embeddings = array_merge($embeddings, $this->parseEmbeddingValues($data));
+            $tokens += $data['usageMetadata']['promptTokenCount'] ?? 0;
+        }
+
+        return new EmbeddingsResponse(
+            $embeddings,
+            $tokens,
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Parse Gemini embedding values from either embedding response shape.
+     */
+    protected function parseEmbeddingValues(array $data): array
+    {
+        return isset($data['embedding']['values'])
+            ? [$data['embedding']['values']]
+            : (new Collection($data['embeddings'] ?? []))->pluck('values')->all();
     }
 
     /**

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Gemini;
 
 use Generator;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
@@ -174,13 +175,9 @@ class GeminiGateway implements Gateway, StepTextGateway
     ): EmbeddingsResponse {
         $model = $this->normalizeEmbeddingModel($model);
 
-        if ($this->usesEmbedContentEndpoint($model, $inputs)) {
-            return $this->generateEmbedContentEmbeddings($provider, $model, $inputs, $dimensions, $timeout, $providerOptions);
-        }
-
-        $requests = array_map(fn (mixed $input): array => array_merge($providerOptions, [
+        $requests = array_map(fn (mixed $input): array => array_merge(Arr::except($providerOptions, 'output_dimensionality'), [
             'model' => "models/{$model}",
-            'content' => ['parts' => [$this->mapEmbeddingInput($provider, $input)]],
+            'content' => ['parts' => [$this->mapEmbeddingInput($input)]],
             'outputDimensionality' => $dimensions,
         ]), $inputs);
 
@@ -194,62 +191,10 @@ class GeminiGateway implements Gateway, StepTextGateway
         $data = $response->json();
 
         return new EmbeddingsResponse(
-            $this->parseEmbeddingValues($data),
+            (new Collection($data['embeddings'] ?? []))->pluck('values')->all(),
             $data['usageMetadata']['promptTokenCount'] ?? 0,
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Determine if embeddings should be generated through Gemini's single content endpoint.
-     */
-    protected function usesEmbedContentEndpoint(string $model, array $inputs): bool
-    {
-        return $this->isGeminiEmbedding2Model($model) || $this->hasMultimodalEmbeddingInputs($inputs);
-    }
-
-    /**
-     * Generate embeddings through Gemini's single content endpoint.
-     */
-    protected function generateEmbedContentEmbeddings(
-        EmbeddingProvider $provider,
-        string $model,
-        array $inputs,
-        int $dimensions,
-        int $timeout = 30,
-        array $providerOptions = [],
-    ): EmbeddingsResponse {
-        $embeddings = [];
-        $tokens = 0;
-
-        foreach ($inputs as $input) {
-            $data = $this->withErrorHandling(
-                $provider->name(),
-                fn () => $this->client($provider, $timeout)->post("models/{$model}:embedContent", array_merge($providerOptions, [
-                    'content' => ['parts' => [$this->mapEmbeddingInput($provider, $input)]],
-                    'outputDimensionality' => $dimensions,
-                ])),
-            )->json();
-
-            $embeddings = array_merge($embeddings, $this->parseEmbeddingValues($data));
-            $tokens += $data['usageMetadata']['promptTokenCount'] ?? 0;
-        }
-
-        return new EmbeddingsResponse(
-            $embeddings,
-            $tokens,
-            new Meta($provider->name(), $model),
-        );
-    }
-
-    /**
-     * Parse Gemini embedding values from either embedding response shape.
-     */
-    protected function parseEmbeddingValues(array $data): array
-    {
-        return isset($data['embedding']['values'])
-            ? [$data['embedding']['values']]
-            : (new Collection($data['embeddings'] ?? []))->pluck('values')->all();
     }
 
     /**

--- a/src/Gateway/VoyageAi/Concerns/MapsEmbeddingInputs.php
+++ b/src/Gateway/VoyageAi/Concerns/MapsEmbeddingInputs.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\Base64Video;
 use Laravel\Ai\Files\Image as ImageFile;
 use Laravel\Ai\Files\ProviderImage;
 use Laravel\Ai\Files\RemoteImage;
@@ -17,11 +19,12 @@ use Laravel\Ai\Responses\EmbeddingsResponse;
 trait MapsEmbeddingInputs
 {
     /**
-     * Determine if any embeddings input requires the multimodal endpoint.
+     * Determine if the model or inputs require Voyage AI's multimodal endpoint.
      */
-    protected function hasMultimodalEmbeddingInputs(array $inputs): bool
+    protected function usesMultimodalEmbeddingEndpoint(string $model, array $inputs): bool
     {
-        return (new Collection($inputs))->contains(fn ($input) => ! is_string($input));
+        return in_array($model, ['voyage-multimodal-3.5', 'voyage-multimodal-3'], true)
+            || array_any($inputs, fn ($input) => ! is_string($input));
     }
 
     /**
@@ -33,18 +36,24 @@ trait MapsEmbeddingInputs
         array $inputs,
         int $dimensions,
         int $timeout = 30,
+        array $providerOptions = [],
     ): EmbeddingsResponse {
+        if ($model === 'voyage-multimodal-3' && $dimensions !== 1024) {
+            throw new InvalidArgumentException(
+                'Model [voyage-multimodal-3] only supports 1024 dimension embeddings. Use [voyage-multimodal-3.5] for other dimensions.'
+            );
+        }
+
         $this->validateMultimodalEmbeddingInputSources($inputs);
 
         $data = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('/multimodalembeddings', [
+            fn () => $this->client($provider, $timeout)->post('/multimodalembeddings', array_merge($providerOptions, [
                 'model' => $model,
                 'inputs' => array_map(fn (mixed $input) => [
                     'content' => [$this->mapMultimodalEmbeddingInput($input)],
                 ], $inputs),
-                'output_dimension' => $dimensions,
-            ]),
+            ], $model === 'voyage-multimodal-3' ? [] : ['output_dimension' => $dimensions])),
         )->json();
 
         return new EmbeddingsResponse(
@@ -115,6 +124,24 @@ trait MapsEmbeddingInputs
             return [
                 'type' => 'video_url',
                 'video_url' => $input->url,
+            ];
+        }
+
+        if ($input instanceof Base64Image) {
+            $mime = $input->mimeType() ?? 'image/png';
+
+            return [
+                'type' => 'image_base64',
+                'image_base64' => "data:{$mime};base64,".$input->base64,
+            ];
+        }
+
+        if ($input instanceof Base64Video) {
+            $mime = $input->mimeType() ?? 'video/mp4';
+
+            return [
+                'type' => 'video_base64',
+                'video_base64' => "data:{$mime};base64,".$input->base64,
             ];
         }
 

--- a/src/Gateway/VoyageAi/Concerns/MapsEmbeddingInputs.php
+++ b/src/Gateway/VoyageAi/Concerns/MapsEmbeddingInputs.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Laravel\Ai\Gateway\VoyageAi\Concerns;
+
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\StorableFile;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Files\Image as ImageFile;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\RemoteVideo;
+use Laravel\Ai\Files\Video as VideoFile;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
+
+trait MapsEmbeddingInputs
+{
+    /**
+     * Determine if any embeddings input requires the multimodal endpoint.
+     */
+    protected function hasMultimodalEmbeddingInputs(array $inputs): bool
+    {
+        return (new Collection($inputs))->contains(fn ($input) => ! is_string($input));
+    }
+
+    /**
+     * Generate embeddings for text and image inputs using Voyage AI's multimodal endpoint.
+     */
+    protected function generateMultimodalEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+    ): EmbeddingsResponse {
+        $this->validateMultimodalEmbeddingInputSources($inputs);
+
+        $data = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('/multimodalembeddings', [
+                'model' => $model,
+                'inputs' => array_map(fn (mixed $input) => [
+                    'content' => [$this->mapMultimodalEmbeddingInput($input)],
+                ], $inputs),
+                'output_dimension' => $dimensions,
+            ]),
+        )->json();
+
+        return new EmbeddingsResponse(
+            (new Collection($data['data'] ?? []))->pluck('embedding')->all(),
+            $data['usage']['total_tokens'] ?? $data['total_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Validate Voyage AI's per-request media source constraint.
+     */
+    protected function validateMultimodalEmbeddingInputSources(array $inputs): void
+    {
+        $source = null;
+
+        foreach ($inputs as $input) {
+            $inputSource = $this->multimodalEmbeddingInputSource($input);
+
+            if (is_null($inputSource)) {
+                continue;
+            }
+
+            $source ??= $inputSource;
+
+            if ($source !== $inputSource) {
+                throw new InvalidArgumentException(
+                    'Voyage AI multimodal embeddings inputs must use either URL media or base64 media exclusively.'
+                );
+            }
+        }
+    }
+
+    /**
+     * Get the media source type used by a multimodal embeddings input.
+     */
+    protected function multimodalEmbeddingInputSource(mixed $input): ?string
+    {
+        return match (true) {
+            $input instanceof RemoteImage,
+            $input instanceof RemoteVideo => 'url',
+            $input instanceof ImageFile && $input instanceof StorableFile && ! $input instanceof ProviderImage,
+            $input instanceof VideoFile && $input instanceof StorableFile => 'base64',
+            default => null,
+        };
+    }
+
+    /**
+     * Map a Laravel embeddings input to Voyage AI's multimodal input segment.
+     */
+    protected function mapMultimodalEmbeddingInput(mixed $input): array
+    {
+        if (is_string($input)) {
+            return [
+                'type' => 'text',
+                'text' => $input,
+            ];
+        }
+
+        if ($input instanceof RemoteImage) {
+            return [
+                'type' => 'image_url',
+                'image_url' => $input->url,
+            ];
+        }
+
+        if ($input instanceof RemoteVideo) {
+            return [
+                'type' => 'video_url',
+                'video_url' => $input->url,
+            ];
+        }
+
+        if ($input instanceof ImageFile && $input instanceof StorableFile && ! $input instanceof ProviderImage) {
+            $mime = $input->mimeType() ?? 'image/png';
+
+            return [
+                'type' => 'image_base64',
+                'image_base64' => "data:{$mime};base64,".base64_encode($input->content()),
+            ];
+        }
+
+        if ($input instanceof VideoFile && $input instanceof StorableFile) {
+            $mime = $input->mimeType() ?? 'video/mp4';
+
+            return [
+                'type' => 'video_base64',
+                'video_base64' => "data:{$mime};base64,".base64_encode($input->content()),
+            ];
+        }
+
+        throw new InvalidArgumentException('Unsupported Voyage AI multimodal embeddings input type ['.get_debug_type($input).']');
+    }
+}

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -30,8 +30,8 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
-        if ($this->hasMultimodalEmbeddingInputs($inputs)) {
-            return $this->generateMultimodalEmbeddings($provider, $model, $inputs, $dimensions, $timeout);
+        if ($this->usesMultimodalEmbeddingEndpoint($model, $inputs)) {
+            return $this->generateMultimodalEmbeddings($provider, $model, $inputs, $dimensions, $timeout, $providerOptions);
         }
 
         $data = $this->withErrorHandling(

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -16,13 +16,11 @@ use Laravel\Ai\Responses\RerankingResponse;
 class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
 {
     use Concerns\CreatesVoyageAiClient;
+    use Concerns\MapsEmbeddingInputs;
     use HandlesFailoverErrors;
 
     /**
-     * Generate embedding vectors representing the given inputs.
-     *
-     * @param  string[]  $inputs
-     * @param  array<string, mixed>  $providerOptions
+     * {@inheritdoc}
      */
     public function generateEmbeddings(
         EmbeddingProvider $provider,
@@ -32,6 +30,10 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
+        if ($this->hasMultimodalEmbeddingInputs($inputs)) {
+            return $this->generateMultimodalEmbeddings($provider, $model, $inputs, $dimensions, $timeout);
+        }
+
         $data = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('/embeddings', array_merge($providerOptions, [

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -7,10 +7,20 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\Files\HasProviderId;
+use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\FakePendingDispatch;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\RemoteAudio;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\RemoteVideo;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Jobs\GenerateEmbeddings;
 use Laravel\Ai\PendingResponses\Concerns\ResolvesProviderOptions;
 use Laravel\Ai\Prompts\QueuedEmbeddingsPrompt;
@@ -35,7 +45,7 @@ class PendingEmbeddingsGeneration
     /**
      * Create a new pending embeddings generation instance.
      *
-     * @param  string[]  $inputs
+     * @param  array<int, string|Audio|Document|Image|Video>  $inputs
      *
      * @throws InvalidArgumentException
      */
@@ -50,8 +60,19 @@ class PendingEmbeddingsGeneration
         }
 
         foreach ($inputs as $index => $input) {
-            if (! is_string($input) || blank($input)) {
-                throw new InvalidArgumentException("The input at index {$index} must be a non-blank string.");
+            if (is_string($input)) {
+                if (blank($input)) {
+                    throw new InvalidArgumentException("The input at index {$index} must be a non-blank string.");
+                }
+
+                continue;
+            }
+
+            if (! $input instanceof Image
+                && ! $input instanceof Audio
+                && ! $input instanceof Document
+                && ! $input instanceof Video) {
+                throw new InvalidArgumentException("The input at index {$index} must be a string or an image, audio, document, or video file.");
             }
         }
     }
@@ -187,12 +208,13 @@ class PendingEmbeddingsGeneration
      */
     protected function cacheKey(Provider $provider, string $model, int $dimensions, array $providerOptions): string
     {
-        $optionsFingerprint = $this->fingerprintProviderOptions($providerOptions);
-
-        return 'laravel-embeddings:'.hash(
-            'sha256',
-            $provider->driver().'-'.$model.'-'.$dimensions.'-'.$optionsFingerprint.'-'.implode('-', $this->inputs),
-        );
+        return 'laravel-embeddings:'.hash('sha256', json_encode([
+            'driver' => $provider->driver(),
+            'model' => $model,
+            'dimensions' => $dimensions,
+            'options' => $this->fingerprintProviderOptions($providerOptions),
+            'inputs' => array_map($this->normalizeInputForCache(...), $this->inputs),
+        ], JSON_THROW_ON_ERROR));
     }
 
     /**
@@ -225,6 +247,54 @@ class PendingEmbeddingsGeneration
         ksort($value);
 
         return array_map($this->normalizeForFingerprint(...), $value);
+    }
+
+    /**
+     * Normalize an embeddings input into a deterministic cache representation.
+     */
+    protected function normalizeInputForCache(mixed $input): array
+    {
+        if (is_string($input)) {
+            return [
+                'type' => 'text',
+                'value' => $input,
+            ];
+        }
+
+        $type = match (true) {
+            $input instanceof Image => 'image',
+            $input instanceof Audio => 'audio',
+            $input instanceof Document => 'document',
+            $input instanceof Video => 'video',
+            default => throw new InvalidArgumentException('Unsupported embeddings input type ['.get_debug_type($input).']'),
+        };
+
+        return match (true) {
+            $input instanceof HasProviderId => [
+                'type' => $type,
+                'source' => 'provider',
+                'id' => $input->id(),
+                'name' => $input->name(),
+            ],
+            $input instanceof RemoteImage,
+            $input instanceof RemoteAudio,
+            $input instanceof RemoteDocument,
+            $input instanceof RemoteVideo => [
+                'type' => $type,
+                'source' => 'remote',
+                'url' => $input->url,
+                'mime' => $input->declaredMimeType(),
+                'name' => $input->name(),
+            ],
+            $input instanceof StorableFile => [
+                'type' => $type,
+                'source' => 'content',
+                'hash' => hash('sha256', $input->content()),
+                'mime' => $input->mimeType(),
+                'name' => $input->name(),
+            ],
+            default => throw new InvalidArgumentException('Unsupported embeddings input type ['.get_debug_type($input).']'),
+        };
     }
 
     /**

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -208,11 +208,20 @@ class PendingEmbeddingsGeneration
      */
     protected function cacheKey(Provider $provider, string $model, int $dimensions, array $providerOptions): string
     {
+        $optionsFingerprint = $this->fingerprintProviderOptions($providerOptions);
+
+        if (array_all($this->inputs, fn ($input) => is_string($input))) {
+            return 'laravel-embeddings:'.hash(
+                'sha256',
+                $provider->driver().'-'.$model.'-'.$dimensions.'-'.$optionsFingerprint.'-'.implode('-', $this->inputs),
+            );
+        }
+
         return 'laravel-embeddings:'.hash('sha256', json_encode([
             'driver' => $provider->driver(),
             'model' => $model,
             'dimensions' => $dimensions,
-            'options' => $this->fingerprintProviderOptions($providerOptions),
+            'options' => $optionsFingerprint,
             'inputs' => array_map($this->normalizeInputForCache(...), $this->inputs),
         ], JSON_THROW_ON_ERROR));
     }

--- a/src/Prompts/EmbeddingsPrompt.php
+++ b/src/Prompts/EmbeddingsPrompt.php
@@ -26,7 +26,7 @@ class EmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
+        return array_any($this->inputs, fn ($input) => is_string($input) && Str::contains($input, $string));
     }
 
     /**

--- a/src/Prompts/QueuedEmbeddingsPrompt.php
+++ b/src/Prompts/QueuedEmbeddingsPrompt.php
@@ -26,7 +26,7 @@ class QueuedEmbeddingsPrompt implements Countable
      */
     public function contains(string $string): bool
     {
-        return array_any($this->inputs, fn ($input) => Str::contains($input, $string));
+        return array_any($this->inputs, fn ($input) => is_string($input) && Str::contains($input, $string));
     }
 
     /**

--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -7,6 +7,10 @@ use InvalidArgumentException;
 use Laravel\Ai\Ai;
 use Laravel\Ai\Events\EmbeddingsGenerated;
 use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Prompts\EmbeddingsPrompt;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 
@@ -15,7 +19,7 @@ trait GeneratesEmbeddings
     /**
      * Get embedding vectors representing the given inputs.
      *
-     * @param  string[]  $inputs
+     * @param  array<int, string|Audio|Document|Image|Video>  $inputs
      * @param  array<string, mixed>  $providerOptions
      */
     public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse
@@ -33,6 +37,8 @@ trait GeneratesEmbeddings
 
         if (Ai::embeddingsAreFaked()) {
             Ai::recordEmbeddingsGeneration($prompt);
+        } else {
+            $this->validateEmbeddingInputs($inputs, $model);
         }
 
         $this->events->dispatch(new GeneratingEmbeddings(
@@ -49,5 +55,23 @@ trait GeneratesEmbeddings
         ), fn (EmbeddingsResponse $response) => $this->events->dispatch(new EmbeddingsGenerated(
             $invocationId, $this, $model, $prompt, $response,
         )));
+    }
+
+    /**
+     * Validate embeddings inputs against the provider's supported media types.
+     *
+     * @param  array<int, string|Audio|Document|Image|Video>  $inputs
+     */
+    protected function validateEmbeddingInputs(array $inputs, string $model): void
+    {
+        foreach ($inputs as $input) {
+            if (is_string($input)) {
+                continue;
+            }
+
+            throw new InvalidArgumentException(
+                'Provider ['.$this->driver().'] only supports text embeddings inputs.'
+            );
+        }
     }
 }

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -179,12 +179,12 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     protected function validateEmbeddingInputs(array $inputs, string $model): void
     {
+        $model = str_starts_with($model, 'models/') ? substr($model, 7) : $model;
+
         foreach ($inputs as $input) {
             if (is_string($input)) {
                 continue;
             }
-
-            $model = str_starts_with($model, 'models/') ? substr($model, 7) : $model;
 
             if (! $this->isGeminiMultimodalEmbeddingModel($model)) {
                 throw new InvalidArgumentException(

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
@@ -171,6 +172,36 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
     public function defaultEmbeddingsDimensions(): int
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 3072;
+    }
+
+    /**
+     * Validate embeddings inputs against Gemini's supported media types.
+     */
+    protected function validateEmbeddingInputs(array $inputs, string $model): void
+    {
+        foreach ($inputs as $input) {
+            if (is_string($input)) {
+                continue;
+            }
+
+            $model = str_starts_with($model, 'models/') ? substr($model, 7) : $model;
+
+            if (! $this->isGeminiMultimodalEmbeddingModel($model)) {
+                throw new InvalidArgumentException(
+                    "Model [{$model}] does not support Gemini multimodal embeddings. Use [gemini-embedding-2] or [gemini-embedding-2-preview]."
+                );
+            }
+
+            return;
+        }
+    }
+
+    /**
+     * Determine if the given model supports Gemini multimodal embeddings.
+     */
+    protected function isGeminiMultimodalEmbeddingModel(string $model): bool
+    {
+        return in_array($model, ['gemini-embedding-2', 'gemini-embedding-2-preview'], true);
     }
 
     /**

--- a/src/Providers/VoyageAiProvider.php
+++ b/src/Providers/VoyageAiProvider.php
@@ -3,10 +3,14 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Gateway\VoyageAi\VoyageAiGateway;
 
 class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingProvider
@@ -35,6 +39,50 @@ class VoyageAiProvider extends Provider implements EmbeddingProvider, RerankingP
     public function defaultEmbeddingsDimensions(): int
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 1024;
+    }
+
+    /**
+     * Validate embeddings inputs against Voyage AI's supported media types.
+     */
+    protected function validateEmbeddingInputs(array $inputs, string $model): void
+    {
+        foreach ($inputs as $input) {
+            if (is_string($input)) {
+                continue;
+            }
+
+            if ($input instanceof Image && ! $input instanceof ProviderImage) {
+                if ($this->isVoyageMultimodalModel($model)) {
+                    continue;
+                }
+
+                throw new InvalidArgumentException(
+                    "Model [{$model}] does not support Voyage AI image embeddings. Use [voyage-multimodal-3.5] or [voyage-multimodal-3]."
+                );
+            }
+
+            if ($input instanceof Video) {
+                if ($model === 'voyage-multimodal-3.5') {
+                    continue;
+                }
+
+                throw new InvalidArgumentException(
+                    "Model [{$model}] does not support Voyage AI video embeddings. Use [voyage-multimodal-3.5]."
+                );
+            }
+
+            throw new InvalidArgumentException(
+                'Provider [voyageai] only supports text, image, and video embeddings inputs.'
+            );
+        }
+    }
+
+    /**
+     * Determine if the given model supports Voyage AI multimodal embeddings.
+     */
+    protected function isVoyageMultimodalModel(string $model): bool
+    {
+        return in_array($model, ['voyage-multimodal-3.5', 'voyage-multimodal-3'], true);
     }
 
     /**

--- a/src/Responses/FileResponse.php
+++ b/src/Responses/FileResponse.php
@@ -10,7 +10,6 @@ class FileResponse
         public readonly string $id,
         ?string $mimeType = null,
         public readonly ?string $content = null,
-        public readonly ?string $uri = null,
     ) {
         $this->mime = $mimeType;
     }
@@ -29,13 +28,5 @@ class FileResponse
     public function content(): ?string
     {
         return $this->content;
-    }
-
-    /**
-     * Get the provider URI for the file.
-     */
-    public function uri(): ?string
-    {
-        return $this->uri;
     }
 }

--- a/src/Responses/FileResponse.php
+++ b/src/Responses/FileResponse.php
@@ -10,6 +10,7 @@ class FileResponse
         public readonly string $id,
         ?string $mimeType = null,
         public readonly ?string $content = null,
+        public readonly ?string $uri = null,
     ) {
         $this->mime = $mimeType;
     }
@@ -28,5 +29,13 @@ class FileResponse
     public function content(): ?string
     {
         return $this->content;
+    }
+
+    /**
+     * Get the provider URI for the file.
+     */
+    public function uri(): ?string
+    {
+        return $this->uri;
     }
 }

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -1,7 +1,12 @@
 <?php
 
+use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 use Laravel\Ai\Prompts\EmbeddingsPrompt;
 use Laravel\Ai\Prompts\QueuedEmbeddingsPrompt;
 
@@ -33,7 +38,7 @@ test('embeddings reject non-string inputs', function (): void {
     Embeddings::fake();
 
     Embeddings::for([123])->generate();
-})->throws(InvalidArgumentException::class, 'The input at index 0 must be a non-blank string.');
+})->throws(InvalidArgumentException::class, 'The input at index 0 must be a string or an image, audio, document, or video file.');
 
 test('embeddings report the offending index for blank inputs', function (): void {
     Embeddings::fake();
@@ -68,7 +73,7 @@ describe('generating embeddings', function (): void {
         expect($response)->toHaveCount(3);
     });
 
-    test('can iterate over response', function () {
+    test('can iterate over response', function (): void {
         Embeddings::fake([
             [
                 array_fill(0, 3, 0.1),
@@ -89,6 +94,52 @@ describe('generating embeddings', function (): void {
             array_fill(0, 3, 0.2),
         ]);
     });
+
+    test('can fake embeddings with image input', function (): void {
+        Embeddings::fake();
+
+        $response = Embeddings::for([
+            Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+        ])->generate();
+
+        expect($response)->toHaveCount(1);
+    });
+
+    test('can fake embeddings with audio input', function (): void {
+        Embeddings::fake();
+
+        $response = Embeddings::for([
+            Audio::fromBase64(base64_encode('audio-bytes'), 'audio/mpeg'),
+        ])->generate();
+
+        expect($response)->toHaveCount(1);
+    });
+
+    test('can fake embeddings with document input', function (): void {
+        Embeddings::fake();
+
+        $response = Embeddings::for([
+            Document::fromBase64(base64_encode('%PDF-1.4 fake'), 'application/pdf'),
+        ])->generate();
+
+        expect($response)->toHaveCount(1);
+    });
+
+    test('can fake embeddings with video input', function (): void {
+        Embeddings::fake();
+
+        $response = Embeddings::for([
+            Video::fromBase64(base64_encode('video-bytes'), 'video/mp4'),
+        ])->generate();
+
+        expect($response)->toHaveCount(1);
+    });
+
+    test('non-text embeddings inputs are rejected by text-only providers', function (): void {
+        Embeddings::for([
+            Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+        ])->generate(provider: 'openai');
+    })->throws(InvalidArgumentException::class, 'Provider [openai] only supports text embeddings inputs.');
 
     test('can fake embeddings with custom response', function (): void {
         $customEmbedding = array_fill(0, 100, 0.5);
@@ -215,6 +266,26 @@ describe('queued embeddings', function (): void {
         Embeddings::assertNotQueued(fn (QueuedEmbeddingsPrompt $prompt): bool => in_array('Goodbye', $prompt->inputs));
     });
 
+    test('contains ignores non-text inputs', function (): void {
+        Embeddings::fake();
+
+        Embeddings::for([
+            Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+        ])->generate();
+
+        Embeddings::assertGenerated(fn (EmbeddingsPrompt $prompt) => ! $prompt->contains('Hello'));
+    });
+
+    test('queued contains ignores non-text inputs', function (): void {
+        Embeddings::fake();
+
+        Embeddings::for([
+            Video::fromBase64(base64_encode('video-bytes'), 'video/mp4'),
+        ])->queue();
+
+        Embeddings::assertQueued(fn (QueuedEmbeddingsPrompt $prompt) => ! $prompt->contains('Hello'));
+    });
+
     test('can assert no embeddings were queued', function (): void {
         Embeddings::fake();
 
@@ -236,6 +307,83 @@ describe('queued embeddings', function (): void {
 
         Embeddings::assertQueued(fn (QueuedEmbeddingsPrompt $prompt): bool => $prompt->timeout === 90 && $prompt->count() === 1);
     });
+
+    test('cached embeddings with media inputs use content hashes', function () {
+        config([
+            'cache.default' => 'array',
+            'ai.caching.embeddings.store' => 'array',
+        ]);
+
+        $path = tempnam(sys_get_temp_dir(), 'ai-embedding-');
+
+        file_put_contents($path, 'first-version');
+
+        try {
+            $calls = 0;
+
+            Embeddings::fake(function (EmbeddingsPrompt $prompt) use (&$calls) {
+                $calls++;
+
+                return array_map(
+                    fn () => array_fill(0, $prompt->dimensions, 0.1),
+                    $prompt->inputs
+                );
+            });
+
+            $request = fn () => Embeddings::for([
+                Document::fromPath($path),
+            ])->cache(60)->generate();
+
+            $request();
+            $request();
+
+            file_put_contents($path, 'second-version');
+
+            $request();
+
+            expect($calls)->toBe(2);
+        } finally {
+            @unlink($path);
+        }
+    });
+
+    test('cached remote embeddings do not fetch remote metadata', function () {
+        config([
+            'cache.default' => 'array',
+            'ai.caching.embeddings.store' => 'array',
+        ]);
+
+        Http::preventStrayRequests();
+
+        $calls = 0;
+
+        Embeddings::fake(function () use (&$calls) {
+            $calls++;
+
+            return [array_fill(0, 100, 0.1)];
+        });
+
+        $request = fn () => Embeddings::for([
+            Document::fromUrl('https://example.com/manual.pdf'),
+        ])->cache(60)->generate();
+
+        $request();
+        $request();
+
+        expect($calls)->toBe(1);
+        Http::assertNothingSent();
+    });
+
+    test('cached embeddings reject unsupported input types with an invalid argument exception', function () {
+        config([
+            'cache.default' => 'array',
+            'ai.caching.embeddings.store' => 'array',
+        ]);
+
+        Embeddings::fake();
+
+        Embeddings::for([123])->cache(60)->generate();
+    })->throws(InvalidArgumentException::class, 'The input at index 0 must be a string or an image, audio, document, or video file.');
 });
 
 describe('provider enum support', function (): void {

--- a/tests/Feature/FileFromArrayTest.php
+++ b/tests/Feature/FileFromArrayTest.php
@@ -3,18 +3,22 @@
 use Laravel\Ai\Files\Base64Audio;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\Base64Video;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\LocalAudio;
 use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\LocalVideo;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Files\ProviderImage;
 use Laravel\Ai\Files\RemoteAudio;
 use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\RemoteVideo;
 use Laravel\Ai\Files\StoredAudio;
 use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Files\StoredVideo;
 
 dataset('attachment types', [
     'base64-image' => [fn (): Base64Image => (new Base64Image('aGVsbG8=', 'image/png'))->as('hi.png'), Base64Image::class, ['base64' => 'aGVsbG8=', 'mime' => 'image/png']],
@@ -31,6 +35,10 @@ dataset('attachment types', [
     'local-audio' => [fn (): LocalAudio => (new LocalAudio('/tmp/a.mp3', 'audio/mpeg'))->as('a.mp3'), LocalAudio::class, ['path' => '/tmp/a.mp3', 'mime' => 'audio/mpeg']],
     'stored-audio' => [fn (): StoredAudio => (new StoredAudio('clips/a.mp3', 'local'))->as('a.mp3'), StoredAudio::class, ['path' => 'clips/a.mp3', 'disk' => 'local']],
     'remote-audio' => [fn (): RemoteAudio => (new RemoteAudio('https://x/y.mp3', 'audio/mpeg'))->as('y.mp3'), RemoteAudio::class, ['url' => 'https://x/y.mp3', 'mime' => 'audio/mpeg']],
+    'base64-video' => [fn (): Base64Video => (new Base64Video('aGVsbG8=', 'video/mp4'))->as('a.mp4'), Base64Video::class, ['base64' => 'aGVsbG8=', 'mime' => 'video/mp4']],
+    'local-video' => [fn (): LocalVideo => (new LocalVideo('/tmp/a.mp4', 'video/mp4'))->as('a.mp4'), LocalVideo::class, ['path' => '/tmp/a.mp4', 'mime' => 'video/mp4']],
+    'stored-video' => [fn (): StoredVideo => (new StoredVideo('clips/a.mp4', 'local'))->as('a.mp4'), StoredVideo::class, ['path' => 'clips/a.mp4', 'disk' => 'local']],
+    'remote-video' => [fn (): RemoteVideo => (new RemoteVideo('https://x/y.mp4', 'video/mp4'))->as('y.mp4'), RemoteVideo::class, ['url' => 'https://x/y.mp4', 'mime' => 'video/mp4']],
 ]);
 
 dataset('malformed attachment types', [
@@ -48,6 +56,10 @@ dataset('malformed attachment types', [
     'local-audio' => [['type' => 'local-audio'], 'path'],
     'stored-audio' => [['type' => 'stored-audio'], 'path'],
     'remote-audio' => [['type' => 'remote-audio'], 'url'],
+    'base64-video' => [['type' => 'base64-video'], 'base64'],
+    'local-video' => [['type' => 'local-video'], 'path'],
+    'stored-video' => [['type' => 'stored-video'], 'path'],
+    'remote-video' => [['type' => 'remote-video'], 'url'],
 ]);
 
 test('File::fromArray round-trips attachment types', function (Closure $factory, string $class, array $properties): void {

--- a/tests/Feature/FileToArrayTest.php
+++ b/tests/Feature/FileToArrayTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files\Audio;
 use Laravel\Ai\Files\Document;
 use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 
 test('stored document toArray falls back to basename without touching the disk', function (): void {
     Storage::fake('docs');
@@ -39,6 +40,16 @@ test('stored image toArray falls back to basename', function (): void {
     expect($array)->not->toHaveKey('mime');
 });
 
+test('stored video toArray falls back to basename', function (): void {
+    Storage::fake('docs');
+
+    $array = Video::fromStorage('clips/demo.mp4', 'docs')->toArray();
+
+    expect($array['type'])->toBe('stored-video');
+    expect($array['name'])->toBe('demo.mp4');
+    expect($array)->not->toHaveKey('mime');
+});
+
 test('local image toArray uses basename and the raw mime property', function (): void {
     $path = tempnam(sys_get_temp_dir(), 'local-image');
     file_put_contents($path, 'data');
@@ -68,6 +79,35 @@ test('local image toArray returns the explicitly set mime type', function (): vo
     }
 });
 
+test('local video toArray uses basename and the raw mime property', function (): void {
+    $path = tempnam(sys_get_temp_dir(), 'local-video');
+    file_put_contents($path, 'data');
+
+    try {
+        $array = Video::fromPath($path)->toArray();
+
+        expect($array['type'])->toBe('local-video');
+        expect($array['name'])->toBe(basename($path));
+        expect($array['path'])->toBe($path);
+        expect($array['mime'])->toBeNull();
+    } finally {
+        @unlink($path);
+    }
+});
+
+test('local video toArray returns the explicitly set mime type', function (): void {
+    $path = tempnam(sys_get_temp_dir(), 'local-video');
+    file_put_contents($path, 'data');
+
+    try {
+        $array = Video::fromPath($path)->withMimeType('video/custom')->toArray();
+
+        expect($array['mime'])->toBe('video/custom');
+    } finally {
+        @unlink($path);
+    }
+});
+
 test('base64 document toArray reflects name and mime', function (): void {
     $doc = Document::fromString('hello world', 'text/plain')->as('greeting.txt');
 
@@ -75,6 +115,16 @@ test('base64 document toArray reflects name and mime', function (): void {
         'type' => 'base64-document',
         'name' => 'greeting.txt',
         'mime' => 'text/plain',
+    ]);
+});
+
+test('base64 video toArray reflects name and mime', function (): void {
+    $video = Video::fromBase64(base64_encode('video'), 'video/mp4')->as('demo.mp4');
+
+    expect($video->toArray())->toMatchArray([
+        'type' => 'base64-video',
+        'name' => 'demo.mp4',
+        'mime' => 'video/mp4',
     ]);
 });
 
@@ -102,6 +152,18 @@ test('remote image toArray returns the explicitly set mime type without HTTP cal
 
     expect($array['mime'])->toBe('image/png');
     expect($array['name'])->toBe('avatar.png');
+
+    Http::assertNothingSent();
+});
+
+test('remote video toArray returns the explicitly set mime type without HTTP calls', function (): void {
+    Http::preventStrayRequests();
+    Http::fake();
+
+    $array = Video::fromUrl('https://example.com/demo.mp4')->withMimeType('video/mp4')->toArray();
+
+    expect($array['mime'])->toBe('video/mp4');
+    expect($array['name'])->toBe('demo.mp4');
 
     Http::assertNothingSent();
 });

--- a/tests/Feature/Providers/Gemini/EmbeddingTest.php
+++ b/tests/Feature/Providers/Gemini/EmbeddingTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Files\Audio;
+use Laravel\Ai\Files\Document;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Files\Video;
 
@@ -29,12 +31,10 @@ function fakeGeminiEmbeddingsResponse(): PromiseInterface
     ]);
 }
 
-function fakeGeminiEmbeddingResponse(array $values = [0.1, 0.2, 0.3], int $tokens = 10): PromiseInterface
+function fakeGeminiBatchEmbeddingsResponse(array $embeddings = [[0.1, 0.2, 0.3]], int $tokens = 10): PromiseInterface
 {
     return Http::response([
-        'embedding' => [
-            'values' => $values,
-        ],
+        'embeddings' => array_map(fn (array $values): array => ['values' => $values], $embeddings),
         'usageMetadata' => [
             'promptTokenCount' => $tokens,
         ],
@@ -106,24 +106,17 @@ test('multiple inputs are sent as separate requests in the batch', function (): 
     expect($response->embeddings)->toHaveCount(2);
 });
 
-test('gemini embedding 2 inputs are sent as separate embedContent requests', function (): void {
-    $responses = [
-        ['embedding' => ['values' => [0.1, 0.2, 0.3]], 'usageMetadata' => ['promptTokenCount' => 10]],
-        ['embedding' => ['values' => [0.4, 0.5, 0.6]], 'usageMetadata' => ['promptTokenCount' => 20]],
-    ];
-
-    Http::fake(function () use (&$responses) {
-        return Http::response(array_shift($responses));
-    });
+test('gemini embedding 2 inputs are sent in a single batch request', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], 30),
+    ]);
 
     $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'gemini', model: 'gemini-embedding-2');
 
-    Http::assertSentCount(2);
-    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
-        && data_get($request->data(), 'content.parts.0.text') === 'Hello');
-    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
-        && data_get($request->data(), 'content.parts.0.text') === 'World');
-    Http::assertNotSent(fn (Request $request) => str_contains($request->url(), ':batchEmbedContents'));
+    Http::assertSentCount(1);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:batchEmbedContents')
+        && data_get($request->data(), 'requests.0.content.parts.0.text') === 'Hello'
+        && data_get($request->data(), 'requests.1.content.parts.0.text') === 'World');
 
     expect($response->embeddings)->toBe([
         [0.1, 0.2, 0.3],
@@ -151,9 +144,9 @@ test('multimodal embeddings require an embedding 2 model', function (): void {
     ])->generate(provider: 'gemini', model: 'gemini-embedding-001');
 })->throws(InvalidArgumentException::class, 'gemini-embedding-2');
 
-test('base64 image embeddings are sent as inline data through embedContent', function (): void {
+test('base64 image embeddings are sent as inline data', function (): void {
     Http::fake([
-        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
     ]);
 
     Embeddings::for([
@@ -163,15 +156,15 @@ test('base64 image embeddings are sent as inline data through embedContent', fun
     Http::assertSent(function (Request $request) {
         $body = json_decode($request->body(), true);
 
-        return str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
-            && data_get($body, 'content.parts.0.inlineData.mimeType') === 'image/png'
-            && data_get($body, 'content.parts.0.inlineData.data') === base64_encode('image-bytes');
+        return str_contains($request->url(), 'models/gemini-embedding-2:batchEmbedContents')
+            && data_get($body, 'requests.0.content.parts.0.inlineData.mimeType') === 'image/png'
+            && data_get($body, 'requests.0.content.parts.0.inlineData.data') === base64_encode('image-bytes');
     });
 });
 
-test('text mixed with media inputs is sent as separate embedContent requests', function (): void {
+test('text mixed with media inputs is sent in a single batch request', function (): void {
     Http::fake([
-        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
     ]);
 
     Embeddings::for([
@@ -179,38 +172,74 @@ test('text mixed with media inputs is sent as separate embedContent requests', f
         Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
     ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
 
-    Http::assertSentCount(2);
-    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
-        && data_get($request->data(), 'content.parts.0.text') === 'Hello world');
-    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
-        && data_get($request->data(), 'content.parts.0.inlineData.data') === base64_encode('image-bytes'));
+    Http::assertSentCount(1);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:batchEmbedContents')
+        && data_get($request->data(), 'requests.0.content.parts.0.text') === 'Hello world'
+        && data_get($request->data(), 'requests.1.content.parts.0.inlineData.data') === base64_encode('image-bytes'));
 });
 
-test('provider file embeddings resolve to Gemini file uris', function (): void {
-    Http::fake(function (Request $request) {
-        return match ([$request->method(), $request->url()]) {
-            ['GET', 'https://generativelanguage.googleapis.com/v1beta/files/file_123'] => Http::response([
-                'name' => 'files/file_123',
-                'mimeType' => 'image/png',
-                'uri' => 'https://generativelanguage.googleapis.com/v1beta/files/file_123',
-            ]),
-            ['POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent'] => fakeGeminiEmbeddingResponse(),
-            default => Http::response(['unexpected_url' => $request->url()], 500),
-        };
-    });
+test('base64 audio embeddings are sent as inline data', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
+    ]);
 
     Embeddings::for([
-        Image::fromId('file_123'),
+        Audio::fromBase64(base64_encode('audio-bytes'), 'audio/mpeg'),
     ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
 
-    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-        && data_get($request->data(), 'content.parts.0.fileData.fileUri') === 'https://generativelanguage.googleapis.com/v1beta/files/file_123'
-        && data_get($request->data(), 'content.parts.0.fileData.mimeType') === 'image/png');
+    Http::assertSent(fn (Request $request) => data_get($request->data(), 'requests.0.content.parts.0.inlineData.mimeType') === 'audio/mpeg'
+        && data_get($request->data(), 'requests.0.content.parts.0.inlineData.data') === base64_encode('audio-bytes'));
+});
+
+test('base64 document embeddings are sent as inline data', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
+    ]);
+
+    Embeddings::for([
+        Document::fromBase64(base64_encode('document-bytes'), 'application/pdf'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSent(fn (Request $request) => data_get($request->data(), 'requests.0.content.parts.0.inlineData.mimeType') === 'application/pdf'
+        && data_get($request->data(), 'requests.0.content.parts.0.inlineData.data') === base64_encode('document-bytes'));
+});
+
+test('local file embeddings are sent as inline data', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
+    ]);
+
+    $path = tempnam(sys_get_temp_dir(), 'gemini-embedding-test');
+    file_put_contents($path, 'image-bytes');
+
+    try {
+        Embeddings::for([
+            Image::fromPath($path, 'image/png'),
+        ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+    } finally {
+        unlink($path);
+    }
+
+    Http::assertSent(fn (Request $request) => data_get($request->data(), 'requests.0.content.parts.0.inlineData.data') === base64_encode('image-bytes'));
+});
+
+test('provider file embeddings are sent as file data', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
+    ]);
+
+    Embeddings::for([
+        Image::fromId('files/file_123'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSentCount(1);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:batchEmbedContents')
+        && data_get($request->data(), 'requests.0.content.parts.0.fileData.fileUri') === 'files/file_123');
 });
 
 test('multimodal embeddings accept canonical model names', function (): void {
     Http::fake([
-        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
     ]);
 
     Embeddings::for([
@@ -218,13 +247,13 @@ test('multimodal embeddings accept canonical model names', function (): void {
     ])->generate(provider: 'gemini', model: 'models/gemini-embedding-2');
 
     Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-        && str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+        && str_contains($request->url(), 'models/gemini-embedding-2:batchEmbedContents')
         && ! str_contains($request->url(), 'models/models/'));
 });
 
 test('multimodal embeddings still accept preview model', function (): void {
     Http::fake([
-        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
     ]);
 
     Embeddings::for([
@@ -232,12 +261,12 @@ test('multimodal embeddings still accept preview model', function (): void {
     ])->generate(provider: 'gemini', model: 'gemini-embedding-2-preview');
 
     Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-        && str_contains($request->url(), 'models/gemini-embedding-2-preview:embedContent'));
+        && str_contains($request->url(), 'models/gemini-embedding-2-preview:batchEmbedContents'));
 });
 
 test('remote video embeddings preserve file uris', function (): void {
     Http::fake([
-        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+        'generativelanguage.googleapis.com/*' => fakeGeminiBatchEmbeddingsResponse(),
     ]);
 
     Embeddings::for([
@@ -245,7 +274,7 @@ test('remote video embeddings preserve file uris', function (): void {
     ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
 
     Http::assertSent(fn (Request $request) => $request->method() === 'POST'
-        && data_get($request->data(), 'content.parts.0.fileData.fileUri') === 'https://www.youtube.com/watch?v=demo');
+        && data_get($request->data(), 'requests.0.content.parts.0.fileData.fileUri') === 'https://www.youtube.com/watch?v=demo');
 });
 
 test('missing embeddings key in response returns empty array', function (): void {
@@ -352,6 +381,7 @@ test('gemini provider options cannot override framework controlled per-request k
             'model' => 'hijacked',
             'content' => ['hijacked'],
             'outputDimensionality' => 1,
+            'output_dimensionality' => 1,
         ])
         ->generate(provider: 'gemini', model: 'gemini-embedding-001');
 
@@ -361,6 +391,7 @@ test('gemini provider options cannot override framework controlled per-request k
 
         return $req['model'] === 'models/gemini-embedding-001'
             && $req['content'] === ['parts' => [['text' => 'Hello']]]
-            && $req['outputDimensionality'] === 3072;
+            && $req['outputDimensionality'] === 3072
+            && ! array_key_exists('output_dimensionality', $req);
     });
 });

--- a/tests/Feature/Providers/Gemini/EmbeddingTest.php
+++ b/tests/Feature/Providers/Gemini/EmbeddingTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 
 beforeEach(function (): void {
     config(['ai.providers.gemini' => [
@@ -23,6 +25,18 @@ function fakeGeminiEmbeddingsResponse(): PromiseInterface
         ],
         'usageMetadata' => [
             'promptTokenCount' => 10,
+        ],
+    ]);
+}
+
+function fakeGeminiEmbeddingResponse(array $values = [0.1, 0.2, 0.3], int $tokens = 10): PromiseInterface
+{
+    return Http::response([
+        'embedding' => [
+            'values' => $values,
+        ],
+        'usageMetadata' => [
+            'promptTokenCount' => $tokens,
         ],
     ]);
 }
@@ -50,7 +64,7 @@ test('embeddings request wraps each input in a request object', function (): voi
 
         return $firstRequest['model'] === 'models/gemini-embedding-001'
             && $firstRequest['content']['parts'][0]['text'] === 'Hello world'
-            && data_get($firstRequest, 'output_dimensionality') === 3072;
+            && data_get($firstRequest, 'outputDimensionality') === 3072;
     });
 });
 
@@ -92,7 +106,32 @@ test('multiple inputs are sent as separate requests in the batch', function (): 
     expect($response->embeddings)->toHaveCount(2);
 });
 
-test('explicit dimensions are sent as output_dimensionality', function (): void {
+test('gemini embedding 2 inputs are sent as separate embedContent requests', function (): void {
+    $responses = [
+        ['embedding' => ['values' => [0.1, 0.2, 0.3]], 'usageMetadata' => ['promptTokenCount' => 10]],
+        ['embedding' => ['values' => [0.4, 0.5, 0.6]], 'usageMetadata' => ['promptTokenCount' => 20]],
+    ];
+
+    Http::fake(function () use (&$responses) {
+        return Http::response(array_shift($responses));
+    });
+
+    $response = Embeddings::for(['Hello', 'World'])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+        && data_get($request->data(), 'content.parts.0.text') === 'Hello');
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+        && data_get($request->data(), 'content.parts.0.text') === 'World');
+    Http::assertNotSent(fn (Request $request) => str_contains($request->url(), ':batchEmbedContents'));
+
+    expect($response->embeddings)->toBe([
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+    ])->and($response->tokens)->toBe(30);
+});
+
+test('explicit dimensions are sent as outputDimensionality', function (): void {
     Http::fake([
         'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingsResponse(),
     ]);
@@ -102,8 +141,111 @@ test('explicit dimensions are sent as output_dimensionality', function (): void 
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);
 
-        return data_get($body, 'requests.0.output_dimensionality') === 768;
+        return data_get($body, 'requests.0.outputDimensionality') === 768;
     });
+});
+
+test('multimodal embeddings require an embedding 2 model', function (): void {
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-001');
+})->throws(InvalidArgumentException::class, 'gemini-embedding-2');
+
+test('base64 image embeddings are sent as inline data through embedContent', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+    ]);
+
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+            && data_get($body, 'content.parts.0.inlineData.mimeType') === 'image/png'
+            && data_get($body, 'content.parts.0.inlineData.data') === base64_encode('image-bytes');
+    });
+});
+
+test('text mixed with media inputs is sent as separate embedContent requests', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+    ]);
+
+    Embeddings::for([
+        'Hello world',
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+        && data_get($request->data(), 'content.parts.0.text') === 'Hello world');
+    Http::assertSent(fn (Request $request) => str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+        && data_get($request->data(), 'content.parts.0.inlineData.data') === base64_encode('image-bytes'));
+});
+
+test('provider file embeddings resolve to Gemini file uris', function (): void {
+    Http::fake(function (Request $request) {
+        return match ([$request->method(), $request->url()]) {
+            ['GET', 'https://generativelanguage.googleapis.com/v1beta/files/file_123'] => Http::response([
+                'name' => 'files/file_123',
+                'mimeType' => 'image/png',
+                'uri' => 'https://generativelanguage.googleapis.com/v1beta/files/file_123',
+            ]),
+            ['POST', 'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent'] => fakeGeminiEmbeddingResponse(),
+            default => Http::response(['unexpected_url' => $request->url()], 500),
+        };
+    });
+
+    Embeddings::for([
+        Image::fromId('file_123'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && data_get($request->data(), 'content.parts.0.fileData.fileUri') === 'https://generativelanguage.googleapis.com/v1beta/files/file_123'
+        && data_get($request->data(), 'content.parts.0.fileData.mimeType') === 'image/png');
+});
+
+test('multimodal embeddings accept canonical model names', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+    ]);
+
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->generate(provider: 'gemini', model: 'models/gemini-embedding-2');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && str_contains($request->url(), 'models/gemini-embedding-2:embedContent')
+        && ! str_contains($request->url(), 'models/models/'));
+});
+
+test('multimodal embeddings still accept preview model', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+    ]);
+
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2-preview');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && str_contains($request->url(), 'models/gemini-embedding-2-preview:embedContent'));
+});
+
+test('remote video embeddings preserve file uris', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiEmbeddingResponse(),
+    ]);
+
+    Embeddings::for([
+        Video::fromUrl('https://www.youtube.com/watch?v=demo'),
+    ])->generate(provider: 'gemini', model: 'gemini-embedding-2');
+
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST'
+        && data_get($request->data(), 'content.parts.0.fileData.fileUri') === 'https://www.youtube.com/watch?v=demo');
 });
 
 test('missing embeddings key in response returns empty array', function (): void {
@@ -191,7 +333,7 @@ test('embeddings request merges provider options into each per-input request', f
                 return false;
             }
 
-            if (! isset($req['model'], $req['content'], $req['output_dimensionality'])) {
+            if (! isset($req['model'], $req['content'], $req['outputDimensionality'])) {
                 return false;
             }
         }
@@ -209,7 +351,7 @@ test('gemini provider options cannot override framework controlled per-request k
         ->withProviderOptions([
             'model' => 'hijacked',
             'content' => ['hijacked'],
-            'output_dimensionality' => 1,
+            'outputDimensionality' => 1,
         ])
         ->generate(provider: 'gemini', model: 'gemini-embedding-001');
 
@@ -219,6 +361,6 @@ test('gemini provider options cannot override framework controlled per-request k
 
         return $req['model'] === 'models/gemini-embedding-001'
             && $req['content'] === ['parts' => [['text' => 'Hello']]]
-            && $req['output_dimensionality'] === 3072;
+            && $req['outputDimensionality'] === 3072;
     });
 });

--- a/tests/Feature/Providers/Gemini/MessageMappingTest.php
+++ b/tests/Feature/Providers/Gemini/MessageMappingTest.php
@@ -7,6 +7,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\Base64Video;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
@@ -186,6 +187,33 @@ test('base64 pdf document maps to inline data', function (): void {
             if (isset($part['inlineData'])) {
                 return $part['inlineData']['mimeType'] === 'application/pdf'
                     && $part['inlineData']['data'] === base64_encode('fake-pdf-content');
+            }
+        }
+
+        return false;
+    });
+});
+
+test('base64 video attachment maps to inline data', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('I see a video'),
+    ]);
+
+    $video = new Base64Video(base64_encode('fake-video-content'), 'video/mp4');
+
+    agent('You are helpful.')->prompt(
+        'What is in this video?',
+        attachments: [$video],
+        provider: 'gemini',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $parts = $request->data()['contents'][0]['parts'];
+
+        foreach ($parts as $part) {
+            if (isset($part['inlineData'])) {
+                return $part['inlineData']['mimeType'] === 'video/mp4'
+                    && $part['inlineData']['data'] === base64_encode('fake-video-content');
             }
         }
 

--- a/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
@@ -89,10 +89,57 @@ test('image embeddings use the multimodal endpoint', function (): void {
         return $request->url() === 'https://api.voyageai.com/v1/multimodalembeddings'
             && data_get($body, 'inputs.0.content.0.type') === 'image_base64'
             && data_get($body, 'inputs.0.content.0.image_base64') === 'data:image/png;base64,'.base64_encode('image-bytes')
-            && data_get($body, 'output_dimension') === 1024;
+            && ! array_key_exists('output_dimension', $body);
     });
 
     expect($response->embeddings)->toHaveCount(1);
+});
+
+test('text-only inputs use the multimodal endpoint for multimodal models', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for(['red sneakers'])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.voyageai.com/v1/multimodalembeddings'
+            && data_get($body, 'inputs.0.content.0.type') === 'text'
+            && data_get($body, 'inputs.0.content.0.text') === 'red sneakers';
+    });
+});
+
+test('unsupported dimensions are rejected for voyage-multimodal-3', function (): void {
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->dimensions(512)->generate(provider: 'voyageai', model: 'voyage-multimodal-3');
+})->throws(InvalidArgumentException::class, 'only supports 1024 dimension embeddings');
+
+test('multimodal embeddings send output dimension for models that support it', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->dimensions(512)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['output_dimension'] === 512);
+});
+
+test('multimodal embeddings forward provider options', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->withProviderOptions(['input_type' => 'query', 'model' => 'hijacked'])
+        ->dimensions(1024)
+        ->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'input_type') === 'query'
+            && data_get($body, 'model') === 'voyage-multimodal-3.5';
+    });
 });
 
 test('image embeddings require a multimodal model', function (): void {

--- a/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
+++ b/tests/Feature/Providers/VoyageAi/EmbeddingTest.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Files\Image;
+use Laravel\Ai\Files\Video;
 
 beforeEach(function (): void {
     config(['ai.providers.voyageai' => [
@@ -72,6 +74,118 @@ test('embeddings default to 1024 dimensions when none specified', function (): v
     Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
 
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['output_dimension'] === 1024);
+});
+
+test('image embeddings use the multimodal endpoint', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    $response = Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.voyageai.com/v1/multimodalembeddings'
+            && data_get($body, 'inputs.0.content.0.type') === 'image_base64'
+            && data_get($body, 'inputs.0.content.0.image_base64') === 'data:image/png;base64,'.base64_encode('image-bytes')
+            && data_get($body, 'output_dimension') === 1024;
+    });
+
+    expect($response->embeddings)->toHaveCount(1);
+});
+
+test('image embeddings require a multimodal model', function (): void {
+    Embeddings::for([
+        Image::fromBase64(base64_encode('image-bytes'), 'image/png'),
+    ])->generate(provider: 'voyageai');
+})->throws(InvalidArgumentException::class, 'voyage-multimodal-3.5');
+
+test('video embeddings require the latest multimodal model', function (): void {
+    Embeddings::for([
+        Video::fromBase64(base64_encode('video-bytes'), 'video/mp4'),
+    ])->generate(provider: 'voyageai', model: 'voyage-multimodal-3');
+})->throws(InvalidArgumentException::class, 'voyage-multimodal-3.5');
+
+test('base64 video embeddings use the multimodal endpoint', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    $response = Embeddings::for([
+        Video::fromBase64(base64_encode('video-bytes'), 'video/mp4'),
+    ])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.voyageai.com/v1/multimodalembeddings'
+            && data_get($body, 'model') === 'voyage-multimodal-3.5'
+            && data_get($body, 'inputs.0.content.0.type') === 'video_base64'
+            && data_get($body, 'inputs.0.content.0.video_base64') === 'data:video/mp4;base64,'.base64_encode('video-bytes');
+    });
+
+    expect($response->embeddings)->toHaveCount(1);
+});
+
+test('remote video embeddings preserve video urls', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for([
+        Video::fromUrl('https://example.com/demo.mp4'),
+    ])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'inputs.0.content.0.type') === 'video_url'
+            && data_get($body, 'inputs.0.content.0.video_url') === 'https://example.com/demo.mp4';
+    });
+});
+
+test('multimodal embeddings reject mixed url and base64 media sources', function (): void {
+    Http::preventStrayRequests();
+
+    Embeddings::for([
+        Image::fromUrl('https://example.com/avatar.png'),
+        Video::fromBase64(base64_encode('video-bytes'), 'video/mp4'),
+    ])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+})->throws(InvalidArgumentException::class, 'either URL media or base64 media exclusively');
+
+test('multimodal embeddings allow mixed media types with the same source type', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    Embeddings::for([
+        Image::fromUrl('https://example.com/avatar.png'),
+        Video::fromUrl('https://example.com/demo.mp4'),
+    ])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'inputs.0.content.0.type') === 'image_url'
+            && data_get($body, 'inputs.1.content.0.type') === 'video_url';
+    });
+});
+
+test('multimodal embeddings allow text mixed with media inputs', function (): void {
+    Http::fake(['*' => fakeVoyageEmbeddingsResponse()]);
+
+    $response = Embeddings::for([
+        'Hello world',
+        Image::fromUrl('https://example.com/avatar.png'),
+        Video::fromUrl('https://example.com/demo.mp4'),
+    ])->dimensions(1024)->generate(provider: 'voyageai', model: 'voyage-multimodal-3.5');
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.voyageai.com/v1/multimodalembeddings'
+            && data_get($body, 'inputs.0.content.0.type') === 'text'
+            && data_get($body, 'inputs.0.content.0.text') === 'Hello world'
+            && data_get($body, 'inputs.1.content.0.type') === 'image_url'
+            && data_get($body, 'inputs.2.content.0.type') === 'video_url';
+    });
+
+    expect($response->embeddings)->toHaveCount(1);
 });
 
 test('embeddings rate limit response throws rate limited exception', function (): void {

--- a/tests/Unit/Files/Base64VideoTest.php
+++ b/tests/Unit/Files/Base64VideoTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use Laravel\Ai\Files\Base64Video;
+
+test('base64 video rejects empty content', function (): void {
+    new Base64Video('');
+})->throws(InvalidArgumentException::class, 'Base64 video content cannot be empty.');

--- a/tests/Unit/Files/RemoteUrlTest.php
+++ b/tests/Unit/Files/RemoteUrlTest.php
@@ -3,6 +3,7 @@
 use Laravel\Ai\Files\RemoteAudio;
 use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\RemoteVideo;
 
 test('remote document rejects empty url', function (): void {
     new RemoteDocument('');
@@ -27,3 +28,11 @@ test('remote audio rejects empty url', function (): void {
 test('remote audio rejects whitespace-only url', function (): void {
     new RemoteAudio("  \t\n");
 })->throws(InvalidArgumentException::class, 'Remote audio URL cannot be empty.');
+
+test('remote video rejects empty url', function (): void {
+    new RemoteVideo('');
+})->throws(InvalidArgumentException::class, 'Remote video URL cannot be empty.');
+
+test('remote video rejects whitespace-only url', function (): void {
+    new RemoteVideo("  \t\n");
+})->throws(InvalidArgumentException::class, 'Remote video URL cannot be empty.');

--- a/tests/Unit/Files/VideoPathTest.php
+++ b/tests/Unit/Files/VideoPathTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\Ai\Files\LocalVideo;
+use Laravel\Ai\Files\StoredVideo;
+
+test('local video rejects empty path', function (): void {
+    new LocalVideo('');
+})->throws(InvalidArgumentException::class, 'Video file path cannot be empty.');
+
+test('local video rejects whitespace-only path', function (): void {
+    new LocalVideo("  \t\n");
+})->throws(InvalidArgumentException::class, 'Video file path cannot be empty.');
+
+test('stored video rejects empty path', function (): void {
+    new StoredVideo('');
+})->throws(InvalidArgumentException::class, 'Video file path cannot be empty.');
+
+test('stored video rejects whitespace-only path', function (): void {
+    new StoredVideo("  \t\n");
+})->throws(InvalidArgumentException::class, 'Video file path cannot be empty.');


### PR DESCRIPTION
Closes #308

Currently `Embeddings::for()` only accepts strings, so embedding anything other than text means stepping out of the SDK and calling the provider APIs by hand, even though Gemini's `gemini-embedding-2` and Voyage's multimodal models happily accept images, video, audio, and documents.

This PR lets you pass file attachments alongside text:

```php
use Laravel\Ai\Embeddings;
use Laravel\Ai\Files\Image;
use Laravel\Ai\Files\Video;

$embeddings = Embeddings::for([
    'A description of the scene',
    Image::fromPath(storage_path('photo.jpg')),
    Video::fromUrl('https://example.com/clip.mp4'),
])->using('gemini', 'gemini-embedding-2')->generate();
```

Gemini supports text, image, audio, document, and video inputs. Voyage AI routes to its multimodal endpoint and supports text, image, and video. Every other provider throws an `InvalidArgumentException` for non-text inputs, so nothing fails silently. There was no `Video` file type yet, so this adds one mirroring the existing image, audio, and document classes.

Builds on #351 (credited in the commits), as there seemed to be no activity on that one and it's something we'd really love to see merged :) The main differences are an added test case for text/mixed inputs plus extra `blank()` guards and tests for the `Video` classes, consistent with the other file type classes.

> [!NOTE]
> My PRs use atomic commits. It's helpful/easiest to review them commit by commit.
