### PR TITLE
Replace deprected DeepSeek model  name with deepseek-v4-flash

### DIFF
--- a/src/Providers/DeepSeekProvider.php
+++ b/src/Providers/DeepSeekProvider.php
@@ -31,7 +31,7 @@ class DeepSeekProvider extends Provider implements TextProvider
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['text']['default'] ?? 'deepseek-chat';
+        return $this->config['models']['text']['default'] ?? 'deepseek-v4-flash';
     }
 
     /**
@@ -39,7 +39,7 @@ class DeepSeekProvider extends Provider implements TextProvider
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['text']['cheapest'] ?? 'deepseek-chat';
+        return $this->config['models']['text']['cheapest'] ?? 'deepseek-v4-flash';
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR updates the default DeepSeek model from `deepseek-chat` to `deepseek-v4-flash`.

## Motivation

The previous default model (`deepseek-chat`) is no longer accepted by the DeepSeek API and results in a `400 Bad Request` response:

```text
The supported API model names are deepseek-v4-pro or deepseek-v4-flash, but you passed deepseek-chat.
```

Updating the default model to `deepseek-v4-flash` ensures the package works out of the box with the current DeepSeek API without requiring users to override the model configuration.

## Changes

* Changed the default DeepSeek model from `deepseek-chat` to `deepseek-v4-flash`.

## Backward Compatibility

This change aligns the package with the current DeepSeek API. Users who wish to use a different supported model (such as `deepseek-v4-pro`) can continue to override the default configuration as before.
