### PR TITLE
Expose the persisted assistant message ID on AgentResponse

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -143,6 +143,7 @@ class SalesCoach implements Agent, Conversational
 // Start a new conversation
 $response = (new SalesCoach)->forUser($user)->prompt('Hello!');
 $conversationId = $response->conversationId;
+$assistantMessageId = $response->assistantMessageId;
 
 // Continue an existing conversation
 $response = (new SalesCoach)->continue($conversationId, as: $user)->prompt('Tell me more.');

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -63,7 +63,7 @@ class RememberConversation
             }
 
             // Record assistant message...
-            $this->store->storeAssistantMessage(
+            $assistantMessageId = $this->store->storeAssistantMessage(
                 $agent->currentConversation(),
                 $participantType,
                 $participantId,
@@ -74,6 +74,7 @@ class RememberConversation
             $response->withinConversation(
                 $agent->currentConversation(),
                 $participant,
+                $assistantMessageId,
             );
         });
     }

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -16,6 +16,8 @@ class AgentResponse extends TextResponse
 
     public ?object $conversationUser = null;
 
+    public ?string $assistantMessageId = null;
+
     public function __construct(string $invocationId, string $text, Usage $usage, Meta $meta)
     {
         $this->invocationId = $invocationId;
@@ -35,12 +37,13 @@ class AgentResponse extends TextResponse
     }
 
     /**
-     * Set the conversation UUID and participant for this response.
+     * Set the conversation UUID, participant, and persisted assistant message ID for this response.
      */
-    public function withinConversation(string $conversationId, ?object $conversationUser = null): self
+    public function withinConversation(string $conversationId, ?object $conversationUser = null, ?string $assistantMessageId = null): self
     {
         $this->conversationId = $conversationId;
         $this->conversationUser = $conversationUser;
+        $this->assistantMessageId = $assistantMessageId;
 
         return $this;
     }

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -30,6 +30,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
     public ?object $conversationUser = null;
 
+    public ?string $assistantMessageId = null;
+
     protected array $thenCallbacks = [];
 
     protected bool $usesVercelProtocol = false;
@@ -80,12 +82,13 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     }
 
     /**
-     * Set the conversation UUID for this response.
+     * Set the conversation UUID and persisted assistant message ID for this response.
      */
-    public function withinConversation(?string $conversationId, ?object $conversationUser = null): self
+    public function withinConversation(?string $conversationId, ?object $conversationUser = null, ?string $assistantMessageId = null): self
     {
         $this->conversationId = $conversationId;
         $this->conversationUser = $conversationUser;
+        $this->assistantMessageId = $assistantMessageId;
 
         return $this;
     }
@@ -102,7 +105,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         }
 
         if ($response->conversationId !== null) {
-            $this->withinConversation($response->conversationId, $response->conversationUser);
+            $this->withinConversation($response->conversationId, $response->conversationUser, $response->assistantMessageId);
         }
 
         return $this;
@@ -177,7 +180,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         if ($this->conversationId !== null) {
             $this->streamedResponse->withinConversation(
                 $this->conversationId,
-                $this->conversationUser
+                $this->conversationUser,
+                $this->assistantMessageId
             );
         }
 
@@ -196,5 +200,6 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
         $this->conversationId = $this->streamedResponse->conversationId;
         $this->conversationUser = $this->streamedResponse->conversationUser;
+        $this->assistantMessageId = $this->streamedResponse->assistantMessageId;
     }
 }

--- a/tests/Feature/AgentMiddlewareTest.php
+++ b/tests/Feature/AgentMiddlewareTest.php
@@ -87,6 +87,35 @@ test('agent streamed event receives prompt when middleware short circuits a stre
         && $event->prompt->prompt === 'Test prompt');
 });
 
+test('response exposes the persisted assistant message id after a remembered conversation', function (): void {
+    app()->instance(ConversationStore::class, new FakeConversationStore);
+
+    RememberingAssistantAgent::fake([
+        'Fake response',
+    ]);
+
+    $user = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)->forUser($user)->prompt('Test prompt');
+
+    expect($response->conversationId)->toBe('conversation-123')
+        ->and($response->assistantMessageId)->toBe('assistant-message-123');
+});
+
+test('response assistant message id is null when the conversation is not remembered', function (): void {
+    AssistantAgent::fake([
+        'Fake response',
+    ]);
+
+    $response = (new AssistantAgent)->prompt('Test prompt');
+
+    expect($response->conversationId)->toBeNull()
+        ->and($response->assistantMessageId)->toBeNull();
+});
+
 test('stream response conversation id is available after remembered conversations stream completes', function (): void {
     app()->instance(ConversationStore::class, new FakeConversationStore);
 
@@ -106,7 +135,8 @@ test('stream response conversation id is available after remembered conversation
     }
 
     expect($response->conversationId)->toBe('conversation-123')
-        ->and($response->conversationUser)->toBe($user);
+        ->and($response->conversationUser)->toBe($user)
+        ->and($response->assistantMessageId)->toBe('assistant-message-123');
 });
 
 test('stream response conversation id is available when continuing an existing conversation', function (): void {
@@ -130,7 +160,8 @@ test('stream response conversation id is available when continuing an existing c
     }
 
     expect($response->conversationId)->toBe('existing-conversation-id')
-        ->and($response->conversationUser)->toBe($user);
+        ->and($response->conversationUser)->toBe($user)
+        ->and($response->assistantMessageId)->toBe('assistant-message-123');
 });
 
 test('stream response conversation id syncs after late then callbacks', function (): void {

--- a/tests/Feature/AgentStreamFailoverTest.php
+++ b/tests/Feature/AgentStreamFailoverTest.php
@@ -294,8 +294,13 @@ test('stream conversation state survives failover', function (): void {
     foreach ($response as $_) {
     }
 
+    $assistantMessageId = collect($store->messages)->firstWhere('role', 'assistant')['id'];
+
+    // The response exposes the ID of the assistant message that was actually persisted...
     expect($thenResponse->conversationId)->toBe($existingConversationId)
-        ->and($thenResponse->conversationUser)->toBe($user);
+        ->and($thenResponse->conversationUser)->toBe($user)
+        ->and($thenResponse->assistantMessageId)->toBe($assistantMessageId)
+        ->and($response->assistantMessageId)->toBe($assistantMessageId);
 });
 
 function fakeGroqStreamBodyForStreamFailover(): string


### PR DESCRIPTION
When conversation persistence is enabled, `RememberConversation` stores the assistant
message via `ConversationStore::storeAssistantMessage()`, which returns the ID of the
newly persisted message — but the middleware currently discards it. The response
exposes `conversationId`, yet not the ID of the message that was just written.

Applications that want to attach additional data to that exact message after the turn
(citations/sources, attachments, scores, metadata) currently have to guess "the latest
assistant message in the conversation" or subclass the conversation store just to
intercept the return value.

This PR keeps the ID and passes it through `withinConversation()` into a new nullable
`assistantMessageId` property on `AgentResponse` (inherited by `StreamedAgentResponse`,
and propagated through `StreamableAgentResponse` for the streaming path):

    // Non-streamed
    $response = $agent->prompt('...');
    $response->assistantMessageId; // ID of the assistant message just persisted, or null

    // Streamed
    $stream = $agent->stream('...');
    foreach ($stream as $event) { /* ... */ }
    $stream->assistantMessageId;   // same, once the stream has been consumed

`null` remains a legitimate state: when persistence is not enabled, or when the store
itself returns `null` (approval-resume turns that produce no text, no tool calls, and
no new tool results insert no row).

Fully backward compatible: optional trailing parameters, nullable properties, no
behavior change anywhere else. Covered by new and extended tests in
`AgentMiddlewareTest` (non-streamed, streamed, not-remembered) and
`AgentStreamFailoverTest` (ID survives failover and `then()` callbacks).
