### PR TITLE
Handle Mistral responses that return content as a list of blocks

### DIFF
--- a/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Mistral/Concerns/HandlesTextStreaming.php
@@ -73,7 +73,9 @@ trait HandlesTextStreaming
                 ))->withInvocationId($invocationId);
             }
 
-            if (isset($delta['content']) && $delta['content'] !== '') {
+            $content = $this->extractContentText($delta['content'] ?? '');
+
+            if ($content !== '') {
                 if (! $textStartEmitted) {
                     $textStartEmitted = true;
 
@@ -84,12 +86,12 @@ trait HandlesTextStreaming
                     ))->withInvocationId($invocationId);
                 }
 
-                $currentText .= $delta['content'];
+                $currentText .= $content;
 
                 yield (new TextDelta(
                     $this->generateEventId(),
                     $messageId,
-                    $delta['content'],
+                    $content,
                     time(),
                 ))->withInvocationId($invocationId);
             }

--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -43,7 +43,7 @@ trait ParsesTextResponses
         $message = $choice['message'] ?? [];
         $model = $data['model'] ?? '';
 
-        $text = $message['content'] ?? '';
+        $text = $this->extractContentText($message['content'] ?? '');
         $rawToolCalls = $message['tool_calls'] ?? [];
 
         $toolCalls = array_map(fn (array $toolCall): ToolCall => new ToolCall(
@@ -61,6 +61,21 @@ trait ParsesTextResponses
             meta: new Meta($provider->name(), $model),
             structured: $structured ? $this->decodeStructuredOutput($text) : null,
         );
+    }
+
+    /**
+     * Extract the text from a message content value, which may be a list of content chunks.
+     */
+    protected function extractContentText(mixed $content): string
+    {
+        if (! is_array($content)) {
+            return (string) $content;
+        }
+
+        return implode('', array_map(
+            fn (mixed $chunk): string => is_array($chunk) ? (string) ($chunk['text'] ?? '') : (string) $chunk,
+            $content,
+        ));
     }
 
     /**

--- a/tests/Feature/Providers/Mistral/MistralHelpers.php
+++ b/tests/Feature/Providers/Mistral/MistralHelpers.php
@@ -8,7 +8,7 @@ use Tests\Fixtures\Agents\AssistantAgent;
 
 trait MistralHelpers
 {
-    protected function fakeTextResponse(string $text = 'Hello'): PromiseInterface
+    protected function fakeTextResponse(string|array $text = 'Hello'): PromiseInterface
     {
         return Http::response([
             'id' => 'chatcmpl-123',

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -42,6 +42,28 @@ test('streaming emits text events', function (): void {
         ->and($events[5])->toBeInstanceOf(StreamEnd::class);
 });
 
+test('streaming flattens block content deltas', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => [['type' => 'text', 'text' => 'Hello']]], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => ['content' => [['type' => 'reference', 'reference_ids' => ['search_documents']]]], 'finish_reason' => null]]],
+                ['id' => 'chatcmpl-123', 'object' => 'chat.completion.chunk', 'model' => 'mistral-medium-latest', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect($events[0])->toBeInstanceOf(StreamStart::class)
+        ->and($events[1])->toBeInstanceOf(TextStart::class)
+        ->and($events[2])->toBeInstanceOf(TextDelta::class)->delta->toBe('Hello')
+        ->and($events[3])->toBeInstanceOf(TextEnd::class)
+        ->and($events[4])->toBeInstanceOf(StreamEnd::class);
+});
+
 test('streaming handles tool calls', function (): void {
     Http::fake([
         '*' => Http::sequence([

--- a/tests/Feature/Providers/Mistral/ToolCallLoopTest.php
+++ b/tests/Feature/Providers/Mistral/ToolCallLoopTest.php
@@ -126,3 +126,22 @@ test('follow up request includes original messages', function (): void {
 
     expect($userMsg)->not->toBeNull();
 });
+
+test('follow up response with block content is flattened to text', function (): void {
+    Http::fake([
+        '*' => Http::sequence([
+            $this->fakeToolCallResponse('FixedNumberGenerator', 'call_'.uniqid()),
+            $this->fakeTextResponse([
+                ['type' => 'text', 'text' => 'The number is 72019'],
+                ['type' => 'reference', 'reference_ids' => ['search_documents']],
+            ]),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'mistral',
+    );
+
+    expect($response->text)->toBe('The number is 72019');
+});


### PR DESCRIPTION
When a Mistral answer draws on a tool result, `content` comes back as a list of chunks rather than a string, for example `[{"type": "reference", "reference_ids": ["search_documents"]}]`. Both Mistral paths assume a string and break on it: the streaming loop concatenates the delta straight onto `$currentText` and raises `Array to string conversion`, and `parseTextResponse()` passes the array into `StepResponse::$text`, which raises a `TypeError`. Either way the caller ends up with no answer.

This flattens the content value before it is used, keeping the `text` of each text chunk and dropping the rest, the same thing the Anthropic gateway already does when it walks block content. Non-text chunks such as references produce no text delta.

Fixes #865