### PR TITLE
Run the test suite in parallel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
             "pint --format agent",
             "phpstan --memory-limit=-1"
         ],
-        "test": "pest",
+        "test": "pest --parallel",
         "test:lint": "pint --test --format agent",
         "test:types": "phpstan",
         "check": [

--- a/tests/Feature/Providers/Groq/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Groq/ProviderOptionsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
@@ -64,32 +63,3 @@ test('provider options are persisted in tool call follow up requests', function 
 
     expect(data_get($followUpBody, 'frequency_penalty'))->toBe(0.5);
 });
-
-function fakeGroqToolCallResponse(): PromiseInterface
-{
-    return Http::response([
-        'id' => 'chatcmpl-tool-123',
-        'object' => 'chat.completion',
-        'model' => 'openai/gpt-oss-20b',
-        'choices' => [[
-            'index' => 0,
-            'message' => [
-                'role' => 'assistant',
-                'content' => null,
-                'tool_calls' => [[
-                    'id' => 'call_123',
-                    'type' => 'function',
-                    'function' => [
-                        'name' => 'FixedNumberGenerator',
-                        'arguments' => '{}',
-                    ],
-                ]],
-            ],
-            'finish_reason' => 'tool_calls',
-        ]],
-        'usage' => [
-            'prompt_tokens' => 10,
-            'completion_tokens' => 5,
-        ],
-    ]);
-}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -58,6 +58,35 @@ function fakeGroqResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
+function fakeGroqToolCallResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'chatcmpl-tool-123',
+        'object' => 'chat.completion',
+        'model' => 'openai/gpt-oss-20b',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_123',
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+        ],
+    ]);
+}
+
 function fakeOllamaResponse(string $text = 'Hello'): PromiseInterface
 {
     return Http::response([


### PR DESCRIPTION
The suite runs serially today, which takes about 50s locally. `pest --parallel` gets that down to ~8s, and paratest is already installed since Pest requires it.
