### PR TITLE
Correlate tool invocation ids across nested generations

### DIFF
--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -42,6 +42,17 @@ trait GeneratesText
     protected string $currentToolInvocationId;
 
     /**
+     * The invocation IDs of the tools that are currently executing.
+     *
+     * A tool may start a nested generation while it runs, which an AgentTool does by design when
+     * it prompts its sub-agent. Providers are memoized per name, so the nested generation shares
+     * this instance. Invocations always unwind in LIFO order.
+     *
+     * @var array<int, string>
+     */
+    protected array $toolInvocationIds = [];
+
+    /**
      * Invoke the given agent.
      */
     public function prompt(AgentPrompt $prompt): AgentResponse
@@ -190,15 +201,19 @@ trait GeneratesText
     {
         $this->textGenerationLoop()->onToolInvocation(
             invoking: function (Tool $tool, array $arguments) use ($invocationId, $agent): void {
-                $this->currentToolInvocationId = (string) Str::uuid7();
+                $this->toolInvocationIds[] = $this->currentToolInvocationId = (string) Str::uuid7();
 
                 $this->events->dispatch(new InvokingTool(
                     $invocationId, $this->currentToolInvocationId, $agent, $tool, $arguments
                 ));
             },
             invoked: function (Tool $tool, array $arguments, mixed $result) use ($invocationId, $agent): void {
+                $toolInvocationId = array_pop($this->toolInvocationIds) ?? $this->currentToolInvocationId;
+
+                $this->currentToolInvocationId = end($this->toolInvocationIds) ?: $toolInvocationId;
+
                 $this->events->dispatch(new ToolInvoked(
-                    $invocationId, $this->currentToolInvocationId, $agent, $tool, $arguments, $result
+                    $invocationId, $toolInvocationId, $agent, $tool, $arguments, $result
                 ));
             },
         );

--- a/tests/Feature/NestedToolInvocationIdTest.php
+++ b/tests/Feature/NestedToolInvocationIdTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\CanActAsTool;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Tools\AgentTool;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+class NestedResearchAgent implements Agent, CanActAsTool, HasTools
+{
+    use Promptable;
+
+    public function name(): string
+    {
+        return 'research_agent';
+    }
+
+    public function description(): string
+    {
+        return 'Research a topic in depth and return a summary.';
+    }
+
+    public function instructions(): string
+    {
+        return 'You are a research agent. Summarize your findings concisely.';
+    }
+
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator];
+    }
+}
+
+class NestedDelegatingAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a project manager that delegates research tasks to your research_agent sub-agent.';
+    }
+
+    public function tools(): iterable
+    {
+        return [new NestedResearchAgent];
+    }
+}
+
+function nestedFakeOpenAiToolCallResponse(string $callId, string $name, string $arguments): PromiseInterface
+{
+    return Http::response([
+        'id' => 'resp_tool_'.$callId,
+        'status' => 'completed',
+        'model' => 'gpt-5.4',
+        'output' => [[
+            'type' => 'function_call',
+            'id' => 'fc_'.$callId,
+            'call_id' => $callId,
+            'name' => $name,
+            'arguments' => $arguments,
+            'status' => 'completed',
+        ]],
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ]);
+}
+
+function nestedFakeOpenAiTextResponse(string $text): PromiseInterface
+{
+    return Http::response([
+        'id' => 'resp_123',
+        'status' => 'completed',
+        'model' => 'gpt-5.4',
+        'output' => [[
+            'type' => 'message',
+            'status' => 'completed',
+            'content' => [['type' => 'output_text', 'text' => $text]],
+        ]],
+        'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+    ]);
+}
+
+test('tool invocation ids correlate when a tool invokes a sub-agent', function (): void {
+    Http::fake([
+        '*' => Http::sequence([
+            nestedFakeOpenAiToolCallResponse('call_outer', 'research_agent', '{"task":"Research Laravel"}'),
+            nestedFakeOpenAiToolCallResponse('call_inner', 'FixedNumberGenerator', '{}'),
+            nestedFakeOpenAiTextResponse('Research complete.'),
+            nestedFakeOpenAiTextResponse('Delegated.'),
+        ]),
+    ]);
+
+    config(['ai.providers.openai.key' => 'test-key']);
+
+    $invoking = [];
+    $invoked = [];
+
+    // The sub-agent is wrapped in an AgentTool, so the tool type distinguishes the outer
+    // invocation from the leaf tool the sub-agent calls while the outer one is still running.
+    Event::listen(InvokingTool::class, function (InvokingTool $event) use (&$invoking): void {
+        $invoking[$event->tool instanceof AgentTool ? 'outer' : 'inner'] = $event->toolInvocationId;
+    });
+
+    Event::listen(ToolInvoked::class, function (ToolInvoked $event) use (&$invoked): void {
+        $invoked[$event->tool instanceof AgentTool ? 'outer' : 'inner'] = $event->toolInvocationId;
+    });
+
+    (new NestedDelegatingAgent)->prompt('Delegate research about Laravel', provider: 'openai');
+
+    expect($invoked)->toHaveKeys(['outer', 'inner'])
+        ->and($invoked['inner'])->toBe($invoking['inner'])
+        ->and($invoked['outer'])->toBe($invoking['outer'])
+        ->and($invoked['outer'])->not->toBe($invoked['inner']);
+});


### PR DESCRIPTION
Fixes #855.

`GeneratesText::$currentToolInvocationId` is a single scalar on the provider, and providers are
memoized per name by `MultipleInstanceManager`. When a tool starts a nested generation — which
`AgentTool` does by design when it prompts its sub-agent — the nested generation overwrites that
property and never restores it. The outer tool's `ToolInvoked` then carries the inner tool's id.

The two ids handed to the same constructor are scoped differently, which is the whole of the bug:

```php
invoking: function (Tool $tool, array $arguments) use ($invocationId, $agent): void {
    $this->currentToolInvocationId = (string) Str::uuid7();
    $this->events->dispatch(new InvokingTool(
        $invocationId, $this->currentToolInvocationId, $agent, $tool, $arguments
    ));
},
```

`$invocationId` is captured lexically and stays correct under nesting. `$this->currentToolInvocationId`
is read off the shared provider and does not. The result is a `ToolInvoked` carrying an outer
generation's `invocationId` beside a `toolInvocationId` that was only ever issued inside the inner
generation — a pair that cannot exist.

## The change

A stack instead of a scalar: push in `invoking`, pop in `invoked`. `InvokesTools` already treats
re-entrancy as real one layer down — `$toolInvocationCallbackStack` with
`pushToolInvocationCallbacks()` / `popToolInvocationCallbacks()` in a `try`/`finally` exists for
exactly this reason. The id living one layer up did not get the same treatment. Because
`executeTool()` brackets both callbacks in one synchronous frame, unwinding is strictly LIFO.

`$currentToolInvocationId` is kept and kept accurate — it now returns to the enclosing tool when a
nested invocation completes, rather than being left pointing at the finished inner one. No signatures
change and the fix stays inside `GeneratesText`.

## Test

`tests/Feature/NestedToolInvocationIdTest.php` drives a parent agent through a sub-agent to a leaf
tool with an `Http::fake()` sequence, following the shape of
`tests/Feature/Providers/TimeoutInToolLoopTest.php`. It asserts that each `ToolInvoked` carries the
id its own `InvokingTool` announced, and that the two invocations do not share an id.

The test fails on `0.x` and passes with the fix:

| | result |
|---|---|
| `0.x` | 1 failed, 1980 passed |
| with fix | 1981 passed |

No other test changes state. `pint` and `phpstan` are clean.

Existing coverage does not catch this. `tests/Integration/AgentTest.php:232` is the only assertion on
`toolInvocationId` in the suite and it checks `! is_null($event->toolInvocationId)` — the clobbered
value is a valid uuid, just the wrong one, so it passes. `tests/Integration/MultiAgentTest.php:56-58`
runs the exact parent → sub-agent shape and asserts on `ToolInvoked`, but never inspects the id.

Note that a test written with `Agent::fake()` cannot reproduce this: `AiManager::textProviderFor()`
clones the provider per resolution for faked agents, so each agent gets its own instance and the
shared property is never actually shared. The `Http::fake()` approach keeps both generations on the
one memoized provider that production uses.

## Impact

Any listener correlating `InvokingTool` to `ToolInvoked` gets mismatched pairs whenever a sub-agent is
involved: audit trails attribute a completed tool call to the wrong invocation, and span-based
telemetry mis-parents. Sibling tool calls in a single step are unaffected — `TextGenerationLoop` runs
them sequentially through `array_map`, so only re-entrancy triggers it.
