### PR TITLE
Preserve input boundaries in embeddings cache key

### DIFF
--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -213,7 +213,7 @@ class PendingEmbeddingsGeneration
         if (array_all($this->inputs, fn ($input) => is_string($input))) {
             return 'laravel-embeddings:'.hash(
                 'sha256',
-                $provider->driver().'-'.$model.'-'.$dimensions.'-'.$optionsFingerprint.'-'.implode('-', $this->inputs),
+                $provider->driver().'-'.$model.'-'.$dimensions.'-'.$optionsFingerprint.'-'.json_encode($this->inputs, JSON_THROW_ON_ERROR),
             );
         }
 

--- a/tests/Feature/EmbeddingsCacheTest.php
+++ b/tests/Feature/EmbeddingsCacheTest.php
@@ -54,6 +54,13 @@ test('negative cache seconds bypasses an existing cached entry', function (): vo
     expect(Http::recorded())->toHaveCount(2);
 });
 
+test('distinct string batches do not share a cache entry', function (): void {
+    Embeddings::for(['a-b', 'c'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['a', 'b-c'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(2);
+});
+
 test('toEmbeddings honors cache false even when enabled globally', function (): void {
     config(['ai.caching.embeddings.cache' => true]);
 


### PR DESCRIPTION
The all-string branch of `cacheKey()` joined inputs with `implode('-', ...)`, which loses the boundaries between items. Batches like `['a-b', 'c']` and `['a', 'b-c']` produced the same key, so a cached response for one could be handed back for the other. Encoding the inputs as JSON keeps each item distinct.

Fixes #826