### PR TITLE
Add explicit prompt cache breakpoints

### DIFF
--- a/src/Enums/PromptCacheTarget.php
+++ b/src/Enums/PromptCacheTarget.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Ai\Enums;
+
+use Illuminate\Support\Arr;
+
+enum PromptCacheTarget: string
+{
+    case System = 'system';
+    case Tools = 'tools';
+
+    /**
+     * Normalize a raw prompt cache option value into target cases.
+     *
+     * @return array<int, self>
+     */
+    public static function normalize(mixed $targets): array
+    {
+        return array_map(
+            fn (self|string $target): self => $target instanceof self ? $target : self::from($target),
+            Arr::wrap($targets ?: []),
+        );
+    }
+}

--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Laravel\Ai\Enums\PromptCacheTarget;
 use Laravel\Ai\Gateway\Anthropic\AnthropicSchemaSanitizer;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -30,13 +31,17 @@ trait BuildsTextRequests
             'max_tokens' => $options?->maxTokens ?? 64_000,
         ];
 
+        $providerOptions = $options?->providerOptions($provider->driver()) ?? [];
+
+        $cacheTargets = PromptCacheTarget::normalize(Arr::pull($providerOptions, 'prompt_cache'));
+
         if (filled($instructions)) {
-            $body['system'] = $instructions;
+            $body['system'] = in_array(PromptCacheTarget::System, $cacheTargets, true)
+                ? [['type' => 'text', 'text' => $instructions, 'cache_control' => ['type' => 'ephemeral']]]
+                : $instructions;
         }
 
         $mappedTools = filled($tools) ? $this->mapTools($tools, $provider) : [];
-
-        $providerOptions = $options?->providerOptions($provider->driver()) ?? [];
 
         if (filled($schema) && $this->supportsNativeStructuredOutput($provider)) {
             $body['output_config'] = [
@@ -61,6 +66,10 @@ trait BuildsTextRequests
                 $body['tools'] = $mappedTools;
                 $body['tool_choice'] = $this->resolveToolChoice($schema, $tools, $providerOptions, $options?->toolChoice);
             }
+        }
+
+        if (isset($body['tools']) && in_array(PromptCacheTarget::Tools, $cacheTargets, true)) {
+            $body['tools'][array_key_last($body['tools'])]['cache_control'] = ['type' => 'ephemeral'];
         }
 
         $body = array_merge($body, Arr::whereNotNull([

--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -13,6 +13,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Enums\PromptCacheTarget;
 use Laravel\Ai\Gateway\Bedrock\Concerns\CreatesBedrockClient;
 use Laravel\Ai\Gateway\Bedrock\Concerns\MapsAttachments;
 use Laravel\Ai\Gateway\Cohere\Concerns\ParsesEmbeddings;
@@ -642,13 +643,25 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
             'messages' => $conversationMessages,
         ];
 
+        $providerOptions = $options?->providerOptions(Lab::Bedrock) ?? [];
+
+        $cacheTargets = PromptCacheTarget::normalize(Arr::pull($providerOptions, 'prompt_cache'));
+
         if ($instructions) {
             $parameters['system'] = [['text' => $instructions]];
+
+            if (in_array(PromptCacheTarget::System, $cacheTargets, true)) {
+                $parameters['system'][] = ['cachePoint' => ['type' => 'default']];
+            }
         }
 
         $toolConfig = $this->buildToolConfig($schemaTools, $formattedTools, $toolsEmpty, $isFinalStep);
 
         if ($toolConfig !== null) {
+            if (in_array(PromptCacheTarget::Tools, $cacheTargets, true)) {
+                $toolConfig['tools'][] = ['cachePoint' => ['type' => 'default']];
+            }
+
             $parameters['toolConfig'] = $toolConfig;
         }
 
@@ -658,13 +671,7 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
             $parameters['inferenceConfig'] = $inferenceConfig;
         }
 
-        $providerOptions = $options?->providerOptions(Lab::Bedrock);
-
-        if (! empty($providerOptions)) {
-            return array_merge($parameters, $providerOptions);
-        }
-
-        return $parameters;
+        return filled($providerOptions) ? array_merge($parameters, $providerOptions) : $parameters;
     }
 
     /**

--- a/tests/Feature/Providers/Anthropic/PromptCacheTest.php
+++ b/tests/Feature/Providers/Anthropic/PromptCacheTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Enums\PromptCacheTarget;
+use Tests\Fixtures\Agents\PromptCacheAgent;
+use Tests\Fixtures\Agents\PromptCacheStructuredAgent;
+
+$ephemeral = ['type' => 'ephemeral'];
+
+test('system target sends instructions as a cached text block', function () use ($ephemeral): void {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new PromptCacheAgent(cache: [PromptCacheTarget::System], withTools: false))->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(function ($request) use ($ephemeral): bool {
+        $body = $request->data();
+
+        return $body['system'] === [[
+            'type' => 'text',
+            'text' => 'You are a helpful assistant.',
+            'cache_control' => $ephemeral,
+        ]] && ! array_key_exists('prompt_cache', $body);
+    });
+});
+
+test('tools target stamps the last tool only', function () use ($ephemeral): void {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new PromptCacheAgent(cache: ['tools']))->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(function ($request) use ($ephemeral): bool {
+        $body = $request->data();
+        $tools = $body['tools'];
+
+        return is_string($body['system'])
+            && $tools[array_key_last($tools)]['cache_control'] === $ephemeral;
+    });
+});
+
+test('both targets may be combined with other provider options', function () use ($ephemeral): void {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new PromptCacheAgent(
+        cache: [PromptCacheTarget::System, PromptCacheTarget::Tools],
+        otherOptions: ['cache_control' => ['type' => 'ephemeral']],
+    ))->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(function ($request) use ($ephemeral): bool {
+        $body = $request->data();
+
+        return $body['system'][0]['cache_control'] === $ephemeral
+            && $body['tools'][array_key_last($body['tools'])]['cache_control'] === $ephemeral
+            && $body['cache_control'] === $ephemeral
+            && ! array_key_exists('prompt_cache', $body);
+    });
+});
+
+test('synthetic structured output tool receives the tools breakpoint', function () use ($ephemeral): void {
+    config(['ai.providers.anthropic' => [
+        ...config('ai.providers.anthropic'),
+        'use_native_structured_output' => false,
+    ]]);
+
+    Http::fake(['api.anthropic.com/*' => $this->fakeSyntheticStructuredResponse(['number' => 42])]);
+
+    (new PromptCacheStructuredAgent(cache: ['tools']))->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(function ($request) use ($ephemeral): bool {
+        $tools = $request->data()['tools'];
+
+        return $tools[array_key_last($tools)]['name'] === 'output_structured_data'
+            && $tools[array_key_last($tools)]['cache_control'] === $ephemeral
+            && ! isset($tools[0]['cache_control']);
+    });
+});
+
+test('empty prompt cache leaves the payload untouched', function (): void {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new PromptCacheAgent(cache: []))->prompt('Hi', provider: 'anthropic');
+
+    Http::assertSent(function ($request): bool {
+        $body = $request->data();
+
+        return is_string($body['system'])
+            && ! isset($body['tools'][0]['cache_control'])
+            && ! array_key_exists('prompt_cache', $body);
+    });
+});
+
+test('unknown prompt cache target throws', function (): void {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse()]);
+
+    (new PromptCacheAgent(cache: ['systemm']))->prompt('Hi', provider: 'anthropic');
+})->throws(ValueError::class);

--- a/tests/Feature/Providers/Bedrock/PromptCacheTest.php
+++ b/tests/Feature/Providers/Bedrock/PromptCacheTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Aws\MockHandler;
+use Aws\Result;
+use Laravel\Ai\Enums\PromptCacheTarget;
+use Laravel\Ai\Gateway\StepContext;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\UserMessage;
+use Tests\Fixtures\Agents\PromptCacheAgent;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+function bedrockConverseParameters(PromptCacheAgent $agent): array
+{
+    $mock = new MockHandler([new Result([
+        'output' => ['message' => ['content' => [['text' => 'Hi']]]],
+        'usage' => ['inputTokens' => 1, 'outputTokens' => 1],
+        'stopReason' => 'end_turn',
+    ])]);
+
+    test()->gatewayWithClient(test()->bedrockClient($mock))->generateTextStep(
+        test()->bedrockProvider(),
+        'anthropic.claude-opus-4-7-v1:0',
+        'You are a helpful assistant.',
+        [new UserMessage('Hi')],
+        $agent->withTools ? [new FixedNumberGenerator] : [],
+        null,
+        new TextGenerationOptions(agent: $agent),
+        null,
+        new StepContext,
+    );
+
+    return $mock->getLastCommand()->toArray();
+}
+
+test('system target appends a cache point after the instructions', function (): void {
+    $parameters = bedrockConverseParameters(new PromptCacheAgent(cache: [PromptCacheTarget::System], withTools: false));
+
+    expect($parameters['system'])->toBe([
+        ['text' => 'You are a helpful assistant.'],
+        ['cachePoint' => ['type' => 'default']],
+    ])->and($parameters)->not->toHaveKey('prompt_cache');
+});
+
+test('tools target appends a cache point after the tool list', function (): void {
+    $parameters = bedrockConverseParameters(new PromptCacheAgent(cache: ['tools']));
+
+    $tools = $parameters['toolConfig']['tools'];
+
+    expect($parameters['system'])->toBe([['text' => 'You are a helpful assistant.']])
+        ->and(end($tools))->toBe(['cachePoint' => ['type' => 'default']])
+        ->and($tools)->toHaveCount(2);
+});
+
+test('empty prompt cache leaks nothing to aws', function (): void {
+    $parameters = bedrockConverseParameters(new PromptCacheAgent(cache: []));
+
+    expect($parameters)->not->toHaveKey('prompt_cache')
+        ->and($parameters['system'])->toBe([['text' => 'You are a helpful assistant.']])
+        ->and($parameters['toolConfig']['tools'])->toHaveCount(1);
+});
+
+test('unknown prompt cache target throws', function (): void {
+    bedrockConverseParameters(new PromptCacheAgent(cache: ['toolz']));
+})->throws(ValueError::class);

--- a/tests/Fixtures/Agents/PromptCacheAgent.php
+++ b/tests/Fixtures/Agents/PromptCacheAgent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Enums\PromptCacheTarget;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+class PromptCacheAgent implements Agent, HasProviderOptions, HasTools
+{
+    use Promptable;
+
+    public function __construct(
+        public mixed $cache = [PromptCacheTarget::System, PromptCacheTarget::Tools],
+        public bool $withTools = true,
+        public array $otherOptions = [],
+    ) {}
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+
+    public function tools(): iterable
+    {
+        return $this->withTools ? [new FixedNumberGenerator] : [];
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        return ['prompt_cache' => $this->cache, ...$this->otherOptions];
+    }
+}

--- a/tests/Fixtures/Agents/PromptCacheStructuredAgent.php
+++ b/tests/Fixtures/Agents/PromptCacheStructuredAgent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+
+class PromptCacheStructuredAgent extends PromptCacheAgent implements HasStructuredOutput
+{
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'number' => $schema->integer()->required(),
+        ];
+    }
+}


### PR DESCRIPTION
Currently there is no provider-neutral way to place prompt cache breakpoints around stable system instructions and tool definitions, so Anthropic and Bedrock requests cannot opt into those cache boundaries through agent provider options.

Agents can now return:

```php
public function providerOptions(Lab|string $provider): array
{
    return [
        'prompt_cache' => [
            PromptCacheTarget::System,
            PromptCacheTarget::Tools,
        ],
    ];
}
```

The gateways translate these targets into Anthropic `cache_control` blocks and Bedrock `cachePoint` entries without leaking the SDK-specific option into the provider request.

Tests cover individual and combined targets, empty configuration, invalid targets, and structured output tools.