### PR TITLE
Fix OpenAI gateway dropping cache write tokens from usage

### DIFF
--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -267,11 +267,14 @@ trait HandlesTextGeneration
                 $responseId = $response['id'] ?? $responseId;
                 $responseUsage = $response['usage'] ?? [];
 
+                $cachedTokens = $responseUsage['input_tokens_details']['cached_tokens'] ?? 0;
+                $cacheWriteTokens = $responseUsage['input_tokens_details']['cache_write_tokens'] ?? 0;
+
                 $usage = new Usage(
-                    ($responseUsage['input_tokens'] ?? 0) - ($responseUsage['input_tokens_details']['cached_tokens'] ?? 0),
+                    ($responseUsage['input_tokens'] ?? 0) - $cachedTokens - $cacheWriteTokens,
                     $responseUsage['output_tokens'] ?? 0,
-                    0,
-                    $responseUsage['input_tokens_details']['cached_tokens'] ?? 0,
+                    $cacheWriteTokens,
+                    $cachedTokens,
                     $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
                 );
             }

--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -265,18 +265,8 @@ trait HandlesTextGeneration
                 $response = $data['response'] ?? [];
                 $responseData = $response;
                 $responseId = $response['id'] ?? $responseId;
-                $responseUsage = $response['usage'] ?? [];
 
-                $cachedTokens = $responseUsage['input_tokens_details']['cached_tokens'] ?? 0;
-                $cacheWriteTokens = $responseUsage['input_tokens_details']['cache_write_tokens'] ?? 0;
-
-                $usage = new Usage(
-                    ($responseUsage['input_tokens'] ?? 0) - $cachedTokens - $cacheWriteTokens,
-                    $responseUsage['output_tokens'] ?? 0,
-                    $cacheWriteTokens,
-                    $cachedTokens,
-                    $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
-                );
+                $usage = $this->extractUsage($response);
             }
         }
 

--- a/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAi/Concerns/ParsesTextResponses.php
@@ -126,11 +126,12 @@ trait ParsesTextResponses
         $usage = $data['usage'] ?? [];
         $inputTokens = $usage['input_tokens'] ?? 0;
         $cachedTokens = $usage['input_tokens_details']['cached_tokens'] ?? 0;
+        $cacheWriteTokens = $usage['input_tokens_details']['cache_write_tokens'] ?? 0;
 
         return new Usage(
-            $inputTokens - $cachedTokens,
+            $inputTokens - $cachedTokens - $cacheWriteTokens,
             $usage['output_tokens'] ?? 0,
-            0,
+            $cacheWriteTokens,
             $cachedTokens,
             $usage['output_tokens_details']['reasoning_tokens'] ?? 0,
         );

--- a/tests/Feature/Providers/OpenAi/OpenAiHelpers.php
+++ b/tests/Feature/Providers/OpenAi/OpenAiHelpers.php
@@ -35,13 +35,13 @@ trait OpenAiHelpers
         return implode("\n\n", $lines)."\n\n";
     }
 
-    protected function responseCreated(): array
+    protected function responseCreated(string $model = 'gpt-5.4'): array
     {
         return [
             'type' => 'response.created',
             'response' => [
                 'id' => 'resp_1',
-                'model' => 'gpt-5.4',
+                'model' => $model,
                 'status' => 'in_progress',
                 'output' => [],
             ],
@@ -106,13 +106,13 @@ trait OpenAiHelpers
         ];
     }
 
-    protected function responseCompleted(int $inputTokens, int $outputTokens, int $cachedTokens = 0, int $reasoningTokens = 0, ?array $output = null): array
+    protected function responseCompleted(int $inputTokens, int $outputTokens, int $cachedTokens = 0, int $reasoningTokens = 0, int $cacheWriteTokens = 0, string $model = 'gpt-5.4', ?array $output = null): array
     {
         return [
             'type' => 'response.completed',
             'response' => [
                 'id' => 'resp_1',
-                'model' => 'gpt-5.4',
+                'model' => $model,
                 'status' => 'completed',
                 'output' => $output ?? [
                     [
@@ -127,6 +127,7 @@ trait OpenAiHelpers
                     'output_tokens' => $outputTokens,
                     'input_tokens_details' => [
                         'cached_tokens' => $cachedTokens,
+                        'cache_write_tokens' => $cacheWriteTokens,
                     ],
                     'output_tokens_details' => [
                         'reasoning_tokens' => $reasoningTokens,

--- a/tests/Feature/Providers/OpenAi/OpenAiHelpers.php
+++ b/tests/Feature/Providers/OpenAi/OpenAiHelpers.php
@@ -35,13 +35,13 @@ trait OpenAiHelpers
         return implode("\n\n", $lines)."\n\n";
     }
 
-    protected function responseCreated(string $model = 'gpt-5.4'): array
+    protected function responseCreated(): array
     {
         return [
             'type' => 'response.created',
             'response' => [
                 'id' => 'resp_1',
-                'model' => $model,
+                'model' => 'gpt-5.4',
                 'status' => 'in_progress',
                 'output' => [],
             ],
@@ -106,13 +106,13 @@ trait OpenAiHelpers
         ];
     }
 
-    protected function responseCompleted(int $inputTokens, int $outputTokens, int $cachedTokens = 0, int $reasoningTokens = 0, int $cacheWriteTokens = 0, string $model = 'gpt-5.4', ?array $output = null): array
+    protected function responseCompleted(int $inputTokens, int $outputTokens, int $cachedTokens = 0, int $reasoningTokens = 0, int $cacheWriteTokens = 0, ?array $output = null): array
     {
         return [
             'type' => 'response.completed',
             'response' => [
                 'id' => 'resp_1',
-                'model' => $model,
+                'model' => 'gpt-5.4',
                 'status' => 'completed',
                 'output' => $output ?? [
                     [

--- a/tests/Feature/Providers/OpenAi/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/RequestMappingTest.php
@@ -316,3 +316,65 @@ test('none tool choice prevents tool calls', function (): void {
 
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['tool_choice'] === 'none');
 });
+
+test('response usage captures cache write tokens', function (): void {
+    Http::fake(['*' => Http::response([
+        'id' => 'resp_123',
+        'status' => 'completed',
+        'model' => 'gpt-5.6-luna',
+        'output' => [[
+            'type' => 'message',
+            'status' => 'completed',
+            'content' => [['type' => 'output_text', 'text' => 'Hello']],
+        ]],
+        'usage' => [
+            'input_tokens' => 8817,
+            'output_tokens' => 120,
+            'input_tokens_details' => [
+                'cache_write_tokens' => 8814,
+                'cached_tokens' => 0,
+            ],
+            'output_tokens_details' => [
+                'reasoning_tokens' => 64,
+            ],
+        ],
+    ])]);
+
+    $response = agent()->prompt('Hello', provider: 'openai');
+
+    expect($response->usage->cacheWriteInputTokens)->toBe(8814)
+        ->and($response->usage->cacheReadInputTokens)->toBe(0)
+        ->and($response->usage->promptTokens)->toBe(3)
+        ->and($response->usage->completionTokens)->toBe(120)
+        ->and($response->usage->reasoningTokens)->toBe(64);
+});
+
+test('response usage separates cache reads from cache writes', function (): void {
+    Http::fake(['*' => Http::response([
+        'id' => 'resp_123',
+        'status' => 'completed',
+        'model' => 'gpt-5.6-luna',
+        'output' => [[
+            'type' => 'message',
+            'status' => 'completed',
+            'content' => [['type' => 'output_text', 'text' => 'Hello']],
+        ]],
+        'usage' => [
+            'input_tokens' => 8817,
+            'output_tokens' => 120,
+            'input_tokens_details' => [
+                'cache_write_tokens' => 0,
+                'cached_tokens' => 8814,
+            ],
+            'output_tokens_details' => [
+                'reasoning_tokens' => 64,
+            ],
+        ],
+    ])]);
+
+    $response = agent()->prompt('Hello', provider: 'openai');
+
+    expect($response->usage->cacheWriteInputTokens)->toBe(0)
+        ->and($response->usage->cacheReadInputTokens)->toBe(8814)
+        ->and($response->usage->promptTokens)->toBe(3);
+});

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -193,3 +193,27 @@ test('streaming finish reason maps correctly', function (string $status, string 
     'unknown status maps to Unknown' => ['mystery_status', 'message', FinishReason::Unknown],
     'completed unknown type maps to Unknown' => ['completed', 'mystery_output', FinishReason::Unknown],
 ]);
+
+test('streaming captures cache write tokens from response completed', function (): void {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated('gpt-5.6-luna'),
+                $this->outputTextDelta('Hello'),
+                $this->outputTextDone('Hello'),
+                $this->responseCompleted(8817, 120, cachedTokens: 0, cacheWriteTokens: 8814, model: 'gpt-5.6-luna'),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $streamEnd = array_values(array_filter($events, fn ($e): bool => $e instanceof StreamEnd))[0];
+
+    expect($streamEnd->usage->cacheWriteInputTokens)->toBe(8814)
+        ->and($streamEnd->usage->cacheReadInputTokens)->toBe(0)
+        ->and($streamEnd->usage->promptTokens)->toBe(3)
+        ->and($streamEnd->usage->completionTokens)->toBe(120);
+});

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -198,10 +198,10 @@ test('streaming captures cache write tokens from response completed', function (
     Http::fake([
         'api.openai.com/*' => Http::response(
             body: $this->ssePayload([
-                $this->responseCreated('gpt-5.6-luna'),
+                $this->responseCreated(),
                 $this->outputTextDelta('Hello'),
                 $this->outputTextDone('Hello'),
-                $this->responseCompleted(8817, 120, cachedTokens: 0, cacheWriteTokens: 8814, model: 'gpt-5.6-luna'),
+                $this->responseCompleted(8817, 120, cachedTokens: 0, cacheWriteTokens: 8814),
             ]),
             status: 200,
             headers: ['Content-Type' => 'text/event-stream'],


### PR DESCRIPTION
The OpenAI gateway hardcodes `cacheWriteInputTokens` to `0` and never reads `cache_write_tokens` from the response, so cache writes get counted as plain input.

That was harmless while writes were priced like normal input. The `gpt-5.6` family charges a premium to write the prefix into cache, so any cost derived from `Usage` now comes out under the real spend.

Same ~18k prefix sent twice to `gpt-5.6-luna`:

```jsonc
// write
"input_tokens": 18014,
"input_tokens_details": { "cache_write_tokens": 18011, "cached_tokens": 0 }

// read
"input_tokens": 18014,
"input_tokens_details": { "cache_write_tokens": 0, "cached_tokens": 18011 }
```

The field is under `input_tokens_details` (Responses API), not `prompt_tokens_details` where the OpenRouter gateway reads it.

`input_tokens` is the total and both detail fields are slices of it: `18014 = 3 + 18011 + 0` on the write, `3 + 0 + 18011` on the read. The premium is charged **in place of** the input rate, not on top of it, so leaving the write inside `promptTokens` would bill the same slice twice. Subtracting it is the same treatment `cached_tokens` already gets in these two methods, and what the Anthropic gateway does.

## Tests

Two cases pin the write, non-streaming and streaming, and both fail on `0.x` before the change. A third covers the read path so the new subtraction can't break it. `OpenAiHelpers` needed `cache_write_tokens` and a model override threaded through; existing callers keep their defaults.

Also checked live against `gpt-5.6-luna`, a cold prefix reports 26,111 write, 0 read, 3 prompt.

[prompt caching docs](https://developers.openai.com/api/docs/guides/prompt-caching)
