### PR TITLE
Preserve header casing when merging configured headers

### DIFF
--- a/src/Gateway/Concerns/CreatesClient.php
+++ b/src/Gateway/Concerns/CreatesClient.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Concerns;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 
 trait CreatesClient
@@ -20,7 +21,8 @@ trait CreatesClient
     ): PendingRequest {
         $headers = collect($headers)
             ->merge($configuredHeaders)
-            ->mapWithKeys(fn (mixed $value, string $name): array => [strtolower($name) => $value])
+            ->groupBy(fn (mixed $value, string $name): string => strtolower($name), preserveKeys: true)
+            ->mapWithKeys(fn (Collection $group): array => [$group->keys()->first() => $group->last()])
             ->all();
 
         return Http::baseUrl($baseUrl)

--- a/tests/Feature/Gateway/Concerns/CreatesClientTest.php
+++ b/tests/Feature/Gateway/Concerns/CreatesClientTest.php
@@ -27,8 +27,8 @@ test('configured headers override defaults case insensitively', function (): voi
     )->getOptions()['headers'];
 
     expect($headers)->toBe([
-        'authorization' => 'Bearer proxy-token',
-        'content-type' => 'application/json',
-        'x-session-affinity' => 'abc-123',
+        'Authorization' => 'Bearer proxy-token',
+        'Content-Type' => 'application/json',
+        'X-Session-Affinity' => 'abc-123',
     ]);
 });


### PR DESCRIPTION
#838 lowercases every header name before sending it. That's fine on Laravel 13, where `Http\Client\Request::header()` and `hasHeader()` delegate to PSR-7 and match case insensitively, but Laravel 12 does an exact array key lookup. So `hasHeader('Authorization')` returns false and the whole suite goes red on the Laravel 12 job, which is what's happening on `0.x` right now (https://github.com/laravel/ai/actions/runs/31103073526).

It's a BC break for apps too. Anyone asserting `hasHeader('Authorization')` against a faked provider call on Laravel 12 breaks on upgrade.

This groups the merged headers by lowercased name and keeps the first spelling with the last value, so the defaults still supply the casing and the configured header still supplies the winning value:

```php
$headers = collect($headers)
    ->merge($configuredHeaders)
    ->groupBy(fn (mixed $value, string $name): string => strtolower($name), preserveKeys: true)
    ->mapWithKeys(fn (Collection $group): array => [$group->keys()->first() => $group->last()])
    ->all();
```

Only the `CreatesClientTest` expectation changed, since it asserted the lowercasing itself. `CustomHeadersTest` is untouched and now passes on both framework versions.