### PR TITLE
Fail over on transient gateway and Cloudflare upstream errors, not only 503

### DIFF
--- a/src/Gateway/Concerns/HandlesFailoverErrors.php
+++ b/src/Gateway/Concerns/HandlesFailoverErrors.php
@@ -62,13 +62,18 @@ trait HandlesFailoverErrors
     }
 
     /**
-     * The status codes that indicate a provider is overloaded.
+     * The status codes that indicate a provider is transiently unavailable and the request should fail over.
+     *
+     * Covers the standard gateway errors (502 Bad Gateway, 503 Service
+     * Unavailable, 504 Gateway Timeout) and the Cloudflare "unknown error"
+     * and timeout family (520, 522, 524) that providers fronted by Cloudflare
+     * return during upstream incidents.
      *
      * @return list<int>
      */
     protected function overloadedStatusCodes(): array
     {
-        return [503];
+        return [502, 503, 504, 520, 522, 524];
     }
 
     /**

--- a/src/Gateway/Concerns/HandlesFailoverErrors.php
+++ b/src/Gateway/Concerns/HandlesFailoverErrors.php
@@ -64,11 +64,6 @@ trait HandlesFailoverErrors
     /**
      * The status codes that indicate a provider is transiently unavailable and the request should fail over.
      *
-     * Covers the standard gateway errors (502 Bad Gateway, 503 Service
-     * Unavailable, 504 Gateway Timeout) and the Cloudflare "unknown error"
-     * and timeout family (520, 522, 524) that providers fronted by Cloudflare
-     * return during upstream incidents.
-     *
      * @return list<int>
      */
     protected function overloadedStatusCodes(): array

--- a/tests/Feature/Providers/Gemini/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Gemini/ErrorHandlingTest.php
@@ -58,6 +58,19 @@ test('overloaded response throws provider overloaded exception', function (): vo
     );
 })->throws(ProviderOverloadedException::class);
 
+test('transient upstream errors fail over as overloaded', function (int $status): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'error' => ['code' => $status, 'message' => 'The service is temporarily unavailable.'],
+        ], $status),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'gemini',
+    );
+})->with([502, 504, 520, 522, 524])->throws(ProviderOverloadedException::class);
+
 test('error in 200 response throws ai exception', function (): void {
     Http::fake([
         'generativelanguage.googleapis.com/*' => Http::response([


### PR DESCRIPTION
Fixes part of #664.

Failover only fires on a small set of HTTP statuses today. `withErrorHandling` wraps `429`, `402`, and `503` as failoverable, and `overloadedStatusCodes()` is just `[503]`, so the other transient gateway errors fall through as a fatal `RequestException`. That is narrower than the failover docs, which promise failover on a "service interruption".

In the issue thread, @KSneijders reported hitting `520` from OpenAI and wiring their own failover for it, and @stuartbrameld ran into the same over-promise.

This widens the default overloaded set to the transient upstream errors:

- `502` Bad Gateway, `503` Service Unavailable, `504` Gateway Timeout
- `520`, `522`, `524`: the Cloudflare "unknown error" and timeout family that providers fronted by Cloudflare (OpenAI and others) return during upstream incidents

`500` is deliberately left out, since a bare `500` can be a deterministic error and auto-failing-over on it can mask real bugs. Anthropic keeps its own `529` override.

This is the HTTP-status half of #664. The connection-level half (`ConnectionException`, host down / refused) is handled separately in #781, so the two together cover the "service interruption" case the docs describe.

**Tests**

Added a data-driven test asserting each new code (`502`, `504`, `520`, `522`, `524`) fails over as `ProviderOverloadedException`, alongside the existing `503` test. The error-handling/failover suite, Pint, and PHPStan all pass.
