### PR TITLE
Preserve conversation title language

### DIFF
--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -104,7 +104,7 @@ class RememberConversation
             $response = $this->provider->textGenerationLoop()->generate(
                 $this->provider,
                 $this->provider->cheapestTextModel(),
-                'Generate a concise 3-5 word title for a conversation that starts with the following message. Respond with only the title, no quotes or punctuation.',
+                'Generate a concise 3-5 word title for a conversation that starts with the following message. Use the same language as the message. Respond with only the title, no quotes or punctuation.',
                 [new UserMessage(Str::limit($prompt, 500))],
             );
 


### PR DESCRIPTION
## Summary

- instruct conversation title generation to use the same language as the initial message

## Why

The existing prompt constrained title length and formatting but did not specify a language. As a result, models could generate English titles for conversations started in another language.

This change makes the language requirement explicit so generated titles remain consistent with the user's initial message.

## Impact

New conversation titles will use the same language as the conversation's first prompt. There are no API changes.

## Testing

- `vendor/bin/pest tests/Feature/RemembersConversationsTest.php`
- `php -d memory_limit=-1 vendor/bin/pest --compact`
- `vendor/bin/phpstan --memory-limit=-1 --no-progress`
- `composer test:lint`
