### PR TITLE
Add web search support to the xAI provider

### DIFF
--- a/src/Gateway/Xai/Concerns/MapsTools.php
+++ b/src/Gateway/Xai/Concerns/MapsTools.php
@@ -23,9 +23,7 @@ trait MapsTools
 
         foreach ($tools as $tool) {
             if ($tool instanceof ProviderTool) {
-                $providerTool = $this->mapProviderTool($tool, $provider);
-
-                if (filled($providerTool)) {
+                if (filled($providerTool = $this->mapProviderTool($tool, $provider))) {
                     $mapped[] = $providerTool;
                 }
             } elseif ($tool instanceof Tool) {

--- a/src/Gateway/Xai/Concerns/MapsTools.php
+++ b/src/Gateway/Xai/Concerns/MapsTools.php
@@ -3,11 +3,14 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Tools\ToolNameResolver;
+use RuntimeException;
 
 trait MapsTools
 {
@@ -20,15 +23,43 @@ trait MapsTools
 
         foreach ($tools as $tool) {
             if ($tool instanceof ProviderTool) {
-                continue;
-            }
+                $providerTool = $this->mapProviderTool($tool, $provider);
 
-            if ($tool instanceof Tool) {
+                if (filled($providerTool)) {
+                    $mapped[] = $providerTool;
+                }
+            } elseif ($tool instanceof Tool) {
                 $mapped[] = $this->mapTool($tool);
             }
         }
 
         return $mapped;
+    }
+
+    /**
+     * Map a provider tool to an xAI provider tool definition.
+     */
+    protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
+    {
+        return match (true) {
+            $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
+            default => [],
+        };
+    }
+
+    /**
+     * Map a web search tool to an xAI web search definition.
+     */
+    protected function mapWebSearchTool(WebSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
+        }
+
+        return [
+            'type' => 'web_search',
+            ...$provider->webSearchToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -6,11 +6,14 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Xai\XaiGateway;
 use Laravel\Ai\Gateway\Xai\XaiImageGateway;
+use Laravel\Ai\Providers\Tools\WebSearch;
 
-class XaiProvider extends Provider implements ImageProvider, TextProvider
+class XaiProvider extends Provider implements ImageProvider, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
@@ -22,6 +25,18 @@ class XaiProvider extends Provider implements ImageProvider, TextProvider
         protected array $config,
         protected Dispatcher $events,
     ) {}
+
+    /**
+     * Get the web search tool options for the provider.
+     */
+    public function webSearchToolOptions(WebSearch $search): array
+    {
+        $options = $search->providerOptions(Lab::xAI);
+
+        return array_filter([
+            'allowed_domains' => filled($search->allowedDomains) ? $search->allowedDomains : null,
+        ]) + $options;
+    }
 
     /**
      * Get the provider's text gateway.

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -82,6 +83,90 @@ test('tool parameters are not wrapped in schema definition', function (): void {
         return ! array_key_exists('schema_definition', $tool['parameters']['properties'] ?? [])
             && ! in_array('schema_definition', $tool['parameters']['required'] ?? []);
     });
+});
+
+test('web search tool sends type web_search', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [new WebSearch])->prompt('Search the web', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return $tool !== null;
+    });
+});
+
+test('web search tool sends allowed_domains', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [(new WebSearch)->allow(['example.com', 'docs.example.com'])])
+        ->prompt('Search', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'allowed_domains') === ['example.com', 'docs.example.com'];
+    });
+});
+
+test('web search tool forwards xai provider options into the tool payload', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [
+        (new WebSearch)->withProviderOptions([
+            'excluded_domains' => ['spam.example.com'],
+            'enable_image_understanding' => true,
+        ]),
+    ])->prompt('Search', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
+
+        return data_get($tool, 'excluded_domains') === ['spam.example.com']
+            && data_get($tool, 'enable_image_understanding') === true;
+    });
+});
+
+test('web search response citations are parsed from url_citation annotations', function (): void {
+    Http::fake(['*' => Http::response([
+        'id' => 'resp_123',
+        'object' => 'response',
+        'status' => 'completed',
+        'model' => 'grok-4.3',
+        'output' => [
+            [
+                'type' => 'message',
+                'status' => 'completed',
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'output_text',
+                        'text' => 'xAI builds Grok. [[1]](https://x.ai)',
+                        'annotations' => [
+                            [
+                                'type' => 'url_citation',
+                                'url' => 'https://x.ai',
+                                'title' => '1',
+                                'start_index' => 17,
+                                'end_index' => 37,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+    ])]);
+
+    $response = agent(tools: [new WebSearch])->prompt('What is xAI?', provider: 'xai');
+
+    expect($response->meta->citations)->toHaveCount(1)
+        ->and($response->meta->citations[0]->url)->toBe('https://x.ai')
+        ->and($response->meta->citations[0]->startIndex)->toBe(17);
 });
 
 function fakeXaiToolMappingResponse(string $text): PromiseInterface

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -3,6 +3,8 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\FileSearch;
+use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
@@ -119,6 +121,7 @@ test('web search tool forwards xai provider options into the tool payload', func
         (new WebSearch)->withProviderOptions([
             'excluded_domains' => ['spam.example.com'],
             'enable_image_understanding' => true,
+            'enable_image_search' => true,
         ]),
     ])->prompt('Search', provider: 'xai');
 
@@ -127,7 +130,21 @@ test('web search tool forwards xai provider options into the tool payload', func
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
 
         return data_get($tool, 'excluded_domains') === ['spam.example.com']
-            && data_get($tool, 'enable_image_understanding') === true;
+            && data_get($tool, 'enable_image_understanding') === true
+            && data_get($tool, 'enable_image_search') === true;
+    });
+});
+
+test('unsupported provider tools are omitted from the tools payload', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [new WebFetch, new FileSearch(['store-id']), new WebSearch])
+        ->prompt('Search', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return data_get($body, 'tools') === [['type' => 'web_search']];
     });
 });
 

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -131,44 +131,6 @@ test('web search tool forwards xai provider options into the tool payload', func
     });
 });
 
-test('web search response citations are parsed from url_citation annotations', function (): void {
-    Http::fake(['*' => Http::response([
-        'id' => 'resp_123',
-        'object' => 'response',
-        'status' => 'completed',
-        'model' => 'grok-4.3',
-        'output' => [
-            [
-                'type' => 'message',
-                'status' => 'completed',
-                'role' => 'assistant',
-                'content' => [
-                    [
-                        'type' => 'output_text',
-                        'text' => 'xAI builds Grok. [[1]](https://x.ai)',
-                        'annotations' => [
-                            [
-                                'type' => 'url_citation',
-                                'url' => 'https://x.ai',
-                                'title' => '1',
-                                'start_index' => 17,
-                                'end_index' => 37,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ],
-        'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
-    ])]);
-
-    $response = agent(tools: [new WebSearch])->prompt('What is xAI?', provider: 'xai');
-
-    expect($response->meta->citations)->toHaveCount(1)
-        ->and($response->meta->citations[0]->url)->toBe('https://x.ai')
-        ->and($response->meta->citations[0]->startIndex)->toBe(17);
-});
-
 function fakeXaiToolMappingResponse(string $text): PromiseInterface
 {
     return Http::response([


### PR DESCRIPTION
Adds web search (Grok Live Search) to the xAI provider, matching what OpenAI, Anthropic, Gemini, OpenRouter, and Azure already support.

On the Responses API (which the xAI gateway already uses), Live Search is just a `web_search` tool in the tools array (`{"type":"web_search"}`), the same shape as OpenAI, so it maps the same way. The response side was already in place — xAI's `ParsesTextResponses` already reads `url_citation` annotations into `UrlCitation`s — it just couldn't be triggered because `MapsTools` skipped every provider tool. So this is two small changes:

- `XaiProvider` implements `SupportsWebSearch` and forwards `allowed_domains` (plus xAI-specific options like `excluded_domains` / `enable_image_understanding` via `withProviderOptions`).
- xAI's `MapsTools` maps the `WebSearch` tool to `{"type":"web_search", ...}` instead of dropping it, mirroring the OpenAI gateway.

Tests cover the request mapping (type, allowed_domains, provider options) and citations parsing end-to-end. Docs: https://docs.x.ai/developers/tools/web-search
