### PR TITLE
Add static message broadcasting without invoking an agent

### DIFF
--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -82,4 +82,29 @@ interface Agent
         Lab|array|string|null $provider = null,
         ?string $model = null
     ): QueuedAgentResponse;
+
+    /**
+     * Broadcast a static message without invoking the agent.
+     */
+    public function broadcastMessage(
+        string $message,
+        Channel|array $channels,
+        bool $now = false
+    ): void;
+
+    /**
+     * Broadcast a static message immediately without invoking the agent.
+     */
+    public function broadcastMessageNow(
+        string $message,
+        Channel|array $channels
+    ): void;
+
+    /**
+     * Queue a static message for broadcasting without invoking the agent.
+     */
+    public function broadcastMessageOnQueue(
+        string $message,
+        Channel|array $channels
+    ): QueuedAgentResponse;
 }

--- a/src/Jobs/BroadcastStaticMessage.php
+++ b/src/Jobs/BroadcastStaticMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Ai\Jobs;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Laravel\Ai\Contracts\Agent;
+
+class BroadcastStaticMessage implements ShouldQueue
+{
+    use Concerns\InvokesQueuedResponseCallbacks;
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Agent $agent,
+        public string $message,
+        public Channel|array $channels,
+    ) {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->withCallbacks(function (): string {
+            $this->agent->broadcastMessageNow($this->message, $this->channels);
+
+            return $this->message;
+        });
+    }
+
+    /**
+     * Get the display name for the queued job.
+     */
+    public function displayName(): string
+    {
+        return $this->agent::class;
+    }
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -22,15 +22,23 @@ use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Gateway\FakeTextGateway;
 use Laravel\Ai\Jobs\BroadcastAgent;
+use Laravel\Ai\Jobs\BroadcastStaticMessage;
 use Laravel\Ai\Jobs\InvokeAgent;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\QueuedAgentResponse;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
+use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
 use ReflectionClass;
 use RuntimeException;
 
@@ -232,6 +240,52 @@ trait Promptable
 
         return new QueuedAgentResponse(
             BroadcastAgent::dispatch($this, $prompt, $channels, $attachments, $provider, $model)
+        );
+    }
+
+    /**
+     * Broadcast a static message without invoking the agent.
+     */
+    public function broadcastMessage(string $message, Channel|array $channels, bool $now = false): void
+    {
+        $invocationId = (string) Str::uuid7();
+        $messageId = ulid();
+        $timestamp = time();
+        $without = WithoutBroadcasting::eventsFor($this);
+
+        $events = [
+            new StreamStart(ulid(), 'static', 'static', $timestamp),
+            new TextStart(ulid(), $messageId, $timestamp),
+            new TextDelta(ulid(), $messageId, $message, $timestamp),
+            new TextEnd(ulid(), $messageId, $timestamp),
+            new StreamEnd(ulid(), FinishReason::Stop->value, new Usage, $timestamp),
+        ];
+
+        foreach ($events as $event) {
+            if (WithoutBroadcasting::excludes($without, $event)) {
+                continue;
+            }
+
+            $event->withInvocationId($invocationId)
+                ->{$now ? 'broadcastNow' : 'broadcast'}($channels);
+        }
+    }
+
+    /**
+     * Broadcast a static message immediately without invoking the agent.
+     */
+    public function broadcastMessageNow(string $message, Channel|array $channels): void
+    {
+        $this->broadcastMessage($message, $channels, now: true);
+    }
+
+    /**
+     * Queue a static message for broadcasting without invoking the agent.
+     */
+    public function broadcastMessageOnQueue(string $message, Channel|array $channels): QueuedAgentResponse
+    {
+        return new QueuedAgentResponse(
+            BroadcastStaticMessage::dispatch($this, $message, $channels)
         );
     }
 

--- a/tests/Feature/StaticMessageBroadcastTest.php
+++ b/tests/Feature/StaticMessageBroadcastTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Broadcasting\AnonymousEvent;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Ai\Jobs\BroadcastStaticMessage;
+use Laravel\Ai\Responses\QueuedAgentResponse;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+test('a static message broadcasts a complete stream without prompting the agent', function (): void {
+    Event::fake();
+    AssistantAgent::fake()->preventStrayPrompts();
+
+    $channel = new Channel('announcements');
+
+    (new AssistantAgent)->broadcastMessageNow('Welcome aboard!', $channel);
+
+    AssistantAgent::assertNeverPrompted();
+
+    $events = collect(Event::dispatched(AnonymousEvent::class))
+        ->map(fn (array $arguments): AnonymousEvent => $arguments[0]);
+    $payloads = $events->map(fn (AnonymousEvent $event): array => $event->broadcastWith());
+
+    expect($events->map(fn (AnonymousEvent $event): string => $event->broadcastAs())->all())
+        ->toBe(['stream_start', 'text_start', 'text_delta', 'text_end', 'stream_end'])
+        ->and($events->every(fn (AnonymousEvent $event): bool => $event->broadcastOn() === [$channel]))->toBeTrue()
+        ->and($payloads->pluck('invocation_id')->unique())->toHaveCount(1)
+        ->and($payloads[0]['provider'])->toBe('static')
+        ->and($payloads[0]['model'])->toBe('static')
+        ->and($payloads[2]['delta'])->toBe('Welcome aboard!')
+        ->and($payloads[4]['reason'])->toBe('stop')
+        ->and($payloads[4]['usage'])->toBe([
+            'prompt_tokens' => 0,
+            'completion_tokens' => 0,
+            'cache_write_input_tokens' => 0,
+            'cache_read_input_tokens' => 0,
+            'reasoning_tokens' => 0,
+        ]);
+});
+
+test('a static message can be queued for broadcasting', function (): void {
+    Queue::fake();
+
+    $channel = new Channel('announcements');
+
+    $response = (new AssistantAgent)->broadcastMessageOnQueue('Scheduled maintenance.', $channel);
+
+    expect($response)->toBeInstanceOf(QueuedAgentResponse::class);
+
+    unset($response);
+
+    Queue::assertPushed(BroadcastStaticMessage::class, fn (BroadcastStaticMessage $job): bool => $job->message === 'Scheduled maintenance.'
+        && $job->channels === $channel);
+});
+
+test('the queued static message broadcasts without prompting the agent', function (): void {
+    Event::fake();
+    AssistantAgent::fake()->preventStrayPrompts();
+
+    $received = null;
+
+    $job = new BroadcastStaticMessage(
+        agent: new AssistantAgent,
+        message: 'Scheduled maintenance.',
+        channels: new Channel('announcements'),
+    );
+
+    $job->then(function (string $message) use (&$received): void {
+        $received = $message;
+    });
+
+    $job->handle();
+
+    AssistantAgent::assertNeverPrompted();
+
+    expect($received)->toBe('Scheduled maintenance.');
+
+    Event::assertDispatched(AnonymousEvent::class, fn (AnonymousEvent $event): bool => $event->broadcastAs() === 'text_delta'
+        && $event->broadcastWith()['delta'] === 'Scheduled maintenance.');
+});


### PR DESCRIPTION
Closes #147.

Static application messages currently need to go through an agent prompt before they can use the AI SDK broadcasting flow. This adds a small, symmetric API for broadcasting known text without a provider request or token usage.

The new methods emit the existing stream event lifecycle, respect `WithoutBroadcasting`, and support immediate or queued delivery. The queued path also keeps the existing then/catch callback behavior.

Validation:
- Focused static-broadcast regression: 3 tests, 14 assertions
- Unit and Feature suites: 1,883 passed, 24 skipped, 3,933 assertions
- Pint and PHPStan pass

Provider integration tests require live API credentials and were not part of the deterministic local validation.