### PR TITLE
Fail over when Anthropic rejects a request for hitting a usage limit

### DIFF
--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -200,6 +200,7 @@ class AnthropicGateway implements Gateway, StepTextGateway
             'quota exceeded',
             'exceeded your current quota',
             'billing',
+            'usage limit',
         ];
     }
 }

--- a/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
@@ -63,6 +63,7 @@ test('insufficient credit response throws insufficient credits exception', funct
     'quota exceeded' => ['Your monthly quota exceeded the configured limit.'],
     'exceeded your current quota' => ['You have exceeded your current quota, please check your plan.'],
     'billing' => ['There is a billing issue with your account; please update your payment method.'],
+    'usage limit' => ['You have reached your specified API usage limits. To continue, please adjust your limits.'],
 ])->throws(InsufficientCreditsException::class);
 
 test('error in 200 response throws ai exception', function (): void {


### PR DESCRIPTION
When an Anthropic organisation reaches a configured spend/usage cap, the API rejects the request with HTTP 400 `invalid_request_error`:

```json
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "You have reached your specified API usage limits. To continue, please adjust your limits."
  }
}
```

`AnthropicGateway::insufficientCreditPatterns()` currently matches `credit balance`, `insufficient`, `quota exceeded`, `exceeded your current quota` and `billing`. None of those appear in that message, so `withErrorHandling()` rethrows the raw `RequestException` rather than an `InsufficientCreditsException`. Because `RequestException` is not a `FailoverableException`, `Promptable::withModelFailover()` never catches it and the remaining providers in the failover chain are never tried.

The result is that a spend cap on one key takes an application down even when other providers are configured and healthy, which is exactly the case failover exists for. It is the same class of condition as the patterns already listed: the account cannot spend any more, so move on to the next provider.

This adds `usage limit` to the pattern list, which covers both the singular and plural wording, and extends the existing dataset in `tests/Feature/Providers/Anthropic/ErrorHandlingTest.php` with Anthropic's real message.

We hit this in production: a cap on the primary key produced ~990 unhandled `RequestException`s in a month while a second Anthropic key and an OpenAI provider sat idle in the same chain.

Full suite passes locally (1980 passed, 257 skipped, no failures).