### PR TITLE
Fix Gemini file import operation handling

### DIFF
--- a/src/Gateway/Gemini/GeminiStoreGateway.php
+++ b/src/Gateway/Gemini/GeminiStoreGateway.php
@@ -4,9 +4,12 @@ namespace Laravel\Ai\Gateway\Gemini;
 
 use DateInterval;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Sleep;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Providers\Provider;
@@ -17,6 +20,10 @@ class GeminiStoreGateway implements StoreGateway
 {
     use CreatesClient;
     use HandlesFailoverErrors;
+
+    protected const IMPORT_OPERATION_MAX_ATTEMPTS = 60;
+
+    protected const IMPORT_OPERATION_POLL_INTERVAL_SECONDS = 5;
 
     /**
      * Get a vector store by its ID.
@@ -83,7 +90,53 @@ class GeminiStoreGateway implements StoreGateway
             'customMetadata' => $metadata === [] ? null : $this->formatMetadata($metadata),
         ]))->throw());
 
-        return basename((string) $response->json('name'));
+        $operation = $this->waitForImportOperation($provider, $response);
+
+        if ($operation->json('error') !== null) {
+            throw new AiException(sprintf(
+                'Gemini file import failed: [%s] %s',
+                $operation->json('error.code', 'unknown'),
+                $operation->json('error.message', 'Unknown Gemini error.'),
+            ));
+        }
+
+        $documentName = $operation->json('response.documentName');
+
+        if (! is_string($documentName) || $documentName === '') {
+            throw new AiException('Gemini file import completed without a document name.');
+        }
+
+        return basename($documentName);
+    }
+
+    /**
+     * Wait for a Gemini file import operation to complete.
+     */
+    protected function waitForImportOperation(StoreProvider $provider, Response $operation): Response
+    {
+        $operationName = $operation->json('name');
+
+        if (! is_string($operationName) || $operationName === '') {
+            throw new AiException('Gemini file import did not return an operation name.');
+        }
+
+        $attempts = 0;
+
+        while (! $operation->json('done', false)) {
+            if ($attempts >= self::IMPORT_OPERATION_MAX_ATTEMPTS) {
+                throw new AiException('Gemini file import operation timed out.');
+            }
+
+            $attempts++;
+            Sleep::for(self::IMPORT_OPERATION_POLL_INTERVAL_SECONDS)->seconds();
+
+            $operation = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider)->get($this->baseUrl($provider)."/{$operationName}")->throw(),
+            );
+        }
+
+        return $operation;
     }
 
     /**

--- a/src/Gateway/Gemini/GeminiStoreGateway.php
+++ b/src/Gateway/Gemini/GeminiStoreGateway.php
@@ -21,10 +21,6 @@ class GeminiStoreGateway implements StoreGateway
     use CreatesClient;
     use HandlesFailoverErrors;
 
-    protected const IMPORT_OPERATION_MAX_ATTEMPTS = 60;
-
-    protected const IMPORT_OPERATION_POLL_INTERVAL_SECONDS = 5;
-
     /**
      * Get a vector store by its ID.
      */
@@ -94,7 +90,7 @@ class GeminiStoreGateway implements StoreGateway
 
         if ($operation->json('error') !== null) {
             throw new AiException(sprintf(
-                'Gemini file import failed: [%s] %s',
+                'Gemini Error: [%s] %s',
                 $operation->json('error.code', 'unknown'),
                 $operation->json('error.message', 'Unknown Gemini error.'),
             ));
@@ -103,7 +99,7 @@ class GeminiStoreGateway implements StoreGateway
         $documentName = $operation->json('response.documentName');
 
         if (! is_string($documentName) || $documentName === '') {
-            throw new AiException('Gemini file import completed without a document name.');
+            throw new AiException('Gemini Error: [invalid_response] File import completed without a document name.');
         }
 
         return basename($documentName);
@@ -116,19 +112,12 @@ class GeminiStoreGateway implements StoreGateway
     {
         $operationName = $operation->json('name');
 
-        if (! is_string($operationName) || $operationName === '') {
-            throw new AiException('Gemini file import did not return an operation name.');
-        }
-
-        $attempts = 0;
-
-        while (! $operation->json('done', false)) {
-            if ($attempts >= self::IMPORT_OPERATION_MAX_ATTEMPTS) {
-                throw new AiException('Gemini file import operation timed out.');
+        for ($attempt = 0; ! $operation->json('done', false); $attempt++) {
+            if ($attempt >= 60) {
+                throw new AiException('Gemini Error: [timeout] File import operation did not complete.');
             }
 
-            $attempts++;
-            Sleep::for(self::IMPORT_OPERATION_POLL_INTERVAL_SECONDS)->seconds();
+            Sleep::for(5)->seconds();
 
             $operation = $this->withErrorHandling(
                 $provider->name(),

--- a/tests/Feature/Providers/Gemini/StoreGatewayTest.php
+++ b/tests/Feature/Providers/Gemini/StoreGatewayTest.php
@@ -1,10 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
 use Laravel\Ai\AiManager;
+use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Stores;
 
 beforeEach(function (): void {
+    Sleep::fake(false);
+
     config(['ai.providers.gemini' => [
         ...config('ai.providers.gemini'),
         'key' => 'test-gemini-key',
@@ -77,8 +81,16 @@ test('create store with file ids adds files', function (): void {
         'generativelanguage.googleapis.com/*' => Http::sequence([
             Http::response(['name' => 'fileSearchStores/store123']),
             Http::response(fakeStoreResponse()),
-            Http::response(['name' => 'fileSearchStores/store123/documents/doc1']),
-            Http::response(['name' => 'fileSearchStores/store123/documents/doc2']),
+            Http::response([
+                'name' => 'fileSearchStores/store123/operations/import1',
+                'done' => true,
+                'response' => ['documentName' => 'fileSearchStores/store123/documents/doc1'],
+            ]),
+            Http::response([
+                'name' => 'fileSearchStores/store123/operations/import2',
+                'done' => true,
+                'response' => ['documentName' => 'fileSearchStores/store123/documents/doc2'],
+            ]),
         ]),
     ]);
 
@@ -90,7 +102,11 @@ test('create store with file ids adds files', function (): void {
 test('add file sends correct request', function (): void {
     Http::fake([
         'generativelanguage.googleapis.com/*' => Http::response([
-            'name' => 'fileSearchStores/store123/documents/doc456',
+            'name' => 'fileSearchStores/store123/operations/import456',
+            'done' => true,
+            'response' => [
+                'documentName' => 'fileSearchStores/store123/documents/doc456',
+            ],
         ]),
     ]);
 
@@ -104,10 +120,77 @@ test('add file sends correct request', function (): void {
         && ($request->data()['fileName'] ?? null) === 'files/file789');
 });
 
+test('add file waits for the import operation and returns the document id', function (): void {
+    Sleep::fake();
+
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            Http::response([
+                'name' => 'fileSearchStores/store123/operations/import456',
+                'done' => false,
+            ]),
+            Http::response([
+                'name' => 'fileSearchStores/store123/operations/import456',
+                'done' => true,
+                'response' => [
+                    'documentName' => 'fileSearchStores/store123/documents/doc456',
+                ],
+            ]),
+        ]),
+    ]);
+
+    $provider = geminiProvider();
+    $documentId = $provider->storeGateway()->addFile($provider, 'store123', 'file789');
+
+    expect($documentId)->toBe('doc456');
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn ($request): bool => $request->method() === 'GET'
+        && str_contains((string) $request->url(), 'fileSearchStores/store123/operations/import456'));
+    Sleep::assertSequence([Sleep::for(5)->seconds()]);
+});
+
+test('add file reports an import operation error', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'name' => 'fileSearchStores/store123/operations/import456',
+            'done' => true,
+            'error' => [
+                'code' => 13,
+                'message' => 'Indexing failed.',
+            ],
+        ]),
+    ]);
+
+    $provider = geminiProvider();
+
+    expect(fn (): string => $provider->storeGateway()->addFile($provider, 'store123', 'file789'))
+        ->toThrow(AiException::class, 'Gemini file import failed: [13] Indexing failed.');
+});
+
+test('add file rejects a completed import without a document name', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'name' => 'fileSearchStores/store123/operations/import456',
+            'done' => true,
+            'response' => [],
+        ]),
+    ]);
+
+    $provider = geminiProvider();
+
+    expect(fn (): string => $provider->storeGateway()->addFile($provider, 'store123', 'file789'))
+        ->toThrow(AiException::class, 'Gemini file import completed without a document name.');
+});
+
 test('add file with metadata formats correctly', function (): void {
     Http::fake([
         'generativelanguage.googleapis.com/*' => Http::response([
-            'name' => 'fileSearchStores/store123/documents/doc456',
+            'name' => 'fileSearchStores/store123/operations/import456',
+            'done' => true,
+            'response' => [
+                'documentName' => 'fileSearchStores/store123/documents/doc456',
+            ],
         ]),
     ]);
 

--- a/tests/Feature/Providers/Gemini/StoreGatewayTest.php
+++ b/tests/Feature/Providers/Gemini/StoreGatewayTest.php
@@ -7,8 +7,6 @@ use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Stores;
 
 beforeEach(function (): void {
-    Sleep::fake(false);
-
     config(['ai.providers.gemini' => [
         ...config('ai.providers.gemini'),
         'key' => 'test-gemini-key',
@@ -165,7 +163,7 @@ test('add file reports an import operation error', function (): void {
     $provider = geminiProvider();
 
     expect(fn (): string => $provider->storeGateway()->addFile($provider, 'store123', 'file789'))
-        ->toThrow(AiException::class, 'Gemini file import failed: [13] Indexing failed.');
+        ->toThrow(AiException::class, 'Gemini Error: [13] Indexing failed.');
 });
 
 test('add file rejects a completed import without a document name', function (): void {
@@ -180,7 +178,25 @@ test('add file rejects a completed import without a document name', function ():
     $provider = geminiProvider();
 
     expect(fn (): string => $provider->storeGateway()->addFile($provider, 'store123', 'file789'))
-        ->toThrow(AiException::class, 'Gemini file import completed without a document name.');
+        ->toThrow(AiException::class, 'Gemini Error: [invalid_response] File import completed without a document name.');
+});
+
+test('add file times out when the import operation never completes', function (): void {
+    Sleep::fake();
+
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response([
+            'name' => 'fileSearchStores/store123/operations/import456',
+            'done' => false,
+        ]),
+    ]);
+
+    $provider = geminiProvider();
+
+    expect(fn (): string => $provider->storeGateway()->addFile($provider, 'store123', 'file789'))
+        ->toThrow(AiException::class, 'Gemini Error: [timeout] File import operation did not complete.');
+
+    Http::assertSentCount(61);
 });
 
 test('add file with metadata formats correctly', function (): void {


### PR DESCRIPTION
`fileSearchStores.importFile` returns a long-running operation, but the Gemini store gateway currently treats that operation name as the imported document ID. This makes `Store::add()` return an operation ID and causes later document operations to target the wrong resource.

This change waits for the import operation to finish, surfaces operation failures and invalid responses, and returns the completed `response.documentName`. Polling is bounded and uses Laravel's sleep utility so the behavior remains testable.

Fixes #817

### Testing

- `vendor/bin/pest tests/Feature/Providers/Gemini/StoreGatewayTest.php --compact` — 15 passed, 32 assertions
- `php -d memory_limit=-1 vendor/bin/pest --compact --testsuite=Unit,Feature` — 1,883 passed, 24 skipped, 3,928 assertions
- `vendor/bin/pint --test src/Gateway/Gemini/GeminiStoreGateway.php tests/Feature/Providers/Gemini/StoreGatewayTest.php`
- `vendor/bin/phpstan analyse --memory-limit=-1`
