### PR TITLE
Add Gemini tool-loop coverage for thought signature preservation

### DIFF
--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -166,6 +166,49 @@ describe('tool calls', function (): void {
             }
         }
     });
+
+    test('streaming preserves the thought signature across the tool call continuation', function (): void {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence([
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunk([['text' => 'thinking...', 'thought' => true]]),
+                        $this->geminiChunkWithUsage([[
+                            'functionCall' => ['id' => 'call_1', 'name' => 'FixedNumberGenerator', 'args' => (object) []],
+                            'thoughtSignature' => 'sig_stream_555',
+                        ]], 10, 5),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+                Http::response(
+                    body: $this->ssePayload([
+                        $this->geminiChunkWithUsage([['text' => 'The number is 72019']], 20, 10),
+                    ]),
+                    status: 200,
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+            ]),
+        ]);
+
+        $this->collectStreamEvents(agent: new ProviderOptionsWithToolsAgent);
+
+        $followUpContents = Http::recorded()[1][0]->data()['contents'];
+
+        $signature = null;
+
+        foreach ($followUpContents as $content) {
+            if ($content['role'] === 'model') {
+                foreach ($content['parts'] as $part) {
+                    if (isset($part['functionCall'])) {
+                        $signature = $part['thoughtSignature'] ?? null;
+                    }
+                }
+            }
+        }
+
+        expect($signature)->toBe('sig_stream_555');
+    });
 });
 
 describe('thinking blocks', function (): void {

--- a/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Gemini/ToolCallLoopTest.php
@@ -247,3 +247,50 @@ test('thinking parts are excluded from tool call continuation', function (): voi
         }
     }
 });
+
+test('thought signature is preserved across the tool call continuation', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::sequence([
+            Http::response([
+                'candidates' => [[
+                    'content' => [
+                        'parts' => [
+                            ['text' => 'Let me generate that...', 'thought' => true],
+                            [
+                                'functionCall' => ['id' => 'call_1', 'name' => 'FixedNumberGenerator', 'args' => (object) []],
+                                'thoughtSignature' => 'sig_abc_123',
+                            ],
+                        ],
+                        'role' => 'model',
+                    ],
+                    'finishReason' => 'STOP',
+                ]],
+                'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5],
+            ]),
+            $this->fakeTextResponse('The number is 72019'),
+        ]),
+    ]);
+
+    (new ToolUsingAgent(fixed: true))->prompt('Generate', provider: 'gemini');
+
+    $recorded = Http::recorded();
+    expect($recorded)->toHaveCount(2);
+
+    $followUpContents = $recorded[1][0]->data()['contents'];
+
+    $signature = null;
+
+    foreach ($followUpContents as $content) {
+        if ($content['role'] === 'model') {
+            foreach ($content['parts'] as $part) {
+                if (isset($part['functionCall'])) {
+                    $signature = $part['thoughtSignature'] ?? null;
+                }
+            }
+        }
+    }
+
+    // Gemini 3 rejects tool-call history whose functionCall part is missing its
+    // thoughtSignature, so the signature must survive the round trip verbatim.
+    expect($signature)->toBe('sig_abc_123');
+});


### PR DESCRIPTION
Adds a couple of tests pinning that the `thoughtSignature` on a Gemini function-call part survives the tool-call continuation, on both the non-streaming and streaming paths.

Why it matters: on the `generateContent` API the signature comes back as a sibling of `functionCall`, and Gemini 3 rejects tool history whose functionCall part is missing it (`Function call ... is missing a thought_signature`). The default text model is `gemini-3.x`, so this is the default agent tool path, and it wasn't covered. The gateway already preserves it (`sanitizeRequestParts` only rebuilds the inner `functionCall` and keeps the rest of the part), these tests just lock that in so a future refactor can't quietly drop it.

Tests only, no behavior change. Both pass on `0.x`, and I checked they go red if the sanitizer stops preserving the sibling.

Came out of the discussion on #816.
