### PR TITLE
Add Vercel protocol coverage for citation, error, and default tool error parts

### DIFF
--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -4,6 +4,8 @@ use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamableAgentResponse;
+use Laravel\Ai\Streaming\Events\Citation;
+use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
@@ -74,6 +76,42 @@ test('a reasoning stream emits start, delta, and end parts for the reasoning blo
         ['type' => 'reasoning-delta', 'id' => 'reasoning-1', 'delta' => 'Considering the options.'],
         ['type' => 'reasoning-end', 'id' => 'reasoning-1'],
         ['type' => 'finish'],
+        ['type' => 'done'],
+    ]);
+});
+
+test('a cited text stream emits a source url part for the cited page', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new TextStart('event-1', 'msg-1', time()),
+        new TextDelta('event-2', 'msg-1', 'Laravel is a PHP framework.', time()),
+        new Citation('event-3', 'msg-1', new Data\UrlCitation('https://laravel.com/docs', 'Laravel Documentation'), time()),
+        new TextEnd('event-4', 'msg-1', time()),
+        new StreamEnd('event-5', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'text-start', 'id' => 'msg-1'],
+        ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Laravel is a PHP framework.'],
+        ['type' => 'source-url', 'sourceId' => 'https://laravel.com/docs', 'url' => 'https://laravel.com/docs'],
+        ['type' => 'text-end', 'id' => 'msg-1'],
+        ['type' => 'finish'],
+        ['type' => 'done'],
+    ]);
+});
+
+test('a failed stream emits an error part instead of a finish part', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new TextStart('event-1', 'msg-1', time()),
+        new Error('event-2', 'overloaded_error', 'Overloaded', false, time()),
+    ]);
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'text-start', 'id' => 'msg-1'],
+        ['type' => 'error', 'errorText' => 'Overloaded'],
         ['type' => 'done'],
     ]);
 });
@@ -163,6 +201,21 @@ test('an unexecuted tool call streams as a tool output error', function () {
         'type' => 'tool-output-error',
         'toolCallId' => 'call-1',
         'errorText' => 'The agent reached its maximum number of steps without running this tool call.',
+    ]);
+});
+
+test('a failed tool call without an error message streams a default error text', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new ToolCall('event-1', new Data\ToolCall('call-1', 'GetWeather', ['city' => 'Lisbon']), time()),
+        new ToolResult('event-2', new Data\ToolResult('call-1', 'GetWeather', ['city' => 'Lisbon'], null), false, null, time()),
+        new StreamEnd('event-3', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts[2])->toBe([
+        'type' => 'tool-output-error',
+        'toolCallId' => 'call-1',
+        'errorText' => 'The tool call failed.',
     ]);
 });
 


### PR DESCRIPTION
This fills the last gaps in `VercelProtocolStreamTest`. Three `toVercelProtocolArray()` mappings still had no coverage anywhere in the suite:                                                                    
                                                                                                                                                                                                                                         
  - `Citation` - `source-url`, emitted by the Anthropic and OpenRouter streaming gateways when a web search result is cited mid-text.                                                                                                    
  - `Error` - `error` / `errorText`, emitted by every streaming gateway (Anthropic, Gemini, Groq, Mistral, Ollama, OpenAI, OpenAI-compatible, OpenRouter, DeepSeek, xAI) as well as the `BroadcastAgent` job.                            
  - The `errorText` fallback in `ToolResult`, used when a tool call fails without an error message. The existing unexecuted-tool-call test only covers the branch where an explicit message is present, so the `'The tool call failed.'` default was never asserted. It is reachable from `TextGenerationLoop`, which passes the tool result as the error text on the final step — that is `null` whenever the tool itself returned `null`.                                     
                                                                                                                                                                                                                                         
This adds three tests: a cited text stream emitting `source-url` between its `text-delta` and `text-end` frames, a failed stream emitting `error` with no `finish` frame (matching how the gateways yield an error and stop), and a failed tool call falling back to the default error text. All three reuse the existing `vercelProtocolParts()` helper and follow the style of the surrounding tests.                                                                    
                                                                                                                                                                                                                                         
Tests only, no source changes. 