### PR TITLE
Add summarize macro for text summarization

### DIFF
--- a/src/Agents/SummarizeAgent.php
+++ b/src/Agents/SummarizeAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Ai\Agents;
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Attributes\UseCheapestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+
+#[UseCheapestModel]
+final class SummarizeAgent implements Agent
+{
+    use Promptable;
+
+    protected int $sentences;
+
+    public function __construct(int $sentences = 3)
+    {
+        $this->sentences = max(1, $sentences);
+    }
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return sprintf(
+            'Summarize the given text in no more than %d %s. Respond with only the summary and nothing else.',
+            $this->sentences,
+            Str::plural('sentence', $this->sentences),
+        );
+    }
+}

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -5,7 +5,9 @@ namespace Laravel\Ai;
 use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Laravel\Ai\Agents\SummarizeAgent;
 use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeAgentMiddlewareCommand;
@@ -98,6 +100,24 @@ class AiServiceProvider extends ServiceProvider
 
             return $request->generate(provider: $provider, model: $model);
         });
+
+        // Summarize macros...
+        Stringable::macro('summarize', fn (
+            int $sentences = 3,
+            Lab|array|string|null $provider = null,
+            ?string $model = null,
+            ?int $timeout = null,
+        ): string => (new SummarizeAgent($sentences))
+            ->prompt($this->value(), provider: $provider, model: $model, timeout: $timeout)->text);
+
+        Str::macro('summarize', fn (
+            string $value,
+            int $sentences = 3,
+            Lab|array|string|null $provider = null,
+            ?string $model = null,
+            ?int $timeout = null,
+        ): string => (new SummarizeAgent($sentences))
+            ->prompt($value, provider: $provider, model: $model, timeout: $timeout)->text);
 
         // Reranking macro...
         Collection::macro('rerank', function (

--- a/tests/Feature/SummarizeMacroTest.php
+++ b/tests/Feature/SummarizeMacroTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Support\Str;
+use Laravel\Ai\Agents\SummarizeAgent;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Providers\OpenAiProvider;
+
+test('summary can be generated from stringable macro', function (): void {
+    SummarizeAgent::fake(['A short summary.']);
+
+    $summary = Str::of('A very long piece of text that needs summarizing.')->summarize();
+
+    expect($summary)->toBe('A short summary.');
+
+    SummarizeAgent::assertPrompted(fn (AgentPrompt $prompt): bool => $prompt->prompt === 'A very long piece of text that needs summarizing.'
+        && str_contains($prompt->agent->instructions(), '3 sentences'));
+});
+
+test('summary honors requested sentence count', function (): void {
+    SummarizeAgent::fake();
+
+    str('Some text.')->summarize(sentences: 1);
+
+    SummarizeAgent::assertPrompted(fn (AgentPrompt $prompt): bool => str_contains($prompt->agent->instructions(), '1 sentence')
+        && ! str_contains($prompt->agent->instructions(), '1 sentences'));
+});
+
+test('summary uses the cheapest model by default', function (): void {
+    SummarizeAgent::fake();
+
+    str('Some text.')->summarize();
+
+    SummarizeAgent::assertPrompted(fn (AgentPrompt $prompt): bool => $prompt->model === $prompt->provider->cheapestTextModel());
+});
+
+test('summary can be generated from static Str macro', function (): void {
+    SummarizeAgent::fake(['A short summary.']);
+
+    $summary = Str::summarize('A very long piece of text that needs summarizing.', sentences: 4);
+
+    expect($summary)->toBe('A short summary.');
+
+    SummarizeAgent::assertPrompted(fn (AgentPrompt $prompt): bool => $prompt->prompt === 'A very long piece of text that needs summarizing.'
+        && str_contains($prompt->agent->instructions(), '4 sentences'));
+});
+
+test('summary macro passes through options', function (): void {
+    SummarizeAgent::fake();
+
+    str('Some text.')->summarize(
+        sentences: 4,
+        provider: Lab::OpenAI,
+        model: 'custom-model',
+        timeout: 45,
+    );
+
+    SummarizeAgent::assertPrompted(fn (AgentPrompt $prompt): bool => $prompt->prompt === 'Some text.'
+        && $prompt->provider instanceof OpenAiProvider
+        && $prompt->model === 'custom-model'
+        && $prompt->timeout === 45);
+});


### PR DESCRIPTION
Currently there isn't a simple way to summarize a chunk of text. You spin up
an agent and write the prompt yourself every time.

This PR adds a `summarize` helper in two forms, backed by a dedicated
SummarizeAgent:

```php
str($article)->summarize();              // ~3 sentences, default provider/model
str($article)->summarize(sentences: 4);  // control the length
Str::summarize($article, sentences: 4);  // static form
```


Credit to @taylorotwell for the idea and the API shape.