### PR TITLE
Make stream errors throw instead of silently ending the run

### DIFF
--- a/src/Exceptions/StreamErrorException.php
+++ b/src/Exceptions/StreamErrorException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Ai\Exceptions;
+
+use Laravel\Ai\Streaming\Events\Error;
+
+class StreamErrorException extends AiException
+{
+    public function __construct(public readonly ?Error $error = null)
+    {
+        parent::__construct($error?->message ?? 'The provider ended the stream without completing the step.');
+    }
+}

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Exceptions\NoSuchToolException;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Gateway\Concerns\HandlesToolApprovals;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -160,7 +161,6 @@ class TextGenerationLoop
         $continuationToken = null;
         $accumulatedUsage = new Usage;
         $finalReason = null;
-        $sawError = false;
 
         if ($approval !== null) {
             $resumption = $this->resumeFromApproval($approval, $messages, $tools, $validatedApproval);
@@ -218,18 +218,21 @@ class TextGenerationLoop
                 $stepContext,
             );
 
+            $lastError = null;
+
             foreach ($stream as $event) {
                 yield $event;
 
                 if ($event instanceof Error) {
-                    $sawError = true;
+                    $lastError = $event;
                 }
             }
 
             $result = $stream->getReturn();
 
+            // A provider may report an error in the stream itself rather than throwing, which still ends the step. The error event travels on the exception so its type and metadata are not lost...
             if (! $result instanceof StepResponse) {
-                break;
+                throw new StreamErrorException($lastError);
             }
 
             $accumulatedUsage = $accumulatedUsage->add($result->usage);
@@ -271,16 +274,13 @@ class TextGenerationLoop
             $continuationToken = $result->continuationToken;
         }
 
-        $reason = $finalReason ?? ($sawError ? null : FinishReason::Error);
-
-        if ($reason !== null) {
-            yield (new StreamEnd(
-                $this->generateEventId(),
-                $reason->value,
-                $accumulatedUsage,
-                time(),
-            ))->withInvocationId($invocationId);
-        }
+        // A step that never produced a response has already thrown, so the loop only reaches here having set a reason...
+        yield (new StreamEnd(
+            $this->generateEventId(),
+            ($finalReason ?? FinishReason::Stop)->value,
+            $accumulatedUsage,
+            time(),
+        ))->withInvocationId($invocationId);
     }
 
     /**

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -127,7 +127,7 @@ trait Promptable
                 $lastException = null;
 
                 foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
-                    $started = false;
+                    $innerResponse = null;
 
                     try {
                         $innerResponse = $provider->stream(
@@ -137,14 +137,12 @@ trait Promptable
                         $innerResponse->then(fn (StreamedAgentResponse $response): StreamableAgentResponse => $outer->adoptStateFrom($response));
 
                         foreach ($innerResponse as $event) {
-                            $started = true;
-
                             yield $event;
                         }
 
                         return;
                     } catch (FailoverableException $e) {
-                        if ($started) {
+                        if ($innerResponse?->hasYielded()) {
                             throw $e;
                         }
 

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -38,12 +38,22 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
     protected ?StreamedAgentResponse $streamedResponse = null;
 
+    protected bool $hasYielded = false;
+
     public function __construct(
         public string $invocationId,
         protected Closure $generator,
         protected ?Meta $meta = null,
     ) {
         $this->events = new Collection;
+    }
+
+    /**
+     * Determine whether this response has handed at least one event to a consumer.
+     */
+    public function hasYielded(): bool
+    {
+        return $this->hasYielded;
     }
 
     /**
@@ -149,6 +159,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         // Use existing events if we've already streamed them once...
         if (count($this->events) > 0) {
             foreach ($this->events as $event) {
+                $this->hasYielded = true;
+
                 yield $event;
             }
 
@@ -160,6 +172,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         // Resolve the stream of the prompt and yield the events...
         foreach (call_user_func($this->generator) as $event) {
             $events[] = $event;
+
+            $this->hasYielded = true;
 
             yield $event;
         }

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -40,6 +40,9 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
     protected bool $hasYielded = false;
 
+    /**
+     * Create a new streamable agent response instance.
+     */
     public function __construct(
         public string $invocationId,
         protected Closure $generator,
@@ -194,6 +197,9 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         $this->syncConversationFromStreamedResponse();
     }
 
+    /**
+     * Synchronize the conversation state from the completed streamed response.
+     */
     protected function syncConversationFromStreamedResponse(): void
     {
         if ($this->streamedResponse->conversationId === null) {

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -49,14 +49,6 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     }
 
     /**
-     * Determine whether this response has handed at least one event to a consumer.
-     */
-    public function hasYielded(): bool
-    {
-        return $this->hasYielded;
-    }
-
-    /**
      * Execute a callback over each event.
      */
     public function each(callable $callback): self
@@ -210,5 +202,13 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
         $this->conversationId = $this->streamedResponse->conversationId;
         $this->conversationUser = $this->streamedResponse->conversationUser;
+    }
+
+    /**
+     * Determine whether this response has handed at least one event to a consumer.
+     */
+    public function hasYielded(): bool
+    {
+        return $this->hasYielded;
     }
 }

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
@@ -258,10 +259,15 @@ describe('error handling', function (): void {
             ),
         ]);
 
-        $events = $this->collectStreamEvents();
+        $error = null;
 
-        expect($events)->toHaveCount(1)
-            ->and($events[0])->toBeInstanceOf(Error::class)->type->toBe('overloaded_error')->message->toBe('Server overloaded');
+        try {
+            $this->collectStreamEvents();
+        } catch (StreamErrorException $exception) {
+            $error = $exception->error;
+        }
+
+        expect($error)->toBeInstanceOf(Error::class)->type->toBe('overloaded_error')->message->toBe('Server overloaded');
     });
 });
 

--- a/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -98,12 +99,17 @@ test('streaming error event stops stream', function (): void {
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('rate_limit_exceeded')
-        ->and($events[0]->message)->toBe('Rate limit exceeded');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('rate_limit_exceeded')
+        ->and($error->message)->toBe('Rate limit exceeded');
 });
 
 test('streaming captures usage from completed event', function (): void {

--- a/tests/Feature/Providers/DeepSeek/StreamingTest.php
+++ b/tests/Feature/Providers/DeepSeek/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -90,12 +91,17 @@ test('streaming error event stops stream', function (): void {
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('rate_limit_exceeded')
-        ->and($events[0]->message)->toBe('Rate limit exceeded');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('rate_limit_exceeded')
+        ->and($error->message)->toBe('Rate limit exceeded');
 });
 
 test('streaming captures usage from final chunk', function (): void {

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -250,10 +251,15 @@ describe('error handling', function (): void {
             ),
         ]);
 
-        $events = $this->collectStreamEvents();
+        $error = null;
 
-        expect($events)->toHaveCount(1)
-            ->and($events[0])->toBeInstanceOf(Error::class)->type->toBe('overloaded')->message->toBe('Server overloaded');
+        try {
+            $this->collectStreamEvents();
+        } catch (StreamErrorException $exception) {
+            $error = $exception->error;
+        }
+
+        expect($error)->toBeInstanceOf(Error::class)->type->toBe('overloaded')->message->toBe('Server overloaded');
     });
 });
 

--- a/tests/Feature/Providers/Groq/StreamingTest.php
+++ b/tests/Feature/Providers/Groq/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -122,12 +123,17 @@ test('streaming error event stops stream', function (): void {
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('rate_limit_exceeded')
-        ->and($events[0]->message)->toBe('Rate limit exceeded');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('rate_limit_exceeded')
+        ->and($error->message)->toBe('Rate limit exceeded');
 });
 
 test('streaming captures usage from final chunk', function (): void {

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -133,12 +134,17 @@ test('streaming error event stops stream', function (): void {
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('server_error')
-        ->and($events[0]->message)->toBe('Internal server error');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('server_error')
+        ->and($error->message)->toBe('Internal server error');
 });
 
 test('streaming finish reason maps correctly', function (string $apiReason, $expected): void {

--- a/tests/Feature/Providers/Ollama/StreamingTest.php
+++ b/tests/Feature/Providers/Ollama/StreamingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -100,12 +101,17 @@ test('streaming error event stops stream with string payload', function (): void
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('unknown_error')
-        ->and($events[0]->message)->toBe('model not found');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('unknown_error')
+        ->and($error->message)->toBe('model not found');
 });
 
 test('streaming error event also handles structured payload', function (): void {
@@ -116,12 +122,17 @@ test('streaming error event also handles structured payload', function (): void 
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('model_error')
-        ->and($events[0]->message)->toBe('Model not found');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('model_error')
+        ->and($error->message)->toBe('Model not found');
 });
 
 test('streaming accumulates tool call arguments across chunks', function (): void {

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -175,12 +176,17 @@ test('streaming error event stops stream', function (): void {
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('server_error')
-        ->and($events[0]->message)->toBe('Server overloaded');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('server_error')
+        ->and($error->message)->toBe('Server overloaded');
 });
 
 test('streaming captures usage from response completed', function (): void {

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
@@ -89,13 +90,21 @@ test('streaming error event stops stream', function (): void {
     ]);
 
     $events = [];
-    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
-        $events[] = $event;
+    $error = null;
+
+    try {
+        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
     }
 
     $errorEvents = array_values(array_filter($events, fn ($e): bool => $e instanceof Error));
+
     expect($errorEvents)->toHaveCount(1)
-        ->and($errorEvents[0]->type)->toBe('server_error');
+        ->and($errorEvents[0]->type)->toBe('server_error')
+        ->and($error)->toBe($errorEvents[0]);
 });
 
 test('streaming error finish reason emits error event', function (): void {
@@ -107,13 +116,21 @@ test('streaming error finish reason emits error event', function (): void {
     ]);
 
     $events = [];
-    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
-        $events[] = $event;
+    $error = null;
+
+    try {
+        foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+            $events[] = $event;
+        }
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
     }
 
     $errorEvents = array_values(array_filter($events, fn ($e): bool => $e instanceof Error));
+
     expect($errorEvents)->toHaveCount(1)
-        ->and($errorEvents[0]->type)->toBe('502');
+        ->and($errorEvents[0]->type)->toBe('502')
+        ->and($error)->toBe($errorEvents[0]);
 });
 
 test('streaming captures usage from final chunk', function (): void {

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -148,12 +149,17 @@ test('streaming error event stops stream', function (): void {
         ),
     ]);
 
-    $events = $this->collectStreamEvents();
+    $error = null;
 
-    expect($events)->toHaveCount(1)
-        ->and($events[0])->toBeInstanceOf(Error::class)
-        ->and($events[0]->type)->toBe('server_error')
-        ->and($events[0]->message)->toBe('Internal server error');
+    try {
+        $this->collectStreamEvents();
+    } catch (StreamErrorException $exception) {
+        $error = $exception->error;
+    }
+
+    expect($error)->toBeInstanceOf(Error::class)
+        ->and($error->type)->toBe('server_error')
+        ->and($error->message)->toBe('Internal server error');
 });
 
 test('streaming finish reason maps correctly', function (string $status, string $type, $expected): void {

--- a/tests/Unit/Gateway/TextGenerationLoopTest.php
+++ b/tests/Unit/Gateway/TextGenerationLoopTest.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Exceptions\NoSuchToolException;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationLoop;
@@ -732,12 +733,12 @@ test('it throws when streaming tool calls do not match local tools', function ()
     )))->toThrow(NoSuchToolException::class);
 });
 
-test('it emits a terminal stream end when a turn yields no stream end or error', function (): void {
+test('it throws when a turn completes without a step response', function (): void {
     $gateway = new TextGenerationLoopFakeGateway(streams: [
         textGenerationLoopStreamStep(events: [new TextDelta('text-delta', 'message-1', 'partial', time())]),
     ]);
 
-    $events = iterator_to_array((new TextGenerationLoop($gateway))->stream(
+    expect(fn (): array => iterator_to_array((new TextGenerationLoop($gateway))->stream(
         'invocation-1',
         textGenerationLoopProvider(),
         'model',
@@ -747,33 +748,42 @@ test('it emits a terminal stream end when a turn yields no stream end or error',
         null,
         null,
         null,
-    ));
-
-    $streamEnds = collect($events)->whereInstanceOf(StreamEnd::class);
-
-    expect($streamEnds)->toHaveCount(1)
-        ->and($streamEnds->first()->reason)->toBe(FinishReason::Error->value);
+    )))->toThrow(StreamErrorException::class, 'The provider ended the stream without completing the step.');
 });
 
-test('it does not emit a stream end when a turn errors without a stream end', function (): void {
+test('it yields the error and then throws it when a turn errors without a stream end', function (): void {
+    $error = new Error('error-1', 'server_error', 'Server overloaded', false, time());
+
     $gateway = new TextGenerationLoopFakeGateway(streams: [
-        textGenerationLoopStreamStep(events: [new Error('error-1', 'server_error', 'Server overloaded', false, time())]),
+        textGenerationLoopStreamStep(events: [$error]),
     ]);
 
-    $events = iterator_to_array((new TextGenerationLoop($gateway))->stream(
-        'invocation-1',
-        textGenerationLoopProvider(),
-        'model',
-        null,
-        [],
-        [],
-        null,
-        null,
-        null,
-    ));
+    $events = [];
+    $thrown = null;
 
+    try {
+        foreach ((new TextGenerationLoop($gateway))->stream(
+            'invocation-1',
+            textGenerationLoopProvider(),
+            'model',
+            null,
+            [],
+            [],
+            null,
+            null,
+            null,
+        ) as $event) {
+            $events[] = $event;
+        }
+    } catch (StreamErrorException $exception) {
+        $thrown = $exception;
+    }
+
+    // The consumer still sees the provider's own error event before the step fails...
     expect(collect($events)->whereInstanceOf(StreamEnd::class))->toHaveCount(0)
-        ->and(collect($events)->whereInstanceOf(Error::class))->toHaveCount(1);
+        ->and(collect($events)->whereInstanceOf(Error::class))->toHaveCount(1)
+        ->and($thrown?->error)->toBe($error)
+        ->and($thrown?->getMessage())->toBe('Server overloaded');
 });
 
 function textGenerationLoopProvider(): TextProvider


### PR DESCRIPTION
Splits #848 into a reviewable stack. This is the bottom layer.

A provider that reports an error inside the stream body rather than throwing (an HTTP 200 whose SSE payload carries `{"error": {...}}`) ended the step with a `break`. The consumer was handed a partial `->text`, no finish reason, no terminal `StreamEnd`, and no signal that the run had failed at all.

The step now throws a `StreamErrorException` carrying the provider’s own `Error` event on `->error`, so its type and message survive. `StreamEnd` is emitted unconditionally, since a step that produced no response has already thrown by the time the loop reaches it.

`StreamableAgentResponse::hasYielded()` replaces the `$started` flag stream failover used to decide whether anything had already reached the consumer, so that decision reads from the response itself.

### Behaviour changes

- A mid-stream provider error now throws instead of quietly ending the stream. It is deliberately **not** a `FailoverableException`: these arrive as HTTP 200, so failover does not apply.
- A malformed stream that produced no `Error` event previously fell through to `StreamEnd(FinishReason::Error)`; it now throws with a generic message and a null `->error`.

The ten provider `StreamingTest` files are updated for the new contract.