### PR TITLE
[0.x] Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,8 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 CHANGELOG.md export-ignore
-phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore
+phpstan.neon.dist export-ignore
 rector.php export-ignore
 testbench.yaml export-ignore
 UPGRADE.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,9 +9,13 @@
 /.github export-ignore
 /art export-ignore
 /tests export-ignore
+/workbench export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 CHANGELOG.md export-ignore
+phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore
+rector.php export-ignore
+testbench.yaml export-ignore
 UPGRADE.md export-ignore


### PR DESCRIPTION
This adds the below to export ignore 
- /workbench -
- `phpstan.neon.dist`
-  `rector.php`
- `testbench.yaml`

We don't need them exported:
<img width="293" height="308" alt="Screenshot 2026-07-21 at 17 30 24" src="https://github.com/user-attachments/assets/7571adfb-2169-4f26-a901-cba81a1a3b94" />

This means, end users dont end up with them in their vendor..
Saves a bunch of data cos the workbench folder 

HYB