### PR TITLE
Update Gemini default models

### DIFF
--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -93,7 +93,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['text']['default'] ?? 'gemini-3.5-flash';
+        return $this->config['models']['text']['default'] ?? 'gemini-3.6-flash';
     }
 
     /**
@@ -101,7 +101,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['text']['cheapest'] ?? 'gemini-3.1-flash-lite';
+        return $this->config['models']['text']['cheapest'] ?? 'gemini-3.5-flash-lite';
     }
 
     /**
@@ -109,7 +109,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['text']['smartest'] ?? 'gemini-3.5-flash';
+        return $this->config['models']['text']['smartest'] ?? 'gemini-3.6-flash';
     }
 
     /**

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -163,7 +163,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultEmbeddingsModel(): string
     {
-        return $this->config['models']['embeddings']['default'] ?? 'gemini-embedding-001';
+        return $this->config['models']['embeddings']['default'] ?? 'gemini-embedding-2';
     }
 
     /**


### PR DESCRIPTION
Currently the Gemini provider defaults to `gemini-3.5-flash` for text, `gemini-3.1-flash-lite` as the cheapest model, and `gemini-embedding-001` for embeddings. This PR bumps them to the latest stable generation:

- Default and smartest text model: `gemini-3.6-flash`
- Cheapest text model: `gemini-3.5-flash-lite`
- Default embeddings model: `gemini-embedding-2`, which also unlocks multimodal embeddings out of the box

Embedding dimensions stay at 3072, and config overrides via `models.*` are unaffected. No test changes since tests pin models explicitly.
