### PR TITLE
Thread one invocation id through an entire agent run

### DIFF
--- a/src/Events/AgentFailedOver.php
+++ b/src/Events/AgentFailedOver.php
@@ -12,5 +12,6 @@ class AgentFailedOver extends ProviderFailedOver
         public Agent $agent,
         public Provider $provider,
         public string $model,
-        public FailoverableException $exception) {}
+        public FailoverableException $exception,
+        public string $invocationId) {}
 }

--- a/src/Events/AgentFailedOver.php
+++ b/src/Events/AgentFailedOver.php
@@ -9,9 +9,9 @@ use Laravel\Ai\Providers\Provider;
 class AgentFailedOver extends ProviderFailedOver
 {
     public function __construct(
+        public string $invocationId,
         public Agent $agent,
         public Provider $provider,
         public string $model,
-        public FailoverableException $exception,
-        public string $invocationId) {}
+        public FailoverableException $exception) {}
 }

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -299,7 +299,7 @@ trait Promptable
      */
     private function recordAgentFailover(string $invocationId, Provider $provider, string $model, FailoverableException $exception): FailoverableException
     {
-        event(new AgentFailedOver($this, $provider, $model, $exception, $invocationId));
+        event(new AgentFailedOver($invocationId, $this, $provider, $model, $exception));
 
         return $exception;
     }

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -62,19 +62,27 @@ trait Promptable
     {
         [$text, $approvalDecisions] = $this->extractPromptInput($prompt);
 
+        $invocationId = (string) Str::uuid7();
+
+        $providers = $approvalDecisions !== null
+            ? $this->providersForApprovalContinuation($provider, $model)
+            : $this->getProvidersAndModelsForFailover($provider, $model);
+
         $run = fn (TextProvider $provider, string $model): AgentResponse => $provider->prompt(
-            new AgentPrompt($this, $text, $attachments, $provider, $model, $this->getTimeout($timeout), approvalDecisions: $approvalDecisions)
+            new AgentPrompt(
+                $this, $text, $attachments, $provider, $model, $this->getTimeout($timeout),
+                invocationId: $invocationId,
+                approvalDecisions: $approvalDecisions,
+            )
         );
 
         if ($approvalDecisions !== null) {
-            [$provider, $model] = $this->iterateProvidersWithFailover(
-                $this->providersForApprovalContinuation($provider, $model)
-            )->current();
+            [$provider, $model] = $this->iterateProvidersWithFailover($providers)->current();
 
             return $run($provider, $model);
         }
 
-        return $this->withModelFailover($run, $provider, $model);
+        return $this->withModelFailover($run, $providers, $invocationId);
     }
 
     /**
@@ -146,7 +154,7 @@ trait Promptable
                             throw $e;
                         }
 
-                        $lastException = $this->recordAgentFailover($provider, $model, $e);
+                        $lastException = $this->recordAgentFailover($invocationId, $provider, $model, $e);
                     }
                 }
 
@@ -231,16 +239,18 @@ trait Promptable
 
     /**
      * Invoke the given Closure with provider / model failover.
+     *
+     * @param  array<string, string|null>  $providers
      */
-    private function withModelFailover(Closure $callback, Lab|array|string|null $provider, ?string $model): mixed
+    private function withModelFailover(Closure $callback, array $providers, string $invocationId): mixed
     {
         $lastException = null;
 
-        foreach ($this->iterateProvidersWithFailover($this->getProvidersAndModelsForFailover($provider, $model)) as [$provider, $model]) {
+        foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
             try {
                 return $callback($provider, $model);
             } catch (FailoverableException $e) {
-                $lastException = $this->recordAgentFailover($provider, $model, $e);
+                $lastException = $this->recordAgentFailover($invocationId, $provider, $model, $e);
             }
         }
 
@@ -287,9 +297,9 @@ trait Promptable
     /**
      * Record that an agent failed over to the next configured provider.
      */
-    private function recordAgentFailover(Provider $provider, string $model, FailoverableException $exception): FailoverableException
+    private function recordAgentFailover(string $invocationId, Provider $provider, string $model, FailoverableException $exception): FailoverableException
     {
-        event(new AgentFailedOver($this, $provider, $model, $exception));
+        event(new AgentFailedOver($this, $provider, $model, $exception, $invocationId));
 
         return $exception;
     }

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -47,7 +47,7 @@ trait GeneratesText
      */
     public function prompt(AgentPrompt $prompt): AgentResponse
     {
-        $invocationId = (string) Str::uuid7();
+        $invocationId = $prompt->invocationId ?? (string) Str::uuid7();
 
         $processedPrompt = null;
         $resolvedApprovalResults = null;

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Events\AgentFailedOver;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Prompts\AgentPrompt;
+use Tests\Fixtures\Agents\AssistantAgent;
+
+test('a synchronous prompt threads one invocation id through the prompt and its events', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake(['Hello!']);
+
+    $response = (new AssistantAgent)->prompt('Hi');
+
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->invocationId === $response->invocationId
+        && $event->prompt->invocationId === $response->invocationId);
+
+    Event::assertDispatched(AgentPrompted::class, fn (AgentPrompted $event): bool => $event->invocationId === $response->invocationId);
+});
+
+test('synchronous middleware receives the invocation id the run reports', function (): void {
+    AssistantAgent::fake(['Hello!']);
+
+    $seen = null;
+
+    $response = (new AssistantAgent)->withMiddleware([
+        function (AgentPrompt $prompt, Closure $next) use (&$seen) {
+            $seen = $prompt->invocationId;
+
+            return $next($prompt);
+        },
+    ])->prompt('Hi');
+
+    expect($seen)->not->toBeNull()->toBe($response->invocationId);
+});
+
+test('every failover attempt shares the run invocation id', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->pushResponse(fakeGroqResponse('Hello from the backup.'));
+
+    $response = (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']);
+
+    expect($response->text)->toBe('Hello from the backup.');
+
+    Event::assertDispatched(AgentFailedOver::class, fn (AgentFailedOver $event): bool => $event->invocationId === $response->invocationId);
+
+    $invocationIds = Event::dispatched(PromptingAgent::class)
+        ->map(fn (array $dispatched): string => $dispatched[0]->invocationId)
+        ->unique();
+
+    expect($invocationIds)->toHaveCount(1);
+});
+
+test('a failed over run names the invocation it belongs to', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->pushResponse(fakeGroqResponse('Hello from the backup.'));
+
+    $response = (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']);
+
+    Event::assertDispatched(AgentFailedOver::class, fn (AgentFailedOver $event): bool => $event->invocationId === $response->invocationId);
+});


### PR DESCRIPTION
Part of the #848 stack. Base: #870.

`streamPrompt()` already minted a run-level invocation id and handed it to the provider on the prompt, but `prompt()` did not. Three consequences:

- Synchronous middleware saw `$prompt->invocationId === null` while streaming middleware saw a real value.
- The provider minted its own id per attempt, so a three-provider failover produced three unrelated ids for one run.
- `AgentFailedOver` had no correlation id at all, so a failover could not be attached to the run it belonged to.

`prompt()` now mints the id up front and the provider reuses whatever the caller supplied, so every attempt of a run reports under one id.

### Breaking change

`AgentFailedOver` gains a required `string $invocationId` as its last constructor argument. Anything constructing that event by hand needs updating; listeners are unaffected.