### PR TITLE
Support custom HTTP headers via provider connection config

### DIFF
--- a/src/Gateway/Anthropic/AnthropicFileGateway.php
+++ b/src/Gateway/Anthropic/AnthropicFileGateway.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Gateway\Anthropic;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
@@ -75,15 +74,16 @@ class AnthropicFileGateway implements FileGateway
     {
         $config = $provider->additionalConfiguration();
 
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders(array_filter([
+        return $this->createClient(
+            $this->baseUrl($provider),
+            array_filter([
                 'x-api-key' => $provider->providerCredentials()['key'],
                 'anthropic-version' => $config['version'] ?? '2023-06-01',
                 'anthropic-beta' => 'files-api-2025-04-14',
-            ]))
-            ->replaceHeaders($config['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+            ]),
+            $config['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/Anthropic/AnthropicFileGateway.php
+++ b/src/Gateway/Anthropic/AnthropicFileGateway.php
@@ -73,12 +73,15 @@ class AnthropicFileGateway implements FileGateway
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
+        $config = $provider->additionalConfiguration();
+
         return Http::baseUrl($this->baseUrl($provider))
             ->withHeaders(array_filter([
                 'x-api-key' => $provider->providerCredentials()['key'],
-                'anthropic-version' => $provider->additionalConfiguration()['version'] ?? '2023-06-01',
+                'anthropic-version' => $config['version'] ?? '2023-06-01',
                 'anthropic-beta' => 'files-api-2025-04-14',
             ]))
+            ->replaceHeaders($config['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
+++ b/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
@@ -23,6 +23,7 @@ trait CreatesAnthropicClient
 
         return Http::baseUrl($this->baseUrl($provider))
             ->withHeaders($headers)
+            ->replaceHeaders($config['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
+++ b/src/Gateway/Anthropic/Concerns/CreatesAnthropicClient.php
@@ -3,11 +3,13 @@
 namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesAnthropicClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Anthropic API.
      */
@@ -21,11 +23,12 @@ trait CreatesAnthropicClient
             'anthropic-beta' => $config['anthropic_beta'] ?? 'web-fetch-2025-09-10',
         ]);
 
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders($headers)
-            ->replaceHeaders($config['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            $headers,
+            $config['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
+++ b/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
@@ -3,11 +3,13 @@
 namespace Laravel\Ai\Gateway\AzureOpenAi\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesAzureOpenAiClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Azure OpenAI v1-compatible API.
      */
@@ -17,10 +19,11 @@ trait CreatesAzureOpenAiClient
 
         $base = rtrim($config['url'] ?? '', '/');
 
-        return Http::baseUrl("{$base}/openai/v1")
-            ->withHeaders(['api-key' => $provider->providerCredentials()['key']])
-            ->replaceHeaders($config['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            "{$base}/openai/v1",
+            ['api-key' => $provider->providerCredentials()['key']],
+            $config['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 }

--- a/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
+++ b/src/Gateway/AzureOpenAi/Concerns/CreatesAzureOpenAiClient.php
@@ -19,6 +19,7 @@ trait CreatesAzureOpenAiClient
 
         return Http::baseUrl("{$base}/openai/v1")
             ->withHeaders(['api-key' => $provider->providerCredentials()['key']])
+            ->replaceHeaders($config['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Bedrock/Concerns/CreatesBedrockClient.php
+++ b/src/Gateway/Bedrock/Concerns/CreatesBedrockClient.php
@@ -5,9 +5,11 @@ namespace Laravel\Ai\Gateway\Bedrock\Concerns;
 use Aws\BedrockRuntime\BedrockRuntimeClient;
 use Aws\Credentials\AssumeRoleCredentialProvider;
 use Aws\Credentials\CredentialProvider;
+use Aws\Middleware;
 use Aws\Sts\StsClient;
 use Closure;
 use Laravel\Ai\Providers\Provider;
+use Psr\Http\Message\RequestInterface;
 
 trait CreatesBedrockClient
 {
@@ -37,7 +39,21 @@ trait CreatesBedrockClient
             $clientConfig['http'] = ['timeout' => $timeout];
         }
 
-        return new BedrockRuntimeClient($clientConfig);
+        $client = new BedrockRuntimeClient($clientConfig);
+
+        if ($headers = $config['headers'] ?? []) {
+            $client->getHandlerList()->appendBuild(Middleware::mapRequest(
+                function (RequestInterface $request) use ($headers): RequestInterface {
+                    foreach ($headers as $name => $value) {
+                        $request = $request->withHeader($name, $value);
+                    }
+
+                    return $request;
+                }
+            ), 'laravel-ai.headers');
+        }
+
+        return $client;
     }
 
     /**

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -105,6 +105,7 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
+            ->replaceHeaders($config['headers'] ?? [])
             ->timeout($timeout)
             ->throw();
     }

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -4,7 +4,6 @@ namespace Laravel\Ai\Gateway;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
@@ -18,6 +17,7 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class CohereGateway implements EmbeddingGateway, RerankingGateway
 {
+    use Concerns\CreatesClient;
     use HandlesFailoverErrors;
     use ParsesEmbeddings;
 
@@ -102,13 +102,14 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
     {
         $config = $provider->additionalConfiguration();
 
-        return Http::baseUrl($config['url'] ?? 'https://api.cohere.com/v2')
-            ->withHeaders([
+        return $this->createClient(
+            $config['url'] ?? 'https://api.cohere.com/v2',
+            [
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
-            ])
-            ->replaceHeaders($config['headers'] ?? [])
-            ->timeout($timeout)
-            ->throw();
+            ],
+            $config['headers'] ?? [],
+            $timeout,
+        );
     }
 }

--- a/src/Gateway/Concerns/CreatesClient.php
+++ b/src/Gateway/Concerns/CreatesClient.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+trait CreatesClient
+{
+    /**
+     * @param  array<string, mixed>  $headers
+     * @param  array<string, mixed>  $configuredHeaders
+     */
+    protected function createClient(
+        string $baseUrl,
+        array $headers = [],
+        array $configuredHeaders = [],
+        ?int $timeout = 60,
+        bool $throw = true,
+    ): PendingRequest {
+        $headers = collect($headers)
+            ->merge($configuredHeaders)
+            ->mapWithKeys(fn (mixed $value, string $name): array => [strtolower($name) => $value])
+            ->all();
+
+        return Http::baseUrl($baseUrl)
+            ->withHeaders($headers)
+            ->when($timeout !== null, fn (PendingRequest $client) => $client->timeout($timeout))
+            ->when($throw, fn (PendingRequest $client) => $client->throw());
+    }
+}

--- a/src/Gateway/DeepSeek/Concerns/CreatesDeepSeekClient.php
+++ b/src/Gateway/DeepSeek/Concerns/CreatesDeepSeekClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\DeepSeek\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesDeepSeekClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the DeepSeek API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/DeepSeek/Concerns/CreatesDeepSeekClient.php
+++ b/src/Gateway/DeepSeek/Concerns/CreatesDeepSeekClient.php
@@ -15,6 +15,7 @@ trait CreatesDeepSeekClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withToken($provider->providerCredentials()['key'])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -105,6 +105,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withHeaders(array_filter(['xi-api-key' => $provider->providerCredentials()['key']]))
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout);
     }
 

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -4,7 +4,6 @@ namespace Laravel\Ai\Gateway;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
@@ -19,6 +18,7 @@ use Laravel\Ai\Responses\TranscriptionResponse;
 
 class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 {
+    use Concerns\CreatesClient;
     use Concerns\HandlesFailoverErrors;
 
     /**
@@ -103,10 +103,13 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
      */
     protected function client(AudioProvider|TranscriptionProvider $provider, int $timeout = 30): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders(array_filter(['xi-api-key' => $provider->providerCredentials()['key']]))
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout);
+        return $this->createClient(
+            $this->baseUrl($provider),
+            array_filter(['xi-api-key' => $provider->providerCredentials()['key']]),
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout,
+            false,
+        );
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/CreatesGeminiClient.php
+++ b/src/Gateway/Gemini/Concerns/CreatesGeminiClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesGeminiClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Gemini API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders(array_filter(['x-goog-api-key' => $provider->providerCredentials()['key']]))
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            array_filter(['x-goog-api-key' => $provider->providerCredentials()['key']]),
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/CreatesGeminiClient.php
+++ b/src/Gateway/Gemini/Concerns/CreatesGeminiClient.php
@@ -15,6 +15,7 @@ trait CreatesGeminiClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withHeaders(array_filter(['x-goog-api-key' => $provider->providerCredentials()['key']]))
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Gemini/GeminiFileGateway.php
+++ b/src/Gateway/Gemini/GeminiFileGateway.php
@@ -2,11 +2,12 @@
 
 namespace Laravel\Ai\Gateway\Gemini;
 
-use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\PendingRequest;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\PreparesStorableFiles;
 use Laravel\Ai\Providers\Provider;
@@ -15,6 +16,7 @@ use Laravel\Ai\Responses\StoredFileResponse;
 
 class GeminiFileGateway implements FileGateway
 {
+    use CreatesClient;
     use HandlesFailoverErrors;
     use PreparesStorableFiles;
 
@@ -25,9 +27,10 @@ class GeminiFileGateway implements FileGateway
     {
         $fileId = str_starts_with($fileId, 'files/') ? $fileId : "files/{$fileId}";
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->get($this->baseUrl($provider)."/{$fileId}")->throw());
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->get($this->baseUrl($provider)."/{$fileId}")->throw(),
+        );
 
         return new FileResponse(
             id: $response->json('name'),
@@ -48,9 +51,7 @@ class GeminiFileGateway implements FileGateway
 
         $providerOptions = $this->resolveProviderOptions($file, Lab::Gemini);
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->attach(
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider)->attach(
             'file', $content, $name, ['Content-Type' => $mime]
         )->post("{$uploadUrl}/files", array_replace_recursive([
             'file' => ['display_name' => $name],
@@ -66,9 +67,21 @@ class GeminiFileGateway implements FileGateway
     {
         $fileId = str_starts_with($fileId, 'files/') ? $fileId : "files/{$fileId}";
 
-        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->delete($this->baseUrl($provider)."/{$fileId}")->throw());
+        $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->delete($this->baseUrl($provider)."/{$fileId}")->throw(),
+        );
+    }
+
+    protected function client(Provider $provider): PendingRequest
+    {
+        return $this->createClient(
+            $this->baseUrl($provider),
+            array_filter(['x-goog-api-key' => $provider->providerCredentials()['key']]),
+            $provider->additionalConfiguration()['headers'] ?? [],
+            timeout: null,
+            throw: false,
+        );
     }
 
     /**

--- a/src/Gateway/Gemini/GeminiFileGateway.php
+++ b/src/Gateway/Gemini/GeminiFileGateway.php
@@ -27,7 +27,7 @@ class GeminiFileGateway implements FileGateway
 
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->get($this->baseUrl($provider)."/{$fileId}")->throw());
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->get($this->baseUrl($provider)."/{$fileId}")->throw());
 
         return new FileResponse(
             id: $response->json('name'),
@@ -50,7 +50,7 @@ class GeminiFileGateway implements FileGateway
 
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->attach(
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->attach(
             'file', $content, $name, ['Content-Type' => $mime]
         )->post("{$uploadUrl}/files", array_replace_recursive([
             'file' => ['display_name' => $name],
@@ -68,7 +68,7 @@ class GeminiFileGateway implements FileGateway
 
         $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->delete($this->baseUrl($provider)."/{$fileId}")->throw());
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->delete($this->baseUrl($provider)."/{$fileId}")->throw());
     }
 
     /**

--- a/src/Gateway/Gemini/GeminiStoreGateway.php
+++ b/src/Gateway/Gemini/GeminiStoreGateway.php
@@ -25,7 +25,7 @@ class GeminiStoreGateway implements StoreGateway
 
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->get($this->baseUrl($provider)."/{$storeId}")->throw());
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->get($this->baseUrl($provider)."/{$storeId}")->throw());
 
         return new Store(
             provider: $provider,
@@ -54,7 +54,7 @@ class GeminiStoreGateway implements StoreGateway
 
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->post($this->baseUrl($provider).'/fileSearchStores', [
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->post($this->baseUrl($provider).'/fileSearchStores', [
             'displayName' => $name,
         ])->throw());
 
@@ -79,7 +79,7 @@ class GeminiStoreGateway implements StoreGateway
 
         $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->post($this->baseUrl($provider)."/{$storeId}:importFile", array_filter([
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->post($this->baseUrl($provider)."/{$storeId}:importFile", array_filter([
             'fileName' => $fileId,
             'customMetadata' => $metadata === [] ? null : $this->formatMetadata($metadata),
         ]))->throw());
@@ -109,7 +109,7 @@ class GeminiStoreGateway implements StoreGateway
 
         $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->delete($this->baseUrl($provider)."/{$documentId}", [
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->delete($this->baseUrl($provider)."/{$documentId}", [
             'force' => true,
         ])->throw());
 
@@ -125,7 +125,7 @@ class GeminiStoreGateway implements StoreGateway
 
         $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
             'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->delete($this->baseUrl($provider)."/{$storeId}")->throw());
+        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->delete($this->baseUrl($provider)."/{$storeId}")->throw());
 
         return true;
     }

--- a/src/Gateway/Gemini/GeminiStoreGateway.php
+++ b/src/Gateway/Gemini/GeminiStoreGateway.php
@@ -3,10 +3,11 @@
 namespace Laravel\Ai\Gateway\Gemini;
 
 use DateInterval;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\StoreFileCounts;
@@ -14,6 +15,7 @@ use Laravel\Ai\Store;
 
 class GeminiStoreGateway implements StoreGateway
 {
+    use CreatesClient;
     use HandlesFailoverErrors;
 
     /**
@@ -23,9 +25,10 @@ class GeminiStoreGateway implements StoreGateway
     {
         $storeId = $this->normalizeStoreId($storeId);
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->get($this->baseUrl($provider)."/{$storeId}")->throw());
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->get($this->baseUrl($provider)."/{$storeId}")->throw(),
+        );
 
         return new Store(
             provider: $provider,
@@ -52,9 +55,7 @@ class GeminiStoreGateway implements StoreGateway
     ): Store {
         $fileIds ??= new Collection;
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->post($this->baseUrl($provider).'/fileSearchStores', [
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider)->post($this->baseUrl($provider).'/fileSearchStores', [
             'displayName' => $name,
         ])->throw());
 
@@ -77,9 +78,7 @@ class GeminiStoreGateway implements StoreGateway
         $storeId = $this->normalizeStoreId($storeId);
         $fileId = $this->normalizeFileId($fileId);
 
-        $response = $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->post($this->baseUrl($provider)."/{$storeId}:importFile", array_filter([
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider)->post($this->baseUrl($provider)."/{$storeId}:importFile", array_filter([
             'fileName' => $fileId,
             'customMetadata' => $metadata === [] ? null : $this->formatMetadata($metadata),
         ]))->throw());
@@ -107,9 +106,7 @@ class GeminiStoreGateway implements StoreGateway
         $storeId = $this->normalizeStoreId($storeId);
         $documentId = $this->normalizeDocumentId($storeId, $documentId);
 
-        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->delete($this->baseUrl($provider)."/{$documentId}", [
+        $this->withErrorHandling($provider->name(), fn () => $this->client($provider)->delete($this->baseUrl($provider)."/{$documentId}", [
             'force' => true,
         ])->throw());
 
@@ -123,11 +120,23 @@ class GeminiStoreGateway implements StoreGateway
     {
         $storeId = $this->normalizeStoreId($storeId);
 
-        $this->withErrorHandling($provider->name(), fn () => Http::withHeaders(array_filter([
-            'x-goog-api-key' => $provider->providerCredentials()['key'],
-        ]))->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])->delete($this->baseUrl($provider)."/{$storeId}")->throw());
+        $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider)->delete($this->baseUrl($provider)."/{$storeId}")->throw(),
+        );
 
         return true;
+    }
+
+    protected function client(Provider $provider): PendingRequest
+    {
+        return $this->createClient(
+            $this->baseUrl($provider),
+            array_filter(['x-goog-api-key' => $provider->providerCredentials()['key']]),
+            $provider->additionalConfiguration()['headers'] ?? [],
+            timeout: null,
+            throw: false,
+        );
     }
 
     /**

--- a/src/Gateway/Groq/Concerns/CreatesGroqClient.php
+++ b/src/Gateway/Groq/Concerns/CreatesGroqClient.php
@@ -15,6 +15,7 @@ trait CreatesGroqClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withToken($provider->providerCredentials()['key'])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Groq/Concerns/CreatesGroqClient.php
+++ b/src/Gateway/Groq/Concerns/CreatesGroqClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesGroqClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Groq API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -4,7 +4,6 @@ namespace Laravel\Ai\Gateway;
 
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
@@ -17,6 +16,7 @@ use Laravel\Ai\Responses\RerankingResponse;
 
 class JinaGateway implements EmbeddingGateway, RerankingGateway
 {
+    use Concerns\CreatesClient;
     use HandlesFailoverErrors;
 
     /**
@@ -98,14 +98,15 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
      */
     protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withHeaders([
+        return $this->createClient(
+            $this->baseUrl($provider),
+            [
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
-            ])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout)
-            ->throw();
+            ],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout,
+        );
     }
 
     /**

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -103,6 +103,7 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
                 'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'Content-Type' => 'application/json',
             ])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout)
             ->throw();
     }

--- a/src/Gateway/Mistral/Concerns/CreatesMistralClient.php
+++ b/src/Gateway/Mistral/Concerns/CreatesMistralClient.php
@@ -15,6 +15,7 @@ trait CreatesMistralClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withToken($provider->providerCredentials()['key'])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/Mistral/Concerns/CreatesMistralClient.php
+++ b/src/Gateway/Mistral/Concerns/CreatesMistralClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\Mistral\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesMistralClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Mistral API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/Ollama/Concerns/CreatesOllamaClient.php
+++ b/src/Gateway/Ollama/Concerns/CreatesOllamaClient.php
@@ -3,27 +3,26 @@
 namespace Laravel\Ai\Gateway\Ollama\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesOllamaClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Ollama API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        $client = Http::baseUrl($this->baseUrl($provider))
-            ->timeout($timeout ?? 60)
-            ->throw();
-
         $key = $provider->providerCredentials()['key'] ?? null;
 
-        if (filled($key)) {
-            $client->withToken($key);
-        }
-
-        return $client->replaceHeaders($provider->additionalConfiguration()['headers'] ?? []);
+        return $this->createClient(
+            $this->baseUrl($provider),
+            filled($key) ? ['Authorization' => 'Bearer '.$key] : [],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/Ollama/Concerns/CreatesOllamaClient.php
+++ b/src/Gateway/Ollama/Concerns/CreatesOllamaClient.php
@@ -20,10 +20,10 @@ trait CreatesOllamaClient
         $key = $provider->providerCredentials()['key'] ?? null;
 
         if (filled($key)) {
-            return $client->withToken($key);
+            $client->withToken($key);
         }
 
-        return $client;
+        return $client->replaceHeaders($provider->additionalConfiguration()['headers'] ?? []);
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
+++ b/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
@@ -15,6 +15,7 @@ trait CreatesOpenAiClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withToken($provider->providerCredentials()['key'])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
+++ b/src/Gateway/OpenAi/Concerns/CreatesOpenAiClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesOpenAiClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the OpenAI API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/OpenAiCompatible/Concerns/CreatesOpenAiCompatibleClient.php
+++ b/src/Gateway/OpenAiCompatible/Concerns/CreatesOpenAiCompatibleClient.php
@@ -3,26 +3,27 @@
 namespace Laravel\Ai\Gateway\OpenAiCompatible\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesOpenAiCompatibleClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the OpenAI-compatible API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        $client = Http::baseUrl($this->baseUrl($provider))
-            ->timeout($timeout ?? 60)
-            ->throw();
+        $key = $provider->providerCredentials()['key'] ?? null;
 
-        if (filled($key = $provider->providerCredentials()['key'] ?? null)) {
-            $client->withToken($key);
-        }
-
-        return $client->replaceHeaders($provider->additionalConfiguration()['headers'] ?? []);
+        return $this->createClient(
+            $this->baseUrl($provider),
+            filled($key) ? ['Authorization' => 'Bearer '.$key] : [],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/OpenAiCompatible/Concerns/CreatesOpenAiCompatibleClient.php
+++ b/src/Gateway/OpenAiCompatible/Concerns/CreatesOpenAiCompatibleClient.php
@@ -22,7 +22,7 @@ trait CreatesOpenAiCompatibleClient
             $client->withToken($key);
         }
 
-        return $client;
+        return $client->replaceHeaders($provider->additionalConfiguration()['headers'] ?? []);
     }
 
     /**

--- a/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
+++ b/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
@@ -3,11 +3,13 @@
 namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesOpenRouterClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the OpenRouter API.
      */
@@ -15,15 +17,16 @@ trait CreatesOpenRouterClient
     {
         $config = $provider->additionalConfiguration();
 
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->withHeaders(array_filter([
+        return $this->createClient(
+            $this->baseUrl($provider),
+            array_filter([
+                'Authorization' => 'Bearer '.$provider->providerCredentials()['key'],
                 'HTTP-Referer' => $config['http_referer'] ?? null,
                 'X-OpenRouter-Title' => $config['x_title'] ?? null,
-            ]))
-            ->replaceHeaders($config['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+            ]),
+            $config['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
+++ b/src/Gateway/OpenRouter/Concerns/CreatesOpenRouterClient.php
@@ -21,6 +21,7 @@ trait CreatesOpenRouterClient
                 'HTTP-Referer' => $config['http_referer'] ?? null,
                 'X-OpenRouter-Title' => $config['x_title'] ?? null,
             ]))
+            ->replaceHeaders($config['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Gateway/VoyageAi/Concerns/CreatesVoyageAiClient.php
+++ b/src/Gateway/VoyageAi/Concerns/CreatesVoyageAiClient.php
@@ -15,6 +15,7 @@ trait CreatesVoyageAiClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withToken($provider->providerCredentials()['key'])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 30)
             ->throw();
     }

--- a/src/Gateway/VoyageAi/Concerns/CreatesVoyageAiClient.php
+++ b/src/Gateway/VoyageAi/Concerns/CreatesVoyageAiClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\VoyageAi\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesVoyageAiClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the Voyage AI API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 30)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 30,
+        );
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/CreatesXaiClient.php
+++ b/src/Gateway/Xai/Concerns/CreatesXaiClient.php
@@ -3,21 +3,24 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
 use Laravel\Ai\Providers\Provider;
 
 trait CreatesXaiClient
 {
+    use CreatesClient;
+
     /**
      * Get an HTTP client for the xAI API.
      */
     protected function client(Provider $provider, ?int $timeout = null): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($provider))
-            ->withToken($provider->providerCredentials()['key'])
-            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
-            ->timeout($timeout ?? 60)
-            ->throw();
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout ?? 60,
+        );
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/CreatesXaiClient.php
+++ b/src/Gateway/Xai/Concerns/CreatesXaiClient.php
@@ -15,6 +15,7 @@ trait CreatesXaiClient
     {
         return Http::baseUrl($this->baseUrl($provider))
             ->withToken($provider->providerCredentials()['key'])
+            ->replaceHeaders($provider->additionalConfiguration()['headers'] ?? [])
             ->timeout($timeout ?? 60)
             ->throw();
     }

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -174,6 +174,7 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FilePro
             'url' => rtrim($this->config['url'] ?? '', '/'),
             'api_version' => $this->config['api_version'] ?? '2025-04-01-preview',
             'store' => $this->config['store'] ?? true,
+            'headers' => $this->config['headers'] ?? [],
         ];
     }
 

--- a/src/Providers/BedrockProvider.php
+++ b/src/Providers/BedrockProvider.php
@@ -50,6 +50,7 @@ class BedrockProvider extends Provider implements EmbeddingProvider, ImageProvid
         return [
             'region' => $this->config['region'] ?? 'us-east-1',
             'use_default_credential_provider' => $this->config['use_default_credential_provider'] ?? true,
+            'headers' => $this->config['headers'] ?? [],
             'assume_role' => [
                 'arn' => $this->config['assume_role']['arn'] ?? null,
                 'session_name' => $this->config['assume_role']['session_name'] ?? null,

--- a/tests/Feature/Gateway/Concerns/CreatesClientTest.php
+++ b/tests/Feature/Gateway/Concerns/CreatesClientTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Http\Client\PendingRequest;
+use Laravel\Ai\Gateway\Concerns\CreatesClient;
+
+function httpClient(array $headers = [], array $configuredHeaders = []): PendingRequest
+{
+    return (new class
+    {
+        use CreatesClient;
+
+        public function client(array $headers, array $configuredHeaders): PendingRequest
+        {
+            return $this->createClient('https://example.com', $headers, $configuredHeaders);
+        }
+    })->client($headers, $configuredHeaders);
+}
+
+test('configured headers override defaults case insensitively', function (): void {
+    $headers = httpClient(
+        ['Authorization' => 'Bearer provider-key', 'Content-Type' => 'application/json'],
+        [
+            'authorization' => 'Bearer proxy-token',
+            'X-Session-Affinity' => 'discarded',
+            'x-session-affinity' => 'abc-123',
+        ],
+    )->getOptions()['headers'];
+
+    expect($headers)->toBe([
+        'authorization' => 'Bearer proxy-token',
+        'content-type' => 'application/json',
+        'x-session-affinity' => 'abc-123',
+    ]);
+});

--- a/tests/Feature/Providers/CustomHeadersTest.php
+++ b/tests/Feature/Providers/CustomHeadersTest.php
@@ -33,7 +33,7 @@ test('configured headers override gateway default headers', function (): void {
     config(['ai.providers.voyageai' => [
         ...config('ai.providers.voyageai'),
         'key' => 'test-key',
-        'headers' => ['Authorization' => 'Bearer proxy-token'],
+        'headers' => ['authorization' => 'Bearer proxy-token'],
     ]]);
 
     Http::fake(['*' => fakeCustomHeadersEmbeddingsResponse()]);

--- a/tests/Feature/Providers/CustomHeadersTest.php
+++ b/tests/Feature/Providers/CustomHeadersTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Embeddings;
+
+function fakeCustomHeadersEmbeddingsResponse(): PromiseInterface
+{
+    return Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]]],
+        'model' => 'voyage-4',
+        'usage' => ['total_tokens' => 5],
+    ]);
+}
+
+test('configured headers are sent with provider requests', function (): void {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+        'headers' => ['X-Session-Affinity' => 'abc-123'],
+    ]]);
+
+    Http::fake(['*' => fakeCustomHeadersEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(fn (Request $r): bool => $r->header('X-Session-Affinity') === ['abc-123']);
+});
+
+test('configured headers override gateway default headers', function (): void {
+    config(['ai.providers.voyageai' => [
+        ...config('ai.providers.voyageai'),
+        'key' => 'test-key',
+        'headers' => ['Authorization' => 'Bearer proxy-token'],
+    ]]);
+
+    Http::fake(['*' => fakeCustomHeadersEmbeddingsResponse()]);
+
+    Embeddings::for(['Hello'])->generate(provider: 'voyageai', model: 'voyage-4');
+
+    Http::assertSent(fn (Request $r): bool => $r->header('Authorization') === ['Bearer proxy-token']);
+});

--- a/tests/Unit/Gateway/Bedrock/CreatesBedrockClientTest.php
+++ b/tests/Unit/Gateway/Bedrock/CreatesBedrockClientTest.php
@@ -1,9 +1,13 @@
 <?php
 
+use Aws\BedrockRuntime\BedrockRuntimeClient;
 use Aws\MockHandler;
 use Aws\Result;
 use Aws\Sts\StsClient;
+use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Gateway\Bedrock\Concerns\CreatesBedrockClient;
+use Laravel\Ai\Providers\BedrockProvider;
+use Laravel\Ai\Providers\Provider;
 
 function bedrockClientTrait(?MockHandler $handler = null): object
 {
@@ -19,6 +23,11 @@ function bedrockClientTrait(?MockHandler $handler = null): object
         public function resolve(array $credentials, array $config): array
         {
             return $this->resolveAuthConfig($credentials, $config);
+        }
+
+        public function create(Provider $provider): BedrockRuntimeClient
+        {
+            return $this->createBedrockClient($provider);
         }
 
         protected function createStsClient(array $credentials, array $config): StsClient
@@ -66,6 +75,30 @@ test('bearer token credentials use http bearer auth scheme', function (): void {
         'token' => ['token' => 'bedrock-token'],
         'auth_scheme_preference' => ['smithy.api#httpBearerAuth'],
     ]);
+});
+
+test('configured headers are added before request signing', function (): void {
+    $provider = new BedrockProvider([
+        'access_key_id' => 'test-key',
+        'secret_access_key' => 'test-secret',
+        'region' => 'us-east-1',
+        'headers' => ['X-Session-Affinity' => 'abc-123'],
+    ], Mockery::mock(Dispatcher::class));
+
+    $client = bedrockClientTrait()->create($provider);
+    $handler = new MockHandler([new Result]);
+    $client->getHandlerList()->setHandler($handler);
+
+    $client->invokeModel([
+        'modelId' => 'amazon.titan-embed-text-v2:0',
+        'body' => '{}',
+        'contentType' => 'application/json',
+    ]);
+
+    $request = $handler->getLastRequest();
+
+    expect($request->getHeaderLine('X-Session-Affinity'))->toBe('abc-123')
+        ->and($request->getHeaderLine('Authorization'))->toContain('x-session-affinity');
 });
 
 test('bearer token takes priority over iam credentials', function (): void {

--- a/tests/Unit/Providers/BedrockProviderTest.php
+++ b/tests/Unit/Providers/BedrockProviderTest.php
@@ -80,6 +80,16 @@ test('returns additional configuration with region', function (): void {
         ->and($additionalConfig['use_default_credential_provider'])->toBeTrue();
 });
 
+test('returns configured headers', function (): void {
+    $provider = new BedrockProvider([
+        'headers' => ['X-Session-Affinity' => 'abc-123'],
+    ], $this->dispatcher);
+
+    expect($provider->additionalConfiguration()['headers'])->toBe([
+        'X-Session-Affinity' => 'abc-123',
+    ]);
+});
+
 test('preserves false value for use default credential provider', function (): void {
     $config = [
         'region' => 'us-east-1',


### PR DESCRIPTION
Closes #833 

Adds a `headers` key to provider connection configuration. Any headers defined there are applied to the outgoing HTTP request for that provider.

```php
'openai' => [
    'driver' => 'openai',
    'key' => env('OPENAI_API_KEY'),
    'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
    'headers' => [
        'OpenAI-Organization' => 'some-random-id',
        'OpenAI-Project' => 'some-random-project',
    ],
],
```

Each gateway's `client()` now calls `->replaceHeaders($config['headers'] ?? [])` after its own headers are set, so configured values take precedence over the gateway defaults.