### PR TITLE
Report tool invocations through a run context

### DIFF
--- a/src/Events/InvokingTool.php
+++ b/src/Events/InvokingTool.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Contracts\Tool;
 
 class InvokingTool
 {
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
     public function __construct(
         public string $invocationId,
         public string $toolInvocationId,

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -2,51 +2,31 @@
 
 namespace Laravel\Ai\Gateway\Concerns;
 
-use Closure;
+use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Laravel\Ai\Tools\Request;
 use Laravel\Ai\Tools\ToolNameResolver;
 
 trait InvokesTools
 {
-    protected Closure $invokingToolCallback;
-
-    protected Closure $toolInvokedCallback;
-
-    /**
-     * @var array<int, array{invoking: Closure, invoked: Closure}>
-     */
-    protected array $toolInvocationCallbackStack = [];
-
-    /**
-     * Specify callbacks that should be invoked when tools are invoking / invoked.
-     */
-    public function onToolInvocation(Closure $invoking, Closure $invoked): self
-    {
-        $this->invokingToolCallback = $invoking;
-        $this->toolInvokedCallback = $invoked;
-
-        return $this;
-    }
-
     /**
      * Execute the given tool with the given arguments.
+     *
+     * @param  array<string, mixed>  $arguments
      */
-    protected function executeTool(Tool $tool, array $arguments, ?string $toolCallId = null): string
+    protected function executeTool(Tool $tool, array $arguments, ?string $toolCallId = null, ?RunContext $context = null): string
     {
-        $callbacks = $this->pushToolInvocationCallbacks();
+        $toolInvocationId = (string) Str::uuid7();
 
-        try {
-            call_user_func($callbacks['invoking'], $tool, $arguments);
+        $context?->invokingTool($tool, $arguments, $toolInvocationId);
 
-            return (string) tap(
-                $tool->handle(new Request($arguments, $toolCallId)),
-                fn ($result): mixed => call_user_func($callbacks['invoked'], $tool, $arguments, $result)
-            );
-        } finally {
-            $this->popToolInvocationCallbacks();
-        }
+        $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
+
+        $context?->toolInvoked($tool, $arguments, $result, $toolInvocationId);
+
+        return (string) $result;
     }
 
     /**
@@ -69,44 +49,5 @@ trait InvokesTools
         }
 
         return null;
-    }
-
-    /**
-     * Initialize the tool invocation callbacks.
-     */
-    protected function initializeToolCallbacks(): void
-    {
-        $this->invokingToolCallback ??= fn (): true => true;
-        $this->toolInvokedCallback ??= fn (): true => true;
-    }
-
-    /**
-     * Snapshot the current callbacks for the duration of a single tool invocation.
-     *
-     * @return array{invoking: Closure, invoked: Closure}
-     */
-    protected function pushToolInvocationCallbacks(): array
-    {
-        $this->initializeToolCallbacks();
-
-        return $this->toolInvocationCallbackStack[] = [
-            'invoking' => $this->invokingToolCallback,
-            'invoked' => $this->toolInvokedCallback,
-        ];
-    }
-
-    /**
-     * Restore the callbacks that were active before the current tool invocation.
-     */
-    protected function popToolInvocationCallbacks(): void
-    {
-        $callbacks = array_pop($this->toolInvocationCallbackStack);
-
-        if ($callbacks === null) {
-            return;
-        }
-
-        $this->invokingToolCallback = $callbacks['invoking'];
-        $this->toolInvokedCallback = $callbacks['invoked'];
     }
 }

--- a/src/Gateway/RunContext.php
+++ b/src/Gateway/RunContext.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
+
+class RunContext
+{
+    public function __construct(
+        public readonly string $invocationId,
+        public readonly Agent $agent,
+        public readonly TextProvider $provider,
+        public readonly string $model,
+        protected readonly Dispatcher $events,
+    ) {}
+
+    /**
+     * Report that a tool is about to be invoked.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    public function invokingTool(Tool $tool, array $arguments, string $toolInvocationId): void
+    {
+        $this->events->dispatch(new InvokingTool(
+            $this->invocationId, $toolInvocationId, $this->agent, $tool, $arguments,
+        ));
+    }
+
+    /**
+     * Report that a tool returned a result.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    public function toolInvoked(Tool $tool, array $arguments, mixed $result, string $toolInvocationId): void
+    {
+        $this->events->dispatch(new ToolInvoked(
+            $this->invocationId, $toolInvocationId, $this->agent, $tool, $arguments, $result,
+        ));
+    }
+}

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -56,10 +56,7 @@ class TextGenerationLoop
     /**
      * Create a new text generation loop instance.
      */
-    public function __construct(protected StepTextGateway $gateway)
-    {
-        $this->initializeToolCallbacks();
-    }
+    public function __construct(protected StepTextGateway $gateway) {}
 
     /**
      * @param  array<Tool|ProviderTool>  $tools
@@ -77,6 +74,7 @@ class TextGenerationLoop
         ?int $timeout = null,
         ?array $approval = null,
         ?Closure $recordApprovalResults = null,
+        ?RunContext $context = null,
     ): TextResponse {
         $this->ensureToolSearchIsApplicable($provider, $tools);
 
@@ -86,7 +84,7 @@ class TextGenerationLoop
         $lastResult = null;
 
         if ($approval !== null) {
-            $resumption = $this->resumeFromApproval($approval, $messages, $tools);
+            $resumption = $this->resumeFromApproval($approval, $messages, $tools, context: $context);
 
             $allMessages = $resumption->messages;
             $newMessages = $resumption->newMessages;
@@ -123,7 +121,7 @@ class TextGenerationLoop
                 $stepContext,
             );
 
-            [$toolResults, $pendingApprovals] = $this->stepToolResultsWithOptions($lastResult, $stepContext->isFinalStep, $tools, $options);
+            [$toolResults, $pendingApprovals] = $this->stepToolResultsWithOptions($lastResult, $stepContext->isFinalStep, $tools, $options, $context);
 
             $steps->push($this->buildStep($lastResult, $toolResults));
 
@@ -171,6 +169,7 @@ class TextGenerationLoop
         ?array $approval = null,
         ?Closure $recordApprovalResults = null,
         ?array $validatedApproval = null,
+        ?RunContext $context = null,
     ): Generator {
         $this->ensureToolSearchIsApplicable($provider, $tools);
 
@@ -180,7 +179,7 @@ class TextGenerationLoop
         $finalReason = null;
 
         if ($approval !== null) {
-            $resumption = $this->resumeFromApproval($approval, $messages, $tools, $validatedApproval);
+            $resumption = $this->resumeFromApproval($approval, $messages, $tools, $validatedApproval, $context);
 
             $allMessages = $resumption->messages;
 
@@ -255,7 +254,7 @@ class TextGenerationLoop
             $accumulatedUsage = $accumulatedUsage->add($result->usage);
             $finalReason = $result->finishReason;
 
-            [$toolResults, $pendingApprovals] = $this->stepToolResultsWithOptions($result, $stepContext->isFinalStep, $tools, $options);
+            [$toolResults, $pendingApprovals] = $this->stepToolResultsWithOptions($result, $stepContext->isFinalStep, $tools, $options, $context);
 
             foreach ($toolResults as $toolResult) {
                 $successful = ! $stepContext->isFinalStep && $this->findTool($toolResult->name, $tools) instanceof Tool;
@@ -325,14 +324,14 @@ class TextGenerationLoop
      * @param  array<Tool|ProviderTool>  $tools
      * @return array{array<int, ToolResult>, Collection<int, PendingApproval>}
      */
-    private function stepToolResultsWithOptions(StepResponse $result, bool $isFinalStep, array $tools, ?TextGenerationOptions $options): array
+    private function stepToolResultsWithOptions(StepResponse $result, bool $isFinalStep, array $tools, ?TextGenerationOptions $options, ?RunContext $context = null): array
     {
         $repairsToolCalls = $this->repairsToolCalls;
 
         $this->repairsToolCalls = RepairToolCalls::isAppliedTo($options?->agent);
 
         try {
-            return $this->stepToolResults($result, $isFinalStep, $tools);
+            return $this->stepToolResults($result, $isFinalStep, $tools, $context);
         } finally {
             $this->repairsToolCalls = $repairsToolCalls;
         }
@@ -344,7 +343,7 @@ class TextGenerationLoop
      * @param  array<Tool|ProviderTool>  $tools
      * @return array{array<int, ToolResult>, Collection<int, PendingApproval>}
      */
-    protected function stepToolResults(StepResponse $result, bool $isFinalStep, array $tools): array
+    protected function stepToolResults(StepResponse $result, bool $isFinalStep, array $tools, ?RunContext $context = null): array
     {
         if (filled($result->pendingApprovals)) {
             return [[], collect($result->pendingApprovals)];
@@ -354,7 +353,7 @@ class TextGenerationLoop
             return [[], collect()];
         }
 
-        return $this->approvalAwareToolResults($result->toolCalls, $tools, $isFinalStep);
+        return $this->approvalAwareToolResults($result->toolCalls, $tools, $isFinalStep, $context);
     }
 
     /**
@@ -362,7 +361,7 @@ class TextGenerationLoop
      * @param  array<Tool|ProviderTool>  $tools
      * @return array{array<int, ToolResult>, Collection<int, PendingApproval>}
      */
-    protected function approvalAwareToolResults(array $toolCalls, array $tools, bool $isFinalStep = false): array
+    protected function approvalAwareToolResults(array $toolCalls, array $tools, bool $isFinalStep = false, ?RunContext $context = null): array
     {
         $pendingApprovals = collect();
         $resolved = [];
@@ -390,7 +389,7 @@ class TextGenerationLoop
             $resolved[] = [$toolCall, $tool];
         }
 
-        $toolResults = array_map(function (array $pair) use ($tools, $isFinalStep) {
+        $toolResults = array_map(function (array $pair) use ($tools, $isFinalStep, $context) {
             [$toolCall, $tool] = $pair;
 
             return new ToolResult(
@@ -400,7 +399,7 @@ class TextGenerationLoop
                 match (true) {
                     ! $tool instanceof Tool && $this->repairsToolCalls => "Tool '{$toolCall->name}' does not exist. Available tools: {$this->availableToolNames($tools)}.",
                     $isFinalStep => 'The agent reached its maximum number of steps without running this tool call.',
-                    default => $this->executeTool($tool, $toolCall->arguments, $toolCall->id),
+                    default => $this->executeTool($tool, $toolCall->arguments, $toolCall->id, $context),
                 },
                 $toolCall->resultId,
             );
@@ -430,11 +429,11 @@ class TextGenerationLoop
      * @param  array<Tool|ProviderTool>  $tools
      * @param  array{Collection<int, ToolCall>, Collection<string, ?Tool>}|null  $validatedApproval  a caller's own eager validateApproval() result, reused instead of re-validating
      */
-    protected function resumeFromApproval(array $approval, array $messages, array $tools, ?array $validatedApproval = null): ApprovalResumption
+    protected function resumeFromApproval(array $approval, array $messages, array $tools, ?array $validatedApproval = null, ?RunContext $context = null): ApprovalResumption
     {
         $messages = $this->settleAbandonedToolCalls($messages, exceptLatestAssistantTurn: true);
 
-        [$approvalResults, $shouldContinue, $failedToolCallIds] = $this->resolveApprovalResults($approval, $messages, $tools, $validatedApproval);
+        [$approvalResults, $shouldContinue, $failedToolCallIds] = $this->resolveApprovalResults($approval, $messages, $tools, $validatedApproval, $context);
 
         $newMessages = [];
 
@@ -458,7 +457,7 @@ class TextGenerationLoop
      * @param  array{Collection<int, ToolCall>, Collection<string, ?Tool>}|null  $validatedApproval  a caller's own eager validateApproval() result, reused instead of re-validating
      * @return array{array<int, ToolResult>, bool, array<int, string>}
      */
-    protected function resolveApprovalResults(array $approval, array $messages, array $tools, ?array $validatedApproval = null): array
+    protected function resolveApprovalResults(array $approval, array $messages, array $tools, ?array $validatedApproval = null, ?RunContext $context = null): array
     {
         [$pendingToolCalls, $resolvedTools] = $validatedApproval ?? $this->validateApproval($approval, $messages, $tools);
 
@@ -494,7 +493,7 @@ class TextGenerationLoop
             }
 
             try {
-                $result = $this->executeTool($tool, $arguments, $toolCall->id);
+                $result = $this->executeTool($tool, $arguments, $toolCall->id, $context);
             } catch (Throwable $exception) {
                 $failedToolCallIds[] = $toolCall->id;
                 $result = 'The tool call failed: '.$exception->getMessage();

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -15,12 +15,11 @@ use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Events\AgentPrompted;
-use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\ToolApprovalRequested;
 use Laravel\Ai\Events\ToolApprovalResolved;
-use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Exceptions\ApprovalNotResumableException;
+use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Middleware\RememberConversation;
@@ -39,8 +38,6 @@ use function Laravel\Ai\pipeline;
 trait GeneratesText
 {
     use ResumesToolApprovals;
-
-    protected string $currentToolInvocationId;
 
     /**
      * Invoke the given agent.
@@ -70,8 +67,6 @@ trait GeneratesText
                     $messages[] = new UserMessage($prompt->prompt, $prompt->attachments->all());
                 }
 
-                $this->listenForToolInvocations($invocationId, $agent);
-
                 $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
 
                 $response = $this->textGenerationLoop()->generate(
@@ -85,6 +80,7 @@ trait GeneratesText
                     $prompt->timeout,
                     $this->resumableApprovalFor($prompt),
                     $this->approvalResultRecorderFor($prompt, $resolvedApprovalResults),
+                    $this->runContextFor($invocationId, $prompt),
                 );
 
                 if ($response->hasPendingApprovals()) {
@@ -188,24 +184,11 @@ trait GeneratesText
     }
 
     /**
-     * Listen for gateway tool invocations and dispatch events for the given agent when the tools are invoked.
+     * Build the context that identifies this run and reports its tool events.
      */
-    protected function listenForToolInvocations(string $invocationId, Agent $agent): void
+    protected function runContextFor(string $invocationId, AgentPrompt $prompt): RunContext
     {
-        $this->textGenerationLoop()->onToolInvocation(
-            invoking: function (Tool $tool, array $arguments) use ($invocationId, $agent): void {
-                $this->currentToolInvocationId = (string) Str::uuid7();
-
-                $this->events->dispatch(new InvokingTool(
-                    $invocationId, $this->currentToolInvocationId, $agent, $tool, $arguments
-                ));
-            },
-            invoked: function (Tool $tool, array $arguments, mixed $result) use ($invocationId, $agent): void {
-                $this->events->dispatch(new ToolInvoked(
-                    $invocationId, $this->currentToolInvocationId, $agent, $tool, $arguments, $result
-                ));
-            },
-        );
+        return new RunContext($invocationId, $prompt->agent, $this, $prompt->model, $this->events);
     }
 
     /**

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -70,8 +70,6 @@ trait StreamsText
                     function () use ($invocationId, $prompt, $agent, $messages, $tools, $approval, $recordApprovalResults, $validatedApproval) {
                         $this->events->dispatch(new StreamingAgent($invocationId, $prompt));
 
-                        $this->listenForToolInvocations($invocationId, $agent);
-
                         foreach ($this->textGenerationLoop()->stream(
                             $invocationId,
                             $this,
@@ -85,6 +83,7 @@ trait StreamsText
                             $approval,
                             $recordApprovalResults,
                             $validatedApproval,
+                            $this->runContextFor($invocationId, $prompt),
                         ) as $event) {
                             if ($event instanceof ToolApprovalRequest) {
                                 $this->throwIfNotResumable($agent);

--- a/src/Tools/Request.php
+++ b/src/Tools/Request.php
@@ -14,8 +14,11 @@ class Request implements Arrayable, ArrayAccess
     use InteractsWithData;
     use Macroable;
 
-    public function __construct(protected array $arguments = [], protected ?string $toolCallId = null)
-    {
+    public function __construct(
+        protected array $arguments = [],
+        protected ?string $toolCallId = null,
+        protected ?string $toolInvocationId = null,
+    ) {
         //
     }
 
@@ -25,6 +28,14 @@ class Request implements Arrayable, ArrayAccess
     public function toolCallId(): ?string
     {
         return $this->toolCallId;
+    }
+
+    /**
+     * Get the ID correlating this execution with the tool invocation events dispatched around it.
+     */
+    public function toolInvocationId(): ?string
+    {
+        return $this->toolInvocationId;
     }
 
     /**

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -4,9 +4,15 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Tools\AgentTool;
 use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\MiddleManagerAgent;
+use Tests\Fixtures\Agents\OrchestratorAgent;
+use Tests\Fixtures\Agents\ResearchAgent;
 
 test('a synchronous prompt threads one invocation id through the prompt and its events', function (): void {
     Event::fake();
@@ -81,4 +87,42 @@ test('a failed over run names the invocation it belongs to', function (): void {
     $response = (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']);
 
     Event::assertDispatched(AgentFailedOver::class, fn (AgentFailedOver $event): bool => $event->invocationId === $response->invocationId);
+});
+test('a nested sub agent sharing the parent provider instance does not overwrite the parent tool invocation id', function (): void {
+    Event::fake();
+
+    // Unfaked agents share one memoized provider, and therefore one generation loop, which is the case the tool invocation id has to survive...
+    config([
+        'ai.default' => 'shared',
+        'ai.providers.shared' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->pushResponse(fakeGroqToolCallResponse('middle_manager', ['task' => 'Deep-dive on Laravel caching'], 'call_001'))
+        ->pushResponse(fakeGroqToolCallResponse('research_agent', ['task' => 'Research Laravel caching internals'], 'call_002'))
+        ->pushResponse(fakeGroqResponse('Deep research result'))
+        ->pushResponse(fakeGroqResponse('Research delegated.'))
+        ->pushResponse(fakeGroqResponse('Delegated to middle manager.'));
+
+    (new OrchestratorAgent)->prompt('Do a deep dive on Laravel caching');
+
+    $invoking = Event::dispatched(InvokingTool::class)->map(fn (array $dispatched) => $dispatched[0]);
+    $invoked = Event::dispatched(ToolInvoked::class)->map(fn (array $dispatched) => $dispatched[0]);
+
+    expect($invoking)->toHaveCount(2)->and($invoked)->toHaveCount(2);
+
+    $delegatedTo = fn (string $agent): Closure => fn ($event): bool => $event->tool instanceof AgentTool
+        && $event->tool->agent() instanceof $agent;
+
+    foreach ([MiddleManagerAgent::class, ResearchAgent::class] as $agent) {
+        $start = $invoking->first($delegatedTo($agent));
+        $end = $invoked->first($delegatedTo($agent));
+
+        expect($end)->not->toBeNull()
+            ->and($end->toolInvocationId)->toBe($start->toolInvocationId);
+    }
+
+    expect($invoking->map(fn ($event): string => $event->toolInvocationId)->unique())->toHaveCount(2);
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -58,7 +58,7 @@ function fakeGroqResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
-function fakeGroqToolCallResponse(): PromiseInterface
+function fakeGroqToolCallResponse(string $name = 'FixedNumberGenerator', array $arguments = [], string $id = 'call_123'): PromiseInterface
 {
     return Http::response([
         'id' => 'chatcmpl-tool-123',
@@ -70,11 +70,11 @@ function fakeGroqToolCallResponse(): PromiseInterface
                 'role' => 'assistant',
                 'content' => null,
                 'tool_calls' => [[
-                    'id' => 'call_123',
+                    'id' => $id,
                     'type' => 'function',
                     'function' => [
-                        'name' => 'FixedNumberGenerator',
-                        'arguments' => '{}',
+                        'name' => $name,
+                        'arguments' => $arguments === [] ? '{}' : json_encode($arguments),
                     ],
                 ]],
             ],

--- a/tests/Unit/Gateway/Concerns/ResolvesToolNameTest.php
+++ b/tests/Unit/Gateway/Concerns/ResolvesToolNameTest.php
@@ -37,11 +37,6 @@ function resolverHost(): object
     {
         use InvokesTools;
 
-        public function __construct()
-        {
-            $this->initializeToolCallbacks();
-        }
-
         public function callResolve(Tool $tool): string
         {
             return ToolNameResolver::resolve($tool);

--- a/tests/Unit/Gateway/InvokesToolsTest.php
+++ b/tests/Unit/Gateway/InvokesToolsTest.php
@@ -1,25 +1,33 @@
 <?php
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Events\Dispatcher;
 use Illuminate\JsonSchema\Types\Type;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Tools\Request;
 
-test('tool invocation callbacks are restored after nested tool invocations', function (): void {
-    $events = [];
-
-    $gateway = new class
+function toolInvokingGateway(): object
+{
+    return new class
     {
         use InvokesTools;
 
-        public function invoke(Tool $tool, array $arguments = []): string
+        public function invoke(Tool $tool, array $arguments = [], ?RunContext $context = null): string
         {
-            return $this->executeTool($tool, $arguments);
+            return $this->executeTool($tool, $arguments, null, $context);
         }
     };
+}
 
-    $makeTool = fn (string $name, Closure $handler): Tool => new class($name, $handler) implements Tool
+function stubTool(string $name, Closure $handler): Tool
+{
+    return new class($name, $handler) implements Tool
     {
         public function __construct(
             protected string $name,
@@ -44,39 +52,52 @@ test('tool invocation callbacks are restored after nested tool invocations', fun
             return [];
         }
     };
+}
 
-    $gateway->onToolInvocation(
-        invoking: function (Tool $tool) use (&$events): void {
-            $events[] = 'parent invoking '.($tool->description());
-        },
-        invoked: function (Tool $tool, array $arguments, mixed $result) use (&$events): void {
-            $events[] = 'parent invoked '.($tool->description()).':'.$result;
-        },
+function stubRunContext(Dispatcher $events, string $invocationId = 'inv_1'): RunContext
+{
+    return new RunContext(
+        $invocationId,
+        Mockery::mock(Agent::class),
+        Mockery::mock(TextProvider::class),
+        'stub-model',
+        $events,
     );
+}
 
-    $nestedTool = $makeTool('nested', fn (): string => 'nested result');
+test('each tool invocation reports against the context it was given', function (): void {
+    $seen = [];
 
-    $delegatingTool = $makeTool('delegating', function () use ($gateway, $nestedTool, &$events): string {
-        $gateway->onToolInvocation(
-            invoking: function (Tool $tool) use (&$events): void {
-                $events[] = 'sub invoking '.($tool->description());
-            },
-            invoked: function (Tool $tool, array $arguments, mixed $result) use (&$events): void {
-                $events[] = 'sub invoked '.($tool->description()).':'.$result;
-            },
-        );
+    $context = function (string $label) use (&$seen): RunContext {
+        $events = new Dispatcher;
 
-        $gateway->invoke($nestedTool);
+        $events->listen(InvokingTool::class, function (InvokingTool $event) use (&$seen, $label): void {
+            $seen[] = $label.' invoking '.$event->tool->description();
+        });
+
+        $events->listen(ToolInvoked::class, function (ToolInvoked $event) use (&$seen, $label): void {
+            $seen[] = $label.' invoked '.$event->tool->description().':'.$event->result;
+        });
+
+        return stubRunContext($events);
+    };
+
+    $gateway = toolInvokingGateway();
+
+    $nestedTool = stubTool('nested', fn (): string => 'nested result');
+
+    $delegatingTool = stubTool('delegating', function () use ($gateway, $nestedTool, $context): string {
+        $gateway->invoke($nestedTool, context: $context('sub'));
 
         return 'delegated result';
     });
 
-    $siblingTool = $makeTool('sibling', fn (): string => 'sibling result');
+    $siblingTool = stubTool('sibling', fn (): string => 'sibling result');
 
-    $gateway->invoke($delegatingTool);
-    $gateway->invoke($siblingTool);
+    $gateway->invoke($delegatingTool, context: $context('parent'));
+    $gateway->invoke($siblingTool, context: $context('parent'));
 
-    expect($events)->toBe([
+    expect($seen)->toBe([
         'parent invoking delegating',
         'sub invoking nested',
         'sub invoked nested:nested result',
@@ -84,4 +105,35 @@ test('tool invocation callbacks are restored after nested tool invocations', fun
         'parent invoking sibling',
         'parent invoked sibling:sibling result',
     ]);
+});
+
+test('the invoking and invoked events share a tool invocation id', function (): void {
+    $ids = [];
+
+    $events = new Dispatcher;
+    $events->listen(InvokingTool::class, function (InvokingTool $event) use (&$ids): void {
+        $ids[] = $event->toolInvocationId;
+    });
+    $events->listen(ToolInvoked::class, function (ToolInvoked $event) use (&$ids): void {
+        $ids[] = $event->toolInvocationId;
+    });
+
+    toolInvokingGateway()->invoke(stubTool('paired', fn (): string => 'result'), context: stubRunContext($events));
+
+    expect($ids)->toHaveCount(2)
+        ->and($ids[0])->toBe($ids[1]);
+});
+
+test('a tool invocation without a run context is silent', function (): void {
+    $gateway = new class
+    {
+        use InvokesTools;
+
+        public function invoke(Tool $tool): string
+        {
+            return $this->executeTool($tool, []);
+        }
+    };
+
+    expect($gateway->invoke(stubTool('unobserved', fn (): string => 'result')))->toBe('result');
 });

--- a/tests/Unit/Gateway/TextGenerationLoopTest.php
+++ b/tests/Unit/Gateway/TextGenerationLoopTest.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Exceptions\NoSuchToolException;
 use Laravel\Ai\Exceptions\StreamErrorException;
+use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationLoop;
@@ -1202,14 +1203,14 @@ class TextGenerationLoopAgent implements Agent
 
 class ExtendedTextGenerationLoop extends TextGenerationLoop
 {
-    protected function stepToolResults(StepResponse $result, bool $isFinalStep, array $tools): array
+    protected function stepToolResults(StepResponse $result, bool $isFinalStep, array $tools, ?RunContext $context = null): array
     {
-        return parent::stepToolResults($result, $isFinalStep, $tools);
+        return parent::stepToolResults($result, $isFinalStep, $tools, $context);
     }
 
-    protected function approvalAwareToolResults(array $toolCalls, array $tools, bool $isFinalStep = false): array
+    protected function approvalAwareToolResults(array $toolCalls, array $tools, bool $isFinalStep = false, ?RunContext $context = null): array
     {
-        return parent::approvalAwareToolResults($toolCalls, $tools, $isFinalStep);
+        return parent::approvalAwareToolResults($toolCalls, $tools, $isFinalStep, $context);
     }
 }
 


### PR DESCRIPTION
Part of the #848 stack. Base: #871. Net-negative refactor — **no new events**, behaviour identical.

The gateway reported tool invocations by having each provider register a pair of callbacks on the generation loop, which the loop then had to snapshot and restore around every call so a sub-agent invoked as a tool could not clobber its parent’s. The provider also tracked the current tool invocation id in a single mutable property, and the same nesting broke it: because `AiManager` returns one provider instance per name and `textGenerationLoop()` is memoized on it, an inner invocation overwrote the id before the outer `ToolInvoked` fired — so the outer end-event carried the inner’s id.

A `RunContext` carries the run’s identity and dispatches its events directly. That deletes `onToolInvocation()`, the callback stack, the push/pop helpers, and the mutable id. The id is now minted inside `executeTool()`, so each invocation owns its own by construction rather than by bookkeeping.

The context is nullable because `RememberConversation::generateTitle()` drives the loop directly, and that generation is not part of the run that triggered it.

Tools can now read the id via `Request::toolInvocationId()`.

This is the plumbing the next two PRs hang events on.