### PR TITLE
Reset text part state after TextEnd in Responses API streams

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -55,7 +55,7 @@ trait HandlesTextStreaming
         $usage = null;
         $stopReason = '';
 
-        $emitTextStart = function () use (&$textStartEmitted, $messageId, $invocationId): ?\Laravel\Ai\Streaming\Events\StreamEvent {
+        $emitTextStart = function () use (&$textStartEmitted, &$messageId, $invocationId): ?\Laravel\Ai\Streaming\Events\StreamEvent {
             if ($textStartEmitted) {
                 return null;
             }
@@ -250,6 +250,7 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
 
                     $textStartEmitted = false;
+                    $messageId = $this->generateEventId();
                 } elseif ($currentBlockType === 'thinking' && $reasoningStartEmitted) {
                     if (isset($responseContent[$currentBlockIndex])) {
                         $responseContent[$currentBlockIndex]['thinking'] = $currentThinkingText;

--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -104,6 +104,9 @@ trait HandlesTextGeneration
                     time(),
                 ))->withInvocationId($invocationId);
 
+                $textStartEmitted = false;
+                $messageId = $this->generateEventId();
+
                 continue;
             }
 

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -106,6 +106,9 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
 
+                $textStartEmitted = false;
+                $messageId = $this->generateEventId();
+
                 continue;
             }
 

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -41,6 +41,42 @@ describe('text streaming', function (): void {
             ->and($events[4])->toBeInstanceOf(TextEnd::class)
             ->and($events[5])->toBeInstanceOf(StreamEnd::class);
     });
+
+    test('streaming starts a new text part after each text block', function (): void {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'First']),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'server_tool_use', 'id' => 'srvtoolu_1', 'name' => 'web_search']),
+                    $this->contentBlockStop(1),
+                    $this->contentBlockStart(2, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(2, ['type' => 'text_delta', 'text' => 'Second']),
+                    $this->contentBlockStop(2),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $textStarts = array_values(array_filter($events, fn ($e): bool => $e instanceof TextStart));
+        $textEnds = array_values(array_filter($events, fn ($e): bool => $e instanceof TextEnd));
+        $textDeltas = array_values(array_filter($events, fn ($e): bool => $e instanceof TextDelta));
+
+        expect($textStarts)->toHaveCount(2)
+            ->and($textEnds)->toHaveCount(2)
+            ->and($textDeltas)->toHaveCount(2)
+            ->and($textStarts[0]->messageId)->not->toBe($textStarts[1]->messageId)
+            ->and($textEnds[0]->messageId)->toBe($textStarts[0]->messageId)
+            ->and($textEnds[1]->messageId)->toBe($textStarts[1]->messageId)
+            ->and($textDeltas[0]->messageId)->toBe($textStarts[0]->messageId)
+            ->and($textDeltas[1]->messageId)->toBe($textStarts[1]->messageId);
+    });
 });
 
 describe('tool calls', function (): void {

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -46,6 +46,48 @@ test('streaming emits text events', function (): void {
         ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
 });
 
+test('streaming starts a new text part after each text end in the same step', function (): void {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                $this->outputTextDelta('First'),
+                $this->outputTextDone('First'),
+                $this->outputTextDelta('Second'),
+                $this->outputTextDone('Second'),
+                $this->responseCompleted(10, 5, output: [
+                    [
+                        'type' => 'message',
+                        'status' => 'completed',
+                        'role' => 'assistant',
+                        'content' => [
+                            ['type' => 'output_text', 'text' => 'First'],
+                            ['type' => 'output_text', 'text' => 'Second'],
+                        ],
+                    ],
+                ]),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $textStarts = array_values(array_filter($events, fn ($e): bool => $e instanceof TextStart));
+    $textEnds = array_values(array_filter($events, fn ($e): bool => $e instanceof TextEnd));
+    $textDeltas = array_values(array_filter($events, fn ($e): bool => $e instanceof TextDelta));
+
+    expect($textStarts)->toHaveCount(2)
+        ->and($textEnds)->toHaveCount(2)
+        ->and($textDeltas)->toHaveCount(2)
+        ->and($textStarts[0]->messageId)->not->toBe($textStarts[1]->messageId)
+        ->and($textEnds[0]->messageId)->toBe($textStarts[0]->messageId)
+        ->and($textEnds[1]->messageId)->toBe($textStarts[1]->messageId)
+        ->and($textDeltas[0]->messageId)->toBe($textStarts[0]->messageId)
+        ->and($textDeltas[1]->messageId)->toBe($textStarts[1]->messageId);
+});
+
 test('streaming handles tool calls', function (): void {
     Http::fake([
         'api.openai.com/*' => Http::sequence([

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -44,6 +44,38 @@ test('streaming emits text events', function (): void {
         ->and($events[5])->toBeInstanceOf(StreamEnd::class);
 });
 
+test('streaming starts a new text part after each text end in the same step', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.created', 'response' => ['id' => 'resp_123', 'model' => 'grok-4-1-fast-reasoning']],
+                ['type' => 'response.output_text.delta', 'delta' => 'First'],
+                ['type' => 'response.output_text.done'],
+                ['type' => 'response.output_text.delta', 'delta' => 'Second'],
+                ['type' => 'response.output_text.done'],
+                ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'message', 'status' => 'completed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'FirstSecond']]]], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $textStarts = array_values(array_filter($events, fn ($e): bool => $e instanceof TextStart));
+    $textEnds = array_values(array_filter($events, fn ($e): bool => $e instanceof TextEnd));
+    $textDeltas = array_values(array_filter($events, fn ($e): bool => $e instanceof TextDelta));
+
+    expect($textStarts)->toHaveCount(2)
+        ->and($textEnds)->toHaveCount(2)
+        ->and($textDeltas)->toHaveCount(2)
+        ->and($textStarts[0]->messageId)->not->toBe($textStarts[1]->messageId)
+        ->and($textEnds[0]->messageId)->toBe($textStarts[0]->messageId)
+        ->and($textEnds[1]->messageId)->toBe($textStarts[1]->messageId)
+        ->and($textDeltas[0]->messageId)->toBe($textStarts[0]->messageId)
+        ->and($textDeltas[1]->messageId)->toBe($textStarts[1]->messageId);
+});
+
 test('streaming handles tool calls', function (): void {
     Http::fake([
         '*' => Http::sequence([


### PR DESCRIPTION
Fixes #853

## Summary

When the OpenAI Responses gateway emits multiple text segments in one response step, later `response.output_text.delta` events must be preceded by a new `text-start` chunk for Vercel AI SDK UI clients.

After each `TextEnd`, reset the text part state so a later delta in the same step starts a fresh text part:

- set `$textStartEmitted = false`
- generate a new `$messageId`

This matches the existing reasoning reset pattern in the same method.

## Changes

- Reset text part state after `TextEnd` in `HandlesTextGeneration` (OpenAI and Azure OpenAI)
- Apply the same fix in `HandlesTextStreaming` (xAI uses the same Responses API event shape)
- Add multi-segment streaming tests for OpenAI and xAI

## Test plan

- [x] `./vendor/bin/pest tests/Feature/Providers/OpenAi/StreamingTest.php --filter="text part"`
- [x] `./vendor/bin/pest tests/Feature/Providers/Xai/StreamingTest.php --filter="text part"`
- [x] `./vendor/bin/pest tests/Feature/Providers/OpenAi/StreamingTest.php tests/Feature/Providers/Xai/StreamingTest.php tests/Feature/Providers/AzureOpenAi/StreamingTest.php`