### PR TITLE
Fix: SimilaritySearch tool output with additional JSON flags (for other languages)

### DIFF
--- a/src/Tools/SimilaritySearch.php
+++ b/src/Tools/SimilaritySearch.php
@@ -94,7 +94,7 @@ class SimilaritySearch implements Tool
         }
 
         return "Relevant results found. They are listed below in order of relevance:\n\n".
-            $results->toJson(JSON_PRETTY_PRINT);
+            $results->toJson(JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     }
 
     /**


### PR DESCRIPTION
SimilaritySearch::handle() currently serializes passages with json_encode's default escaping, so any non-ASCII content reaches the model as escape sequences; é -> \u00e9

Models frequently copy retrieved titles verbatim into their answers, so these escapes leak into user-visible text, and escaped output also costs ~2-6 tokens per word with an accented character instead of 1.

This PR adds JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES to the serialization, aligning the tool with the flags already used elsewhere in the SDK (NormalizesMcpResult, Tools/Filesystem/*).