### PR TITLE
Pass provider to the agent tools method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,39 @@
 # Upgrade Guide
 
+## Upgrading To 1.0 From 0.x
+
+### Provider Aware Agent Tools
+
+**Likelihood Of Impact: High**
+
+The `HasTools` contract now receives the provider that is being invoked, allowing an agent to offer a different set of tools to each provider. Agents implementing `HasTools` should add the `$provider` argument to their `tools` method:
+
+```php
+use Laravel\Ai\Enums\Lab;
+
+/**
+ * Get the tools available to the agent for the given provider.
+ */
+public function tools(Lab|string $provider): iterable
+{
+    return [new SearchKnowledgeBase];
+}
+```
+
+The argument is the `Lab` the provider belongs to, so tools may be limited to the providers that support them. This is particularly useful when failing over between providers, since the tools are resolved again for each provider that is attempted:
+
+```php
+public function tools(Lab|string $provider): iterable
+{
+    return match ($provider) {
+        Lab::Anthropic => [new SearchKnowledgeBase, new WebFetch],
+        default => [new SearchKnowledgeBase],
+    };
+}
+```
+
+Connections using the `openai-compatible` driver receive their connection name instead, matching the existing behavior of `providerOptions`.
+
 ## Upgrading To 0.11 From 0.10
 
 ### Connection Failures Throw `ProviderConnectionException`

--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -312,15 +312,28 @@ Implement the `HasTools` interface and scaffold tools with `php artisan make:too
 
 ```php
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 
 class MyAgent implements Agent, HasTools
 {
     use Promptable;
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new MyCustomTool];
     }
+}
+```
+
+The `$provider` argument is the `Lab` currently being invoked, so tools may be limited to the providers that support them. Tools are resolved again for each provider attempted during failover:
+
+```php
+public function tools(Lab|string $provider): iterable
+{
+    return match ($provider) {
+        Lab::Anthropic => [new MyCustomTool, new WebFetch],
+        default => [new MyCustomTool],
+    };
 }
 ```
 
@@ -329,7 +342,7 @@ class MyAgent implements Agent, HasTools
 ```php
 use Laravel\Ai\Providers\Tools\{WebSearch, WebFetch, FileSearch};
 
-public function tools(): iterable
+public function tools(Lab|string $provider): iterable
 {
     return [
         (new WebSearch)->max(5)->allow(['laravel.com']),

--- a/src/AnonymousAgent.php
+++ b/src/AnonymousAgent.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 
 /**
  * @phpstan-consistent-constructor
@@ -25,7 +26,7 @@ class AnonymousAgent implements Agent, Conversational, HasTools
         return $this->messages;
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return $this->tools;
     }

--- a/src/Contracts/HasTools.php
+++ b/src/Contracts/HasTools.php
@@ -2,14 +2,15 @@
 
 namespace Laravel\Ai\Contracts;
 
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 
 interface HasTools
 {
     /**
-     * Get the tools available to the agent.
+     * Get the tools available to the agent for the given provider.
      *
      * @return array<Tool|ProviderTool>
      */
-    public function tools(): iterable;
+    public function tools(Lab|string $provider): iterable;
 }

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -172,7 +172,7 @@ trait GeneratesText
 
         return array_map(
             fn ($tool) => $this->resolveTool($tool),
-            [...$agent->tools()],
+            [...$agent->tools($this->lab())],
         );
     }
 

--- a/src/Providers/OpenAiCompatibleProvider.php
+++ b/src/Providers/OpenAiCompatibleProvider.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\OpenAiCompatible\OpenAiCompatibleGateway;
 
 class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider
@@ -34,6 +35,15 @@ class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, Te
     public function providerCredentials(): array
     {
         return ['key' => $this->config['key'] ?? null];
+    }
+
+    /**
+     * Get the lab that provider-specific configuration should be resolved by.
+     */
+    #[\Override]
+    public function lab(): Lab|string
+    {
+        return $this->name();
     }
 
     /**

--- a/src/Providers/Provider.php
+++ b/src/Providers/Provider.php
@@ -32,6 +32,14 @@ abstract class Provider implements \Stringable, ProviderContract
     }
 
     /**
+     * Get the lab that provider-specific configuration should be resolved by.
+     */
+    public function lab(): Lab|string
+    {
+        return Lab::tryFrom($this->driver()) ?? $this->driver();
+    }
+
+    /**
      * Get the credentials for the underlying AI provider.
      */
     public function providerCredentials(): array

--- a/stubs/agent.stub
+++ b/stubs/agent.stub
@@ -6,6 +6,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Promptable;
 use Stringable;
@@ -33,11 +34,11 @@ class {{ class }} implements Agent, Conversational, HasTools
     }
 
     /**
-     * Get the tools available to the agent.
+     * Get the tools available to the agent for the given provider.
      *
      * @return Tool[]
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [];
     }

--- a/stubs/structured-agent.stub
+++ b/stubs/structured-agent.stub
@@ -8,6 +8,7 @@ use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Promptable;
 use Stringable;
@@ -35,11 +36,11 @@ class {{ class }} implements Agent, Conversational, HasStructuredOutput, HasTool
     }
 
     /**
-     * Get the tools available to the agent.
+     * Get the tools available to the agent for the given provider.
      *
      * @return Tool[]
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [];
     }

--- a/tests/Feature/AgentProviderToolsTest.php
+++ b/tests/Feature/AgentProviderToolsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Fixtures\Agents\ProviderToolsAgent;
+
+test('agent tools receive the lab of the provider being invoked', function (): void {
+    Http::fake(['api.anthropic.com/*' => fakeAnthropicResponse()]);
+
+    (new ProviderToolsAgent)->prompt('Fetch something', provider: 'anthropic');
+
+    Http::assertSent(function (Request $request): bool {
+        $names = collect($request->data()['tools'] ?? [])->pluck('name')->all();
+
+        return in_array('web_fetch', $names, true)
+            && in_array('FixedNumberGenerator', $names, true);
+    });
+});
+
+test('provider specific tools are omitted when another provider is invoked', function (): void {
+    Http::fake(['api.openai.com/*' => fakeOpenAiResponse()]);
+
+    (new ProviderToolsAgent)->prompt('Fetch something', provider: 'openai');
+
+    Http::assertSent(function (Request $request): bool {
+        $tools = collect($request->data()['tools'] ?? []);
+
+        return $tools->count() === 1
+            && $tools->pluck('name')->all() === ['FixedNumberGenerator'];
+    });
+});
+
+test('agent tools receive the lab of the provider rather than its connection name', function (): void {
+    config(['ai.providers.primary' => ['driver' => 'anthropic', 'key' => 'test-key']]);
+
+    Http::fake(['api.anthropic.com/*' => fakeAnthropicResponse()]);
+
+    (new ProviderToolsAgent)->prompt('Fetch something', provider: 'primary');
+
+    Http::assertSent(function (Request $request): bool {
+        $names = collect($request->data()['tools'] ?? [])->pluck('name')->all();
+
+        return in_array('web_fetch', $names, true);
+    });
+});
+
+test('tools are resolved again for each provider during failover', function (): void {
+    config([
+        'ai.providers.primary' => ['driver' => 'anthropic', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'openai', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(status: 429),
+        'api.openai.com/*' => fakeOpenAiResponse('Hello'),
+    ]);
+
+    $response = (new ProviderToolsAgent)->prompt(
+        'Fetch something',
+        provider: ['primary', 'backup'],
+    );
+
+    expect($response->text)->toBe('Hello');
+
+    Http::assertSent(function (Request $request): bool {
+        $names = collect($request->data()['tools'] ?? [])->pluck('name')->all();
+
+        return str_contains($request->url(), 'api.anthropic.com')
+            && in_array('web_fetch', $names, true);
+    });
+
+    Http::assertSent(function (Request $request): bool {
+        $names = collect($request->data()['tools'] ?? [])->pluck('name')->all();
+
+        return str_contains($request->url(), 'api.openai.com')
+            && $names === ['FixedNumberGenerator'];
+    });
+});

--- a/tests/Feature/FilesystemToolsTest.php
+++ b/tests/Feature/FilesystemToolsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Tools\FileStorage;
 use Laravel\Ai\Tools\Filesystem\CopyFile;
@@ -348,7 +349,7 @@ class FileStorageAgent implements Agent, HasTools
         return 'You manage files on disk using the available tools.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return FileStorage::all('local');
     }

--- a/tests/Feature/McpServerToolTest.php
+++ b/tests/Feature/McpServerToolTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Tests\Fixtures\Mcp\FakeMcpServerTool;
@@ -20,7 +21,7 @@ test('agents can return mcp server tools directly', function (): void {
             return 'Use available tools.';
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return [$this->tool];
         }

--- a/tests/Feature/McpToolTest.php
+++ b/tests/Feature/McpToolTest.php
@@ -2,6 +2,7 @@
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Tools\McpTool;
@@ -36,7 +37,7 @@ test('agents can return mcp client tools directly', function (): void {
             return 'Use available tools.';
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return [$this->tool];
         }
@@ -90,7 +91,7 @@ test('it runs mcp client tools whose schema uses unrepresentable json schema', f
             return 'Use available tools.';
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return [$this->tool];
         }

--- a/tests/Feature/Providers/AzureOpenAi/ToolSearchTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ToolSearchTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Tests\Fixtures\Tools\DeferredTool;
@@ -29,7 +30,7 @@ test('Azure rejects a ToolSearch tool because it does not support hosted tool se
             return 'You are a helpful assistant.';
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return [new NonStrictTool, new ToolSearch(tools: [new DeferredTool])];
         }

--- a/tests/Feature/Providers/OpenAi/MessageMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/MessageMappingTest.php
@@ -202,7 +202,7 @@ test('empty tool arguments serialize as object string on assistant replay', func
             ])),
             new UserMessage('thanks'),
         ],
-        tools: [(new ToolUsingAgent(fixed: true))->tools()[0]],
+        tools: [(new ToolUsingAgent(fixed: true))->tools(Lab::OpenAI)[0]],
     )->prompt('', provider: 'openai');
 
     Http::assertSent(function (Request $request): bool {
@@ -242,7 +242,7 @@ test('non-empty tool arguments preserve shape on assistant replay', function ():
             ])),
             new UserMessage('thanks'),
         ],
-        tools: [(new ToolUsingAgent(fixed: true))->tools()[0]],
+        tools: [(new ToolUsingAgent(fixed: true))->tools(Lab::OpenAI)[0]],
     )->prompt('', provider: 'openai');
 
     Http::assertSent(function (Request $request): bool {
@@ -298,7 +298,7 @@ test('reasoning blocks are interleaved with associated tool calls on assistant r
             ])),
             new UserMessage('thanks'),
         ],
-        tools: [(new ToolUsingAgent(fixed: true))->tools()[0]],
+        tools: [(new ToolUsingAgent(fixed: true))->tools(Lab::OpenAI)[0]],
     )->prompt('', provider: 'openai');
 
     Http::assertSent(function (Request $request): bool {

--- a/tests/Feature/Providers/OpenAi/ToolSearchTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolSearchTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Tests\Fixtures\Agents\OpenAiToolSearchAgent;
@@ -63,7 +64,7 @@ test('an agent whose only tool is an empty ToolSearch omits the tool fields', fu
             return 'You are a helpful assistant.';
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return [new ToolSearch];
         }

--- a/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\AgentResponse;
@@ -12,6 +13,7 @@ use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
 use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
 use function Laravel\Ai\agent;
 
@@ -325,6 +327,51 @@ test('named instances resolve provider options by their instance name', function
 
     Http::assertSent(fn (Request $request): bool => $request->url() === 'http://localhost:8000/v1/chat/completions'
         && data_get(json_decode($request->body(), true), 'top_k') === 10);
+});
+
+test('named instances resolve tools by their instance name', function (): void {
+    config(['ai.providers.lm-studio' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:4321/v1',
+        'key' => 'lm-studio-key',
+        'models' => ['text' => ['default' => 'lm-studio-model']],
+    ]]);
+
+    config(['ai.providers.vllm' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:8000/v1',
+        'key' => 'vllm-key',
+        'models' => ['text' => ['default' => 'vllm-model']],
+    ]]);
+
+    Http::fake(['*' => fakeOpenAiCompatibleResponse('Hello')]);
+
+    $agent = new class implements Agent, HasTools
+    {
+        use Promptable;
+
+        public function instructions(): string
+        {
+            return 'You are a helpful assistant.';
+        }
+
+        public function tools(Lab|string $provider): iterable
+        {
+            return match ($provider) {
+                'lm-studio' => [new FixedNumberGenerator],
+                default => [],
+            };
+        }
+    };
+
+    $agent->prompt('Hello', provider: 'lm-studio');
+    $agent->prompt('Hello', provider: 'vllm');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'http://localhost:4321/v1/chat/completions'
+        && collect(data_get(json_decode($request->body(), true), 'tools'))->pluck('function.name')->all() === ['FixedNumberGenerator']);
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'http://localhost:8000/v1/chat/completions'
+        && data_get(json_decode($request->body(), true), 'tools') === null);
 });
 
 function configureOpenAiCompatible(): void

--- a/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolCallLoopTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Exceptions\NoSuchToolException;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\AgentResponse;
@@ -66,7 +67,7 @@ test('max steps limits tool call depth', function (): void {
             return 'You are a helpful assistant.';
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return [new FixedNumberGenerator];
         }

--- a/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
+++ b/tests/Feature/Providers/TextGenerationOptionsInToolLoopTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Groq\GroqGateway;
 use Laravel\Ai\Gateway\OpenAi\OpenAiGateway;
 use Laravel\Ai\Promptable;
@@ -27,7 +28,7 @@ class TextGenOptionsToolAgent implements Agent, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new FixedNumberGenerator];
     }

--- a/tests/Feature/Providers/TimeoutInToolLoopTest.php
+++ b/tests/Feature/Providers/TimeoutInToolLoopTest.php
@@ -8,6 +8,7 @@ use Laravel\Ai\AiManager;
 use Laravel\Ai\Attributes\Timeout;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
 use Laravel\Ai\Gateway\Gemini\GeminiGateway;
 use Laravel\Ai\Gateway\Groq\GroqGateway;
@@ -30,7 +31,7 @@ class TimeoutToolAgent implements Agent, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new FixedNumberGenerator];
     }

--- a/tests/Feature/Providers/Xai/MessageMappingTest.php
+++ b/tests/Feature/Providers/Xai/MessageMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Files\Base64Image;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\RemoteDocument;
@@ -193,7 +194,7 @@ test('reasoning blocks are interleaved with associated tool calls on assistant r
             ])),
             new UserMessage('thanks'),
         ],
-        tools: [(new ToolUsingAgent(fixed: true))->tools()[0]],
+        tools: [(new ToolUsingAgent(fixed: true))->tools(Lab::xAI)[0]],
     )->prompt('', provider: 'xai');
 
     Http::assertSent(function (Request $request): bool {

--- a/tests/Feature/SubAgentTest.php
+++ b/tests/Feature/SubAgentTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\ToolCall;
@@ -84,7 +85,7 @@ test('agent tool falls back to a generic description that does not leak instruct
 });
 
 test('framework wraps an agent in tools automatically when resolving', function (): void {
-    $tools = (new DelegatingAgent)->tools();
+    $tools = (new DelegatingAgent)->tools(Lab::OpenAI);
 
     $resolved = array_map(
         fn ($tool) => $tool instanceof Agent ? new AgentTool($tool) : $tool,

--- a/tests/Fixtures/Agents/AnthropicToolSearchAgent.php
+++ b/tests/Fixtures/Agents/AnthropicToolSearchAgent.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Attributes\Model;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Tests\Fixtures\Tools\DeferredTool;
@@ -22,7 +23,7 @@ class AnthropicToolSearchAgent implements Agent, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new NonStrictTool, new ToolSearch(tools: [new DeferredTool])];
     }

--- a/tests/Fixtures/Agents/AttributeToolChoiceAgent.php
+++ b/tests/Fixtures/Agents/AttributeToolChoiceAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\ToolChoice;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -18,7 +19,7 @@ class AttributeToolChoiceAgent implements Agent, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new RandomNumberGenerator,

--- a/tests/Fixtures/Agents/DelegatingAgent.php
+++ b/tests/Fixtures/Agents/DelegatingAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 class DelegatingAgent implements Agent, HasTools
@@ -15,7 +16,7 @@ class DelegatingAgent implements Agent, HasTools
         return 'You are a project manager that delegates research tasks to your research_agent sub-agent.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new ResearchAgent,

--- a/tests/Fixtures/Agents/DelegatingViaCustomToolAgent.php
+++ b/tests/Fixtures/Agents/DelegatingViaCustomToolAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\AgentCallingTool;
 
@@ -16,7 +17,7 @@ class DelegatingViaCustomToolAgent implements Agent, HasTools
         return 'You delegate research using your tool.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new AgentCallingTool,

--- a/tests/Fixtures/Agents/MiddleManagerAgent.php
+++ b/tests/Fixtures/Agents/MiddleManagerAgent.php
@@ -5,6 +5,7 @@ namespace Tests\Fixtures\Agents;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\CanActAsTool;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 class MiddleManagerAgent implements Agent, CanActAsTool, HasTools
@@ -26,7 +27,7 @@ class MiddleManagerAgent implements Agent, CanActAsTool, HasTools
         return 'You are a middle manager that breaks down tasks and delegates to the research_agent sub-agent.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new ResearchAgent,

--- a/tests/Fixtures/Agents/MultiStepToolAgent.php
+++ b/tests/Fixtures/Agents/MultiStepToolAgent.php
@@ -5,6 +5,7 @@ namespace Tests\Fixtures\Agents;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 
@@ -18,7 +19,7 @@ class MultiStepToolAgent implements Agent, HasTools
         return 'You are a helpful assistant that generates numbers.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new FixedNumberGenerator];
     }

--- a/tests/Fixtures/Agents/NamedToolAgent.php
+++ b/tests/Fixtures/Agents/NamedToolAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\NamedTool;
 
@@ -18,7 +19,7 @@ class NamedToolAgent implements Agent, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new NamedTool($this->toolName),

--- a/tests/Fixtures/Agents/NestedObjectToolAgent.php
+++ b/tests/Fixtures/Agents/NestedObjectToolAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\NestedObjectTool;
 
@@ -22,7 +23,7 @@ class NestedObjectToolAgent implements Agent, HasTools
     /**
      * Get the tools available to the agent.
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new NestedObjectTool,

--- a/tests/Fixtures/Agents/OpenAiToolSearchAgent.php
+++ b/tests/Fixtures/Agents/OpenAiToolSearchAgent.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Attributes\Model;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Tests\Fixtures\Tools\DeferredTool;
@@ -22,7 +23,7 @@ class OpenAiToolSearchAgent implements Agent, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new NonStrictTool, new ToolSearch(tools: [new DeferredTool])];
     }

--- a/tests/Fixtures/Agents/OrchestratorAgent.php
+++ b/tests/Fixtures/Agents/OrchestratorAgent.php
@@ -5,6 +5,7 @@ namespace Tests\Fixtures\Agents;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\CanActAsTool;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 
 class OrchestratorAgent implements Agent, CanActAsTool, HasTools
@@ -26,7 +27,7 @@ class OrchestratorAgent implements Agent, CanActAsTool, HasTools
         return 'You are an orchestrator that breaks down complex tasks and delegates to the middle_manager sub-agent.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new MiddleManagerAgent,

--- a/tests/Fixtures/Agents/PromptCacheAgent.php
+++ b/tests/Fixtures/Agents/PromptCacheAgent.php
@@ -25,7 +25,7 @@ class PromptCacheAgent implements Agent, HasProviderOptions, HasTools
         return 'You are a helpful assistant that generates numbers.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return $this->withTools ? [new FixedNumberGenerator] : [];
     }

--- a/tests/Fixtures/Agents/ProviderOptionsWithToolsAgent.php
+++ b/tests/Fixtures/Agents/ProviderOptionsWithToolsAgent.php
@@ -18,7 +18,7 @@ class ProviderOptionsWithToolsAgent implements Agent, HasProviderOptions, HasToo
         return 'You are a helpful assistant that generates numbers.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new FixedNumberGenerator,

--- a/tests/Fixtures/Agents/ProviderToolsAgent.php
+++ b/tests/Fixtures/Agents/ProviderToolsAgent.php
@@ -6,9 +6,10 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
-use Tests\Fixtures\Tools\NullableParamTool;
+use Laravel\Ai\Providers\Tools\WebFetch;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
-class NullableToolAgent implements Agent, HasTools
+class ProviderToolsAgent implements Agent, HasTools
 {
     use Promptable;
 
@@ -21,12 +22,13 @@ class NullableToolAgent implements Agent, HasTools
     }
 
     /**
-     * Get the tools available to the agent.
+     * Get the tools available to the agent for the given provider.
      */
     public function tools(Lab|string $provider): iterable
     {
-        return [
-            new NullableParamTool,
-        ];
+        return match ($provider) {
+            Lab::Anthropic => [new FixedNumberGenerator, new WebFetch],
+            default => [new FixedNumberGenerator],
+        };
     }
 }

--- a/tests/Fixtures/Agents/RateLimitedToolAgent.php
+++ b/tests/Fixtures/Agents/RateLimitedToolAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\RateLimitedNumberGenerator;
 
@@ -22,7 +23,7 @@ class RateLimitedToolAgent implements Agent, HasTools
     /**
      * Get the tools available to the agent.
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new RateLimitedNumberGenerator];
     }

--- a/tests/Fixtures/Agents/RememberingApprovableAgent.php
+++ b/tests/Fixtures/Agents/RememberingApprovableAgent.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\ApprovableNumberGenerator;
 
@@ -25,7 +26,7 @@ class RememberingApprovableAgent implements Agent, Conversational, HasTools
     /**
      * Get the tools available to the agent.
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new ApprovableNumberGenerator];
     }

--- a/tests/Fixtures/Agents/RememberingThrowingApprovableAgent.php
+++ b/tests/Fixtures/Agents/RememberingThrowingApprovableAgent.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\ThrowingApprovableGenerator;
 
@@ -25,7 +26,7 @@ class RememberingThrowingApprovableAgent implements Agent, Conversational, HasTo
     /**
      * Get the tools available to the agent.
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new ThrowingApprovableGenerator];
     }

--- a/tests/Fixtures/Agents/RememberingToolAgent.php
+++ b/tests/Fixtures/Agents/RememberingToolAgent.php
@@ -22,7 +22,7 @@ class RememberingToolAgent implements Agent, HasProviderOptions, HasTools
         return 'Call the FixedNumberGenerator tool before answering. Answer with one short sentence.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new FixedNumberGenerator];
     }

--- a/tests/Fixtures/Agents/RememberingToolUsingAgent.php
+++ b/tests/Fixtures/Agents/RememberingToolUsingAgent.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 
@@ -25,7 +26,7 @@ class RememberingToolUsingAgent implements Agent, Conversational, HasTools
     /**
      * Get the tools available to the agent.
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new FixedNumberGenerator];
     }

--- a/tests/Fixtures/Agents/StatelessApprovableAgent.php
+++ b/tests/Fixtures/Agents/StatelessApprovableAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\ApprovableNumberGenerator;
 
@@ -19,7 +20,7 @@ class StatelessApprovableAgent implements Agent, HasTools
     /**
      * @return Tool[]
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new ApprovableNumberGenerator];
     }

--- a/tests/Fixtures/Agents/StatelessMixedToolsAgent.php
+++ b/tests/Fixtures/Agents/StatelessMixedToolsAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\ApprovableNumberGenerator;
 use Tests\Fixtures\Tools\SideEffectRecorder;
@@ -20,7 +21,7 @@ class StatelessMixedToolsAgent implements Agent, HasTools
     /**
      * @return Tool[]
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [new SideEffectRecorder, new ApprovableNumberGenerator];
     }

--- a/tests/Fixtures/Agents/ThinkingToolChoiceAgent.php
+++ b/tests/Fixtures/Agents/ThinkingToolChoiceAgent.php
@@ -20,7 +20,7 @@ class ThinkingToolChoiceAgent implements Agent, HasProviderOptions, HasTools
         return 'You are a helpful assistant.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new RandomNumberGenerator,

--- a/tests/Fixtures/Agents/ToolChoiceAgent.php
+++ b/tests/Fixtures/Agents/ToolChoiceAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\ToolChoice;
 use Tests\Fixtures\Tools\NamedTool;
@@ -27,7 +28,7 @@ class ToolChoiceAgent implements Agent, HasTools
         return $this->toolChoice;
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new RandomNumberGenerator,

--- a/tests/Fixtures/Agents/ToolSearchAgent.php
+++ b/tests/Fixtures/Agents/ToolSearchAgent.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Agents;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
@@ -21,7 +22,7 @@ class ToolSearchAgent implements Agent, HasTools
             .'When asked for the secret authorization code, find and call the tool that returns it.';
     }
 
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             new FixedNumberGenerator,

--- a/tests/Fixtures/Agents/ToolUsingAgent.php
+++ b/tests/Fixtures/Agents/ToolUsingAgent.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -29,7 +30,7 @@ class ToolUsingAgent implements Agent, HasStructuredOutput, HasTools
      *
      * @return Tool[]
      */
-    public function tools(): iterable
+    public function tools(Lab|string $provider): iterable
     {
         return [
             $this->fixed

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -178,6 +178,19 @@ function fakeAzureResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
+function fakeAnthropicResponse(string $text = 'Hello'): PromiseInterface
+{
+    return Http::response([
+        'id' => 'msg_123',
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-sonnet-4-6',
+        'content' => [['type' => 'text', 'text' => $text]],
+        'stop_reason' => 'end_turn',
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ]);
+}
+
 function fakeOpenAiResponse(string $text = 'Hello'): PromiseInterface
 {
     return Http::response([

--- a/tests/Integration/AgentReasoningTest.php
+++ b/tests/Integration/AgentReasoningTest.php
@@ -46,7 +46,7 @@ test('models can replay conversation history with tool calls', function (string 
             return $this->messages;
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return $this->tools;
         }

--- a/tests/Integration/AgentTest.php
+++ b/tests/Integration/AgentTest.php
@@ -269,7 +269,7 @@ test('agents can replay empty tool arguments', function (string $provider, strin
             return $this->messages;
         }
 
-        public function tools(): iterable
+        public function tools(Lab|string $provider): iterable
         {
             return $this->tools;
         }

--- a/workbench/app/Agents/Assistant.php
+++ b/workbench/app/Agents/Assistant.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Workbench\App\Tools\ConvertTemperature;
 use Workbench\App\Tools\CurrentLocation;
@@ -19,7 +20,7 @@ class Assistant implements Agent, Conversational, HasTools
     /**
      * Get the tools available to the agent.
      */
-    public function tools(): array
+    public function tools(Lab|string $provider): array
     {
         return [
             new CurrentLocation,


### PR DESCRIPTION
Agents that fail over currently expose the same tools to every provider. A provider-specific tool such as Anthropic's `WebFetch` can therefore be sent to OpenAI during failover, causing the fallback request to fail too.

This passes the active provider to `tools()` so each provider receives only the tools it supports:

```php
use Laravel\Ai\Enums\Lab;

public function tools(Lab|string $provider): iterable
{
    return match ($provider) {
        Lab::Anthropic => [new SearchKnowledgeBase, new WebFetch],
        default => [new SearchKnowledgeBase],
    };
}
```

Tools are resolved again for every provider attempted during failover. Standard and aliased connections receive their provider `Lab`; named OpenAI-compatible connections receive the connection name so separate endpoints can expose different tools.

This changes the `HasTools` contract, so existing agents must add the `Lab|string $provider` parameter even when they don't need provider-specific tools. The upgrade guide and generated agent stubs document the new signature.

Tests cover provider selection, aliased connections, failover, and named OpenAI-compatible connections.

Fixes #281.
