### PR TITLE
Add AG-UI protocol streaming support

### DIFF
--- a/src/Responses/Concerns/CanStreamUsingAgUiProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingAgUiProtocol.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace Laravel\Ai\Responses\Concerns;
+
+use Generator;
+use Laravel\Ai\Streaming\Events\Citation;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+trait CanStreamUsingAgUiProtocol
+{
+    /**
+     * Create an HTTP response using the Agent User Interaction Protocol.
+     */
+    protected function toAgUiProtocolResponse(): Response
+    {
+        $state = new class
+        {
+            public bool $runFinished = false;
+
+            public ?string $activeTextMessageId = null;
+
+            public ?string $activeTextSourceId = null;
+
+            public ?string $activeReasoningMessageId = null;
+
+            public ?string $activeReasoningSourceId = null;
+
+            public ?string $lastMessageId = null;
+
+            /** @var array<string, int> */
+            public array $messageIdUses = [];
+
+            /** @var array<string, true> */
+            public array $toolCallIds = [];
+        };
+
+        return response()->stream(function () use ($state) {
+            $threadId = $this->agUiThreadId ?? $this->conversationId ?? $this->invocationId;
+            $runId = $this->agUiRunId ?? $this->invocationId;
+
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'RUN_STARTED',
+                'threadId' => $threadId,
+                'runId' => $runId,
+            ]);
+
+            try {
+                foreach ($this as $event) {
+                    if ($state->runFinished) {
+                        continue;
+                    }
+
+                    yield from $this->toAgUiProtocolEvents($state, $event, $threadId, $runId);
+                }
+            } catch (Throwable $e) {
+                // Report the exception to the handler by hand: the stream is already open, so it is closed with a terminal frame instead of being re-thrown out of the send callback.
+                report($e);
+
+                if (! $state->runFinished) {
+                    yield from $this->closeAgUiMessages($state);
+
+                    $state->runFinished = true;
+
+                    yield $this->toAgUiProtocolFrame([
+                        'type' => 'RUN_ERROR',
+                        'message' => $e->getMessage(),
+                        'code' => 'error',
+                    ]);
+                }
+            }
+
+            if (! $state->runFinished) {
+                yield from $this->closeAgUiMessages($state);
+                yield $this->finishAgUiRun($state, $threadId, $runId);
+            }
+        }, headers: [
+            'Cache-Control' => 'no-cache, no-transform',
+            'Content-Type' => 'text/event-stream',
+        ]);
+    }
+
+    /**
+     * Translate a Laravel AI stream event into one or more AG-UI events.
+     */
+    protected function toAgUiProtocolEvents(object $state, StreamEvent $event, string $threadId, string $runId): Generator
+    {
+        if ($event instanceof StreamStart) {
+            return;
+        }
+
+        if ($event instanceof TextStart) {
+            // Defer TEXT_MESSAGE_START to the first non-empty delta so a content-less text block emits no empty message.
+            return;
+        }
+
+        if ($event instanceof TextDelta) {
+            if ($event->delta === '') {
+                return;
+            }
+
+            yield from $this->startAgUiTextMessage($state, $event->messageId);
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'TEXT_MESSAGE_CONTENT',
+                'messageId' => $state->activeTextMessageId,
+                'delta' => $event->delta,
+            ]);
+
+            return;
+        }
+
+        if ($event instanceof TextEnd) {
+            if ($state->activeTextSourceId === $event->messageId) {
+                yield from $this->endAgUiTextMessage($state);
+            }
+
+            return;
+        }
+
+        if ($event instanceof ReasoningStart) {
+            yield from $this->startAgUiReasoningMessage($state, $event->reasoningId);
+
+            return;
+        }
+
+        if ($event instanceof ReasoningDelta) {
+            if ($event->delta === '') {
+                return;
+            }
+
+            yield from $this->startAgUiReasoningMessage($state, $event->reasoningId);
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'REASONING_MESSAGE_CONTENT',
+                'messageId' => $state->activeReasoningMessageId,
+                'delta' => $event->delta,
+            ]);
+
+            return;
+        }
+
+        if ($event instanceof ReasoningEnd) {
+            if ($state->activeReasoningSourceId === $event->reasoningId) {
+                yield from $this->endAgUiReasoningMessage($state);
+            }
+
+            return;
+        }
+
+        if ($event instanceof ToolCall) {
+            yield from $this->closeAgUiMessages($state);
+            yield from $this->startAgUiToolCall($state, $event->toolCall->id, $event->toolCall->name, $event->toolCall->arguments);
+
+            return;
+        }
+
+        if ($event instanceof ToolResult) {
+            yield from $this->closeAgUiMessages($state);
+
+            // On an approval-resume the tool call was introduced in a prior run, so synthesize its start/end here to keep the result from being orphaned.
+            if (! isset($state->toolCallIds[$event->toolResult->id])) {
+                yield from $this->startAgUiToolCall($state, $event->toolResult->id, $event->toolResult->name, $event->toolResult->arguments);
+            }
+
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'TOOL_CALL_RESULT',
+                'messageId' => $event->toolResult->resultId ?? $event->id,
+                'toolCallId' => $event->toolResult->id,
+                'content' => $this->encodeAgUiContent($event),
+                'role' => 'tool',
+            ]);
+
+            return;
+        }
+
+        if ($event instanceof ToolApprovalRequest) {
+            yield from $this->closeAgUiMessages($state);
+
+            $interrupts = $event->pendingApprovals->values()->map(fn ($approval): array => [
+                'id' => $approval->id,
+                'reason' => 'tool_call',
+                'message' => $approval->reason ?? "Approve the {$approval->tool} tool call?",
+                'toolCallId' => $approval->id,
+                'responseSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'approved' => ['type' => 'boolean'],
+                        'editedArgs' => ['type' => 'object'],
+                    ],
+                    'required' => ['approved'],
+                ],
+            ])->all();
+
+            $state->runFinished = true;
+
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'RUN_FINISHED',
+                'threadId' => $threadId,
+                'runId' => $runId,
+                'outcome' => [
+                    'type' => 'interrupt',
+                    'interrupts' => $interrupts,
+                ],
+            ]);
+
+            return;
+        }
+
+        if ($event instanceof Error) {
+            if ($event->recoverable) {
+                yield $this->toAgUiProtocolFrame([
+                    'type' => 'CUSTOM',
+                    'name' => 'error',
+                    'value' => $event->toArray(),
+                ]);
+
+                return;
+            }
+
+            yield from $this->closeAgUiMessages($state);
+
+            $state->runFinished = true;
+
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'RUN_ERROR',
+                'message' => $event->message,
+                'code' => $event->type,
+            ]);
+
+            return;
+        }
+
+        if ($event instanceof Citation) {
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'CUSTOM',
+                'name' => 'citation',
+                'value' => $event->toArray(),
+            ]);
+
+            return;
+        }
+
+        if ($event instanceof ProviderToolEvent) {
+            yield $this->toAgUiProtocolFrame([
+                'type' => 'CUSTOM',
+                'name' => $event->type,
+                'value' => $event->toArray(),
+            ]);
+        }
+    }
+
+    /**
+     * Emit the AG-UI start/args/end frames for a single tool call.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    protected function startAgUiToolCall(object $state, string $toolCallId, string $toolCallName, array $arguments): Generator
+    {
+        $start = [
+            'type' => 'TOOL_CALL_START',
+            'toolCallId' => $toolCallId,
+            'toolCallName' => $toolCallName,
+        ];
+
+        if ($state->lastMessageId !== null) {
+            $start['parentMessageId'] = $state->lastMessageId;
+        }
+
+        yield $this->toAgUiProtocolFrame($start);
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'TOOL_CALL_ARGS',
+            'toolCallId' => $toolCallId,
+            'delta' => $arguments === [] ? '{}' : $this->encodeAgUiValue($arguments),
+        ]);
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'TOOL_CALL_END',
+            'toolCallId' => $toolCallId,
+        ]);
+
+        $state->toolCallIds[$toolCallId] = true;
+    }
+
+    /**
+     * Start an AG-UI text message, closing any open message first.
+     */
+    protected function startAgUiTextMessage(object $state, string $messageId): Generator
+    {
+        if ($state->activeTextSourceId === $messageId) {
+            return;
+        }
+
+        yield from $this->closeAgUiMessages($state);
+
+        $resolved = $this->resolveAgUiMessageId($state, $messageId);
+
+        $state->activeTextSourceId = $messageId;
+        $state->activeTextMessageId = $resolved;
+        $state->lastMessageId = $resolved;
+
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'TEXT_MESSAGE_START',
+            'messageId' => $resolved,
+            'role' => 'assistant',
+        ]);
+    }
+
+    /**
+     * End the active AG-UI text message.
+     */
+    protected function endAgUiTextMessage(object $state): Generator
+    {
+        if ($state->activeTextMessageId === null) {
+            return;
+        }
+
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'TEXT_MESSAGE_END',
+            'messageId' => $state->activeTextMessageId,
+        ]);
+
+        $state->messageIdUses[$state->activeTextSourceId] = ($state->messageIdUses[$state->activeTextSourceId] ?? 0) + 1;
+        $state->activeTextMessageId = null;
+        $state->activeTextSourceId = null;
+    }
+
+    /**
+     * Start an AG-UI reasoning message, closing any open message first.
+     */
+    protected function startAgUiReasoningMessage(object $state, string $messageId): Generator
+    {
+        if ($state->activeReasoningSourceId === $messageId) {
+            return;
+        }
+
+        yield from $this->closeAgUiMessages($state);
+
+        $resolved = $this->resolveAgUiMessageId($state, $messageId);
+
+        $state->activeReasoningSourceId = $messageId;
+        $state->activeReasoningMessageId = $resolved;
+
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'REASONING_START',
+            'messageId' => $resolved,
+        ]);
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'REASONING_MESSAGE_START',
+            'messageId' => $resolved,
+            'role' => 'reasoning',
+        ]);
+    }
+
+    /**
+     * End the active AG-UI reasoning message.
+     */
+    protected function endAgUiReasoningMessage(object $state): Generator
+    {
+        if ($state->activeReasoningMessageId === null) {
+            return;
+        }
+
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'REASONING_MESSAGE_END',
+            'messageId' => $state->activeReasoningMessageId,
+        ]);
+        yield $this->toAgUiProtocolFrame([
+            'type' => 'REASONING_END',
+            'messageId' => $state->activeReasoningMessageId,
+        ]);
+
+        $state->messageIdUses[$state->activeReasoningSourceId] = ($state->messageIdUses[$state->activeReasoningSourceId] ?? 0) + 1;
+        $state->activeReasoningMessageId = null;
+        $state->activeReasoningSourceId = null;
+    }
+
+    /**
+     * Resolve a unique AG-UI message id, deriving a fresh id when one is reopened.
+     */
+    protected function resolveAgUiMessageId(object $state, string $messageId): string
+    {
+        $uses = $state->messageIdUses[$messageId] ?? 0;
+
+        return $uses === 0 ? $messageId : $messageId.'#'.$uses;
+    }
+
+    /**
+     * Close any active AG-UI text or reasoning message.
+     */
+    protected function closeAgUiMessages(object $state): Generator
+    {
+        yield from $this->endAgUiReasoningMessage($state);
+        yield from $this->endAgUiTextMessage($state);
+    }
+
+    /**
+     * Finish the active AG-UI run successfully.
+     */
+    protected function finishAgUiRun(object $state, string $threadId, string $runId): string
+    {
+        $state->runFinished = true;
+
+        return $this->toAgUiProtocolFrame([
+            'type' => 'RUN_FINISHED',
+            'threadId' => $threadId,
+            'runId' => $runId,
+            'outcome' => ['type' => 'success'],
+        ]);
+    }
+
+    /**
+     * Get the protocol content for a tool result.
+     */
+    protected function encodeAgUiContent(ToolResult $event): string
+    {
+        if ($event->denied) {
+            return $event->error ?? 'The user rejected this tool call.';
+        }
+
+        if (! $event->successful) {
+            return $event->error ?? 'The tool call failed.';
+        }
+
+        return is_string($event->toolResult->result)
+            ? $event->toolResult->result
+            : $this->encodeAgUiValue($event->toolResult->result);
+    }
+
+    /**
+     * JSON encode a value embedded as AG-UI string content.
+     */
+    protected function encodeAgUiValue(mixed $value): string
+    {
+        return (string) json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+    }
+
+    /**
+     * Encode an AG-UI event as a server-sent event frame.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    protected function toAgUiProtocolFrame(array $event): string
+    {
+        $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR;
+
+        $json = json_encode($event, $flags);
+
+        // json_encode can still fail (e.g. nesting beyond the depth limit); fall back to a valid frame that preserves the event type rather than emitting a malformed empty data line.
+        if ($json === false) {
+            $json = (string) json_encode(['type' => $event['type'] ?? 'RAW'], $flags);
+        }
+
+        return 'data: '.$json."\n\n";
+    }
+}

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -17,6 +17,7 @@ use Traversable;
 
 class StreamableAgentResponse implements IteratorAggregate, Responsable
 {
+    use Concerns\CanStreamUsingAgUiProtocol;
     use Concerns\CanStreamUsingVercelProtocol;
 
     public ?string $text = null;
@@ -35,6 +36,12 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     protected bool $usesVercelProtocol = false;
 
     protected ?string $vercelProtocolMessageId = null;
+
+    protected bool $usesAgUiProtocol = false;
+
+    protected ?string $agUiThreadId = null;
+
+    protected ?string $agUiRunId = null;
 
     protected ?StreamedAgentResponse $streamedResponse = null;
 
@@ -122,12 +129,32 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     }
 
     /**
+     * Stream the response using the AG-UI protocol.
+     *
+     * Pass a $threadId to correlate runs across turns; without one, a conversation started during this turn cannot be reflected in RUN_STARTED and the thread falls back to the invocation id.
+     *
+     * See: https://docs.ag-ui.com/concepts/events
+     */
+    public function usingAgUiProtocol(?string $threadId = null, ?string $runId = null): self
+    {
+        $this->usesAgUiProtocol = true;
+        $this->agUiThreadId = $threadId;
+        $this->agUiRunId = $runId;
+
+        return $this;
+    }
+
+    /**
      * Create an HTTP response that represents the object.
      *
      * @param  Request  $request
      */
     public function toResponse($request): Response
     {
+        if ($this->usesAgUiProtocol) {
+            return $this->toAgUiProtocolResponse();
+        }
+
         if ($this->usesVercelProtocol) {
             return $this->toVercelProtocolResponse();
         }

--- a/tests/Feature/AgUiProtocolStreamTest.php
+++ b/tests/Feature/AgUiProtocolStreamTest.php
@@ -1,0 +1,281 @@
+<?php
+
+use Illuminate\Support\Facades\Exceptions;
+use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Responses\Data;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\StreamEnd;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
+use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @return array{response: Response, events: array<int, array<string, mixed>>}
+ */
+function agUiProtocolResponse(array $events, ?string $threadId = null, ?string $runId = null, ?string $conversationId = null): array
+{
+    $stream = (new StreamableAgentResponse('invocation-1', fn () => yield from $events, new Data\Meta('anthropic', 'claude-sonnet-4-6')))
+        ->withinConversation($conversationId)
+        ->usingAgUiProtocol(threadId: $threadId, runId: $runId);
+
+    $response = $stream->toResponse(request());
+    $output = '';
+
+    ob_start(function (string $buffer) use (&$output): string {
+        $output .= $buffer;
+
+        return '';
+    });
+
+    $response->sendContent();
+
+    ob_end_clean();
+
+    $decoded = collect(explode("\n\n", trim($output)))
+        ->map(fn (string $frame): string => str_replace('data: ', '', $frame))
+        ->map(fn (string $payload): array => json_decode($payload, true, flags: JSON_THROW_ON_ERROR))
+        ->all();
+
+    return ['response' => $response, 'events' => $decoded];
+}
+
+test('it streams text reasoning and tools using the ag ui event protocol', function () {
+    $result = agUiProtocolResponse([
+        new StreamStart('stream-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new TextStart('event-1', 'message-1', time()),
+        new TextDelta('event-2', 'message-1', 'I will check.', time()),
+        new TextEnd('event-3', 'message-1', time()),
+        new ReasoningStart('event-4', 'reasoning-1', time()),
+        new ReasoningDelta('event-5', 'reasoning-1', 'Looking it up.', time()),
+        new ReasoningEnd('event-6', 'reasoning-1', time()),
+        new ToolCall('event-7', new Data\ToolCall('call-1', 'GetWeather', ['city' => 'Lisbon']), time()),
+        new ToolResult('result-message-1', new Data\ToolResult('call-1', 'GetWeather', ['city' => 'Lisbon'], ['condition' => 'sunny']), true, null, time()),
+        new StreamEnd('event-8', 'stop', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-1');
+
+    expect($result['events'])->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-1'],
+        ['type' => 'TEXT_MESSAGE_START', 'messageId' => 'message-1', 'role' => 'assistant'],
+        ['type' => 'TEXT_MESSAGE_CONTENT', 'messageId' => 'message-1', 'delta' => 'I will check.'],
+        ['type' => 'TEXT_MESSAGE_END', 'messageId' => 'message-1'],
+        ['type' => 'REASONING_START', 'messageId' => 'reasoning-1'],
+        ['type' => 'REASONING_MESSAGE_START', 'messageId' => 'reasoning-1', 'role' => 'reasoning'],
+        ['type' => 'REASONING_MESSAGE_CONTENT', 'messageId' => 'reasoning-1', 'delta' => 'Looking it up.'],
+        ['type' => 'REASONING_MESSAGE_END', 'messageId' => 'reasoning-1'],
+        ['type' => 'REASONING_END', 'messageId' => 'reasoning-1'],
+        ['type' => 'TOOL_CALL_START', 'toolCallId' => 'call-1', 'toolCallName' => 'GetWeather', 'parentMessageId' => 'message-1'],
+        ['type' => 'TOOL_CALL_ARGS', 'toolCallId' => 'call-1', 'delta' => '{"city":"Lisbon"}'],
+        ['type' => 'TOOL_CALL_END', 'toolCallId' => 'call-1'],
+        ['type' => 'TOOL_CALL_RESULT', 'messageId' => 'result-message-1', 'toolCallId' => 'call-1', 'content' => '{"condition":"sunny"}', 'role' => 'tool'],
+        ['type' => 'RUN_FINISHED', 'threadId' => 'thread-1', 'runId' => 'run-1', 'outcome' => ['type' => 'success']],
+    ])->and($result['response']->headers->get('Content-Type'))->toContain('text/event-stream')
+        ->and($result['response']->headers->get('Cache-Control'))->toContain('no-cache')
+        ->and($result['events'])->not->toContain('[DONE]');
+});
+
+test('it synthesizes required run and message lifecycle events', function () {
+    $result = agUiProtocolResponse([
+        new TextDelta('event-1', 'message-1', 'Hello', time()),
+    ], conversationId: 'conversation-1');
+
+    expect($result['events'])->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'conversation-1', 'runId' => 'invocation-1'],
+        ['type' => 'TEXT_MESSAGE_START', 'messageId' => 'message-1', 'role' => 'assistant'],
+        ['type' => 'TEXT_MESSAGE_CONTENT', 'messageId' => 'message-1', 'delta' => 'Hello'],
+        ['type' => 'TEXT_MESSAGE_END', 'messageId' => 'message-1'],
+        ['type' => 'RUN_FINISHED', 'threadId' => 'conversation-1', 'runId' => 'invocation-1', 'outcome' => ['type' => 'success']],
+    ]);
+});
+
+test('a stream error terminates the ag ui run with run error', function () {
+    $result = agUiProtocolResponse([
+        new TextDelta('event-1', 'message-1', 'Partial', time()),
+        new Error('event-2', 'server_error', 'Server overloaded', false, time()),
+        new StreamEnd('event-3', 'error', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-1');
+
+    expect($result['events'])->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-1'],
+        ['type' => 'TEXT_MESSAGE_START', 'messageId' => 'message-1', 'role' => 'assistant'],
+        ['type' => 'TEXT_MESSAGE_CONTENT', 'messageId' => 'message-1', 'delta' => 'Partial'],
+        ['type' => 'TEXT_MESSAGE_END', 'messageId' => 'message-1'],
+        ['type' => 'RUN_ERROR', 'message' => 'Server overloaded', 'code' => 'server_error'],
+    ]);
+});
+
+test('a resumed run emits a result for a tool call from the interrupted run', function () {
+    $result = agUiProtocolResponse([
+        new ToolResult('result-message-1', new Data\ToolResult('call-1', 'DeleteFile', ['path' => 'a.txt'], 'deleted'), true, null, time()),
+        new TextDelta('event-1', 'message-1', 'Done.', time()),
+        new StreamEnd('event-2', 'stop', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-2');
+
+    expect($result['events'])->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-2'],
+        ['type' => 'TOOL_CALL_START', 'toolCallId' => 'call-1', 'toolCallName' => 'DeleteFile'],
+        ['type' => 'TOOL_CALL_ARGS', 'toolCallId' => 'call-1', 'delta' => '{"path":"a.txt"}'],
+        ['type' => 'TOOL_CALL_END', 'toolCallId' => 'call-1'],
+        ['type' => 'TOOL_CALL_RESULT', 'messageId' => 'result-message-1', 'toolCallId' => 'call-1', 'content' => 'deleted', 'role' => 'tool'],
+        ['type' => 'TEXT_MESSAGE_START', 'messageId' => 'message-1', 'role' => 'assistant'],
+        ['type' => 'TEXT_MESSAGE_CONTENT', 'messageId' => 'message-1', 'delta' => 'Done.'],
+        ['type' => 'TEXT_MESSAGE_END', 'messageId' => 'message-1'],
+        ['type' => 'RUN_FINISHED', 'threadId' => 'thread-1', 'runId' => 'run-2', 'outcome' => ['type' => 'success']],
+    ]);
+});
+
+test('reasoning interleaved within a text message does not reuse a message id', function () {
+    $result = agUiProtocolResponse([
+        new TextDelta('event-1', 'message-1', 'Before', time()),
+        new ReasoningDelta('event-2', 'reasoning-1', 'Thinking.', time()),
+        new TextDelta('event-3', 'message-1', 'After', time()),
+        new TextEnd('event-4', 'message-1', time()),
+        new StreamEnd('event-5', 'stop', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-1');
+
+    $starts = collect($result['events'])
+        ->where('type', 'TEXT_MESSAGE_START')
+        ->pluck('messageId');
+
+    expect($result['events'])->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-1'],
+        ['type' => 'TEXT_MESSAGE_START', 'messageId' => 'message-1', 'role' => 'assistant'],
+        ['type' => 'TEXT_MESSAGE_CONTENT', 'messageId' => 'message-1', 'delta' => 'Before'],
+        ['type' => 'TEXT_MESSAGE_END', 'messageId' => 'message-1'],
+        ['type' => 'REASONING_START', 'messageId' => 'reasoning-1'],
+        ['type' => 'REASONING_MESSAGE_START', 'messageId' => 'reasoning-1', 'role' => 'reasoning'],
+        ['type' => 'REASONING_MESSAGE_CONTENT', 'messageId' => 'reasoning-1', 'delta' => 'Thinking.'],
+        ['type' => 'REASONING_MESSAGE_END', 'messageId' => 'reasoning-1'],
+        ['type' => 'REASONING_END', 'messageId' => 'reasoning-1'],
+        ['type' => 'TEXT_MESSAGE_START', 'messageId' => 'message-1#1', 'role' => 'assistant'],
+        ['type' => 'TEXT_MESSAGE_CONTENT', 'messageId' => 'message-1#1', 'delta' => 'After'],
+        ['type' => 'TEXT_MESSAGE_END', 'messageId' => 'message-1#1'],
+        ['type' => 'RUN_FINISHED', 'threadId' => 'thread-1', 'runId' => 'run-1', 'outcome' => ['type' => 'success']],
+    ])->and($starts->duplicates())->toBeEmpty();
+});
+
+test('a recoverable error is emitted without terminating the run', function () {
+    $result = agUiProtocolResponse([
+        new TextDelta('event-1', 'message-1', 'Partial', time()),
+        new Error('event-2', 'rate_limit', 'Slow down', true, time()),
+        new TextDelta('event-3', 'message-1', 'Resumed', time()),
+        new StreamEnd('event-4', 'stop', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-1');
+
+    $types = collect($result['events'])->pluck('type');
+
+    expect($types->all())->toBe([
+        'RUN_STARTED',
+        'TEXT_MESSAGE_START',
+        'TEXT_MESSAGE_CONTENT',
+        'CUSTOM',
+        'TEXT_MESSAGE_CONTENT',
+        'TEXT_MESSAGE_END',
+        'RUN_FINISHED',
+    ])->and($types)->not->toContain('RUN_ERROR')
+        ->and($result['events'][3]['name'])->toBe('error');
+});
+
+test('a content-less text block emits no empty message frames', function () {
+    $result = agUiProtocolResponse([
+        new TextStart('event-1', 'message-1', time()),
+        new TextEnd('event-2', 'message-1', time()),
+        new ToolCall('event-3', new Data\ToolCall('call-1', 'GetWeather', ['city' => 'Lisbon']), time()),
+        new StreamEnd('event-4', 'stop', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-1');
+
+    expect(collect($result['events'])->pluck('type')->all())->toBe([
+        'RUN_STARTED',
+        'TOOL_CALL_START',
+        'TOOL_CALL_ARGS',
+        'TOOL_CALL_END',
+        'RUN_FINISHED',
+    ]);
+});
+
+test('an exception thrown mid stream terminates the run cleanly and reports the exception', function () {
+    Exceptions::fake();
+
+    $events = (function () {
+        yield new TextDelta('event-1', 'message-1', 'Partial', time());
+
+        throw new RuntimeException('Stream exploded');
+    })();
+
+    $stream = (new StreamableAgentResponse('invocation-1', fn () => yield from $events, new Data\Meta('anthropic', 'claude-sonnet-4-6')))
+        ->usingAgUiProtocol(threadId: 'thread-1', runId: 'run-1');
+
+    $response = $stream->toResponse(request());
+
+    $output = '';
+    ob_start(function (string $buffer) use (&$output): string {
+        $output .= $buffer;
+
+        return '';
+    });
+
+    // The exception must not escape the send callback, or the framework would append error output after the SSE terminal.
+    $response->sendContent();
+
+    ob_end_clean();
+
+    $decoded = collect(explode("\n\n", trim($output)))
+        ->filter()
+        ->map(fn (string $frame): array => json_decode(str_replace('data: ', '', $frame), true, flags: JSON_THROW_ON_ERROR));
+
+    expect($decoded->last())->toBe([
+        'type' => 'RUN_ERROR',
+        'message' => 'Stream exploded',
+        'code' => 'error',
+    ])->and($decoded->pluck('type'))->toContain('TEXT_MESSAGE_END');
+
+    Exceptions::assertReported(RuntimeException::class);
+});
+
+test('tool approvals finish the ag ui run with interrupt outcomes', function () {
+    $result = agUiProtocolResponse([
+        new ToolCall('event-1', new Data\ToolCall('call-1', 'DeleteFile', ['path' => 'a.txt']), time()),
+        new ToolApprovalRequest('event-2', collect([
+            new PendingApproval('call-1', 'DeleteFile', ['path' => 'a.txt'], 'Deleting files requires confirmation.'),
+        ]), time()),
+        new StreamEnd('event-3', 'tool_calls', new Usage, time()),
+    ], threadId: 'thread-1', runId: 'run-1');
+
+    expect($result['events'])->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-1'],
+        ['type' => 'TOOL_CALL_START', 'toolCallId' => 'call-1', 'toolCallName' => 'DeleteFile'],
+        ['type' => 'TOOL_CALL_ARGS', 'toolCallId' => 'call-1', 'delta' => '{"path":"a.txt"}'],
+        ['type' => 'TOOL_CALL_END', 'toolCallId' => 'call-1'],
+        [
+            'type' => 'RUN_FINISHED',
+            'threadId' => 'thread-1',
+            'runId' => 'run-1',
+            'outcome' => [
+                'type' => 'interrupt',
+                'interrupts' => [[
+                    'id' => 'call-1',
+                    'reason' => 'tool_call',
+                    'message' => 'Deleting files requires confirmation.',
+                    'toolCallId' => 'call-1',
+                    'responseSchema' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'approved' => ['type' => 'boolean'],
+                            'editedArgs' => ['type' => 'object'],
+                        ],
+                        'required' => ['approved'],
+                    ],
+                ]],
+            ],
+        ],
+    ]);
+});


### PR DESCRIPTION
Currently a streamed agent response can only speak the Vercel AI SDK protocol (`usingVercelDataProtocol`). There's no built-in way to stream to an [AG-UI](https://docs.ag-ui.com/concepts/events) compatible client (CopilotKit and friends), so you'd have to translate the event stream into AG-UI frames yourself.

This PR adds a sibling protocol you opt into the same way:

```php
return $agent->stream($prompt)
    ->usingAgUiProtocol(threadId: $conversationId, runId: $runId);
```

It maps the Laravel AI stream events (text, reasoning, tool calls/results, approvals, citations, provider tool events, errors) onto the AG-UI SSE frames (`RUN_STARTED`, `TEXT_MESSAGE_*`, `REASONING_*`, `TOOL_CALL_*`, `RUN_FINISHED`/`RUN_ERROR`, `CUSTOM`) and follows the same anonymous-state plus `response()->stream` shape as the Vercel trait.

Tests included.