### PR TITLE
Add Vercel protocol coverage for text and reasoning stream events

### DIFF
--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -4,9 +4,14 @@ use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
@@ -34,6 +39,44 @@ function vercelProtocolParts(array $events, ?string $messageId = null): array
         ->map(fn (string $payload) => $payload === '[DONE]' ? ['type' => 'done'] : json_decode($payload, true))
         ->all();
 }
+
+test('a text stream emits start, delta, and end parts for the message', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new TextStart('event-1', 'msg-1', time()),
+        new TextDelta('event-2', 'msg-1', 'Hello.', time()),
+        new TextEnd('event-3', 'msg-1', time()),
+        new StreamEnd('event-4', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'text-start', 'id' => 'msg-1'],
+        ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hello.'],
+        ['type' => 'text-end', 'id' => 'msg-1'],
+        ['type' => 'finish'],
+        ['type' => 'done'],
+    ]);
+});
+
+test('a reasoning stream emits start, delta, and end parts for the reasoning block', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new ReasoningStart('event-1', 'reasoning-1', time()),
+        new ReasoningDelta('event-2', 'reasoning-1', 'Considering the options.', time()),
+        new ReasoningEnd('event-3', 'reasoning-1', time()),
+        new StreamEnd('event-4', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'reasoning-start', 'id' => 'reasoning-1'],
+        ['type' => 'reasoning-delta', 'id' => 'reasoning-1', 'delta' => 'Considering the options.'],
+        ['type' => 'reasoning-end', 'id' => 'reasoning-1'],
+        ['type' => 'finish'],
+        ['type' => 'done'],
+    ]);
+});
 
 test('a paused stream emits an approval request part for each pending approval', function () {
     $parts = vercelProtocolParts([


### PR DESCRIPTION
`VercelProtocolStreamTest` currently covers only the tool-related parts of the Vercel AI SDK protocol — tool input/output, approval requests, and the start / finish frames. The `toVercelProtocolArray()` mappings for the text and reasoning lifecycle events had no coverage at all, even though every streaming gateway emits them: `TextStart`/`TextEnd` come from the fake gateway plus the Gemini, Groq, OpenRouter and OpenAI-compatible streams, and `ReasoningStart`/`Delta`/`End` come from Anthropic, Gemini, Bedrock, DeepSeek and xAI.                                                                                                                                                                                
                                                                                                                                                                                                                                         
This adds two tests that assert the full frame sequence for each: a text stream emitting `text-start` / `text-delta` / `text-end`, and a reasoning stream emitting `reasoning-start` / `reasoning-delta` / `reasoning-end`. Both reuse the existing `vercelProtocolParts()` helper and follow the style of the surrounding tests.                                                                                                                                                          
                                                                                                                                                                                                                                         
Tests only, no source changes.                                  