### PR TITLE
Add coverage for persisting provider content blocks on paused turns

### DIFF
--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Approvals\Decision;
 use Laravel\Ai\Approvals\Decisions;
+use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Files\RemoteImage;
@@ -22,7 +23,9 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
 
@@ -525,6 +528,85 @@ test('it splits a mid-run pause row so an executed call is answered before the s
         ->and($messages[2]->content)->toBe('Let me delete b too')
         ->and($messages[2]->toolCalls)->toHaveCount(1)
         ->and($messages[2]->toolCalls[0]->id)->toBe('call-2');
+});
+
+test('it records provider content blocks into the message meta when a turn pauses', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Delete config/app.php.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = (new AgentResponse('invocation-id', '', new Usage, new Meta))
+        ->withMessages(collect([
+            new AssistantMessage('Let me think about that', null, [['type' => 'thinking', 'signature' => 'sig-1']]),
+        ]));
+
+    $response->withPendingApprovals(collect([
+        new PendingApproval('call-1', 'DeleteFile', ['path' => 'config/app.php'], 'Deletes a file'),
+    ]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    expect(json_decode((string) $record->meta, true))
+        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']]);
+});
+
+test('it omits provider content blocks when the assistant turn is not paused', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Delete config/app.php.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = (new AgentResponse('invocation-id', 'Deleted the file.', new Usage, new Meta))
+        ->withMessages(collect([
+            new AssistantMessage('Deleted the file.', null, [['type' => 'thinking', 'signature' => 'sig-1']]),
+        ]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    expect(json_decode((string) $record->meta, true))->not->toHaveKey('provider_content_blocks');
+});
+
+test('it records provider content blocks into the message meta when a stream pauses', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Delete config/app.php.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new StreamedAgentResponse('invocation-id', collect([
+        new ToolApprovalRequest('event-1', collect([
+            new PendingApproval('call-1', 'DeleteFile', ['path' => 'config/app.php'], 'Deletes a file'),
+        ]), 0, [['type' => 'thinking', 'signature' => 'sig-1']]),
+    ]), new Meta);
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    expect(json_decode((string) $record->meta, true))
+        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']]);
 });
 
 test('it preserves provider content blocks when a mixed pause carries an executed and a gated call', function (): void {


### PR DESCRIPTION
`DatabaseConversationStore::messageMeta()` writes `provider_content_blocks` from `$response->pausedProviderContentBlocks()` so a resumed turn can replay the provider's raw blocks verbatim.                                                                                                                                                      
                                                                                                                                                                            
Only the read side of that is covered `it preserves provider content blocks when a mixed pause carries an executed and a gated call` inserts a row whose meta already has the key. The write side has no coverage, on either accessor: `AgentResponse::pausedProviderContentBlocks()` (last `AssistantMessage`, non-streaming) or the `StreamedAgentResponse` override (last `ToolApprovalRequest` event, streaming).                                                                                           
                                                                                                                                                                            
Three tests:                                                                                                                                                                                                                                                                                                                               
  - a paused prompt writes its blocks into the row's meta                                                                                                               
  - a completed turn does not, even though its last assistant message still carries blocks pinning the `!hasPendingApprovals()` and `filled($blocks)` guards that keep replay state off ordinary rows                                                                                                                                           
  - a paused stream writes its blocks, covering the override                                                                                                               
                                                                                                                                                                            
  Tests only, no source changes.         