### PR TITLE
Change minimum required AWS SDK version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "php": "^8.3",
-        "aws/aws-sdk-php": "^3.339",
+        "aws/aws-sdk-php": "^3.369.1",
         "illuminate/console": "^12.0|^13.0",
         "illuminate/container": "^12.0|^13.0",
         "illuminate/contracts": "^12.0|^13.0",


### PR DESCRIPTION
In [version 3.369.1](https://github.com/aws/aws-sdk-php/releases/tag/3.369.1) of the AWS PHP SDK, they added in stdClass as a valid type in their validator. Before this version, stdClass was rejected which causes problems with using Tools (we specifically ensure the tools input is an object) and so I'd propose we up the minimum version we depend on to match.

**EDIT: more detail**
To get this error, downgrade the AWS PHP SDK installed in the project to anything before the version listed above. Then attempt to use the Bedrock gateway for any agent with a tool made available to it.