### PR TITLE
Add transcription support to the OpenAI-compatible provider

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -420,6 +420,7 @@ Point the SDK at any OpenAI-compatible endpoint (LM Studio, vLLM, Together, etc.
             'default' => 'some-embedding-model',
             'dimensions' => 1024, // optional; omit to use native dimensions
         ],
+        'transcription' => ['default' => 'some-transcription-model'],
     ],
 ],
 ```
@@ -435,7 +436,7 @@ Embeddings::for(['Hello'])->generate(
 );
 ```
 
-It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, and text embeddings. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
+It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
 
 ## Common Pitfalls
 
@@ -465,7 +466,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 | Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter, OpenAI-compatible |
 | Images     | OpenAI, Gemini, xAI                                            |
 | TTS        | OpenAI, ElevenLabs                                              |
-| STT        | OpenAI, ElevenLabs, Mistral                                     |
+| STT        | OpenAI, ElevenLabs, Mistral, OpenAI-compatible                 |
 | Embeddings | OpenAI, OpenAI-compatible, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI |
 | Reranking  | Cohere, Jina                                                    |
 | Files      | OpenAI, Anthropic, Gemini                                       |

--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -438,6 +438,14 @@ Embeddings::for(['Hello'])->generate(
 
 It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
 
+Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults — pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
+
+```php
+Transcription::fromDisk('recordings', $path)
+    ->withProviderOptions(['response_format' => 'verbose_json'])
+    ->generate(provider: 'my-llm');
+```
+
 ## Common Pitfalls
 
 ### Wrong Namespace

--- a/src/Gateway/Concerns/ResolvesAudioFilenames.php
+++ b/src/Gateway/Concerns/ResolvesAudioFilenames.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use Laravel\Ai\Contracts\Files\HasName;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
+
+trait ResolvesAudioFilenames
+{
+    /**
+     * Determine the appropriate filename for the audio file based on its MIME type.
+     */
+    protected function audioFilename(TranscribableAudio $audio): string
+    {
+        if ($audio instanceof HasName && $audio->name()) {
+            return $audio->name();
+        }
+
+        $extension = match ($audio->mimeType()) {
+            'audio/webm' => 'webm',
+            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
+            'audio/wav', 'audio/x-wav' => 'wav',
+            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/mpeg', 'audio/mp3' => 'mp3',
+            'audio/mpga' => 'mpga',
+            default => 'mp3',
+        };
+
+        return "audio.{$extension}";
+    }
+}

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -3,7 +3,6 @@
 namespace Laravel\Ai\Gateway\Mistral;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
@@ -13,6 +12,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionMessages;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
@@ -36,6 +36,7 @@ class MistralGateway implements EmbeddingGateway, StepTextGateway, Transcription
     use MapsChatCompletionTools;
     use ParsesServerSentEvents;
     use PerformsChatCompletionSteps;
+    use ResolvesAudioFilenames;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -149,28 +150,5 @@ class MistralGateway implements EmbeddingGateway, StepTextGateway, Transcription
         }
 
         return $parts;
-    }
-
-    /**
-     * Determine the appropriate filename for the audio file based on its MIME type.
-     */
-    protected function audioFilename(TranscribableAudio $audio): string
-    {
-        if ($audio instanceof HasName && $audio->name()) {
-            return $audio->name();
-        }
-
-        $extension = match ($audio->mimeType()) {
-            'audio/webm' => 'webm',
-            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
-            'audio/wav', 'audio/x-wav' => 'wav',
-            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
-            'audio/flac', 'audio/x-flac' => 'flac',
-            'audio/mpeg', 'audio/mp3' => 'mp3',
-            'audio/mpga' => 'mpga',
-            default => 'mp3',
-        };
-
-        return "audio.{$extension}";
     }
 }

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -7,7 +7,6 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
-use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
@@ -21,6 +20,7 @@ use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
@@ -43,6 +43,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
     use Concerns\ParsesTextResponses;
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
+    use ResolvesAudioFilenames;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -238,29 +239,6 @@ class OpenAiGateway implements Gateway, StepTextGateway
             ),
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Determine the appropriate filename for the audio file based on its MIME type.
-     */
-    protected function audioFilename(TranscribableAudio $audio): string
-    {
-        if ($audio instanceof HasName && $audio->name()) {
-            return $audio->name();
-        }
-
-        $extension = match ($audio->mimeType()) {
-            'audio/webm' => 'webm',
-            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
-            'audio/wav', 'audio/x-wav' => 'wav',
-            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
-            'audio/flac', 'audio/x-flac' => 'flac',
-            'audio/mpeg', 'audio/mp3' => 'mp3',
-            'audio/mpga' => 'mpga',
-            default => 'mp3',
-        };
-
-        return "audio.{$extension}";
     }
 
     /**

--- a/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
+++ b/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
@@ -3,19 +3,28 @@
 namespace Laravel\Ai\Gateway\OpenAiCompatible;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\HasName;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use LogicException;
 
-class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway
+class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway, TranscriptionGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesOpenAiCompatibleClient;
@@ -90,6 +99,76 @@ class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway
 
             return array_map(floatval(...), $embedding);
         })->all();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): TranscriptionResponse {
+        if ($diarize) {
+            throw new LogicException(
+                'This openai-compatible provider does not support diarized transcription. Use the OpenAI, ElevenLabs, Mistral, or Gemini provider for diarization.'
+            );
+        }
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->attach('file', $audio->content(), $this->audioFilename($audio), array_filter(['Content-Type' => $audio->mimeType()]))
+                ->post('audio/transcriptions', array_merge($providerOptions, array_filter([
+                    'model' => $model,
+                    'language' => $language,
+                    'response_format' => 'json',
+                ]))),
+        );
+
+        $data = $response->json();
+
+        return new TranscriptionResponse(
+            $data['text'] ?? '',
+            collect($data['segments'] ?? [])->map(fn (array $segment): TranscriptionSegment => new TranscriptionSegment(
+                $segment['text'] ?? '',
+                $segment['speaker'] ?? '',
+                $segment['start'] ?? 0,
+                $segment['end'] ?? 0,
+            )),
+            new Usage(
+                Arr::get($data, 'usage.input_tokens', 0),
+                Arr::get($data, 'usage.output_tokens', 0),
+            ),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Resolve a filename for the multipart audio upload from its MIME type.
+     */
+    protected function audioFilename(TranscribableAudio $audio): string
+    {
+        if ($audio instanceof HasName && $audio->name()) {
+            return $audio->name();
+        }
+
+        $extension = match ($audio->mimeType()) {
+            'audio/webm' => 'webm',
+            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
+            'audio/wav', 'audio/x-wav' => 'wav',
+            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/mpeg', 'audio/mp3' => 'mp3',
+            'audio/mpga' => 'mpga',
+            default => 'mp3',
+        };
+
+        return "audio.{$extension}";
     }
 
     /**

--- a/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
+++ b/src/Gateway/OpenAiCompatible/OpenAiCompatibleGateway.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
-use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
@@ -16,13 +15,13 @@ use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Exceptions\AiException;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
-use LogicException;
 
 class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway, TranscriptionGateway
 {
@@ -36,6 +35,7 @@ class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway, Tran
     use Concerns\PerformsChatCompletionSteps;
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
+    use ResolvesAudioFilenames;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -113,21 +113,15 @@ class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway, Tran
         int $timeout = 30,
         array $providerOptions = [],
     ): TranscriptionResponse {
-        if ($diarize) {
-            throw new LogicException(
-                'This openai-compatible provider does not support diarized transcription. Use the OpenAI, ElevenLabs, Mistral, or Gemini provider for diarization.'
-            );
-        }
-
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)
                 ->attach('file', $audio->content(), $this->audioFilename($audio), array_filter(['Content-Type' => $audio->mimeType()]))
-                ->post('audio/transcriptions', array_merge($providerOptions, array_filter([
+                ->post('audio/transcriptions', array_merge(array_filter([
                     'model' => $model,
                     'language' => $language,
-                    'response_format' => 'json',
-                ]))),
+                    'response_format' => $diarize ? 'diarized_json' : 'json',
+                ]), $providerOptions)),
         );
 
         $data = $response->json();
@@ -141,34 +135,11 @@ class OpenAiCompatibleGateway implements EmbeddingGateway, StepTextGateway, Tran
                 $segment['end'] ?? 0,
             )),
             new Usage(
-                Arr::get($data, 'usage.input_tokens', 0),
-                Arr::get($data, 'usage.output_tokens', 0),
+                Arr::get($data, 'usage.input_tokens') ?? Arr::get($data, 'usage.prompt_tokens', 0),
+                Arr::get($data, 'usage.output_tokens') ?? Arr::get($data, 'usage.completion_tokens', 0),
             ),
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Resolve a filename for the multipart audio upload from its MIME type.
-     */
-    protected function audioFilename(TranscribableAudio $audio): string
-    {
-        if ($audio instanceof HasName && $audio->name()) {
-            return $audio->name();
-        }
-
-        $extension = match ($audio->mimeType()) {
-            'audio/webm' => 'webm',
-            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
-            'audio/wav', 'audio/x-wav' => 'wav',
-            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
-            'audio/flac', 'audio/x-flac' => 'flac',
-            'audio/mpeg', 'audio/mp3' => 'mp3',
-            'audio/mpga' => 'mpga',
-            default => 'mp3',
-        };
-
-        return "audio.{$extension}";
     }
 
     /**

--- a/src/Providers/OpenAiCompatibleProvider.php
+++ b/src/Providers/OpenAiCompatibleProvider.php
@@ -6,16 +6,20 @@ use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\OpenAiCompatible\OpenAiCompatibleGateway;
 
-class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, TextProvider
+class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
+    use Concerns\GeneratesTranscriptions;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
+    use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
 
     public function __construct(protected array $config, protected Dispatcher $events)
@@ -46,6 +50,14 @@ class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, Te
     public function embeddingGateway(): EmbeddingGateway
     {
         return $this->embeddingGateway ??= new OpenAiCompatibleGateway($this->events);
+    }
+
+    /**
+     * Get the provider's transcription gateway.
+     */
+    public function transcriptionGateway(): TranscriptionGateway
+    {
+        return $this->transcriptionGateway ??= new OpenAiCompatibleGateway($this->events);
     }
 
     /**
@@ -81,6 +93,16 @@ class OpenAiCompatibleProvider extends Provider implements EmbeddingProvider, Te
     {
         return $this->config['models']['embeddings']['default'] ?? throw new InvalidArgumentException(
             "The [{$this->name()}] openai-compatible provider requires a default embeddings model. Set [models.embeddings.default] in its configuration or pass a model explicitly."
+        );
+    }
+
+    /**
+     * Get the name of the default transcription (STT) model.
+     */
+    public function defaultTranscriptionModel(): string
+    {
+        return $this->config['models']['transcription']['default'] ?? throw new InvalidArgumentException(
+            "The [{$this->name()}] openai-compatible provider requires a default transcription model. Set [models.transcription.default] in its configuration or pass a model explicitly."
         );
     }
 

--- a/tests/Feature/Providers/OpenAiCompatible/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/TranscriptionTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Files\Base64Audio;
 use Laravel\Ai\Responses\TranscriptionResponse;
 use Laravel\Ai\Transcription;
 
@@ -72,15 +73,73 @@ test('transcription omits language when not provided', function (): void {
     Http::assertSent(fn (Request $request): bool => ! str_contains($request->body(), 'name="language"'));
 });
 
-test('transcription diarize throws a logic exception without sending a request', function (): void {
+test('transcription requests the diarized response format when diarizing', function (): void {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hi there',
+        'segments' => [['text' => 'Hi there', 'speaker' => 'speaker_1', 'start' => 0.5, 'end' => 1.5]],
+    ])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->diarize()
+        ->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'diarized_json'));
+
+    expect($response->segments)->toHaveCount(1)
+        ->and($response->segments->first()->speaker)->toBe('speaker_1')
+        ->and($response->segments->first()->startSeconds)->toBe(0.5);
+});
+
+test('transcription provider options override the default response format', function (): void {
     Http::fake(['*' => Http::response(['text' => 'Hi'])]);
 
-    expect(fn (): TranscriptionResponse => Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
-        ->diarize()
-        ->generate(provider: 'openai-compatible'))
-        ->toThrow(LogicException::class, 'does not support diarized transcription');
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->withProviderOptions(['response_format' => 'verbose_json', 'timestamp_granularities' => ['segment']])
+        ->generate(provider: 'openai-compatible');
 
-    Http::assertNothingSent();
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'verbose_json')
+        && ! str_contains($request->body(), "\r\n\r\njson\r\n"));
+});
+
+test('transcription reads chat completion style usage keys', function (): void {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hi',
+        'usage' => ['prompt_tokens' => 12, 'completion_tokens' => 3],
+    ])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    expect($response->usage->promptTokens)->toBe(12)
+        ->and($response->usage->completionTokens)->toBe(3);
+});
+
+test('transcription reads openai style usage keys', function (): void {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hi',
+        'usage' => ['input_tokens' => 7, 'output_tokens' => 2],
+    ])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    expect($response->usage->promptTokens)->toBe(7)
+        ->and($response->usage->completionTokens)->toBe(2);
+});
+
+test('transcription uses the audio name for the upload filename', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::of((new Base64Audio(base64_encode('fake-audio'), 'audio/wav'))->as('meeting.wav'))
+        ->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'filename="meeting.wav"'));
+});
+
+test('transcription derives the upload filename from the mime type', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/flac')->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'filename="audio.flac"'));
 });
 
 test('transcription response text is correctly parsed', function (): void {

--- a/tests/Feature/Providers/OpenAiCompatible/TranscriptionTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/TranscriptionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use Laravel\Ai\Transcription;
+
+beforeEach(function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'key' => 'test-key',
+        'models' => [
+            'text' => ['default' => 'local-model'],
+            'transcription' => ['default' => 'local-whisper'],
+        ],
+    ]]);
+});
+
+test('transcription posts audio to the transcriptions endpoint as multipart', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hello, world!'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'http://localhost:1234/v1/audio/transcriptions'
+        && str_contains($request->header('Content-Type')[0] ?? '', 'multipart/form-data'));
+});
+
+test('transcription uses the configured default model', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'local-whisper'));
+});
+
+test('transcription throws when no default model is configured and none is passed', function (): void {
+    config(['ai.providers.openai-compatible' => [
+        'driver' => 'openai-compatible',
+        'url' => 'http://localhost:1234/v1',
+        'key' => 'test-key',
+        'models' => ['text' => ['default' => 'local-model']],
+    ]]);
+
+    Http::fake();
+
+    expect(fn (): TranscriptionResponse => Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->generate(provider: 'openai-compatible'))
+        ->toThrow(InvalidArgumentException::class, 'requires a default transcription model');
+
+    Http::assertNothingSent();
+});
+
+test('transcription sends language when provided', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Bonjour'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->language('fr')
+        ->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'name="language"'));
+});
+
+test('transcription omits language when not provided', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request): bool => ! str_contains($request->body(), 'name="language"'));
+});
+
+test('transcription diarize throws a logic exception without sending a request', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    expect(fn (): TranscriptionResponse => Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->diarize()
+        ->generate(provider: 'openai-compatible'))
+        ->toThrow(LogicException::class, 'does not support diarized transcription');
+
+    Http::assertNothingSent();
+});
+
+test('transcription response text is correctly parsed', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hello, world!'])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    expect($response->text)->toBe('Hello, world!')
+        ->and($response->segments)->toHaveCount(0)
+        ->and($response->meta->provider)->toBe('openai-compatible')
+        ->and($response->meta->model)->toBe('local-whisper');
+});
+
+test('transcription sends the bearer token', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('transcription rate limit response throws rate limited exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Rate limit exceeded']], 429)]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+})->throws(RateLimitedException::class);
+
+test('transcription overloaded response throws provider overloaded exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Service overloaded']], 503)]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+})->throws(ProviderOverloadedException::class);
+
+test('transcription http error response throws request exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Invalid audio']], 400)]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+})->throws(RequestException::class);
+
+test('transcription can be faked for the openai-compatible provider', function (): void {
+    Transcription::fake(['Faked transcript']);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'openai-compatible');
+
+    expect($response->text)->toBe('Faked transcript');
+});


### PR DESCRIPTION
The `openai-compatible` driver implements text and embeddings but not transcription, so calling `transcribe()` on it fails — even though OpenAI-compatible servers like vLLM, LiteLLM, and LocalAI expose the standard `/v1/audio/transcriptions` endpoint.

This wires the driver into the existing transcription architecture, following #841 (which did the same for embeddings):

- `OpenAiCompatibleProvider` implements `TranscriptionProvider` through the shared `GeneratesTranscriptions` and `HasTranscriptionGateway` concerns, so faking and events work unchanged. The default transcription model must be configured (like text and embeddings), since arbitrary endpoints have no known models.
- `OpenAiCompatibleGateway` gains `generateTranscription()`, which uploads the audio as standard OpenAI **multipart** (`file` + `model` + optional `language`) and reuses the gateway's client and failover handling. It mirrors the **OpenAI** gateway's transcription, not OpenRouter's — OpenRouter sends a non-standard base64 JSON body, whereas compatible servers expect the standard multipart upload. Diarization isn't supported (compatible servers run plain Whisper), so it throws a clear `LogicException`, matching OpenRouter.

```php
'my-llm' => [
    'driver' => 'openai-compatible',
    'url' => env('MY_LLM_URL'),
    'models' => ['transcription' => ['default' => 'whisper-1']],
],
```

Tests mirror the OpenAI transcription suite: multipart endpoint, model + language in the body, missing-model exception, diarize rejection, response parsing, auth header, rate-limit/overload/error handling, and faking.
