### PR TITLE
Add transcription support to the Groq provider

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -474,7 +474,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 | Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter, OpenAI-compatible |
 | Images     | OpenAI, Gemini, xAI                                            |
 | TTS        | OpenAI, ElevenLabs                                              |
-| STT        | OpenAI, ElevenLabs, Mistral, OpenAI-compatible                 |
+| STT        | OpenAI, ElevenLabs, Mistral, Groq, OpenAI-compatible            |
 | Embeddings | OpenAI, OpenAI-compatible, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI |
 | Reranking  | Cohere, Jina                                                    |
 | Files      | OpenAI, Anthropic, Gemini                                       |

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -3,14 +3,23 @@
 namespace Laravel\Ai\Gateway\Groq;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Files\HasName;
+use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionMessages;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use LogicException;
 
-class GroqGateway implements StepTextGateway
+class GroqGateway implements StepTextGateway, TranscriptionGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesGroqClient;
@@ -24,4 +33,76 @@ class GroqGateway implements StepTextGateway
     use PerformsChatCompletionSteps;
 
     public function __construct(protected Dispatcher $events) {}
+
+    /**
+     * Generate text from the given audio.
+     *
+     * @param  array<string, mixed>  $providerOptions
+     */
+    public function generateTranscription(
+        TranscriptionProvider $provider,
+        string $model,
+        TranscribableAudio $audio,
+        ?string $language = null,
+        bool $diarize = false,
+        int $timeout = 30,
+        array $providerOptions = [],
+    ): TranscriptionResponse {
+        if ($diarize) {
+            throw new LogicException(
+                'Groq does not support diarized transcription. Use the OpenAI, ElevenLabs, Mistral, or Gemini provider for diarization.'
+            );
+        }
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)
+                ->attach('file', $audio->content(), $this->audioFilename($audio), array_filter(['Content-Type' => $audio->mimeType()]))
+                ->post('audio/transcriptions', array_merge($providerOptions, array_filter([
+                    'model' => $model,
+                    'language' => $language,
+                    'response_format' => 'json',
+                ]))),
+        );
+
+        $data = $response->json();
+
+        return new TranscriptionResponse(
+            $data['text'] ?? '',
+            collect($data['segments'] ?? [])->map(fn (array $segment): TranscriptionSegment => new TranscriptionSegment(
+                $segment['text'] ?? '',
+                $segment['speaker'] ?? '',
+                $segment['start'] ?? 0,
+                $segment['end'] ?? 0,
+            )),
+            new Usage(
+                $data['usage']['prompt_tokens'] ?? 0,
+                $data['usage']['completion_tokens'] ?? 0,
+            ),
+            new Meta($provider->name(), $model),
+        );
+    }
+
+    /**
+     * Determine the filename to send for the given audio.
+     */
+    protected function audioFilename(TranscribableAudio $audio): string
+    {
+        if ($audio instanceof HasName && $audio->name()) {
+            return $audio->name();
+        }
+
+        $extension = match ($audio->mimeType()) {
+            'audio/webm' => 'webm',
+            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
+            'audio/wav', 'audio/x-wav' => 'wav',
+            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
+            'audio/flac', 'audio/x-flac' => 'flac',
+            'audio/mpeg', 'audio/mp3' => 'mp3',
+            'audio/mpga' => 'mpga',
+            default => 'mp3',
+        };
+
+        return "audio.{$extension}";
+    }
 }

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -3,13 +3,13 @@
 namespace Laravel\Ai\Gateway\Groq;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Laravel\Ai\Contracts\Files\HasName;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionMessages;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
@@ -31,6 +31,7 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
     use MapsChatCompletionTools;
     use ParsesServerSentEvents;
     use PerformsChatCompletionSteps;
+    use ResolvesAudioFilenames;
 
     public function __construct(protected Dispatcher $events) {}
 
@@ -61,7 +62,7 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
                 ->post('audio/transcriptions', array_merge($providerOptions, array_filter([
                     'model' => $model,
                     'language' => $language,
-                    'response_format' => 'json',
+                    'response_format' => $providerOptions['response_format'] ?? 'json',
                 ]))),
         );
 
@@ -81,28 +82,5 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
             ),
             new Meta($provider->name(), $model),
         );
-    }
-
-    /**
-     * Determine the filename to send for the given audio.
-     */
-    protected function audioFilename(TranscribableAudio $audio): string
-    {
-        if ($audio instanceof HasName && $audio->name()) {
-            return $audio->name();
-        }
-
-        $extension = match ($audio->mimeType()) {
-            'audio/webm' => 'webm',
-            'audio/ogg', 'audio/ogg; codecs=opus' => 'ogg',
-            'audio/wav', 'audio/x-wav' => 'wav',
-            'audio/mp4', 'audio/m4a', 'audio/x-m4a' => 'm4a',
-            'audio/flac', 'audio/x-flac' => 'flac',
-            'audio/mpeg', 'audio/mp3' => 'mp3',
-            'audio/mpga' => 'mpga',
-            default => 'mp3',
-        };
-
-        return "audio.{$extension}";
     }
 }

--- a/src/Providers/GroqProvider.php
+++ b/src/Providers/GroqProvider.php
@@ -4,13 +4,17 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
+use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Groq\GroqGateway;
 
-class GroqProvider extends Provider implements TextProvider
+class GroqProvider extends Provider implements TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesText;
+    use Concerns\GeneratesTranscriptions;
     use Concerns\HasTextGateway;
+    use Concerns\HasTranscriptionGateway;
     use Concerns\StreamsText;
 
     public function __construct(protected array $config, protected Dispatcher $events)
@@ -24,6 +28,14 @@ class GroqProvider extends Provider implements TextProvider
     public function textGateway(): StepTextGateway
     {
         return $this->textGateway ??= new GroqGateway($this->events);
+    }
+
+    /**
+     * Get the provider's transcription gateway.
+     */
+    public function transcriptionGateway(): TranscriptionGateway
+    {
+        return $this->transcriptionGateway ??= new GroqGateway($this->events);
     }
 
     /**
@@ -48,5 +60,13 @@ class GroqProvider extends Provider implements TextProvider
     public function smartestTextModel(): string
     {
         return $this->config['models']['text']['smartest'] ?? 'openai/gpt-oss-120b';
+    }
+
+    /**
+     * Get the name of the default transcription model.
+     */
+    public function defaultTranscriptionModel(): string
+    {
+        return $this->config['models']['transcription']['default'] ?? 'whisper-large-v3-turbo';
     }
 }

--- a/tests/Feature/Providers/Groq/TranscriptionTest.php
+++ b/tests/Feature/Providers/Groq/TranscriptionTest.php
@@ -86,6 +86,28 @@ test('transcription response text is correctly parsed', function (): void {
         ->and($response->meta->model)->toBe('whisper-large-v3-turbo');
 });
 
+test('transcription segments are parsed when a verbose response format is requested', function (): void {
+    Http::fake(['*' => Http::response([
+        'text' => 'Hello, world!',
+        'segments' => [
+            ['text' => 'Hello,', 'start' => 0.0, 'end' => 1.5],
+            ['text' => 'world!', 'start' => 1.5, 'end' => 2.75],
+        ],
+    ])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->withProviderOptions(['response_format' => 'verbose_json'])
+        ->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'verbose_json')
+        && substr_count($request->body(), 'name="response_format"') === 1);
+
+    expect($response->segments)->toHaveCount(2)
+        ->and($response->segments->first()->text)->toBe('Hello,')
+        ->and($response->segments->first()->startSeconds)->toBe(0.0)
+        ->and($response->segments->last()->endSeconds)->toBe(2.75);
+});
+
 test('transcription sends the bearer token', function (): void {
     Http::fake(['*' => Http::response(['text' => 'Hi'])]);
 

--- a/tests/Feature/Providers/Groq/TranscriptionTest.php
+++ b/tests/Feature/Providers/Groq/TranscriptionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Responses\TranscriptionResponse;
+use Laravel\Ai\Transcription;
+
+beforeEach(function (): void {
+    config(['ai.providers.groq' => [
+        'driver' => 'groq',
+        'key' => 'test-key',
+    ]]);
+});
+
+test('transcription posts audio to the transcriptions endpoint as multipart', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hello, world!'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.groq.com/openai/v1/audio/transcriptions'
+        && str_contains($request->header('Content-Type')[0] ?? '', 'multipart/form-data'));
+});
+
+test('transcription uses the default whisper model when none is configured', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'whisper-large-v3-turbo'));
+});
+
+test('transcription uses the configured default model when set', function (): void {
+    config(['ai.providers.groq' => [
+        'driver' => 'groq',
+        'key' => 'test-key',
+        'models' => ['transcription' => ['default' => 'custom-whisper-model']],
+    ]]);
+
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'custom-whisper-model'));
+});
+
+test('transcription sends language when provided', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Bonjour'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->language('fr')
+        ->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'name="language"'));
+});
+
+test('transcription omits language when not provided', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request): bool => ! str_contains($request->body(), 'name="language"'));
+});
+
+test('transcription diarize throws a logic exception without sending a request', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    expect(fn (): TranscriptionResponse => Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')
+        ->diarize()
+        ->generate(provider: 'groq'))
+        ->toThrow(LogicException::class, 'does not support diarized transcription');
+
+    Http::assertNothingSent();
+});
+
+test('transcription response text is correctly parsed', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hello, world!'])]);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    expect($response->text)->toBe('Hello, world!')
+        ->and($response->segments)->toHaveCount(0)
+        ->and($response->meta->provider)->toBe('groq')
+        ->and($response->meta->model)->toBe('whisper-large-v3-turbo');
+});
+
+test('transcription sends the bearer token', function (): void {
+    Http::fake(['*' => Http::response(['text' => 'Hi'])]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('transcription rate limit response throws rate limited exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Rate limit exceeded']], 429)]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+})->throws(RateLimitedException::class);
+
+test('transcription overloaded response throws provider overloaded exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Service overloaded']], 503)]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+})->throws(ProviderOverloadedException::class);
+
+test('transcription http error response throws request exception', function (): void {
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Invalid audio']], 400)]);
+
+    Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+})->throws(RequestException::class);
+
+test('transcription can be faked for the groq provider', function (): void {
+    Transcription::fake(['Faked transcript']);
+
+    $response = Transcription::fromBase64(base64_encode('fake-audio'), 'audio/mp3')->generate(provider: 'groq');
+
+    expect($response->text)->toBe('Faked transcript');
+});


### PR DESCRIPTION
groq is one of the more popular whisper hosts but the sdk only had text wired up for it. this adds transcription (STT).

the endpoint is the standard openai shape (`POST /openai/v1/audio/transcriptions`, multipart upload), so it mirrors the existing OpenAI and Mistral transcription gateways. request side only, the rest of the transcription plumbing already exists.

whats in it:
- `GroqProvider` implements `TranscriptionProvider`, default model `whisper-large-v3-turbo` (overridable via `models.transcription.default`)
- `GroqGateway` implements `TranscriptionGateway` with `generateTranscription()`
- diarize throws, groq whisper has no speaker labels
- models: `whisper-large-v3-turbo` (default) and `whisper-large-v3`

docs: https://console.groq.com/docs/speech-to-text

12 tests covering the endpoint, default + configured model, language, diarize throwing, error handling and faking. full suite green, pint + phpstan clean.
