### PR TITLE
Add embeddings support to the OpenAI-compatible provider

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -407,23 +407,35 @@ $store->assertAdded('file_id');
 
 ## OpenAI-Compatible Provider
 
-Point the SDK at any OpenAI Chat Completions endpoint (LM Studio, vLLM, Together, etc.) with the config-driven `openai-compatible` driver. Define named instances in `config/ai.php`, no code required:
+Point the SDK at any OpenAI-compatible endpoint (LM Studio, vLLM, Together, etc.) with the config-driven `openai-compatible` driver. Define named instances in `config/ai.php`, no code required:
 
 ```php
 'my-llm' => [
     'driver' => 'openai-compatible',
     'url' => env('MY_LLM_URL'),        // required
     'key' => env('MY_LLM_API_KEY'),    // optional Bearer token
+    'models' => [
+        'text' => ['default' => 'some-chat-model'],
+        'embeddings' => [
+            'default' => 'some-embedding-model',
+            'dimensions' => 1024, // optional; omit to use native dimensions
+        ],
+    ],
 ],
 ```
 
-Reference it by config key (or `Lab::OpenAiCompatible`). A model is required via `models.text.default` or per-call `model:`:
+Reference it by config key (or `Lab::OpenAiCompatible`). A model is required via the corresponding `models` configuration or per-call `model:`:
 
 ```php
 agent()->prompt('Hello', provider: 'my-llm', model: 'some-model');
+
+Embeddings::for(['Hello'])->generate(
+    provider: 'my-llm',
+    model: 'some-embedding-model',
+);
 ```
 
-It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, and image attachments. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
+It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, and text embeddings. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
 
 ## Common Pitfalls
 
@@ -454,7 +466,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 | Images     | OpenAI, Gemini, xAI                                            |
 | TTS        | OpenAI, ElevenLabs                                              |
 | STT        | OpenAI, ElevenLabs, Mistral                                     |
-| Embeddings | OpenAI, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI         |
+| Embeddings | OpenAI, OpenAI-compatible, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI |
 | Reranking  | Cohere, Jina                                                    |
 | Files      | OpenAI, Anthropic, Gemini                                       |
 
@@ -466,6 +478,6 @@ use Laravel\Ai\Enums\Lab;
 Lab::Anthropic;
 Lab::OpenAI;
 Lab::Gemini;
-Lab::OpenAiCompatible; // configurable OpenAI Chat Completions endpoint
+Lab::OpenAiCompatible; // configurable OpenAI-compatible endpoint
 // ...
 ```

--- a/src/Gateway/FakeEmbeddingGateway.php
+++ b/src/Gateway/FakeEmbeddingGateway.php
@@ -99,6 +99,10 @@ class FakeEmbeddingGateway implements EmbeddingGateway
      */
     protected function generateFakeEmbeddings(int $count, int $dimensions): array
     {
+        if ($dimensions <= 0) {
+            throw new RuntimeException('Unable to generate fake embeddings without positive dimensions. Configure embedding dimensions or provide a fake response.');
+        }
+
         return array_map(
             fn (): array => Embeddings::fakeEmbedding($dimensions),
             range(1, $count)

--- a/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
+++ b/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
@@ -4,9 +4,11 @@ namespace Laravel\Ai\Gateway\OpenAiCompatible;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Providers\Provider;
@@ -42,6 +44,10 @@ class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway
         int $timeout = 30,
         array $providerOptions = [],
     ): EmbeddingsResponse {
+        if (($providerOptions['encoding_format'] ?? 'float') !== 'float') {
+            throw new InvalidArgumentException('This openai-compatible provider only supports float embedding responses.');
+        }
+
         $body = array_merge($providerOptions, array_filter([
             'model' => $model,
             'input' => $inputs,
@@ -58,10 +64,32 @@ class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway
         $this->validateTextResponse($data);
 
         return new EmbeddingsResponse(
-            (new Collection($data['data'] ?? []))->pluck('embedding')->all(),
+            $this->parseEmbeddings($data, count($inputs)),
             $data['usage']['prompt_tokens'] ?? 0,
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * Parse the embedding vectors on an OpenAI-compatible response.
+     *
+     * @return array<int, array<int, float>>
+     */
+    protected function parseEmbeddings(array $data, int $expectedCount): array
+    {
+        $embeddings = (new Collection($data['data'] ?? []))->pluck('embedding');
+
+        if ($embeddings->count() !== $expectedCount) {
+            throw new AiException('OpenAI-compatible Error: [invalid_response] The response did not contain the expected number of embeddings.');
+        }
+
+        return $embeddings->map(function (mixed $embedding): array {
+            if (! is_array($embedding) || $embedding === [] || array_filter($embedding, 'is_numeric') !== $embedding) {
+                throw new AiException('OpenAI-compatible Error: [invalid_response] The response contained an invalid embedding vector.');
+            }
+
+            return array_map(floatval(...), $embedding);
+        })->all();
     }
 
     /**

--- a/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
+++ b/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
@@ -3,12 +3,17 @@
 namespace Laravel\Ai\Gateway\OpenAiCompatible;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\EmbeddingsResponse;
 
-class OpenAiCompatibleGateway implements StepTextGateway
+class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesOpenAiCompatibleClient;
@@ -24,6 +29,39 @@ class OpenAiCompatibleGateway implements StepTextGateway
     public function __construct(protected Dispatcher $events)
     {
         //
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateEmbeddings(
+        EmbeddingProvider $provider,
+        string $model,
+        array $inputs,
+        int $dimensions,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): EmbeddingsResponse {
+        $body = array_merge($providerOptions, array_filter([
+            'model' => $model,
+            'input' => $inputs,
+            'dimensions' => $dimensions ?: null,
+        ]));
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('embeddings', $body),
+        );
+
+        $data = $response->json();
+
+        $this->validateTextResponse($data);
+
+        return new EmbeddingsResponse(
+            (new Collection($data['data'] ?? []))->pluck('embedding')->all(),
+            $data['usage']['prompt_tokens'] ?? 0,
+            new Meta($provider->name(), $model),
+        );
     }
 
     /**

--- a/src/Providers/Concerns/GeneratesEmbeddings.php
+++ b/src/Providers/Concerns/GeneratesEmbeddings.php
@@ -25,7 +25,11 @@ trait GeneratesEmbeddings
     public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): EmbeddingsResponse
     {
         if (! is_null($model) && is_null($dimensions)) {
-            throw new InvalidArgumentException('Dimensions must be provided when model is specified.');
+            if (! $this->supportsNativeEmbeddingDimensions()) {
+                throw new InvalidArgumentException('Dimensions must be provided when model is specified.');
+            }
+
+            $dimensions = 0;
         }
 
         $invocationId = (string) Str::uuid7();
@@ -55,6 +59,14 @@ trait GeneratesEmbeddings
         ), fn (EmbeddingsResponse $response) => $this->events->dispatch(new EmbeddingsGenerated(
             $invocationId, $this, $model, $prompt, $response,
         )));
+    }
+
+    /**
+     * Determine if the provider may omit dimensions and use a model's native embedding dimensions.
+     */
+    protected function supportsNativeEmbeddingDimensions(): bool
+    {
+        return false;
     }
 
     /**

--- a/src/Providers/OpenAiCompatibleProvider.php
+++ b/src/Providers/OpenAiCompatibleProvider.php
@@ -94,4 +94,12 @@ class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, Te
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 0;
     }
+
+    /**
+     * Determine if the provider may omit dimensions and use a model's native embedding dimensions.
+     */
+    protected function supportsNativeEmbeddingDimensions(): bool
+    {
+        return true;
+    }
 }

--- a/src/Providers/OpenAiCompatibleProvider.php
+++ b/src/Providers/OpenAiCompatibleProvider.php
@@ -4,13 +4,17 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Gateway\OpenAiCompatible\OpenAiCompatibleGateway;
 
-class OpenAiCompatibleProvider extends Provider implements TextProvider
+class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, TextProvider
 {
+    use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
+    use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\StreamsText;
 
@@ -37,6 +41,14 @@ class OpenAiCompatibleProvider extends Provider implements TextProvider
     }
 
     /**
+     * Get the provider's embedding gateway.
+     */
+    public function embeddingGateway(): EmbeddingGateway
+    {
+        return $this->embeddingGateway ??= new OpenAiCompatibleGateway($this->events);
+    }
+
+    /**
      * Get the name of the default text model.
      */
     public function defaultTextModel(): string
@@ -60,5 +72,26 @@ class OpenAiCompatibleProvider extends Provider implements TextProvider
     public function smartestTextModel(): string
     {
         return $this->config['models']['text']['smartest'] ?? $this->defaultTextModel();
+    }
+
+    /**
+     * Get the name of the default embeddings model.
+     */
+    public function defaultEmbeddingsModel(): string
+    {
+        return $this->config['models']['embeddings']['default'] ?? throw new InvalidArgumentException(
+            "The [{$this->name()}] openai-compatible provider requires a default embeddings model. Set [models.embeddings.default] in its configuration or pass a model explicitly."
+        );
+    }
+
+    /**
+     * Get the default dimensions of the default embeddings model.
+     *
+     * When no dimensions are configured, the request omits the dimensions
+     * parameter and the model's native dimensions are used.
+     */
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return $this->config['models']['embeddings']['dimensions'] ?? 0;
     }
 }

--- a/src/Providers/OpenAiCompatibleProvider.php
+++ b/src/Providers/OpenAiCompatibleProvider.php
@@ -86,9 +86,6 @@ class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, Te
 
     /**
      * Get the default dimensions of the default embeddings model.
-     *
-     * When no dimensions are configured, the request omits the dimensions
-     * parameter and the model's native dimensions are used.
      */
     public function defaultEmbeddingsDimensions(): int
     {

--- a/tests/Feature/Providers/OpenAiCompatible/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/EmbeddingsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Embeddings;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
@@ -94,15 +95,22 @@ test('embeddings request includes provider options in the request body', functio
 
     Ai::instance('openai-compatible')->embeddings(
         inputs: ['Hello'],
-        providerOptions: ['encoding_format' => 'base64'],
+        providerOptions: ['user' => 'test-user'],
     );
 
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);
 
-        return $body['encoding_format'] === 'base64'
+        return $body['user'] === 'test-user'
             && $body['input'] === ['Hello'];
     });
+});
+
+test('embeddings reject response formats that do not return float vectors', function (): void {
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(
+        inputs: ['Hello'],
+        providerOptions: ['encoding_format' => 'base64'],
+    ))->toThrow(InvalidArgumentException::class, 'only supports float embedding responses');
 });
 
 test('throws when no default embeddings model is configured and none is passed', function (): void {
@@ -138,6 +146,62 @@ test('embeddings request omits dimensions when none are configured', function ()
         return $body['model'] === 'local-embeddings-model'
             && ! array_key_exists('dimensions', $body);
     });
+});
+
+test('embeddings request omits dimensions when an explicit model is passed', function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'key' => 'test-key',
+    ]]);
+
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    Ai::instance('openai-compatible')->embeddings(['Hello'], model: 'explicit-embeddings-model');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'explicit-embeddings-model'
+            && ! array_key_exists('dimensions', $body);
+    });
+});
+
+test('automatic embedding fakes require dimensions when the model dimensions are unknown', function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'models' => ['embeddings' => ['default' => 'local-embeddings-model']],
+    ]]);
+
+    Embeddings::fake();
+
+    Embeddings::for(['Hello'])->generate(provider: 'openai-compatible');
+})->throws(RuntimeException::class, 'Unable to generate fake embeddings without positive dimensions');
+
+test('embeddings reject responses with missing vectors', function (): void {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(['Hello']))
+        ->toThrow(AiException::class, 'expected number of embeddings');
+});
+
+test('embeddings reject malformed vectors', function (): void {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => ['invalid']]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(['Hello']))
+        ->toThrow(AiException::class, 'invalid embedding vector');
 });
 
 test('embeddings rate limit response throws rate limited exception', function (): void {

--- a/tests/Feature/Providers/OpenAiCompatible/EmbeddingsTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/EmbeddingsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+
+beforeEach(function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'key' => 'test-key',
+        'models' => [
+            'text' => ['default' => 'local-model'],
+            'embeddings' => ['default' => 'local-embeddings-model', 'dimensions' => 768],
+        ],
+    ]]);
+});
+
+test('embeddings request is correctly formatted', function (): void {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+        ],
+        'usage' => ['prompt_tokens' => 5],
+    ])]);
+
+    Ai::instance('openai-compatible')->embeddings(['Hello world']);
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'local-embeddings-model'
+            && $body['input'] === ['Hello world']
+            && $body['dimensions'] === 768
+            && $request->url() === 'http://localhost:1234/v1/embeddings';
+    });
+});
+
+test('embeddings response is correctly parsed', function (): void {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [
+            ['object' => 'embedding', 'index' => 0, 'embedding' => [0.1, 0.2, 0.3]],
+            ['object' => 'embedding', 'index' => 1, 'embedding' => [0.4, 0.5, 0.6]],
+        ],
+        'usage' => ['prompt_tokens' => 10],
+    ])]);
+
+    $response = Ai::instance('openai-compatible')->embeddings(['Hello', 'World']);
+
+    expect($response->embeddings)->toHaveCount(2)
+        ->and($response->embeddings[0])->toBe([0.1, 0.2, 0.3])
+        ->and($response->embeddings[1])->toBe([0.4, 0.5, 0.6])
+        ->and($response->tokens)->toBe(10)
+        ->and($response->meta->provider)->toBe('openai-compatible');
+});
+
+test('embeddings request sends bearer token', function (): void {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    Ai::instance('openai-compatible')->embeddings(['test']);
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('embeddings request omits authorization header when no key is configured', function (): void {
+    config(['ai.providers.openai-compatible.key' => null]);
+
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    Ai::instance('openai-compatible')->embeddings(['test']);
+
+    Http::assertSent(fn (Request $request): bool => ! $request->hasHeader('Authorization'));
+});
+
+test('embeddings request includes provider options in the request body', function (): void {
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    Ai::instance('openai-compatible')->embeddings(
+        inputs: ['Hello'],
+        providerOptions: ['encoding_format' => 'base64'],
+    );
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['encoding_format'] === 'base64'
+            && $body['input'] === ['Hello'];
+    });
+});
+
+test('throws when no default embeddings model is configured and none is passed', function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'key' => 'test-key',
+    ]]);
+
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(['Hello']))
+        ->toThrow(InvalidArgumentException::class, 'requires a default embeddings model');
+});
+
+test('embeddings request omits dimensions when none are configured', function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'key' => 'test-key',
+        'models' => ['embeddings' => ['default' => 'local-embeddings-model']],
+    ]]);
+
+    Http::fake(['*' => Http::response([
+        'object' => 'list',
+        'data' => [['object' => 'embedding', 'index' => 0, 'embedding' => [0.1]]],
+        'usage' => ['prompt_tokens' => 1],
+    ])]);
+
+    Ai::instance('openai-compatible')->embeddings(['Hello']);
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'local-embeddings-model'
+            && ! array_key_exists('dimensions', $body);
+    });
+});
+
+test('embeddings rate limit response throws rate limited exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Rate limited']], 429)]);
+
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(['Hello']))
+        ->toThrow(RateLimitedException::class);
+});
+
+test('embeddings overloaded response throws provider overloaded exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Server overloaded']], 503)]);
+
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(['Hello']))
+        ->toThrow(ProviderOverloadedException::class);
+});
+
+test('embeddings error in 200 response throws ai exception', function (): void {
+    Http::fake(['*' => Http::response([
+        'error' => [
+            'type' => 'invalid_request_error',
+            'message' => 'The model does not exist.',
+        ],
+    ])]);
+
+    expect(fn () => Ai::instance('openai-compatible')->embeddings(['Hello']))
+        ->toThrow(AiException::class, 'OpenAI-compatible Error');
+});


### PR DESCRIPTION
Fixes #840.

The `openai-compatible` driver only implements the text contract, so calling `embeddings()` on it fails even though OpenAI-compatible servers such as LM Studio, vLLM, and LiteLLM expose the standard `/v1/embeddings` endpoint.

This PR wires the driver into the existing embeddings architecture:

- `OpenAiCompatibleProvider` now implements `EmbeddingProvider` through the shared `GeneratesEmbeddings` and `HasEmbeddingGateway` concerns, so caching, faking, and events work unchanged.
- `OpenAiCompatibleGateway` gains a `generateEmbeddings()` method that posts to the configured endpoint using the OpenAI wire format. It reuses the gateway's existing client (base URL, optional bearer token, failover error handling) and response validation, and mirrors the OpenRouter gateway's implementation.
- Since arbitrary endpoints have no known models, the default embeddings model must be configured, following the same pattern the driver already uses for `defaultTextModel()`. Dimensions are optional: when configured (or passed explicitly) they are sent with the request, and when omitted the request leaves out the `dimensions` parameter so the model's native dimensions are used. Backends that reject `dimensions` for fixed-dimension models never receive it unless the user opts in. This mirrors how the Ollama gateway filters the parameter.

```php
'openai-compatible' => [
    'driver' => 'openai-compatible',
    'url' => env('OPENAI_COMPATIBLE_URL'),
    'key' => env('OPENAI_COMPATIBLE_API_KEY'),
    'models' => [
        'embeddings' => [
            'default' => 'text-embedding-qwen3-embedding-0.6b',
            'dimensions' => 1024, // optional
        ],
    ],
],
```

Tests mirror the OpenRouter embeddings suite: request formatting, response parsing, dimensions sent when configured and omitted when not, auth header present and absent, provider options passthrough, missing-model exception, and rate limit, overload, and error-in-200 handling.
