### PR TITLE
Preserve tool result failure status across conversations

### DIFF
--- a/src/Gateway/ApprovalResumption.php
+++ b/src/Gateway/ApprovalResumption.php
@@ -11,13 +11,11 @@ class ApprovalResumption
      * @param  Message[]  $messages
      * @param  Message[]  $newMessages
      * @param  array<int, ToolResult>  $results
-     * @param  array<int, string>  $failedToolCallIds
      */
     public function __construct(
         public array $messages,
         public array $newMessages,
         public array $results,
-        public array $failedToolCallIds,
         public bool $shouldContinue,
     ) {}
 }

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -206,8 +206,8 @@ class TextGenerationLoop
                 yield (new ToolResultEvent(
                     $this->generateEventId(),
                     $toolResult,
-                    $toolResult->successful,
-                    $toolResult->error,
+                    $toolResult->successful(),
+                    $toolResult->error(),
                     time(),
                     denied: $toolResult->denied,
                 ))->withInvocationId($invocationId);
@@ -290,8 +290,8 @@ class TextGenerationLoop
                 yield (new ToolResultEvent(
                     $this->generateEventId(),
                     $toolResult,
-                    $toolResult->successful,
-                    $toolResult->error,
+                    $toolResult->successful(),
+                    $toolResult->error(),
                     time(),
                 ))->withInvocationId($invocationId);
             }
@@ -426,16 +426,13 @@ class TextGenerationLoop
                 default => $this->executeTool($tool, $toolCall->arguments, $toolCall->id, $context),
             };
 
-            $successful = $tool instanceof Tool && ! $isFinalStep;
-
             return new ToolResult(
                 $toolCall->id,
                 $toolCall->name,
                 $toolCall->arguments,
                 $result,
                 $toolCall->resultId,
-                successful: $successful,
-                error: $successful ? null : $result,
+                failed: ! $tool instanceof Tool || $isFinalStep,
             );
         }, $resolved);
 
@@ -467,7 +464,7 @@ class TextGenerationLoop
     {
         $messages = $this->settleAbandonedToolCalls($messages, exceptLatestAssistantTurn: true);
 
-        [$approvalResults, $shouldContinue, $failedToolCallIds] = $this->resolveApprovalResults($approval, $messages, $tools, $validatedApproval, $context);
+        [$approvalResults, $shouldContinue] = $this->resolveApprovalResults($approval, $messages, $tools, $validatedApproval, $context);
 
         $newMessages = [];
 
@@ -479,7 +476,6 @@ class TextGenerationLoop
             messages: $messages,
             newMessages: $newMessages,
             results: $approvalResults,
-            failedToolCallIds: $failedToolCallIds,
             shouldContinue: $shouldContinue,
         );
     }
@@ -489,14 +485,13 @@ class TextGenerationLoop
      * @param  Message[]  $messages
      * @param  array<Tool|ProviderTool>  $tools
      * @param  array{Collection<int, ToolCall>, Collection<string, ?Tool>}|null  $validatedApproval  a caller's own eager validateApproval() result, reused instead of re-validating
-     * @return array{array<int, ToolResult>, bool, array<int, string>}
+     * @return array{array<int, ToolResult>, bool}
      */
     protected function resolveApprovalResults(array $approval, array $messages, array $tools, ?array $validatedApproval = null, ?RunContext $context = null): array
     {
         [$pendingToolCalls, $resolvedTools] = $validatedApproval ?? $this->validateApproval($approval, $messages, $tools);
 
         $toolResults = [];
-        $failedToolCallIds = [];
         $hasBareRejection = false;
 
         foreach ($pendingToolCalls as $toolCall) {
@@ -532,7 +527,6 @@ class TextGenerationLoop
                 $result = $this->executeTool($tool, $arguments, $toolCall->id, $context);
             } catch (Throwable $exception) {
                 $failed = true;
-                $failedToolCallIds[] = $toolCall->id;
                 $result = 'The tool call failed: '.$exception->getMessage();
             }
 
@@ -542,12 +536,11 @@ class TextGenerationLoop
                 $arguments,
                 $result,
                 $toolCall->resultId,
-                successful: ! $failed,
-                error: $failed ? $result : null,
+                failed: $failed,
             );
         }
 
-        return [$toolResults, ! $hasBareRejection, $failedToolCallIds];
+        return [$toolResults, ! $hasBareRejection];
     }
 
     /**

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -203,13 +203,11 @@ class TextGenerationLoop
             }
 
             foreach ($resumption->results as $toolResult) {
-                $failed = in_array($toolResult->id, $resumption->failedToolCallIds, true);
-
                 yield (new ToolResultEvent(
                     $this->generateEventId(),
                     $toolResult,
-                    ! $toolResult->denied && ! $failed,
-                    $toolResult->denied || $failed ? $toolResult->result : null,
+                    $toolResult->successful,
+                    $toolResult->error,
                     time(),
                     denied: $toolResult->denied,
                 ))->withInvocationId($invocationId);
@@ -289,13 +287,11 @@ class TextGenerationLoop
             [$toolResults, $pendingApprovals] = $this->stepToolResultsWithOptions($result, $stepContext->isFinalStep, $tools, $options, $context);
 
             foreach ($toolResults as $toolResult) {
-                $successful = ! $stepContext->isFinalStep && $this->findTool($toolResult->name, $tools) instanceof Tool;
-
                 yield (new ToolResultEvent(
                     $this->generateEventId(),
                     $toolResult,
-                    $successful,
-                    $successful ? null : $toolResult->result,
+                    $toolResult->successful,
+                    $toolResult->error,
                     time(),
                 ))->withInvocationId($invocationId);
             }
@@ -424,16 +420,22 @@ class TextGenerationLoop
         $toolResults = array_map(function (array $pair) use ($tools, $isFinalStep, $context) {
             [$toolCall, $tool] = $pair;
 
+            $result = match (true) {
+                ! $tool instanceof Tool && $this->repairsToolCalls => "Tool '{$toolCall->name}' does not exist. Available tools: {$this->availableToolNames($tools)}.",
+                $isFinalStep => 'The agent reached its maximum number of steps without running this tool call.',
+                default => $this->executeTool($tool, $toolCall->arguments, $toolCall->id, $context),
+            };
+
+            $successful = $tool instanceof Tool && ! $isFinalStep;
+
             return new ToolResult(
                 $toolCall->id,
                 $toolCall->name,
                 $toolCall->arguments,
-                match (true) {
-                    ! $tool instanceof Tool && $this->repairsToolCalls => "Tool '{$toolCall->name}' does not exist. Available tools: {$this->availableToolNames($tools)}.",
-                    $isFinalStep => 'The agent reached its maximum number of steps without running this tool call.',
-                    default => $this->executeTool($tool, $toolCall->arguments, $toolCall->id, $context),
-                },
+                $result,
                 $toolCall->resultId,
+                successful: $successful,
+                error: $successful ? null : $result,
             );
         }, $resolved);
 
@@ -524,9 +526,12 @@ class TextGenerationLoop
                 throw new NoSuchToolException($toolCall->name);
             }
 
+            $failed = false;
+
             try {
                 $result = $this->executeTool($tool, $arguments, $toolCall->id, $context);
             } catch (Throwable $exception) {
+                $failed = true;
                 $failedToolCallIds[] = $toolCall->id;
                 $result = 'The tool call failed: '.$exception->getMessage();
             }
@@ -537,6 +542,8 @@ class TextGenerationLoop
                 $arguments,
                 $result,
                 $toolCall->resultId,
+                successful: ! $failed,
+                error: $failed ? $result : null,
             );
         }
 

--- a/src/Responses/Data/ToolResult.php
+++ b/src/Responses/Data/ToolResult.php
@@ -7,6 +7,10 @@ use JsonSerializable;
 
 class ToolResult implements Arrayable, JsonSerializable
 {
+    public bool $successful;
+
+    public ?string $error;
+
     public function __construct(
         public string $id,
         public string $name,
@@ -14,7 +18,12 @@ class ToolResult implements Arrayable, JsonSerializable
         public mixed $result,
         public ?string $resultId = null,
         public bool $denied = false,
-    ) {}
+        ?bool $successful = null,
+        ?string $error = null,
+    ) {
+        $this->successful = $successful ?? ! $denied;
+        $this->error = $error ?? (! $this->successful && is_string($result) ? $result : null);
+    }
 
     /**
      * Reconstruct an instance from a previously serialized toArray() payload.
@@ -28,11 +37,13 @@ class ToolResult implements Arrayable, JsonSerializable
             result: $data['result'],
             resultId: $data['result_id'] ?? null,
             denied: $data['denied'] ?? false,
+            successful: $data['successful'] ?? null,
+            error: $data['error'] ?? null,
         );
     }
 
     /**
-     * Get the instance as an array, only including the denied key when the result is a rejection.
+     * Get the instance as an array, omitting default status values.
      */
     public function toArray(): array
     {
@@ -43,6 +54,8 @@ class ToolResult implements Arrayable, JsonSerializable
             'result' => $this->result,
             'result_id' => $this->resultId,
             ...($this->denied ? ['denied' => true] : []),
+            ...(! $this->successful ? ['successful' => false] : []),
+            ...($this->error !== null ? ['error' => $this->error] : []),
         ];
     }
 

--- a/src/Responses/Data/ToolResult.php
+++ b/src/Responses/Data/ToolResult.php
@@ -7,10 +7,6 @@ use JsonSerializable;
 
 class ToolResult implements Arrayable, JsonSerializable
 {
-    public bool $successful;
-
-    public ?string $error;
-
     public function __construct(
         public string $id,
         public string $name,
@@ -18,12 +14,8 @@ class ToolResult implements Arrayable, JsonSerializable
         public mixed $result,
         public ?string $resultId = null,
         public bool $denied = false,
-        ?bool $successful = null,
-        ?string $error = null,
-    ) {
-        $this->successful = $successful ?? ! $denied;
-        $this->error = $error ?? (! $this->successful && is_string($result) ? $result : null);
-    }
+        public bool $failed = false,
+    ) {}
 
     /**
      * Reconstruct an instance from a previously serialized toArray() payload.
@@ -37,13 +29,28 @@ class ToolResult implements Arrayable, JsonSerializable
             result: $data['result'],
             resultId: $data['result_id'] ?? null,
             denied: $data['denied'] ?? false,
-            successful: $data['successful'] ?? null,
-            error: $data['error'] ?? null,
+            failed: $data['failed'] ?? false,
         );
     }
 
     /**
-     * Get the instance as an array, omitting default status values.
+     * Determine if the tool call ran and produced its own result.
+     */
+    public function successful(): bool
+    {
+        return ! $this->denied && ! $this->failed;
+    }
+
+    /**
+     * Get the message explaining why the tool call did not succeed.
+     */
+    public function error(): ?string
+    {
+        return $this->successful() || ! is_string($this->result) ? null : $this->result;
+    }
+
+    /**
+     * Get the instance as an array, only including the denied and failed keys when they apply.
      */
     public function toArray(): array
     {
@@ -54,8 +61,7 @@ class ToolResult implements Arrayable, JsonSerializable
             'result' => $this->result,
             'result_id' => $this->resultId,
             ...($this->denied ? ['denied' => true] : []),
-            ...(! $this->successful ? ['successful' => false] : []),
-            ...($this->error !== null ? ['error' => $this->error] : []),
+            ...($this->failed ? ['failed' => true] : []),
         ];
     }
 

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -148,6 +148,49 @@ test('it stores sparse keyed tool calls and results as JSON arrays', function ()
         ->and(array_is_list(json_decode((string) $record->tool_results, true)))->toBeTrue();
 });
 
+test('it restores persisted tool result failure status', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => '',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'query-resources', 'arguments' => []],
+        ]),
+        'tool_results' => json_encode([
+            [
+                'id' => 'call-1',
+                'name' => 'query-resources',
+                'arguments' => [],
+                'result' => 'Tool not found',
+                'result_id' => null,
+                'successful' => false,
+                'error' => 'Tool not found',
+            ],
+        ]),
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $result = $store->getLatestConversationMessages($conversationId, 10)
+        ->first(fn (Message $message): bool => $message instanceof ToolResultMessage)
+        ?->toolResults
+        ->first();
+
+    expect($result)->not->toBeNull()
+        ->and($result->successful)->toBeFalse()
+        ->and($result->error)->toBe('Tool not found');
+});
+
 test('a bare rejection resume does not persist a blank assistant row', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Approval conversation');

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -148,7 +148,37 @@ test('it stores sparse keyed tool calls and results as JSON arrays', function ()
         ->and(array_is_list(json_decode((string) $record->tool_results, true)))->toBeTrue();
 });
 
-test('it restores persisted tool result failure status', function (): void {
+test('it round trips tool result failure status through storage', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Where is Berlin?',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new AgentResponse('invocation-id', '', new Usage, new Meta);
+    $response->toolCalls = collect([new ToolCall('call-1', 'query-resources', [])]);
+    $response->toolResults = collect([
+        new ToolResult('call-1', 'query-resources', [], 'Tool not found', failed: true),
+    ]);
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $result = $store->getLatestConversationMessages($conversationId, 10)
+        ->first(fn (Message $message): bool => $message instanceof ToolResultMessage)
+        ?->toolResults
+        ->first();
+
+    expect($result)->not->toBeNull()
+        ->and($result->successful())->toBeFalse()
+        ->and($result->error())->toBe('Tool not found');
+});
+
+test('it treats tool results stored before the failed flag as successful', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -165,15 +195,7 @@ test('it restores persisted tool result failure status', function (): void {
             ['id' => 'call-1', 'name' => 'query-resources', 'arguments' => []],
         ]),
         'tool_results' => json_encode([
-            [
-                'id' => 'call-1',
-                'name' => 'query-resources',
-                'arguments' => [],
-                'result' => 'Tool not found',
-                'result_id' => null,
-                'successful' => false,
-                'error' => 'Tool not found',
-            ],
+            ['id' => 'call-1', 'name' => 'query-resources', 'arguments' => [], 'result' => 'Berlin', 'result_id' => null],
         ]),
         'usage' => '[]',
         'meta' => '[]',
@@ -187,8 +209,8 @@ test('it restores persisted tool result failure status', function (): void {
         ->first();
 
     expect($result)->not->toBeNull()
-        ->and($result->successful)->toBeFalse()
-        ->and($result->error)->toBe('Tool not found');
+        ->and($result->successful())->toBeTrue()
+        ->and($result->error())->toBeNull();
 });
 
 test('a bare rejection resume does not persist a blank assistant row', function (): void {

--- a/tests/Unit/Gateway/TextGenerationLoopTest.php
+++ b/tests/Unit/Gateway/TextGenerationLoopTest.php
@@ -562,8 +562,8 @@ test('it does not execute tool calls on the final generation step', function ():
         ->and($response->toolCalls)->toHaveCount(1)
         ->and($response->toolResults)->toHaveCount(1)
         ->and($response->toolResults[0]->result)->toBe('The agent reached its maximum number of steps without running this tool call.')
-        ->and($response->toolResults[0]->successful)->toBeFalse()
-        ->and($response->toolResults[0]->error)->toBe('The agent reached its maximum number of steps without running this tool call.')
+        ->and($response->toolResults[0]->successful())->toBeFalse()
+        ->and($response->toolResults[0]->error())->toBe('The agent reached its maximum number of steps without running this tool call.')
         ->and($response->steps)->toHaveCount(1)
         ->and($response->steps->first()->toolResults)->toHaveCount(1);
 });
@@ -652,8 +652,8 @@ test('it does not execute streamed tool calls on the final step', function (): v
     expect($tool->calls)->toBe(0)
         ->and($gateway->streamCalls)->toBe(1)
         ->and(collect($events)->whereInstanceOf(ToolResultEvent::class))->toHaveCount(1)
-        ->and(collect($events)->whereInstanceOf(ToolResultEvent::class)->first()->toolResult->successful)->toBeFalse()
-        ->and(collect($events)->whereInstanceOf(ToolResultEvent::class)->first()->toolResult->error)->toBe('The agent reached its maximum number of steps without running this tool call.')
+        ->and(collect($events)->whereInstanceOf(ToolResultEvent::class)->first()->successful)->toBeFalse()
+        ->and(collect($events)->whereInstanceOf(ToolResultEvent::class)->first()->error)->toBe('The agent reached its maximum number of steps without running this tool call.')
         ->and(collect($events)->whereInstanceOf(StreamEnd::class))->toHaveCount(1);
 });
 

--- a/tests/Unit/Gateway/TextGenerationLoopTest.php
+++ b/tests/Unit/Gateway/TextGenerationLoopTest.php
@@ -562,6 +562,8 @@ test('it does not execute tool calls on the final generation step', function ():
         ->and($response->toolCalls)->toHaveCount(1)
         ->and($response->toolResults)->toHaveCount(1)
         ->and($response->toolResults[0]->result)->toBe('The agent reached its maximum number of steps without running this tool call.')
+        ->and($response->toolResults[0]->successful)->toBeFalse()
+        ->and($response->toolResults[0]->error)->toBe('The agent reached its maximum number of steps without running this tool call.')
         ->and($response->steps)->toHaveCount(1)
         ->and($response->steps->first()->toolResults)->toHaveCount(1);
 });
@@ -650,6 +652,8 @@ test('it does not execute streamed tool calls on the final step', function (): v
     expect($tool->calls)->toBe(0)
         ->and($gateway->streamCalls)->toBe(1)
         ->and(collect($events)->whereInstanceOf(ToolResultEvent::class))->toHaveCount(1)
+        ->and(collect($events)->whereInstanceOf(ToolResultEvent::class)->first()->toolResult->successful)->toBeFalse()
+        ->and(collect($events)->whereInstanceOf(ToolResultEvent::class)->first()->toolResult->error)->toBe('The agent reached its maximum number of steps without running this tool call.')
         ->and(collect($events)->whereInstanceOf(StreamEnd::class))->toHaveCount(1);
 });
 

--- a/tests/Unit/Responses/Data/ToolResultTest.php
+++ b/tests/Unit/Responses/Data/ToolResultTest.php
@@ -47,3 +47,51 @@ test('tool result from array hydrates the denied flag from its key', function ()
     expect(ToolResult::fromArray(['id' => 'id', 'name' => 'name', 'arguments' => [], 'result' => 'val'])->denied)->toBeFalse()
         ->and(ToolResult::fromArray(['id' => 'id', 'name' => 'name', 'arguments' => [], 'result' => 'val', 'denied' => true])->denied)->toBeTrue();
 });
+
+test('tool result serializes failure status and error details', function (): void {
+    $result = new ToolResult(
+        id: 'call-1',
+        name: 'query-resources',
+        arguments: [],
+        result: 'Tool not found',
+        successful: false,
+        error: 'Tool not found',
+    );
+
+    expect($result->toArray())->toMatchArray([
+        'successful' => false,
+        'error' => 'Tool not found',
+    ]);
+});
+
+test('tool result hydrates status while remaining compatible with legacy payloads', function (): void {
+    $failed = ToolResult::fromArray([
+        'id' => 'call-1',
+        'name' => 'query-resources',
+        'arguments' => [],
+        'result' => 'Tool not found',
+        'successful' => false,
+        'error' => 'Tool not found',
+    ]);
+
+    $legacySuccess = ToolResult::fromArray([
+        'id' => 'call-2',
+        'name' => 'query-resources',
+        'arguments' => [],
+        'result' => 'Berlin',
+    ]);
+
+    $legacyDenied = ToolResult::fromArray([
+        'id' => 'call-3',
+        'name' => 'delete-resource',
+        'arguments' => [],
+        'result' => 'Not approved',
+        'denied' => true,
+    ]);
+
+    expect($failed->successful)->toBeFalse()
+        ->and($failed->error)->toBe('Tool not found')
+        ->and($legacySuccess->successful)->toBeTrue()
+        ->and($legacySuccess->error)->toBeNull()
+        ->and($legacyDenied->successful)->toBeFalse();
+});

--- a/tests/Unit/Responses/Data/ToolResultTest.php
+++ b/tests/Unit/Responses/Data/ToolResultTest.php
@@ -48,50 +48,22 @@ test('tool result from array hydrates the denied flag from its key', function ()
         ->and(ToolResult::fromArray(['id' => 'id', 'name' => 'name', 'arguments' => [], 'result' => 'val', 'denied' => true])->denied)->toBeTrue();
 });
 
-test('tool result serializes failure status and error details', function (): void {
-    $result = new ToolResult(
-        id: 'call-1',
-        name: 'query-resources',
-        arguments: [],
-        result: 'Tool not found',
-        successful: false,
-        error: 'Tool not found',
-    );
-
-    expect($result->toArray())->toMatchArray([
-        'successful' => false,
-        'error' => 'Tool not found',
-    ]);
+test('tool result to array includes the failed key only when failed', function (): void {
+    expect((new ToolResult('id', 'name', [], 'val'))->toArray())->not->toHaveKey('failed')
+        ->and((new ToolResult('id', 'name', [], 'Tool not found', failed: true))->toArray())->toHaveKey('failed', true);
 });
 
-test('tool result hydrates status while remaining compatible with legacy payloads', function (): void {
-    $failed = ToolResult::fromArray([
-        'id' => 'call-1',
-        'name' => 'query-resources',
-        'arguments' => [],
-        'result' => 'Tool not found',
-        'successful' => false,
-        'error' => 'Tool not found',
-    ]);
+test('tool result from array hydrates the failed flag from its key', function (): void {
+    expect(ToolResult::fromArray(['id' => 'id', 'name' => 'name', 'arguments' => [], 'result' => 'val'])->failed)->toBeFalse()
+        ->and(ToolResult::fromArray(['id' => 'id', 'name' => 'name', 'arguments' => [], 'result' => 'val', 'failed' => true])->failed)->toBeTrue();
+});
 
-    $legacySuccess = ToolResult::fromArray([
-        'id' => 'call-2',
-        'name' => 'query-resources',
-        'arguments' => [],
-        'result' => 'Berlin',
-    ]);
-
-    $legacyDenied = ToolResult::fromArray([
-        'id' => 'call-3',
-        'name' => 'delete-resource',
-        'arguments' => [],
-        'result' => 'Not approved',
-        'denied' => true,
-    ]);
-
-    expect($failed->successful)->toBeFalse()
-        ->and($failed->error)->toBe('Tool not found')
-        ->and($legacySuccess->successful)->toBeTrue()
-        ->and($legacySuccess->error)->toBeNull()
-        ->and($legacyDenied->successful)->toBeFalse();
+test('tool result reports its error only when the call did not succeed', function (): void {
+    expect((new ToolResult('id', 'name', [], 'Berlin'))->successful())->toBeTrue()
+        ->and((new ToolResult('id', 'name', [], 'Berlin'))->error())->toBeNull()
+        ->and((new ToolResult('id', 'name', [], 'Tool not found', failed: true))->successful())->toBeFalse()
+        ->and((new ToolResult('id', 'name', [], 'Tool not found', failed: true))->error())->toBe('Tool not found')
+        ->and((new ToolResult('id', 'name', [], 'Rejected', denied: true))->successful())->toBeFalse()
+        ->and((new ToolResult('id', 'name', [], 'Rejected', denied: true))->error())->toBe('Rejected')
+        ->and((new ToolResult('id', 'name', [], ['code' => 500], failed: true))->error())->toBeNull();
 });


### PR DESCRIPTION
Closes #334.

Tool result stream events know whether execution succeeded, failed, or was denied, but the persisted ToolResult payload did not retain success and error metadata. After a conversation reload, failed results therefore looked the same as successful ones.

This keeps status on the ToolResult value object, serializes only non-default fields, remains compatible with legacy payloads, and makes max-step and approval failure paths populate the same metadata.

Validation:
- Added failing-first value-object and database reload regressions
- Unit and Feature suites: 1,883 passed, 24 skipped, 3,935 assertions
- Pint and PHPStan pass

Provider integration tests require live credentials and were not part of deterministic local validation.