### PR TITLE
Add AgentFailed event when an agent prompt fails

### DIFF
--- a/src/Events/AgentFailed.php
+++ b/src/Events/AgentFailed.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\Data\Usage;
+use Throwable;
+
+class AgentFailed
+{
+    public function __construct(
+        public string $invocationId,
+        public AgentPrompt $prompt,
+        public Throwable $exception,
+        public ?Usage $usage = null,
+    ) {}
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -355,7 +355,7 @@ trait Promptable
      */
     private function recordAgentFailure(string $invocationId, AgentPrompt $prompt, Throwable $exception): void
     {
-        event(new AgentFailed($invocationId, $prompt, $exception));
+        event(new AgentFailed($invocationId, $prompt->processed(), $exception));
     }
 
     /**

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -18,6 +18,7 @@ use Laravel\Ai\Attributes\UseSmartestModel;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Gateway\FakeTextGateway;
@@ -33,6 +34,7 @@ use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use ReflectionClass;
 use RuntimeException;
+use Throwable;
 
 trait Promptable
 {
@@ -61,20 +63,32 @@ trait Promptable
         ?int $timeout = null): AgentResponse
     {
         [$text, $approvalDecisions] = $this->extractPromptInput($prompt);
+        $invocationId = (string) Str::uuid7();
+        $lastPrompt = null;
 
-        $run = fn (TextProvider $provider, string $model): AgentResponse => $provider->prompt(
-            new AgentPrompt($this, $text, $attachments, $provider, $model, $this->getTimeout($timeout), approvalDecisions: $approvalDecisions)
-        );
+        $run = function (TextProvider $provider, string $model) use ($text, $attachments, $timeout, $invocationId, $approvalDecisions, &$lastPrompt): AgentResponse {
+            $lastPrompt = new AgentPrompt($this, $text, $attachments, $provider, $model, $this->getTimeout($timeout), $invocationId, $approvalDecisions);
 
-        if ($approvalDecisions !== null) {
-            [$provider, $model] = $this->iterateProvidersWithFailover(
-                $this->providersForApprovalContinuation($provider, $model)
-            )->current();
+            return $provider->prompt($lastPrompt);
+        };
 
-            return $run($provider, $model);
+        try {
+            if ($approvalDecisions !== null) {
+                [$provider, $model] = $this->iterateProvidersWithFailover(
+                    $this->providersForApprovalContinuation($provider, $model)
+                )->current();
+
+                return $run($provider, $model);
+            }
+
+            return $this->withModelFailover($run, $provider, $model);
+        } catch (Throwable $e) {
+            if ($lastPrompt !== null) {
+                $this->recordAgentFailure($invocationId, $lastPrompt, $e);
+            }
+
+            throw $e;
         }
-
-        return $this->withModelFailover($run, $provider, $model);
     }
 
     /**
@@ -112,10 +126,38 @@ trait Promptable
 
         if (count($providers) === 1) {
             [$resolved, $resolvedModel] = $this->iterateProvidersWithFailover($providers)->current();
+            $lastPrompt = new AgentPrompt($this, $prompt, $attachments, $resolved, $resolvedModel, $resolvedTimeout, $invocationId, $approvalDecisions);
 
-            return $resolved->stream(
-                new AgentPrompt($this, $prompt, $attachments, $resolved, $resolvedModel, $resolvedTimeout, $invocationId, $approvalDecisions)
+            try {
+                $innerResponse = $resolved->stream($lastPrompt);
+            } catch (Throwable $e) {
+                $this->recordAgentFailure($invocationId, $lastPrompt, $e);
+
+                throw $e;
+            }
+
+            $meta = new Meta($resolved->name(), $resolvedModel);
+            $outer = null;
+
+            $outer = new StreamableAgentResponse(
+                $invocationId,
+                function () use ($innerResponse, $invocationId, $lastPrompt, &$outer) {
+                    try {
+                        $innerResponse->then(fn (StreamedAgentResponse $response): StreamableAgentResponse => $outer->adoptStateFrom($response));
+
+                        foreach ($innerResponse as $event) {
+                            yield $event;
+                        }
+                    } catch (Throwable $e) {
+                        $this->recordAgentFailure($invocationId, $lastPrompt, $e);
+
+                        throw $e;
+                    }
+                },
+                $meta,
             );
+
+            return $outer;
         }
 
         $meta = new Meta;
@@ -125,34 +167,42 @@ trait Promptable
             $invocationId,
             function () use ($providers, $prompt, $approvalDecisions, $attachments, $resolvedTimeout, $invocationId, &$outer) {
                 $lastException = null;
+                $lastPrompt = null;
 
-                foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
-                    $started = false;
+                try {
+                    foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
+                        $started = false;
 
-                    try {
-                        $innerResponse = $provider->stream(
-                            new AgentPrompt($this, $prompt, $attachments, $provider, $model, $resolvedTimeout, $invocationId, $approvalDecisions)
-                        );
+                        try {
+                            $lastPrompt = new AgentPrompt($this, $prompt, $attachments, $provider, $model, $resolvedTimeout, $invocationId, $approvalDecisions);
+                            $innerResponse = $provider->stream($lastPrompt);
 
-                        $innerResponse->then(fn (StreamedAgentResponse $response): StreamableAgentResponse => $outer->adoptStateFrom($response));
+                            $innerResponse->then(fn (StreamedAgentResponse $response): StreamableAgentResponse => $outer->adoptStateFrom($response));
 
-                        foreach ($innerResponse as $event) {
-                            $started = true;
+                            foreach ($innerResponse as $event) {
+                                $started = true;
 
-                            yield $event;
+                                yield $event;
+                            }
+
+                            return;
+                        } catch (FailoverableException $e) {
+                            if ($started) {
+                                throw $e;
+                            }
+
+                            $lastException = $this->recordAgentFailover($provider, $model, $e);
                         }
-
-                        return;
-                    } catch (FailoverableException $e) {
-                        if ($started) {
-                            throw $e;
-                        }
-
-                        $lastException = $this->recordAgentFailover($provider, $model, $e);
                     }
-                }
 
-                throw $lastException;
+                    throw $lastException;
+                } catch (Throwable $e) {
+                    if ($lastPrompt !== null) {
+                        $this->recordAgentFailure($invocationId, $lastPrompt, $e);
+                    }
+
+                    throw $e;
+                }
             },
             $meta,
         );
@@ -298,6 +348,14 @@ trait Promptable
         event(new AgentFailedOver($this, $provider, $model, $exception));
 
         return $exception;
+    }
+
+    /**
+     * Record that an agent failed terminally.
+     */
+    private function recordAgentFailure(string $invocationId, AgentPrompt $prompt, Throwable $exception): void
+    {
+        event(new AgentFailed($invocationId, $prompt, $exception));
     }
 
     /**

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -18,6 +18,8 @@ class AgentPrompt extends Prompt
 
     public readonly ?string $invocationId;
 
+    private readonly AgentPromptContext $context;
+
     public function __construct(
         Agent $agent,
         string $prompt,
@@ -27,6 +29,7 @@ class AgentPrompt extends Prompt
         ?int $timeout = null,
         ?string $invocationId = null,
         ?Decisions $approvalDecisions = null,
+        ?AgentPromptContext $context = null,
     ) {
         parent::__construct($prompt, $provider, $model, $approvalDecisions);
 
@@ -34,6 +37,7 @@ class AgentPrompt extends Prompt
         $this->attachments = Collection::make($attachments);
         $this->timeout = $timeout;
         $this->invocationId = $invocationId;
+        $this->context = $context ?? new AgentPromptContext;
     }
 
     /**
@@ -77,6 +81,38 @@ class AgentPrompt extends Prompt
             $this->agent,
             $prompt,
             $attachments ?? $this->attachments,
+            $this->provider,
+            $this->model,
+            $this->timeout,
+            $this->invocationId,
+            $this->approvalDecisions,
+            $this->context,
+        );
+    }
+
+    /**
+     * Record this prompt as the prompt processed by agent middleware.
+     */
+    public function markAsProcessed(): self
+    {
+        $this->context->recordProcessedPrompt($this);
+
+        return $this;
+    }
+
+    /**
+     * Get the prompt processed by agent middleware, if available.
+     */
+    public function processed(): self
+    {
+        if ($this->context->processedPrompt === null) {
+            return $this;
+        }
+
+        return new self(
+            $this->agent,
+            $this->context->processedPrompt,
+            $this->context->processedAttachments ?? $this->attachments,
             $this->provider,
             $this->model,
             $this->timeout,

--- a/src/Prompts/AgentPromptContext.php
+++ b/src/Prompts/AgentPromptContext.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Ai\Prompts;
+
+use Illuminate\Support\Collection;
+
+class AgentPromptContext
+{
+    public ?string $processedPrompt = null;
+
+    /** @var Collection<int, mixed>|null */
+    public ?Collection $processedAttachments = null;
+
+    /**
+     * Record the prompt after agent middleware has been applied.
+     */
+    public function recordProcessedPrompt(AgentPrompt $prompt): void
+    {
+        $this->processedPrompt = $prompt->prompt;
+        $this->processedAttachments = $prompt->attachments;
+    }
+}

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -55,7 +55,7 @@ trait GeneratesText
             ->send($prompt)
             ->through($this->gatherMiddlewareFor($prompt->agent))
             ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt, &$resolvedApprovalResults): TextResponse {
-                $processedPrompt = $prompt;
+                $processedPrompt = $prompt->markAsProcessed();
 
                 $this->events->dispatch(new PromptingAgent($invocationId, $prompt));
 

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -46,7 +46,7 @@ trait GeneratesText
      */
     public function prompt(AgentPrompt $prompt): AgentResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = $prompt->invocationId ?? (string) Str::uuid7();
 
         $processedPrompt = null;
         $resolvedApprovalResults = null;

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -38,7 +38,7 @@ trait StreamsText
             ->send($prompt)
             ->through($this->gatherMiddlewareFor($prompt->agent))
             ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt, &$resolvedApprovalResults): StreamableAgentResponse {
-                $processedPrompt = $prompt;
+                $processedPrompt = $prompt->markAsProcessed();
 
                 $agent = $prompt->agent;
 

--- a/tests/Feature/AgentPromptFailoverTest.php
+++ b/tests/Feature/AgentPromptFailoverTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Events\AgentFailed;
+use Laravel\Ai\Events\AgentFailedOver;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+test('prompt dispatches agent failed when all providers are exhausted', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(status: 429);
+
+    expect(fn () => (new AssistantAgent)->prompt(
+        'Hello',
+        provider: ['primary', 'backup'],
+    ))->toThrow(RateLimitedException::class);
+
+    $failure = null;
+
+    Event::assertDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentFailed::class, function (AgentFailed $event) use (&$failure): bool {
+        $failure = $event;
+
+        return $event->exception instanceof RateLimitedException
+            && $event->prompt->provider()->name() === 'backup'
+            && $event->prompt->invocationId === $event->invocationId
+            && $event->usage === null;
+    });
+
+    $promptingInvocationIds = Event::dispatched(PromptingAgent::class)
+        ->map(fn (array $arguments): string => $arguments[0]->invocationId)
+        ->unique()
+        ->values()
+        ->all();
+
+    expect($promptingInvocationIds)->toBe([$failure->invocationId]);
+
+    Event::assertNotDispatched(AgentPrompted::class);
+});
+
+test('prompt dispatches agent failed for a non failoverable exception', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 400);
+
+    expect(fn () => (new AssistantAgent)->prompt(
+        'Hello',
+        provider: 'primary',
+    ))->toThrow(RequestException::class);
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->exception instanceof RequestException);
+    Event::assertNotDispatched(AgentFailedOver::class);
+    Event::assertNotDispatched(AgentPrompted::class);
+});
+
+test('prompt does not dispatch agent failed when failover succeeds', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push([
+            'id' => 'chatcmpl-123',
+            'object' => 'chat.completion',
+            'model' => 'openai/gpt-oss-20b',
+            'choices' => [[
+                'index' => 0,
+                'message' => ['role' => 'assistant', 'content' => 'Hello'],
+                'finish_reason' => 'stop',
+            ]],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
+        ]);
+
+    $response = (new AssistantAgent)->prompt(
+        'Hello',
+        provider: ['primary', 'backup'],
+    );
+
+    expect($response->text)->toBe('Hello');
+
+    Event::assertDispatched(AgentFailedOver::class);
+    Event::assertNotDispatched(AgentFailed::class);
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->invocationId === $response->invocationId);
+    Event::assertDispatched(AgentPrompted::class, fn (AgentPrompted $event): bool => $event->invocationId === $response->invocationId);
+});
+
+test('prompt does not dispatch agent failed when no provider can be resolved', function (): void {
+    Event::fake();
+
+    expect(fn () => (new AssistantAgent)->prompt(
+        'Hello',
+        provider: [],
+    ))->toThrow(RuntimeException::class, 'No AI providers were configured.');
+
+    Event::assertNotDispatched(AgentFailed::class);
+});

--- a/tests/Feature/AgentPromptFailoverTest.php
+++ b/tests/Feature/AgentPromptFailoverTest.php
@@ -8,6 +8,7 @@ use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Prompts\AgentPrompt;
 use Tests\Fixtures\Agents\AssistantAgent;
 
 test('prompt dispatches agent failed when all providers are exhausted', function (): void {
@@ -64,12 +65,26 @@ test('prompt dispatches agent failed for a non failoverable exception', function
     Http::fakeSequence()
         ->push(status: 400);
 
-    expect(fn () => (new AssistantAgent)->prompt(
+    $agent = (new AssistantAgent)->withMiddleware([
+        new class
+        {
+            public function handle(AgentPrompt $prompt, Closure $next)
+            {
+                return $next($prompt->prepend('Revised by middleware'));
+            }
+        },
+    ]);
+
+    expect(fn () => $agent->prompt(
         'Hello',
         provider: 'primary',
     ))->toThrow(RequestException::class);
 
-    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->exception instanceof RequestException);
+    $processedPrompt = 'Revised by middleware'.PHP_EOL.PHP_EOL.'Hello';
+
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->prompt->prompt === $processedPrompt);
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->exception instanceof RequestException
+        && $event->prompt->prompt === $processedPrompt);
     Event::assertNotDispatched(AgentFailedOver::class);
     Event::assertNotDispatched(AgentPrompted::class);
 });

--- a/tests/Feature/AgentStreamFailoverTest.php
+++ b/tests/Feature/AgentStreamFailoverTest.php
@@ -9,7 +9,9 @@ use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
@@ -155,7 +157,17 @@ test('single provider stream does not dispatch failover event when rate limited'
     Http::fakeSequence()
         ->push(status: 429);
 
-    $response = (new AssistantAgent)->stream(
+    $agent = (new AssistantAgent)->withMiddleware([
+        new class
+        {
+            public function handle(AgentPrompt $prompt, Closure $next)
+            {
+                return $next($prompt->append('Revised by middleware'));
+            }
+        },
+    ]);
+
+    $response = $agent->stream(
         'Hello',
         provider: 'primary',
     );
@@ -166,8 +178,12 @@ test('single provider stream does not dispatch failover event when rate limited'
     })->toThrow(RateLimitedException::class);
 
     Event::assertNotDispatched(AgentFailedOver::class);
+    $processedPrompt = 'Hello'.PHP_EOL.PHP_EOL.'Revised by middleware';
+
+    Event::assertDispatched(StreamingAgent::class, fn (StreamingAgent $event): bool => $event->prompt->prompt === $processedPrompt);
     Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId
-        && $event->exception instanceof RateLimitedException);
+        && $event->exception instanceof RateLimitedException
+        && $event->prompt->prompt === $processedPrompt);
 });
 
 test('stream does not fail over when primary emits event then throws', function (): void {

--- a/tests/Feature/AgentStreamFailoverTest.php
+++ b/tests/Feature/AgentStreamFailoverTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Laravel\Ai\AiManager;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Exceptions\RateLimitedException;
@@ -47,6 +48,7 @@ test('stream fails over to next provider when primary is rate limited', function
         ->and($response->text)->toBe('Hello');
 
     Event::assertDispatched(AgentFailedOver::class);
+    Event::assertNotDispatched(AgentFailed::class);
 
     Event::assertDispatched(AgentStreamed::class, fn (AgentStreamed $event): bool => $event->invocationId === $response->invocationId);
 });
@@ -74,6 +76,11 @@ test('stream throws last exception when all providers fail', function (): void {
         foreach ($response as $_) {
         }
     })->toThrow(RateLimitedException::class);
+
+    Event::assertDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId
+        && $event->exception instanceof RateLimitedException
+        && $event->prompt->provider()->name() === 'backup');
 });
 
 test('stream then callback is invoked after failover', function (): void {
@@ -133,6 +140,7 @@ test('stream does not fail over when primary succeeds', function (): void {
     expect($response->text)->toBe('Hello');
 
     Event::assertNotDispatched(AgentFailedOver::class);
+    Event::assertNotDispatched(AgentFailed::class);
 });
 
 test('single provider stream does not dispatch failover event when rate limited', function (): void {
@@ -158,6 +166,8 @@ test('single provider stream does not dispatch failover event when rate limited'
     })->toThrow(RateLimitedException::class);
 
     Event::assertNotDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId
+        && $event->exception instanceof RateLimitedException);
 });
 
 test('stream does not fail over when primary emits event then throws', function (): void {
@@ -206,6 +216,35 @@ test('stream does not fail over when primary emits event then throws', function 
         }
     })->toThrow(RateLimitedException::class);
 
+    Event::assertNotDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId
+        && $event->exception instanceof RateLimitedException);
+});
+
+test('single provider stream dispatches agent failed when provider throws before returning a response', function (): void {
+    Event::fake();
+
+    $manager = app(AiManager::class);
+
+    $manager->extend('immediately_failing_stream', fn ($app, $config): FakeStreamingProvider => new FakeStreamingProvider(
+        $config,
+        $app->make(Dispatcher::class),
+        function (): StreamableAgentResponse {
+            throw new InvalidArgumentException('Unable to create stream response.');
+        },
+    ));
+
+    config([
+        'ai.providers.primary' => ['driver' => 'immediately_failing_stream'],
+    ]);
+
+    expect(fn () => (new AssistantAgent)->stream(
+        'Hello',
+        provider: 'primary',
+    ))->toThrow(InvalidArgumentException::class, 'Unable to create stream response.');
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->exception instanceof InvalidArgumentException
+        && $event->prompt->provider()->name() === 'primary');
     Event::assertNotDispatched(AgentFailedOver::class);
 });
 
@@ -261,6 +300,8 @@ test('stream does not fail over when primary throws non failoverable exception',
     expect($backupStreamed)->toBeFalse();
 
     Event::assertNotDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId
+        && $event->exception instanceof InvalidArgumentException);
 });
 
 test('stream conversation state survives failover', function (): void {

--- a/tests/Feature/ToolApprovalResumeTest.php
+++ b/tests/Feature/ToolApprovalResumeTest.php
@@ -2,8 +2,10 @@
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Approvals\Decisions;
+use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -523,12 +525,17 @@ test('a resume does not fail over to another provider and re-run the approved to
 
     $paused = (new RememberingApprovableAgent)->forUser($user)->prompt('Generate a number', provider: ['primary', 'backup']);
 
+    Event::fake([AgentFailed::class]);
+
     expect(fn () => (new RememberingApprovableAgent)
         ->continue($paused->conversationId, $user)
         ->prompt(Decisions::from(['toolu_1' => true]), provider: ['primary', 'backup'])
     )->toThrow(RateLimitedException::class);
 
     expect(ApprovableNumberGenerator::$invocations)->toBe(1);
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->exception instanceof RateLimitedException
+        && $event->prompt->hasApprovalDecisions());
 });
 
 test('a successful resume records the approved result exactly once across history', function () {


### PR DESCRIPTION
- **Add event for terminal agent failures**
- **Preserve processed prompts on agent failures**

Closes #782 