### PR TITLE
Fix colliding embeddings cache keys for distinct string batches

### DIFF
--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -208,20 +208,11 @@ class PendingEmbeddingsGeneration
      */
     protected function cacheKey(Provider $provider, string $model, int $dimensions, array $providerOptions): string
     {
-        $optionsFingerprint = $this->fingerprintProviderOptions($providerOptions);
-
-        if (array_all($this->inputs, fn ($input) => is_string($input))) {
-            return 'laravel-embeddings:'.hash(
-                'sha256',
-                $provider->driver().'-'.$model.'-'.$dimensions.'-'.$optionsFingerprint.'-'.implode('-', $this->inputs),
-            );
-        }
-
         return 'laravel-embeddings:'.hash('sha256', json_encode([
             'driver' => $provider->driver(),
             'model' => $model,
             'dimensions' => $dimensions,
-            'options' => $optionsFingerprint,
+            'options' => $this->fingerprintProviderOptions($providerOptions),
             'inputs' => array_map($this->normalizeInputForCache(...), $this->inputs),
         ], JSON_THROW_ON_ERROR));
     }

--- a/tests/Feature/EmbeddingsCacheTest.php
+++ b/tests/Feature/EmbeddingsCacheTest.php
@@ -63,6 +63,27 @@ test('toEmbeddings honors cache false even when enabled globally', function (): 
     expect(Http::recorded())->toHaveCount(2);
 });
 
+test('inputs that differ only in their boundaries do not share a cache entry', function (): void {
+    Embeddings::for(['a-b', 'c'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['a', 'b-c'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(2);
+});
+
+test('identical string inputs still share a cache entry', function (): void {
+    Embeddings::for(['a-b', 'c'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['a-b', 'c'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
+test('reordered string inputs do not share a cache entry', function (): void {
+    Embeddings::for(['a', 'b'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['b', 'a'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(2);
+});
+
 test('toEmbeddings uses cache when enabled globally', function (): void {
     config(['ai.caching.embeddings.cache' => true]);
 


### PR DESCRIPTION
## Summary

- remove the all-strings special case in `PendingEmbeddingsGeneration::cacheKey()` so every input batch is keyed by the structured representation that the method already builds for non-string inputs

Fixes #826.

## Why

When every input is a string, the key material is built with `implode('-', $this->inputs)`. That loses the input boundaries, so distinct batches produce identical keys:

```php
Embeddings::for(['a-b', 'c'])->cache(3600)->generate(...);
Embeddings::for(['a', 'b-c'])->cache(3600)->generate(...);
```

The second call is served the first call's cached vectors, which means the caller silently receives embeddings for text it never sent.

The branch below it already handles this correctly by hashing a JSON structure, and `normalizeInputForCache()` already maps a string to `['type' => 'text', 'value' => $input]`. So the special case is not needed for strings to be supported, and deleting it makes one code path serve every input type.

## Impact

Cache keys for all-string batches change, so previously cached entries are missed once and regenerated. No API changes.

## Testing

Three cases added to `tests/Feature/EmbeddingsCacheTest.php`, covering the colliding batches, identical inputs still sharing an entry, and reordered inputs not sharing one. The first fails on `0.x` before this change and passes after.

- `vendor/bin/pest tests/Feature/EmbeddingsCacheTest.php`
- `php -d memory_limit=-1 vendor/bin/pest`
- `vendor/bin/phpstan --memory-limit=-1 --no-progress`
- `composer test:lint`

