### PR TITLE
Fix provider rejection when resuming multi-step tool approval pauses

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -119,6 +119,66 @@ return new class extends Migration
 };
 ```
 
+### Widened `meta` Column On Conversation Messages
+
+**Likelihood Of Impact: Low**
+
+A paused turn now records the raw provider replay state for every step it ran, not just the step it paused on, so the `meta` column on the conversation messages table is `LONGTEXT` in the published migration. Existing `TEXT` columns keep working, but a long reasoning turn that pauses can exceed their 64KB limit. If you have already published and run the conversation migrations, create a new migration to widen the column, then run `php artisan migrate`:
+
+```php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(config('ai.conversations.tables.messages', 'agent_conversation_messages'), function (Blueprint $table) {
+            $table->longText('meta')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table(config('ai.conversations.tables.messages', 'agent_conversation_messages'), function (Blueprint $table) {
+            $table->text('meta')->change();
+        });
+    }
+};
+```
+
+### Conversations Already Paused For Approval
+
+**Likelihood Of Impact: Low**
+
+Only turns that pause after upgrading record the replay state for their earlier steps. A conversation that was already sitting at a multi-step approval pause when you upgraded has no such state, so resuming it is still rejected by the provider. Prompt the affected agents again to start a fresh turn, or drop the stale replay state so those pauses fall back to the generic mapping:
+
+```php
+use Illuminate\Support\Facades\DB;
+
+DB::table(config('ai.conversations.tables.messages', 'agent_conversation_messages'))
+    ->where('role', 'assistant')
+    ->whereNotNull('approval_state')
+    ->where('tool_results', '!=', '[]')
+    ->get(['id', 'meta'])
+    ->each(function ($message): void {
+        $meta = json_decode($message->meta, true);
+
+        if (! isset($meta['provider_content_blocks']) || isset($meta['preceding_provider_content_block_steps'])) {
+            return;
+        }
+
+        unset($meta['provider_content_blocks']);
+
+        DB::table(config('ai.conversations.tables.messages', 'agent_conversation_messages'))
+            ->where('id', $message->id)
+            ->update(['meta' => json_encode($meta)]);
+    });
+```
+
+Those turns then replay through the provider's own message mapping rather than the raw blocks, which resumes cleanly but drops the reasoning the paused step had already produced.
+
 ### The `Agent` Contract Now Accepts `Decisions|string`
 
 **Likelihood Of Impact: Low**

--- a/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
+++ b/database/migrations/2026_01_11_000001_create_agent_conversations_table.php
@@ -36,7 +36,7 @@ return new class extends AiMigration
             $table->text('tool_calls');
             $table->text('tool_results');
             $table->text('usage');
-            $table->text('meta');
+            $table->longText('meta');
             $table->text('approval_state')->nullable();
             $table->timestamps();
 

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -198,6 +198,8 @@ class TextGenerationLoop
             $allMessages = $this->settleAbandonedToolCalls($messages);
         }
 
+        $turnAssistantMessages = [];
+
         for ($step = 0; $step < $maxSteps; $step++) {
             $stepContext = new StepContext(
                 stepNumber: $step,
@@ -247,7 +249,7 @@ class TextGenerationLoop
                 ))->withInvocationId($invocationId);
             }
 
-            $allMessages[] = $this->buildAssistantMessage($result);
+            $allMessages[] = $turnAssistantMessages[] = $this->buildAssistantMessage($result);
 
             if (filled($toolResults)) {
                 $allMessages[] = new ToolResultMessage(collect($toolResults));
@@ -259,6 +261,7 @@ class TextGenerationLoop
                     $pendingApprovals,
                     time(),
                     $result->providerContentBlocks,
+                    $this->providerContentBlockSteps($turnAssistantMessages),
                 ))->withInvocationId($invocationId);
 
                 break;
@@ -530,6 +533,17 @@ class TextGenerationLoop
             collect($result->toolCalls),
             $result->providerContentBlocks,
         );
+    }
+
+    /**
+     * Build the per-step replay state for a paused turn from each step's assistant message.
+     *
+     * @param  AssistantMessage[]  $assistantMessages
+     * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
+     */
+    protected function providerContentBlockSteps(array $assistantMessages): array
+    {
+        return array_map(fn (AssistantMessage $message): array => $message->toReplayStep(), array_values($assistantMessages));
     }
 
     /**

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -261,7 +261,7 @@ class TextGenerationLoop
                     $pendingApprovals,
                     time(),
                     $result->providerContentBlocks,
-                    $this->providerContentBlockSteps($turnAssistantMessages),
+                    $this->precedingProviderContentBlockSteps($turnAssistantMessages),
                 ))->withInvocationId($invocationId);
 
                 break;
@@ -536,14 +536,18 @@ class TextGenerationLoop
     }
 
     /**
-     * Build the per-step replay state for a paused turn from each step's assistant message.
+     * Build the replay state for the steps that ran before the paused one, which the pause's own blocks do not describe.
      *
-     * @param  AssistantMessage[]  $assistantMessages
+     * @param  AssistantMessage[]  $assistantMessages  every assistant message of the turn, the paused step last
      * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
      */
-    protected function providerContentBlockSteps(array $assistantMessages): array
+    protected function precedingProviderContentBlockSteps(array $assistantMessages): array
     {
-        return array_map(fn (AssistantMessage $message): array => $message->toReplayStep(), array_values($assistantMessages));
+        return array_map(fn (AssistantMessage $message): array => [
+            'tool_call_ids' => $message->toolCalls->pluck('id')->values()->all(),
+            'blocks' => $message->providerContentBlocks,
+            'content' => $message->content,
+        ], array_slice(array_values($assistantMessages), 0, -1));
     }
 
     /**
@@ -584,7 +588,7 @@ class TextGenerationLoop
                 $finalStep->text,
                 $totalUsage,
                 $finalStep->meta,
-            ))->withToolCallsAndResults(
+            ))->withMessages($newMessages)->withToolCallsAndResults(
                 toolCalls: $steps->flatMap(fn (Step $s): array => $s->toolCalls),
                 toolResults: $newMessages
                     ->whereInstanceOf(ToolResultMessage::class)

--- a/src/Messages/AssistantMessage.php
+++ b/src/Messages/AssistantMessage.php
@@ -36,18 +36,4 @@ class AssistantMessage extends Message
         $this->providerContentBlocks = $providerContentBlocks;
         $this->providerContentBlocksProvider = $providerContentBlocksProvider;
     }
-
-    /**
-     * Get the per-step replay state entry persisted for this message when a paused turn spans multiple steps.
-     *
-     * @return array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}
-     */
-    public function toReplayStep(): array
-    {
-        return [
-            'tool_call_ids' => $this->toolCalls->pluck('id')->values()->all(),
-            'blocks' => $this->providerContentBlocks,
-            'content' => $this->content,
-        ];
-    }
 }

--- a/src/Messages/AssistantMessage.php
+++ b/src/Messages/AssistantMessage.php
@@ -36,4 +36,18 @@ class AssistantMessage extends Message
         $this->providerContentBlocks = $providerContentBlocks;
         $this->providerContentBlocksProvider = $providerContentBlocksProvider;
     }
+
+    /**
+     * Get the per-step replay state entry persisted for this message when a paused turn spans multiple steps.
+     *
+     * @return array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}
+     */
+    public function toReplayStep(): array
+    {
+        return [
+            'tool_call_ids' => $this->toolCalls->pluck('id')->values()->all(),
+            'blocks' => $this->providerContentBlocks,
+            'content' => $this->content,
+        ];
+    }
 }

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -92,6 +92,7 @@ trait GeneratesText
 
                 $agentResponse = $response instanceof StructuredTextResponse
                     ? (new StructuredAgentResponse($invocationId, $response->structured, $response->text, $response->usage, $response->meta))
+                        ->withMessages($response->messages)
                         ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
                         ->withSteps($response->steps)
                     : (new AgentResponse($invocationId, $response->text, $response->usage, $response->meta))

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -68,4 +68,22 @@ class AgentResponse extends TextResponse
 
         return $this->messages->whereInstanceOf(AssistantMessage::class)->last()?->providerContentBlocks ?? [];
     }
+
+    /**
+     * Get the per-step raw provider replay state for the paused assistant turn, if any.
+     *
+     * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
+     */
+    public function pausedProviderContentBlockSteps(): array
+    {
+        if (! $this->hasPendingApprovals()) {
+            return [];
+        }
+
+        return $this->messages
+            ->whereInstanceOf(AssistantMessage::class)
+            ->map(fn (AssistantMessage $message): array => $message->toReplayStep())
+            ->values()
+            ->all();
+    }
 }

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -70,11 +70,13 @@ class AgentResponse extends TextResponse
     }
 
     /**
-     * Get the per-step raw provider replay state for the paused assistant turn, if any.
+     * Get the raw provider replay state for the steps that ran before the paused step, if any.
+     *
+     * The paused step is described by pausedProviderContentBlocks(), so it is never repeated here.
      *
      * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
      */
-    public function pausedProviderContentBlockSteps(): array
+    public function precedingProviderContentBlockSteps(): array
     {
         if (! $this->hasPendingApprovals()) {
             return [];
@@ -82,8 +84,13 @@ class AgentResponse extends TextResponse
 
         return $this->messages
             ->whereInstanceOf(AssistantMessage::class)
-            ->map(fn (AssistantMessage $message): array => $message->toReplayStep())
             ->values()
+            ->slice(0, -1)
+            ->map(fn (AssistantMessage $message): array => [
+                'tool_call_ids' => $message->toolCalls->pluck('id')->values()->all(),
+                'blocks' => $message->providerContentBlocks,
+                'content' => $message->content,
+            ])
             ->all();
     }
 }

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -70,9 +70,7 @@ class AgentResponse extends TextResponse
     }
 
     /**
-     * Get the raw provider replay state for the steps that ran before the paused step, if any.
-     *
-     * The paused step is described by pausedProviderContentBlocks(), so it is never repeated here.
+     * Get the raw provider replay state for the steps before the paused one, which pausedProviderContentBlocks() does not describe.
      *
      * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
      */

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -53,12 +53,12 @@ class StreamedAgentResponse extends AgentResponse
     }
 
     /**
-     * Get the per-step raw provider replay state for the paused assistant turn, if any.
+     * Get the raw provider replay state for the steps that ran before the paused step, if any.
      *
      * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
      */
-    public function pausedProviderContentBlockSteps(): array
+    public function precedingProviderContentBlockSteps(): array
     {
-        return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->providerContentBlockSteps ?? [];
+        return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->precedingProviderContentBlockSteps ?? [];
     }
 }

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -51,4 +51,14 @@ class StreamedAgentResponse extends AgentResponse
     {
         return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->providerContentBlocks ?? [];
     }
+
+    /**
+     * Get the per-step raw provider replay state for the paused assistant turn, if any.
+     *
+     * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
+     */
+    public function pausedProviderContentBlockSteps(): array
+    {
+        return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->providerContentBlockSteps ?? [];
+    }
 }

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -208,9 +208,9 @@ class DatabaseConversationStore implements ConversationStore
         if (filled($blocks = $response->pausedProviderContentBlocks())) {
             $meta['provider_content_blocks'] = $blocks;
 
-            // A single-step pause is fully described by the blocks above, so only multi-step turns need the per-step state...
-            if (count($steps = $response->pausedProviderContentBlockSteps()) > 1) {
-                $meta['provider_content_block_steps'] = $steps;
+            // The blocks above describe the paused step; a multi-step turn also needs the steps that ran before it...
+            if (filled($steps = $response->precedingProviderContentBlockSteps())) {
+                $meta['preceding_provider_content_block_steps'] = $steps;
             }
         }
 
@@ -310,18 +310,15 @@ class DatabaseConversationStore implements ConversationStore
 
         $providerContentBlocks = $meta['provider_content_blocks'] ?? [];
 
-        $blockSteps = $meta['provider_content_block_steps'] ?? [];
-
-        if ($isPause && $this->stepsCoverToolCalls($blockSteps, $toolCalls)) {
-            $lastIndex = count($blockSteps) - 1;
-
-            foreach ($blockSteps as $index => $blockStep) {
-                $stepCallIds = $blockStep['tool_call_ids'];
+        if ($isPause && filled($providerContentBlocks)) {
+            // The blocks replay the paused step verbatim, so any step before it has to be replayed ahead of them...
+            foreach ($this->precedingPauseSteps($meta, $toolCalls, $ownResults, $pausedCallIds) as $step) {
+                $stepCallIds = $step['tool_call_ids'];
 
                 $messages[] = new AssistantMessage(
-                    (string) ($blockStep['content'] ?? ($index === $lastIndex ? $record->content : '')),
+                    $step['content'],
                     $toolCalls->filter(fn (array $toolCall) => in_array($toolCall['id'], $stepCallIds, true))->map(ToolCall::fromArray(...))->values(),
-                    $blockStep['blocks'] ?? [],
+                    $step['blocks'],
                     $meta['provider'] ?? null,
                 );
 
@@ -330,26 +327,9 @@ class DatabaseConversationStore implements ConversationStore
                 if ($stepResults->isNotEmpty()) {
                     $messages[] = new ToolResultMessage($stepResults->map(ToolResult::fromArray(...)));
                 }
-            }
 
-            return $messages;
-        }
-
-        if ($isPause && filled($providerContentBlocks)) {
-            $blockCallIds = $this->providerBlockToolCallIds($providerContentBlocks);
-
-            $earlierResults = $blockCallIds === []
-                ? collect()
-                : $ownResults->reject(fn (array $toolResult) => in_array($toolResult['id'], $blockCallIds, true))->values();
-
-            if ($earlierResults->isNotEmpty()) {
-                $earlierResultIds = $earlierResults->pluck('id')->all();
-
-                $messages[] = new AssistantMessage('', $toolCalls->filter(fn (array $toolCall) => in_array($toolCall['id'], $earlierResultIds, true))->map(ToolCall::fromArray(...))->values());
-                $messages[] = new ToolResultMessage($earlierResults->map(ToolResult::fromArray(...)));
-
-                $toolCalls = $toolCalls->reject(fn (array $toolCall) => in_array($toolCall['id'], $earlierResultIds, true))->values();
-                $ownResults = $ownResults->filter(fn (array $toolResult) => in_array($toolResult['id'], $blockCallIds, true))->values();
+                $toolCalls = $toolCalls->reject(fn (array $toolCall) => in_array($toolCall['id'], $stepCallIds, true))->values();
+                $ownResults = $ownResults->reject(fn (array $toolResult) => in_array($toolResult['id'], $stepCallIds, true))->values();
             }
 
             $messages[] = new AssistantMessage($record->content, $toolCalls->map(ToolCall::fromArray(...))->values(), $providerContentBlocks, $meta['provider'] ?? null);
@@ -382,51 +362,52 @@ class DatabaseConversationStore implements ConversationStore
     }
 
     /**
-     * Determine whether stored per-step replay state is well-formed and accounts for every tool call on the row.
+     * Get the replay state for the steps a paused turn ran before the step its raw blocks describe.
      *
+     * Rows stored before this state existed, and rows whose state does not agree with their own tool calls, replay as they always have.
+     *
+     * @param  array<string, mixed>  $meta
      * @param  Collection<int, array<string, mixed>>  $toolCalls
+     * @param  Collection<int, array<string, mixed>>  $ownResults
+     * @param  array<int, string>  $pausedCallIds
+     * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
      */
-    protected function stepsCoverToolCalls(mixed $blockSteps, Collection $toolCalls): bool
+    protected function precedingPauseSteps(array $meta, Collection $toolCalls, Collection $ownResults, array $pausedCallIds): array
     {
-        if (! is_array($blockSteps) || $blockSteps === [] || ! array_is_list($blockSteps)) {
-            return false;
-        }
+        $steps = $meta['preceding_provider_content_block_steps'] ?? null;
 
-        $stepCallIds = [];
-
-        foreach ($blockSteps as $blockStep) {
-            if (! is_array($blockStep) || ! is_array($blockStep['tool_call_ids'] ?? null)) {
-                return false;
-            }
-
-            $stepCallIds = [...$stepCallIds, ...$blockStep['tool_call_ids']];
-        }
-
-        return $toolCalls->every(fn (array $toolCall) => in_array($toolCall['id'], $stepCallIds, true));
-    }
-
-    /**
-     * Get the tool-call IDs present in a paused turn's raw provider blocks, or an empty array when the shape carries none.
-     *
-     * @param  array<int|string, mixed>  $blocks
-     * @return array<int, string>
-     */
-    protected function providerBlockToolCallIds(array $blocks): array
-    {
-        if (! array_is_list($blocks)) {
+        if (! is_array($steps) || $steps === [] || ! array_is_list($steps)) {
             return [];
         }
 
-        return collect($blocks)
-            ->map(fn ($block) => match (true) {
-                ! is_array($block) => null,
-                ($block['type'] ?? null) === 'tool_use' => $block['id'] ?? null,
-                isset($block['toolUse']) => $block['toolUse']['toolUseId'] ?? null,
-                default => null,
-            })
-            ->filter()
-            ->values()
-            ->all();
+        $callIds = $toolCalls->pluck('id')->all();
+        $resultIds = $ownResults->pluck('id')->all();
+
+        $preceding = [];
+
+        foreach ($steps as $step) {
+            if (! is_array($step) || ! is_array($step['tool_call_ids'] ?? null) || ! is_array($step['blocks'] ?? null)) {
+                return [];
+            }
+
+            foreach ($step['tool_call_ids'] as $callId) {
+                // A preceding step ran to completion, so replaying one whose call is missing from the row, still unanswered, or held back by the pause would emit a tool_use nothing can pair with...
+                if (! is_string($callId)
+                    || ! in_array($callId, $callIds, true)
+                    || ! in_array($callId, $resultIds, true)
+                    || in_array($callId, $pausedCallIds, true)) {
+                    return [];
+                }
+            }
+
+            $preceding[] = [
+                'tool_call_ids' => array_values($step['tool_call_ids']),
+                'blocks' => $step['blocks'],
+                'content' => is_string($step['content'] ?? null) ? $step['content'] : '',
+            ];
+        }
+
+        return $preceding;
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -315,7 +315,7 @@ class DatabaseConversationStore implements ConversationStore
 
         if ($blocksDescribeTurn && filled($providerContentBlocks)) {
             // The blocks replay the paused step verbatim, so any step before it has to be replayed ahead of them...
-            foreach ($this->precedingPauseSteps($meta, $toolCalls, $ownResults, $pausedCallIds) as $step) {
+            foreach ($meta['preceding_provider_content_block_steps'] ?? [] as $step) {
                 $stepCallIds = $step['tool_call_ids'];
 
                 $messages[] = new AssistantMessage(
@@ -362,53 +362,6 @@ class DatabaseConversationStore implements ConversationStore
         }
 
         return $messages;
-    }
-
-    /**
-     * Get the replay state for the steps a paused turn ran before the step its raw blocks describe, or nothing when the row predates or disagrees with it.
-     *
-     * @param  array<string, mixed>  $meta
-     * @param  Collection<int, array<string, mixed>>  $toolCalls
-     * @param  Collection<int, array<string, mixed>>  $ownResults
-     * @param  array<int, string>  $pausedCallIds
-     * @return array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>
-     */
-    protected function precedingPauseSteps(array $meta, Collection $toolCalls, Collection $ownResults, array $pausedCallIds): array
-    {
-        $steps = $meta['preceding_provider_content_block_steps'] ?? null;
-
-        if (! is_array($steps) || $steps === [] || ! array_is_list($steps)) {
-            return [];
-        }
-
-        $callIds = $toolCalls->pluck('id')->all();
-        $resultIds = $ownResults->pluck('id')->all();
-
-        $preceding = [];
-
-        foreach ($steps as $step) {
-            if (! is_array($step) || ! is_array($step['tool_call_ids'] ?? null) || ! is_array($step['blocks'] ?? null)) {
-                return [];
-            }
-
-            foreach ($step['tool_call_ids'] as $callId) {
-                // A preceding step ran to completion, so a call the row never made, never answered, or is still gating would replay as an unpairable tool_use...
-                if (! is_string($callId)
-                    || ! in_array($callId, $callIds, true)
-                    || ! in_array($callId, $resultIds, true)
-                    || in_array($callId, $pausedCallIds, true)) {
-                    return [];
-                }
-            }
-
-            $preceding[] = [
-                'tool_call_ids' => array_values($step['tool_call_ids']),
-                'blocks' => $step['blocks'],
-                'content' => is_string($step['content'] ?? null) ? $step['content'] : '',
-            ];
-        }
-
-        return $preceding;
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -297,8 +297,11 @@ class DatabaseConversationStore implements ConversationStore
 
         $pausedCallIds = $this->pausedCallIds($record);
 
-        $isPause = $pendingCalls->isNotEmpty()
-            && $pendingCalls->every(fn (array $toolCall) => in_array($toolCall['id'], $pausedCallIds, true));
+        // The blocks keep describing the turn once its pause resolves, so replay them for any call still gating or answered on a later row...
+        $blocksDescribeTurn = $pendingCalls->every(
+            fn (array $toolCall) => in_array($toolCall['id'], $pausedCallIds, true)
+                || in_array($toolCall['id'], $resolvedCallIds, true)
+        );
 
         $messages = [];
 
@@ -310,7 +313,7 @@ class DatabaseConversationStore implements ConversationStore
 
         $providerContentBlocks = $meta['provider_content_blocks'] ?? [];
 
-        if ($isPause && filled($providerContentBlocks)) {
+        if ($blocksDescribeTurn && filled($providerContentBlocks)) {
             // The blocks replay the paused step verbatim, so any step before it has to be replayed ahead of them...
             foreach ($this->precedingPauseSteps($meta, $toolCalls, $ownResults, $pausedCallIds) as $step) {
                 $stepCallIds = $step['tool_call_ids'];

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -207,6 +207,11 @@ class DatabaseConversationStore implements ConversationStore
 
         if (filled($blocks = $response->pausedProviderContentBlocks())) {
             $meta['provider_content_blocks'] = $blocks;
+
+            // A single-step pause is fully described by the blocks above, so only multi-step turns need the per-step state...
+            if (count($steps = $response->pausedProviderContentBlockSteps()) > 1) {
+                $meta['provider_content_block_steps'] = $steps;
+            }
         }
 
         return $meta;
@@ -305,7 +310,48 @@ class DatabaseConversationStore implements ConversationStore
 
         $providerContentBlocks = $meta['provider_content_blocks'] ?? [];
 
+        $blockSteps = $meta['provider_content_block_steps'] ?? [];
+
+        if ($isPause && $this->stepsCoverToolCalls($blockSteps, $toolCalls)) {
+            $lastIndex = count($blockSteps) - 1;
+
+            foreach ($blockSteps as $index => $blockStep) {
+                $stepCallIds = $blockStep['tool_call_ids'];
+
+                $messages[] = new AssistantMessage(
+                    (string) ($blockStep['content'] ?? ($index === $lastIndex ? $record->content : '')),
+                    $toolCalls->filter(fn (array $toolCall) => in_array($toolCall['id'], $stepCallIds, true))->map(ToolCall::fromArray(...))->values(),
+                    $blockStep['blocks'] ?? [],
+                    $meta['provider'] ?? null,
+                );
+
+                $stepResults = $ownResults->filter(fn (array $toolResult) => in_array($toolResult['id'], $stepCallIds, true))->values();
+
+                if ($stepResults->isNotEmpty()) {
+                    $messages[] = new ToolResultMessage($stepResults->map(ToolResult::fromArray(...)));
+                }
+            }
+
+            return $messages;
+        }
+
         if ($isPause && filled($providerContentBlocks)) {
+            $blockCallIds = $this->providerBlockToolCallIds($providerContentBlocks);
+
+            $earlierResults = $blockCallIds === []
+                ? collect()
+                : $ownResults->reject(fn (array $toolResult) => in_array($toolResult['id'], $blockCallIds, true))->values();
+
+            if ($earlierResults->isNotEmpty()) {
+                $earlierResultIds = $earlierResults->pluck('id')->all();
+
+                $messages[] = new AssistantMessage('', $toolCalls->filter(fn (array $toolCall) => in_array($toolCall['id'], $earlierResultIds, true))->map(ToolCall::fromArray(...))->values());
+                $messages[] = new ToolResultMessage($earlierResults->map(ToolResult::fromArray(...)));
+
+                $toolCalls = $toolCalls->reject(fn (array $toolCall) => in_array($toolCall['id'], $earlierResultIds, true))->values();
+                $ownResults = $ownResults->filter(fn (array $toolResult) => in_array($toolResult['id'], $blockCallIds, true))->values();
+            }
+
             $messages[] = new AssistantMessage($record->content, $toolCalls->map(ToolCall::fromArray(...))->values(), $providerContentBlocks, $meta['provider'] ?? null);
 
             if ($ownResults->isNotEmpty()) {
@@ -333,6 +379,54 @@ class DatabaseConversationStore implements ConversationStore
         }
 
         return $messages;
+    }
+
+    /**
+     * Determine whether stored per-step replay state is well-formed and accounts for every tool call on the row.
+     *
+     * @param  Collection<int, array<string, mixed>>  $toolCalls
+     */
+    protected function stepsCoverToolCalls(mixed $blockSteps, Collection $toolCalls): bool
+    {
+        if (! is_array($blockSteps) || $blockSteps === [] || ! array_is_list($blockSteps)) {
+            return false;
+        }
+
+        $stepCallIds = [];
+
+        foreach ($blockSteps as $blockStep) {
+            if (! is_array($blockStep) || ! is_array($blockStep['tool_call_ids'] ?? null)) {
+                return false;
+            }
+
+            $stepCallIds = [...$stepCallIds, ...$blockStep['tool_call_ids']];
+        }
+
+        return $toolCalls->every(fn (array $toolCall) => in_array($toolCall['id'], $stepCallIds, true));
+    }
+
+    /**
+     * Get the tool-call IDs present in a paused turn's raw provider blocks, or an empty array when the shape carries none.
+     *
+     * @param  array<int|string, mixed>  $blocks
+     * @return array<int, string>
+     */
+    protected function providerBlockToolCallIds(array $blocks): array
+    {
+        if (! array_is_list($blocks)) {
+            return [];
+        }
+
+        return collect($blocks)
+            ->map(fn ($block) => match (true) {
+                ! is_array($block) => null,
+                ($block['type'] ?? null) === 'tool_use' => $block['id'] ?? null,
+                isset($block['toolUse']) => $block['toolUse']['toolUseId'] ?? null,
+                default => null,
+            })
+            ->filter()
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -362,9 +362,7 @@ class DatabaseConversationStore implements ConversationStore
     }
 
     /**
-     * Get the replay state for the steps a paused turn ran before the step its raw blocks describe.
-     *
-     * Rows stored before this state existed, and rows whose state does not agree with their own tool calls, replay as they always have.
+     * Get the replay state for the steps a paused turn ran before the step its raw blocks describe, or nothing when the row predates or disagrees with it.
      *
      * @param  array<string, mixed>  $meta
      * @param  Collection<int, array<string, mixed>>  $toolCalls
@@ -391,7 +389,7 @@ class DatabaseConversationStore implements ConversationStore
             }
 
             foreach ($step['tool_call_ids'] as $callId) {
-                // A preceding step ran to completion, so replaying one whose call is missing from the row, still unanswered, or held back by the pause would emit a tool_use nothing can pair with...
+                // A preceding step ran to completion, so a call the row never made, never answered, or is still gating would replay as an unpairable tool_use...
                 if (! is_string($callId)
                     || ! in_array($callId, $callIds, true)
                     || ! in_array($callId, $resultIds, true)

--- a/src/Streaming/Events/ToolApprovalRequest.php
+++ b/src/Streaming/Events/ToolApprovalRequest.php
@@ -10,14 +10,14 @@ class ToolApprovalRequest extends StreamEvent
     /**
      * @param  Collection<int, PendingApproval>  $pendingApprovals
      * @param  array<int, array<string, mixed>>  $providerContentBlocks  raw provider replay state for the paused turn; never serialized to clients
-     * @param  array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>  $providerContentBlockSteps  per-step replay state for the paused turn; never serialized to clients
+     * @param  array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>  $precedingProviderContentBlockSteps  replay state for the steps before the paused one; never serialized to clients
      */
     public function __construct(
         public string $id,
         public Collection $pendingApprovals,
         public int $timestamp,
         public array $providerContentBlocks = [],
-        public array $providerContentBlockSteps = [],
+        public array $precedingProviderContentBlockSteps = [],
     ) {}
 
     /**

--- a/src/Streaming/Events/ToolApprovalRequest.php
+++ b/src/Streaming/Events/ToolApprovalRequest.php
@@ -10,12 +10,14 @@ class ToolApprovalRequest extends StreamEvent
     /**
      * @param  Collection<int, PendingApproval>  $pendingApprovals
      * @param  array<int, array<string, mixed>>  $providerContentBlocks  raw provider replay state for the paused turn; never serialized to clients
+     * @param  array<int, array{tool_call_ids: array<int, string>, blocks: array<int|string, mixed>, content: string}>  $providerContentBlockSteps  per-step replay state for the paused turn; never serialized to clients
      */
     public function __construct(
         public string $id,
         public Collection $pendingApprovals,
         public int $timestamp,
         public array $providerContentBlocks = [],
+        public array $providerContentBlockSteps = [],
     ) {}
 
     /**

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -565,143 +565,7 @@ test('it preserves provider content blocks when a mixed pause carries an execute
         ->and($messages[1]->toolResults[0]->id)->toBe('call-1');
 });
 
-test('it replays earlier-step results ahead of a paused turn whose raw blocks only cover the final step', function (): void {
-    $store = new DatabaseConversationStore;
-    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
-
-    DB::table('agent_conversation_messages')->insert([
-        'id' => 'message-1',
-        'conversation_id' => $conversationId,
-        'participant_type' => 'user',
-        'participant_id' => 1,
-        'agent' => ToolUsingAgent::class,
-        'role' => 'assistant',
-        'content' => 'Checked the data, now deleting b',
-        'attachments' => '[]',
-        'tool_calls' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
-            ['id' => 'call-2', 'name' => 'delete_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
-        ]),
-        'tool_results' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
-        ]),
-        'usage' => '[]',
-        'meta' => json_encode([
-            'provider' => 'anthropic',
-            'provider_content_blocks' => [
-                ['type' => 'thinking', 'thinking' => '', 'signature' => 'sig-1'],
-                ['type' => 'text', 'text' => 'Checked the data, now deleting b'],
-                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']],
-            ],
-        ]),
-        'approval_state' => json_encode(['pending' => ['call-2' => null]]),
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
-
-    $messages = $store->getLatestConversationMessages($conversationId, 10);
-
-    expect($messages)->toHaveCount(3)
-        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
-        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[0]->providerContentBlocks)->toBe([])
-        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
-        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
-        ->and($messages[2]->content)->toBe('Checked the data, now deleting b')
-        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2'])
-        ->and($messages[2]->providerContentBlocks)->not->toBe([]);
-});
-
-test('it keeps a same-step executed result behind the raw blocks while replaying earlier steps ahead', function (): void {
-    $store = new DatabaseConversationStore;
-    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
-
-    DB::table('agent_conversation_messages')->insert([
-        'id' => 'message-1',
-        'conversation_id' => $conversationId,
-        'participant_type' => 'user',
-        'participant_id' => 1,
-        'agent' => ToolUsingAgent::class,
-        'role' => 'assistant',
-        'content' => 'Deleting b and c',
-        'attachments' => '[]',
-        'tool_calls' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
-            ['id' => 'call-2', 'name' => 'read_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
-            ['id' => 'call-3', 'name' => 'delete_file', 'arguments' => ['path' => 'c'], 'result_id' => 'result-3'],
-        ]),
-        'tool_results' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
-            ['id' => 'call-2', 'name' => 'read_file', 'arguments' => ['path' => 'b'], 'result' => 'contents', 'result_id' => 'result-2'],
-        ]),
-        'usage' => '[]',
-        'meta' => json_encode([
-            'provider' => 'anthropic',
-            'provider_content_blocks' => [
-                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'read_file', 'input' => ['path' => 'b']],
-                ['type' => 'tool_use', 'id' => 'call-3', 'name' => 'delete_file', 'input' => ['path' => 'c']],
-            ],
-        ]),
-        'approval_state' => json_encode(['pending' => ['call-3' => null]]),
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
-
-    $messages = $store->getLatestConversationMessages($conversationId, 10);
-
-    expect($messages)->toHaveCount(4)
-        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2', 'call-3'])
-        ->and($messages[2]->providerContentBlocks)->not->toBe([])
-        ->and($messages[3])->toBeInstanceOf(ToolResultMessage::class)
-        ->and($messages[3]->toolResults->pluck('id')->all())->toBe(['call-2']);
-});
-
-test('it replays earlier-step results ahead of a paused turn holding Bedrock-shaped raw blocks', function (): void {
-    $store = new DatabaseConversationStore;
-    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
-
-    DB::table('agent_conversation_messages')->insert([
-        'id' => 'message-1',
-        'conversation_id' => $conversationId,
-        'participant_type' => 'user',
-        'participant_id' => 1,
-        'agent' => ToolUsingAgent::class,
-        'role' => 'assistant',
-        'content' => 'Now deleting b',
-        'attachments' => '[]',
-        'tool_calls' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
-            ['id' => 'call-2', 'name' => 'delete_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
-        ]),
-        'tool_results' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
-        ]),
-        'usage' => '[]',
-        'meta' => json_encode([
-            'provider' => 'bedrock',
-            'provider_content_blocks' => [
-                ['text' => 'Now deleting b'],
-                ['toolUse' => ['toolUseId' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']]],
-            ],
-        ]),
-        'approval_state' => json_encode(['pending' => ['call-2' => null]]),
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
-
-    $messages = $store->getLatestConversationMessages($conversationId, 10);
-
-    expect($messages)->toHaveCount(3)
-        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2'])
-        ->and($messages[2]->providerContentBlocks)->not->toBe([]);
-});
-
-test('it persists per-step replay state for a multi-step pause and rehydrates each step verbatim', function (): void {
+test('it persists the steps preceding a multi-step pause and replays each one verbatim', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -730,8 +594,11 @@ test('it persists per-step replay state for a multi-step pause and rehydrates ea
 
     $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
 
-    expect($meta['provider_content_block_steps'])->toHaveCount(2)
-        ->and($meta['provider_content_block_steps'][0]['tool_call_ids'])->toBe(['call-1']);
+    // The paused step is described by provider_content_blocks, so only the step before it is stored...
+    expect($meta['preceding_provider_content_block_steps'])->toHaveCount(1)
+        ->and($meta['preceding_provider_content_block_steps'][0]['tool_call_ids'])->toBe(['call-1'])
+        ->and($meta['preceding_provider_content_block_steps'][0]['blocks'])->toBe($stepOneBlocks)
+        ->and($meta['provider_content_blocks'])->toBe($stepTwoBlocks);
 
     $messages = $store->getLatestConversationMessages($conversationId, 10);
 
@@ -739,6 +606,7 @@ test('it persists per-step replay state for a multi-step pause and rehydrates ea
         ->and($messages[0]->content)->toBe('Looking up the order')
         ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
         ->and($messages[0]->providerContentBlocks)->toBe($stepOneBlocks)
+        ->and($messages[0]->providerContentBlocksProvider)->toBe('anthropic')
         ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
         ->and($messages[2]->content)->toBe('Refunding order 883')
@@ -746,15 +614,13 @@ test('it persists per-step replay state for a multi-step pause and rehydrates ea
         ->and($messages[2]->providerContentBlocks)->toBe($stepTwoBlocks);
 });
 
-test('it omits per-step replay state for a single-step pause', function (): void {
+test('it omits preceding-step state for a single-step pause', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
     $prompt = new AgentPrompt(new ToolUsingAgent, 'Refund my order.', [], Mockery::mock(TextProvider::class), 'test-model');
 
-    $blocks = [
-        ['type' => 'tool_use', 'id' => 'call-1', 'name' => 'issue_refund', 'input' => []],
-    ];
+    $blocks = [['type' => 'tool_use', 'id' => 'call-1', 'name' => 'issue_refund', 'input' => []]];
 
     $response = (new AgentResponse('invocation-id', '', new Usage, new Meta('anthropic', 'test-model')))
         ->withMessages(collect([
@@ -767,10 +633,43 @@ test('it omits per-step replay state for a single-step pause', function (): void
     $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
 
     expect($meta['provider_content_blocks'])->toBe($blocks)
-        ->and($meta)->not->toHaveKey('provider_content_block_steps');
+        ->and($meta)->not->toHaveKey('preceding_provider_content_block_steps');
 });
 
-test('it falls back to id-partition reconstruction when stored steps do not cover every tool call', function (): void {
+test('it keeps a same-step executed result behind the paused turn raw blocks', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(new ToolUsingAgent, 'Read b and delete c.', [], Mockery::mock(TextProvider::class), 'test-model');
+
+    $blocks = [
+        ['type' => 'tool_use', 'id' => 'call-1', 'name' => 'read_file', 'input' => ['path' => 'b']],
+        ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'c']],
+    ];
+
+    $response = (new AgentResponse('invocation-id', 'Reading b and deleting c', new Usage, new Meta('anthropic', 'test-model')))
+        ->withMessages(collect([
+            new AssistantMessage('Reading b and deleting c', collect([
+                new ToolCall('call-1', 'read_file', ['path' => 'b']),
+                new ToolCall('call-2', 'delete_file', ['path' => 'c']),
+            ]), $blocks),
+            new ToolResultMessage(collect([new ToolResult('call-1', 'read_file', ['path' => 'b'], 'contents')])),
+        ]))
+        ->withPendingApprovals(collect([new PendingApproval('call-2', 'delete_file', ['path' => 'c'])]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    // Both calls belong to the paused step, so its result stays behind the blocks where the resume merges the approved one...
+    expect($messages)->toHaveCount(2)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1', 'call-2'])
+        ->and($messages[0]->providerContentBlocks)->toBe($blocks)
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1']);
+});
+
+test('it ignores preceding-step state that disagrees with the row tool calls', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -796,8 +695,9 @@ test('it falls back to id-partition reconstruction when stored steps do not cove
             'provider_content_blocks' => [
                 ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']],
             ],
-            'provider_content_block_steps' => [
-                ['tool_call_ids' => ['call-2'], 'blocks' => []],
+            // References a call this row never made, so replaying it would emit an unanswerable tool_use...
+            'preceding_provider_content_block_steps' => [
+                ['tool_call_ids' => ['call-9'], 'blocks' => [['type' => 'tool_use', 'id' => 'call-9', 'name' => 'ghost', 'input' => []]], 'content' => ''],
             ],
         ]),
         'approval_state' => json_encode(['pending' => ['call-2' => null]]),
@@ -807,10 +707,9 @@ test('it falls back to id-partition reconstruction when stored steps do not cove
 
     $messages = $store->getLatestConversationMessages($conversationId, 10);
 
-    expect($messages)->toHaveCount(3)
-        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2']);
+    expect($messages)->toHaveCount(2)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1', 'call-2'])
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1']);
 });
 
 test('it drops a leading orphaned tool_result when the row window splits a pause from its resume', function (): void {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Approvals\Decision;
 use Laravel\Ai\Approvals\Decisions;
+use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Files\RemoteImage;
@@ -562,6 +563,254 @@ test('it preserves provider content blocks when a mixed pause carries an execute
         ->and($messages[0]->providerContentBlocks)->toBe([['type' => 'thinking', 'signature' => 'sig-1']])
         ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[1]->toolResults[0]->id)->toBe('call-1');
+});
+
+test('it replays earlier-step results ahead of a paused turn whose raw blocks only cover the final step', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Checked the data, now deleting b',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
+            ['id' => 'call-2', 'name' => 'delete_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => json_encode([
+            'provider' => 'anthropic',
+            'provider_content_blocks' => [
+                ['type' => 'thinking', 'thinking' => '', 'signature' => 'sig-1'],
+                ['type' => 'text', 'text' => 'Checked the data, now deleting b'],
+                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']],
+            ],
+        ]),
+        'approval_state' => json_encode(['pending' => ['call-2' => null]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[0]->providerContentBlocks)->toBe([])
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[2]->content)->toBe('Checked the data, now deleting b')
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2'])
+        ->and($messages[2]->providerContentBlocks)->not->toBe([]);
+});
+
+test('it keeps a same-step executed result behind the raw blocks while replaying earlier steps ahead', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Deleting b and c',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
+            ['id' => 'call-2', 'name' => 'read_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
+            ['id' => 'call-3', 'name' => 'delete_file', 'arguments' => ['path' => 'c'], 'result_id' => 'result-3'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
+            ['id' => 'call-2', 'name' => 'read_file', 'arguments' => ['path' => 'b'], 'result' => 'contents', 'result_id' => 'result-2'],
+        ]),
+        'usage' => '[]',
+        'meta' => json_encode([
+            'provider' => 'anthropic',
+            'provider_content_blocks' => [
+                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'read_file', 'input' => ['path' => 'b']],
+                ['type' => 'tool_use', 'id' => 'call-3', 'name' => 'delete_file', 'input' => ['path' => 'c']],
+            ],
+        ]),
+        'approval_state' => json_encode(['pending' => ['call-3' => null]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(4)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2', 'call-3'])
+        ->and($messages[2]->providerContentBlocks)->not->toBe([])
+        ->and($messages[3])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[3]->toolResults->pluck('id')->all())->toBe(['call-2']);
+});
+
+test('it replays earlier-step results ahead of a paused turn holding Bedrock-shaped raw blocks', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Now deleting b',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
+            ['id' => 'call-2', 'name' => 'delete_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => json_encode([
+            'provider' => 'bedrock',
+            'provider_content_blocks' => [
+                ['text' => 'Now deleting b'],
+                ['toolUse' => ['toolUseId' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']]],
+            ],
+        ]),
+        'approval_state' => json_encode(['pending' => ['call-2' => null]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2'])
+        ->and($messages[2]->providerContentBlocks)->not->toBe([]);
+});
+
+test('it persists per-step replay state for a multi-step pause and rehydrates each step verbatim', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(new ToolUsingAgent, 'Refund my order.', [], Mockery::mock(TextProvider::class), 'test-model');
+
+    $stepOneBlocks = [
+        ['type' => 'thinking', 'thinking' => 'find the order first', 'signature' => 'sig-1'],
+        ['type' => 'tool_use', 'id' => 'call-1', 'name' => 'lookup_order', 'input' => []],
+    ];
+
+    $stepTwoBlocks = [
+        ['type' => 'thinking', 'thinking' => 'refund it', 'signature' => 'sig-2'],
+        ['type' => 'text', 'text' => 'Refunding order 883'],
+        ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'issue_refund', 'input' => ['order' => 883]],
+    ];
+
+    $response = (new AgentResponse('invocation-id', 'Refunding order 883', new Usage, new Meta('anthropic', 'test-model')))
+        ->withMessages(collect([
+            new AssistantMessage('Looking up the order', collect([new ToolCall('call-1', 'lookup_order', [])]), $stepOneBlocks),
+            new ToolResultMessage(collect([new ToolResult('call-1', 'lookup_order', [], 'Order #883')])),
+            new AssistantMessage('Refunding order 883', collect([new ToolCall('call-2', 'issue_refund', ['order' => 883])]), $stepTwoBlocks),
+        ]))
+        ->withPendingApprovals(collect([new PendingApproval('call-2', 'issue_refund', ['order' => 883])]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
+
+    expect($meta['provider_content_block_steps'])->toHaveCount(2)
+        ->and($meta['provider_content_block_steps'][0]['tool_call_ids'])->toBe(['call-1']);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0]->content)->toBe('Looking up the order')
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[0]->providerContentBlocks)->toBe($stepOneBlocks)
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2]->content)->toBe('Refunding order 883')
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2'])
+        ->and($messages[2]->providerContentBlocks)->toBe($stepTwoBlocks);
+});
+
+test('it omits per-step replay state for a single-step pause', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(new ToolUsingAgent, 'Refund my order.', [], Mockery::mock(TextProvider::class), 'test-model');
+
+    $blocks = [
+        ['type' => 'tool_use', 'id' => 'call-1', 'name' => 'issue_refund', 'input' => []],
+    ];
+
+    $response = (new AgentResponse('invocation-id', '', new Usage, new Meta('anthropic', 'test-model')))
+        ->withMessages(collect([
+            new AssistantMessage('', collect([new ToolCall('call-1', 'issue_refund', [])]), $blocks),
+        ]))
+        ->withPendingApprovals(collect([new PendingApproval('call-1', 'issue_refund', [])]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
+
+    expect($meta['provider_content_blocks'])->toBe($blocks)
+        ->and($meta)->not->toHaveKey('provider_content_block_steps');
+});
+
+test('it falls back to id-partition reconstruction when stored steps do not cover every tool call', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Now deleting b',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
+            ['id' => 'call-2', 'name' => 'delete_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
+        ]),
+        'usage' => '[]',
+        'meta' => json_encode([
+            'provider' => 'anthropic',
+            'provider_content_blocks' => [
+                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']],
+            ],
+            'provider_content_block_steps' => [
+                ['tool_call_ids' => ['call-2'], 'blocks' => []],
+            ],
+        ]),
+        'approval_state' => json_encode(['pending' => ['call-2' => null]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2']);
 });
 
 test('it drops a leading orphaned tool_result when the row window splits a pause from its resume', function (): void {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -669,49 +669,6 @@ test('it keeps a same-step executed result behind the paused turn raw blocks', f
         ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1']);
 });
 
-test('it ignores preceding-step state that disagrees with the row tool calls', function (): void {
-    $store = new DatabaseConversationStore;
-    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
-
-    DB::table('agent_conversation_messages')->insert([
-        'id' => 'message-1',
-        'conversation_id' => $conversationId,
-        'participant_type' => 'user',
-        'participant_id' => 1,
-        'agent' => ToolUsingAgent::class,
-        'role' => 'assistant',
-        'content' => 'Now deleting b',
-        'attachments' => '[]',
-        'tool_calls' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result_id' => 'result-1'],
-            ['id' => 'call-2', 'name' => 'delete_file', 'arguments' => ['path' => 'b'], 'result_id' => 'result-2'],
-        ]),
-        'tool_results' => json_encode([
-            ['id' => 'call-1', 'name' => 'search_data', 'arguments' => [], 'result' => 'rows', 'result_id' => 'result-1'],
-        ]),
-        'usage' => '[]',
-        'meta' => json_encode([
-            'provider' => 'anthropic',
-            'provider_content_blocks' => [
-                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'delete_file', 'input' => ['path' => 'b']],
-            ],
-            // References a call this row never made, so replaying it would emit an unanswerable tool_use...
-            'preceding_provider_content_block_steps' => [
-                ['tool_call_ids' => ['call-9'], 'blocks' => [['type' => 'tool_use', 'id' => 'call-9', 'name' => 'ghost', 'input' => []]], 'content' => ''],
-            ],
-        ]),
-        'approval_state' => json_encode(['pending' => ['call-2' => null]]),
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
-
-    $messages = $store->getLatestConversationMessages($conversationId, 10);
-
-    expect($messages)->toHaveCount(2)
-        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1', 'call-2'])
-        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1']);
-});
-
 test('it drops a leading orphaned tool_result when the row window splits a pause from its resume', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');

--- a/tests/Feature/ToolApprovalResumeTest.php
+++ b/tests/Feature/ToolApprovalResumeTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 use Tests\Fixtures\Agents\RememberingApprovableAgent;
+use Tests\Fixtures\Agents\RememberingMultiStepApprovableAgent;
 use Tests\Fixtures\Tools\ApprovableNumberGenerator;
 
 test('a remembered agent pauses for approval, persists the tool_use, and resumes from history when approved', function () {
@@ -654,4 +655,203 @@ test('a resume that fails after the tool runs does not re-execute the tool on re
     )->toThrow(ApprovalMismatchException::class);
 
     expect(ApprovableNumberGenerator::$invocations)->toBe(1);
+});
+
+test('a resume of a pause on a later step replays every earlier step so no tool_result is orphaned', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'msg_tool_1',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [
+                    ['type' => 'thinking', 'thinking' => 'Research first.', 'signature' => 'signature-1'],
+                    ['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'FixedNumberGenerator', 'input' => (object) []],
+                ],
+                'stop_reason' => 'tool_use',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            Http::response([
+                'id' => 'msg_tool_2',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [
+                    ['type' => 'thinking', 'thinking' => 'Now the gated tool.', 'signature' => 'signature-2'],
+                    ['type' => 'text', 'text' => 'Generating the approved number.'],
+                    ['type' => 'tool_use', 'id' => 'toolu_2', 'name' => 'ApprovableNumberGenerator', 'input' => (object) []],
+                ],
+                'stop_reason' => 'tool_use',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            Http::response([
+                'id' => 'msg_3',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [['type' => 'text', 'text' => 'The number is 72019.']],
+                'stop_reason' => 'end_turn',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingMultiStepApprovableAgent)->forUser($user)->prompt('Research, then generate', provider: 'anthropic');
+
+    expect($paused->pendingApprovals->pluck('id')->all())->toBe(['toolu_2']);
+
+    $resumed = (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_2' => true]), provider: 'anthropic');
+
+    expect($resumed->text)->toBe('The number is 72019.');
+
+    $messages = collect(Http::recorded())->last()[0]->data()['messages'];
+
+    // Anthropic rejects the request unless every tool_result is answered by a tool_use in the message right before it...
+    foreach ($messages as $index => $message) {
+        $resultIds = collect($message['content'])->where('type', 'tool_result')->pluck('tool_use_id')->all();
+
+        if ($resultIds === []) {
+            continue;
+        }
+
+        $callIds = collect($messages[$index - 1]['content'] ?? [])->where('type', 'tool_use')->pluck('id')->all();
+
+        expect(array_diff($resultIds, $callIds))->toBe([], "orphaned tool_result in message {$index}");
+    }
+
+    $assistantTurns = collect($messages)->where('role', 'assistant')->values();
+
+    // Each step replays with its own signed thinking block, in the order it happened...
+    expect($assistantTurns)->toHaveCount(2)
+        ->and($assistantTurns[0]['content'][0]['signature'])->toBe('signature-1')
+        ->and(collect($assistantTurns[0]['content'])->firstWhere('type', 'tool_use')['id'])->toBe('toolu_1')
+        ->and($assistantTurns[1]['content'][0]['signature'])->toBe('signature-2')
+        ->and(collect($assistantTurns[1]['content'])->firstWhere('type', 'tool_use')['id'])->toBe('toolu_2');
+});
+
+function assertToolCallsArePaired(array $messages, string $label): void
+{
+    foreach ($messages as $index => $message) {
+        $resultIds = collect($message['content'])->where('type', 'tool_result')->pluck('tool_use_id')->all();
+
+        if ($resultIds === []) {
+            continue;
+        }
+
+        $callIds = collect($messages[$index - 1]['content'] ?? [])->where('type', 'tool_use')->pluck('id')->all();
+
+        expect(array_diff($resultIds, $callIds))->toBe([], "{$label}: orphaned tool_result in message {$index}");
+    }
+
+    // And the reverse: no tool_use may go unanswered except in the final assistant turn.
+    foreach ($messages as $index => $message) {
+        if (($message['role'] ?? '') !== 'assistant' || $index === count($messages) - 1) {
+            continue;
+        }
+
+        $callIds = collect($message['content'])->where('type', 'tool_use')->pluck('id')->all();
+
+        if ($callIds === []) {
+            continue;
+        }
+
+        $resultIds = collect($messages[$index + 1]['content'] ?? [])->where('type', 'tool_result')->pluck('tool_use_id')->all();
+
+        expect(array_diff($callIds, $resultIds))->toBe([], "{$label}: unanswered tool_use in message {$index}");
+    }
+}
+
+function anthropicToolStep(string $id, string $tool, string $callId, string $signature): array
+{
+    return [
+        'id' => $id,
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-sonnet-4-6',
+        'content' => [
+            ['type' => 'thinking', 'thinking' => 'thinking', 'signature' => $signature],
+            ['type' => 'tool_use', 'id' => $callId, 'name' => $tool, 'input' => (object) []],
+        ],
+        'stop_reason' => 'tool_use',
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ];
+}
+
+function anthropicFinalStep(string $id): array
+{
+    return [
+        'id' => $id,
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-sonnet-4-6',
+        'content' => [['type' => 'text', 'text' => 'Done.']],
+        'stop_reason' => 'end_turn',
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ];
+}
+
+test('a resume that pauses again on a later step resumes cleanly', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            anthropicToolStep('m1', 'FixedNumberGenerator', 'toolu_1', 'sig-1'),
+            anthropicToolStep('m2', 'ApprovableNumberGenerator', 'toolu_2', 'sig-2'),
+            // Resume: an auto step, then a second pause.
+            anthropicToolStep('m3', 'FixedNumberGenerator', 'toolu_3', 'sig-3'),
+            anthropicToolStep('m4', 'ApprovableNumberGenerator', 'toolu_4', 'sig-4'),
+            anthropicFinalStep('m5'),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingMultiStepApprovableAgent)->forUser($user)->prompt('Go', provider: 'anthropic');
+    expect($paused->pendingApprovals->pluck('id')->all())->toBe(['toolu_2']);
+
+    $repaused = (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_2' => true]), provider: 'anthropic');
+
+    expect($repaused->pendingApprovals->pluck('id')->all())->toBe(['toolu_4']);
+
+    assertToolCallsArePaired(collect(Http::recorded())->last()[0]->data()['messages'], 'second pause request');
+
+    $final = (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_4' => true]), provider: 'anthropic');
+
+    expect($final->text)->toBe('Done.');
+
+    assertToolCallsArePaired(collect(Http::recorded())->last()[0]->data()['messages'], 'second resume request');
+});
+
+test('an abandoned multi-step pause settles when the conversation continues', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            anthropicToolStep('m1', 'FixedNumberGenerator', 'toolu_1', 'sig-1'),
+            anthropicToolStep('m2', 'ApprovableNumberGenerator', 'toolu_2', 'sig-2'),
+            anthropicFinalStep('m3'),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingMultiStepApprovableAgent)->forUser($user)->prompt('Go', provider: 'anthropic');
+    expect($paused->hasPendingApprovals())->toBeTrue();
+
+    (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt('Never mind, something else', provider: 'anthropic');
+
+    assertToolCallsArePaired(collect(Http::recorded())->last()[0]->data()['messages'], 'abandoned pause');
 });

--- a/tests/Feature/ToolApprovalResumeTest.php
+++ b/tests/Feature/ToolApprovalResumeTest.php
@@ -855,3 +855,42 @@ test('an abandoned multi-step pause settles when the conversation continues', fu
 
     assertToolCallsArePaired(collect(Http::recorded())->last()[0]->data()['messages'], 'abandoned pause');
 });
+
+test('a resolved pause keeps replaying its steps once the approval has landed', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            anthropicToolStep('m1', 'FixedNumberGenerator', 'toolu_1', 'sig-1'),
+            anthropicToolStep('m2', 'ApprovableNumberGenerator', 'toolu_2', 'sig-2'),
+            anthropicFinalStep('m3'),
+            anthropicFinalStep('m4'),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingMultiStepApprovableAgent)->forUser($user)->prompt('Go', provider: 'anthropic');
+
+    (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_2' => true]), provider: 'anthropic');
+
+    // A fresh turn: the resolved row still describes itself step by step rather than collapsing into one parallel call...
+    (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt('And now something else', provider: 'anthropic');
+
+    $messages = collect(Http::recorded())->last()[0]->data()['messages'];
+
+    assertToolCallsArePaired($messages, 'resolved turn replay');
+
+    $assistantTurns = collect($messages)->where('role', 'assistant')->values();
+
+    expect($assistantTurns)->toHaveCount(3)
+        ->and($assistantTurns[0]['content'][0]['signature'])->toBe('sig-1')
+        ->and(collect($assistantTurns[0]['content'])->where('type', 'tool_use')->pluck('id')->all())->toBe(['toolu_1'])
+        ->and($assistantTurns[1]['content'][0]['signature'])->toBe('sig-2')
+        ->and(collect($assistantTurns[1]['content'])->where('type', 'tool_use')->pluck('id')->all())->toBe(['toolu_2'])
+        ->and($assistantTurns[2]['content'][0]['text'])->toBe('Done.');
+});

--- a/tests/Fixtures/Agents/RememberingMultiStepApprovableAgent.php
+++ b/tests/Fixtures/Agents/RememberingMultiStepApprovableAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\ApprovableNumberGenerator;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+class RememberingMultiStepApprovableAgent implements Agent, Conversational, HasTools
+{
+    use Promptable;
+    use RemembersConversations;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that researches before using the gated tool.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     */
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator, new ApprovableNumberGenerator];
+    }
+}

--- a/tests/Unit/Gateway/TextGenerationLoopTest.php
+++ b/tests/Unit/Gateway/TextGenerationLoopTest.php
@@ -180,6 +180,51 @@ test('it emits streamed approval requests without executing gated tools', functi
         ->and(collect($events)->whereInstanceOf(StreamEnd::class))->toHaveCount(1);
 });
 
+test('a streamed pause on a later step carries the preceding steps replay state', function (): void {
+    $gated = new TextGenerationLoopApprovableTool;
+    $ungated = new TextGenerationLoopCountingTool;
+
+    $ungatedCall = new ToolCall('call-1', TextGenerationLoopCountingTool::class, [], 'call-1');
+    $gatedCall = new ToolCall('call-2', TextGenerationLoopApprovableTool::class, ['value' => 'danger'], 'call-2');
+
+    $stepOneBlocks = [['type' => 'thinking', 'signature' => 'sig-1'], ['type' => 'tool_use', 'id' => 'call-1']];
+    $stepTwoBlocks = [['type' => 'thinking', 'signature' => 'sig-2'], ['type' => 'tool_use', 'id' => 'call-2']];
+
+    $gateway = new TextGenerationLoopFakeGateway(streams: [
+        textGenerationLoopStreamStep(
+            events: [new ToolCallEvent('event-1', $ungatedCall, time())],
+            returns: new StepResponse('looking', [$ungatedCall], FinishReason::ToolCalls, new Usage, new Meta('fake', 'model'), providerContentBlocks: $stepOneBlocks),
+        ),
+        textGenerationLoopStreamStep(
+            events: [new ToolCallEvent('event-2', $gatedCall, time())],
+            returns: new StepResponse('acting', [$gatedCall], FinishReason::ToolCalls, new Usage, new Meta('fake', 'model'), providerContentBlocks: $stepTwoBlocks),
+        ),
+    ]);
+
+    $events = iterator_to_array((new TextGenerationLoop($gateway))->stream(
+        'invocation-1',
+        textGenerationLoopProvider(),
+        'model',
+        null,
+        [],
+        [$ungated, $gated],
+        null,
+        new TextGenerationOptions(maxSteps: 3),
+        null,
+    ));
+
+    $approval = collect($events)->whereInstanceOf(ToolApprovalRequest::class)->first();
+
+    // The paused step travels as providerContentBlocks; only the step before it is carried separately...
+    expect($approval->providerContentBlocks)->toBe($stepTwoBlocks)
+        ->and($approval->precedingProviderContentBlockSteps)->toHaveCount(1)
+        ->and($approval->precedingProviderContentBlockSteps[0]['tool_call_ids'])->toBe(['call-1'])
+        ->and($approval->precedingProviderContentBlockSteps[0]['blocks'])->toBe($stepOneBlocks)
+        ->and($approval->precedingProviderContentBlockSteps[0]['content'])->toBe('looking')
+        ->and($gated->calls)->toBe(0)
+        ->and($ungated->calls)->toBe(1);
+});
+
 test('it resumes a paused step running only the still-pending gated call', function (): void {
     $gated = new TextGenerationLoopApprovableTool;
     $ungated = new TextGenerationLoopCountingTool;


### PR DESCRIPTION
Currently, when an agent turn runs one or more automatic tool steps and then pauses for approval on a later step, resuming the approval fails with a 400 from Anthropic (and Bedrock):

```
messages.N.content.0: unexpected tool_use_id found in tool_result blocks: toolu_xxx
```

The paused turn is stored as one assistant row, but `provider_content_blocks` only captures the final step. On resume the rehydrated history replays results for tool calls the provider was never shown:

```
assistant: [thinking, tool_use call-2]              <- blocks from the paused step only
user:      [tool_result call-1, tool_result call-2] <- call-1 unmatched, request rejected
```

This PR makes the replay read like the turn actually happened:

```
assistant: [tool_use call-1]
user:      [tool_result call-1]
assistant: [thinking, tool_use call-2]              <- signed thinking replayed verbatim
user:      [tool_result call-2]
```

It fixes this in two layers. New pauses persist per-step replay state (`provider_content_block_steps`, each step's tool call ids, blocks, and text) so rehydration replays every step verbatim for all providers, including earlier steps' thinking blocks. For rows stored before this change, the store reconstructs the step structure at read time by partitioning results against the tool_use ids found in the saved blocks (Anthropic and Bedrock shapes). That heals existing paused conversations with no migration. Rows whose blocks carry no recognizable ids keep today's behavior, so DeepSeek and Gemini are untouched.

Single-step pauses don't get the new meta key since the existing blocks fully describe them. Tests cover the round trip, the legacy reconstruction for both block shapes, same-step executed results staying in place, and malformed step data falling back.

Fixes #809.
