### PR TITLE
Report each generation step through the run context

### DIFF
--- a/src/Events/StartingStep.php
+++ b/src/Events/StartingStep.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\Message;
+
+class StartingStep
+{
+    /**
+     * @param  string  $model  the model the step is requested against, which the responding model reported on the completed step may differ from
+     * @param  Message[]  $messages  the messages being sent for this step, including the tool results of the steps before it
+     * @param  TextGenerationOptions|null  $options  the options resolved for this step, which may differ from the agent's own once a forced tool choice has been satisfied
+     */
+    public function __construct(
+        public string $invocationId,
+        public int $stepNumber,
+        public Agent $agent,
+        public TextProvider $provider,
+        public string $model,
+        public bool $isFinalStep,
+        public array $messages,
+        public ?TextGenerationOptions $options,
+    ) {}
+}

--- a/src/Events/StartingStep.php
+++ b/src/Events/StartingStep.php
@@ -10,9 +10,9 @@ use Laravel\Ai\Messages\Message;
 class StartingStep
 {
     /**
-     * @param  string  $model  the model the step is requested against, which the responding model reported on the completed step may differ from
-     * @param  Message[]  $messages  the messages being sent for this step, including the tool results of the steps before it
-     * @param  TextGenerationOptions|null  $options  the options resolved for this step, which may differ from the agent's own once a forced tool choice has been satisfied
+     * @param  string  $model  The model the step is requested against, which the responding model reported on the completed step may differ from.
+     * @param  Message[]  $messages  The messages being sent for this step, including the tool results of the steps before it.
+     * @param  TextGenerationOptions|null  $options  The options resolved for this step, which may differ from the agent's own once a forced tool choice has been satisfied.
      */
     public function __construct(
         public string $invocationId,

--- a/src/Events/StepCompleted.php
+++ b/src/Events/StepCompleted.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\StepResponse;
+
+class StepCompleted
+{
+    /**
+     * @param  string  $model  the model the step was requested against, which the responding model reported in $response->meta may differ from
+     * @param  float  $time  wall time spent in the provider call, in milliseconds
+     */
+    public function __construct(
+        public string $invocationId,
+        public int $stepNumber,
+        public Agent $agent,
+        public TextProvider $provider,
+        public string $model,
+        public bool $isFinalStep,
+        public StepResponse $response,
+        public float $time,
+    ) {}
+}

--- a/src/Events/StepCompleted.php
+++ b/src/Events/StepCompleted.php
@@ -9,8 +9,8 @@ use Laravel\Ai\Gateway\StepResponse;
 class StepCompleted
 {
     /**
-     * @param  string  $model  the model the step was requested against, which the responding model reported in $response->meta may differ from
-     * @param  float  $time  wall time spent in the provider call, in milliseconds
+     * @param  string  $model  The model the step was requested against, which the responding model reported in $response->meta may differ from.
+     * @param  float  $time  Wall time spent in the provider call, in milliseconds.
      */
     public function __construct(
         public string $invocationId,

--- a/src/Events/StepFailed.php
+++ b/src/Events/StepFailed.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Throwable;
+
+class StepFailed
+{
+    /**
+     * @param  Throwable  $exception  a StreamErrorException carries the provider's own error event on ->error
+     * @param  float  $time  wall time spent in the provider call before it failed, in milliseconds
+     */
+    public function __construct(
+        public string $invocationId,
+        public int $stepNumber,
+        public Agent $agent,
+        public TextProvider $provider,
+        public string $model,
+        public bool $isFinalStep,
+        public Throwable $exception,
+        public float $time,
+    ) {}
+}

--- a/src/Events/StepFailed.php
+++ b/src/Events/StepFailed.php
@@ -9,8 +9,8 @@ use Throwable;
 class StepFailed
 {
     /**
-     * @param  Throwable  $exception  a StreamErrorException carries the provider's own error event on ->error
-     * @param  float  $time  wall time spent in the provider call before it failed, in milliseconds
+     * @param  Throwable  $exception  A StreamErrorException carries the provider's own error event on ->error.
+     * @param  float  $time  Wall time spent in the provider call before it failed, in milliseconds.
      */
     public function __construct(
         public string $invocationId,

--- a/src/Gateway/Concerns/MeasuresDuration.php
+++ b/src/Gateway/Concerns/MeasuresDuration.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+trait MeasuresDuration
+{
+    /**
+     * Get the milliseconds elapsed since the given monotonic nanosecond reading.
+     */
+    protected function elapsedMilliseconds(int $startedAt): float
+    {
+        return (hrtime(true) - $startedAt) / 1e6;
+    }
+}

--- a/src/Gateway/RunContext.php
+++ b/src/Gateway/RunContext.php
@@ -7,7 +7,12 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\StartingStep;
+use Laravel\Ai\Events\StepCompleted;
+use Laravel\Ai\Events\StepFailed;
 use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Messages\Message;
+use Throwable;
 
 class RunContext
 {
@@ -18,6 +23,41 @@ class RunContext
         public readonly string $model,
         protected readonly Dispatcher $events,
     ) {}
+
+    /**
+     * Report that a generation step is about to start.
+     *
+     * @param  Message[]  $messages
+     */
+    public function startingStep(StepContext $step, array $messages, ?TextGenerationOptions $options): void
+    {
+        $this->events->dispatch(new StartingStep(
+            $this->invocationId, $step->stepNumber, $this->agent, $this->provider, $this->model, $step->isFinalStep,
+            $messages, $options,
+        ));
+    }
+
+    /**
+     * Report that a generation step returned a response.
+     */
+    public function stepCompleted(StepContext $step, StepResponse $response, float $time): void
+    {
+        $this->events->dispatch(new StepCompleted(
+            $this->invocationId, $step->stepNumber, $this->agent, $this->provider, $this->model, $step->isFinalStep,
+            $response, $time,
+        ));
+    }
+
+    /**
+     * Report that a generation step ended without producing a response.
+     */
+    public function stepFailed(StepContext $step, Throwable $exception, float $time): void
+    {
+        $this->events->dispatch(new StepFailed(
+            $this->invocationId, $step->stepNumber, $this->agent, $this->provider, $this->model, $step->isFinalStep,
+            $exception, $time,
+        ));
+    }
 
     /**
      * Report that a tool is about to be invoked.

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -20,6 +20,7 @@ use Laravel\Ai\Exceptions\NoSuchToolException;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Gateway\Concerns\HandlesToolApprovals;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\Concerns\MeasuresDuration;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -44,7 +45,7 @@ use Throwable;
 
 class TextGenerationLoop
 {
-    use HandlesToolApprovals, InvokesTools;
+    use HandlesToolApprovals, InvokesTools, MeasuresDuration;
 
     private bool $repairsToolCalls = false;
 
@@ -109,17 +110,31 @@ class TextGenerationLoop
                 continuationToken: $continuationToken,
             );
 
-            $lastResult = $this->gateway->generateTextStep(
-                $provider,
-                $model,
-                $instructions,
-                $allMessages,
-                $tools,
-                $schema,
-                $options?->forStep($step),
-                $timeout,
-                $stepContext,
-            );
+            $stepOptions = $options?->forStep($step);
+
+            $context?->startingStep($stepContext, $allMessages, $stepOptions);
+
+            $startedAt = hrtime(true);
+
+            try {
+                $lastResult = $this->gateway->generateTextStep(
+                    $provider,
+                    $model,
+                    $instructions,
+                    $allMessages,
+                    $tools,
+                    $schema,
+                    $stepOptions,
+                    $timeout,
+                    $stepContext,
+                );
+            } catch (Throwable $exception) {
+                $context?->stepFailed($stepContext, $exception, $this->elapsedMilliseconds($startedAt));
+
+                throw $exception;
+            }
+
+            $context?->stepCompleted($stepContext, $lastResult, $this->elapsedMilliseconds($startedAt));
 
             [$toolResults, $pendingApprovals] = $this->stepToolResultsWithOptions($lastResult, $stepContext->isFinalStep, $tools, $options, $context);
 
@@ -221,35 +236,52 @@ class TextGenerationLoop
                 continuationToken: $continuationToken,
             );
 
-            $stream = $this->gateway->generateStreamStep(
-                $invocationId,
-                $provider,
-                $model,
-                $instructions,
-                $allMessages,
-                $tools,
-                $schema,
-                $options?->forStep($step),
-                $timeout,
-                $stepContext,
-            );
+            $stepOptions = $options?->forStep($step);
+
+            $context?->startingStep($stepContext, $allMessages, $stepOptions);
 
             $lastError = null;
+            $startedAt = hrtime(true);
 
-            foreach ($stream as $event) {
-                yield $event;
+            try {
+                $stream = $this->gateway->generateStreamStep(
+                    $invocationId,
+                    $provider,
+                    $model,
+                    $instructions,
+                    $allMessages,
+                    $tools,
+                    $schema,
+                    $stepOptions,
+                    $timeout,
+                    $stepContext,
+                );
 
-                if ($event instanceof Error) {
-                    $lastError = $event;
+                foreach ($stream as $event) {
+                    yield $event;
+
+                    if ($event instanceof Error) {
+                        $lastError = $event;
+                    }
                 }
-            }
 
-            $result = $stream->getReturn();
+                $result = $stream->getReturn();
+            } catch (Throwable $exception) {
+                $context?->stepFailed($stepContext, $exception, $this->elapsedMilliseconds($startedAt));
+
+                throw $exception;
+            }
 
             // A provider may report an error in the stream itself rather than throwing, which still ends the step. The error event travels on the exception so its type and metadata are not lost...
             if (! $result instanceof StepResponse) {
-                throw new StreamErrorException($lastError);
+                $exception = new StreamErrorException($lastError);
+
+                $context?->stepFailed($stepContext, $exception, $this->elapsedMilliseconds($startedAt));
+
+                throw $exception;
             }
+
+            $context?->stepCompleted($stepContext, $result, $this->elapsedMilliseconds($startedAt));
 
             $accumulatedUsage = $accumulatedUsage->add($result->usage);
             $finalReason = $result->finishReason;

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -2,17 +2,33 @@
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\StartingStep;
+use Laravel\Ai\Events\StepCompleted;
+use Laravel\Ai\Events\StepFailed;
 use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Exceptions\StreamErrorException;
+use Laravel\Ai\Gateway\StepResponse;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Tools\AgentTool;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\MiddleManagerAgent;
+use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\OrchestratorAgent;
+use Tests\Fixtures\Agents\RememberingAssistantAgent;
 use Tests\Fixtures\Agents\ResearchAgent;
+use Tests\Fixtures\FakeConversationStore;
 
 test('a synchronous prompt threads one invocation id through the prompt and its events', function (): void {
     Event::fake();
@@ -125,4 +141,219 @@ test('a nested sub agent sharing the parent provider instance does not overwrite
     }
 
     expect($invoking->map(fn ($event): string => $event->toolInvocationId)->unique())->toHaveCount(2);
+});
+
+test('step events are dispatched for each step of a tool calling run', function (): void {
+    Event::fake();
+
+    MultiStepToolAgent::fake([
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+        'The number is 72019.',
+    ]);
+
+    $response = (new MultiStepToolAgent)->prompt('Generate a number');
+
+    Event::assertDispatchedTimes(StartingStep::class, 2);
+    Event::assertDispatchedTimes(StepCompleted::class, 2);
+
+    Event::assertDispatched(StartingStep::class, fn (StartingStep $event): bool => $event->invocationId === $response->invocationId
+        && $event->stepNumber === 0
+        && $event->isFinalStep === false
+        && $event->model !== '');
+
+    Event::assertDispatched(StepCompleted::class, fn (StepCompleted $event): bool => $event->invocationId === $response->invocationId
+        && $event->stepNumber === 0
+        && $event->response->finishReason === FinishReason::ToolCalls
+        && count($event->response->toolCalls) === 1);
+
+    Event::assertDispatched(StepCompleted::class, fn (StepCompleted $event): bool => $event->stepNumber === 1
+        && $event->response->finishReason === FinishReason::Stop
+        && $event->response->toolCalls === []);
+});
+
+test('step completed carries the whole step response', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake(['Hello!']);
+
+    (new AssistantAgent)->prompt('Hi');
+
+    $completed = Event::dispatched(StepCompleted::class)->first()[0];
+
+    // The response travels whole so a consumer can record the text and usage of a step, not only that it finished...
+    expect($completed->response)->toBeInstanceOf(StepResponse::class)
+        ->and($completed->response->text)->toBe('Hello!')
+        ->and($completed->response->meta->model)->not->toBeEmpty()
+        ->and($completed->response->meta->provider)->not->toBeEmpty()
+        ->and($completed->response->usage)->toBeInstanceOf(Usage::class);
+});
+
+test('starting step carries the messages and options the step is sent with', function (): void {
+    Event::fake();
+
+    MultiStepToolAgent::fake([
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+        'The number is 72019.',
+    ]);
+
+    (new MultiStepToolAgent)->prompt('Generate a number');
+
+    [$first, $second] = Event::dispatched(StartingStep::class)->map(fn (array $dispatched): StartingStep => $dispatched[0])->all();
+
+    expect($first->messages)->toHaveCount(1)
+        ->and($first->messages[0])->toBeInstanceOf(UserMessage::class)
+        ->and($first->options)->toBeInstanceOf(TextGenerationOptions::class);
+
+    // The second step is sent the assistant turn and the tool result the first step produced...
+    expect($second->messages)->toHaveCount(3)
+        ->and($second->messages[2])->toBeInstanceOf(ToolResultMessage::class);
+});
+
+test('conversation title generation does not report steps against the run that triggered it', function (): void {
+    app()->instance(ConversationStore::class, new FakeConversationStore);
+
+    Event::fake();
+
+    RememberingAssistantAgent::fake(['Fake response', 'A Nice Title']);
+
+    $user = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)->forUser($user)->prompt('Test prompt');
+
+    // Title generation runs its own loop on the same provider, and must not be attributed to this run...
+    Event::assertDispatchedTimes(StartingStep::class, 1);
+    Event::assertDispatchedTimes(StepCompleted::class, 1);
+
+    Event::assertDispatched(StartingStep::class, fn (StartingStep $event): bool => $event->invocationId === $response->invocationId
+        && $event->stepNumber === 0);
+});
+
+test('step events are dispatched on the streaming path', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake(['Hello!']);
+
+    $response = (new AssistantAgent)->stream('Hi');
+
+    foreach ($response as $event) {
+        //
+    }
+
+    Event::assertDispatchedTimes(StartingStep::class, 1);
+
+    Event::assertDispatched(StepCompleted::class, fn (StepCompleted $event): bool => $event->invocationId === $response->invocationId
+        && $event->stepNumber === 0
+        && $event->response->finishReason === FinishReason::Stop);
+});
+
+test('a step that throws carries no stream error', function (): void {
+    Event::fake();
+
+    config(['ai.providers.only' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->push(status: 429);
+
+    expect(fn (): mixed => (new AssistantAgent)->prompt('Hi', provider: 'only'))
+        ->toThrow(RateLimitedException::class);
+
+    $failed = Event::dispatched(StepFailed::class)->first()[0];
+
+    expect($failed->exception)->toBeInstanceOf(RateLimitedException::class)
+        ->and($failed->exception)->not->toBeInstanceOf(StreamErrorException::class);
+});
+
+test('step events carry the agent that ran them', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake(['Hello!']);
+
+    $agent = new AssistantAgent;
+
+    $agent->prompt('Hi');
+
+    $starting = Event::dispatched(StartingStep::class)->first()[0];
+    $completed = Event::dispatched(StepCompleted::class)->first()[0];
+
+    expect($starting->agent)->toBe($agent)
+        ->and($completed->agent)->toBe($agent)
+        ->and($starting->model)->not->toBeEmpty();
+});
+
+test('a failed step identifies the provider and model that failed it', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->pushResponse(fakeGroqResponse('Hello from the backup.'));
+
+    (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']);
+
+    $starting = Event::dispatched(StartingStep::class)->first()[0];
+    $failed = Event::dispatched(StepFailed::class)->first()[0];
+
+    // Failover attempts share an invocation id and both restart at step zero, so the step events must name their own provider...
+    expect($failed->agent)->toBeInstanceOf(AssistantAgent::class)
+        ->and($failed->provider)->toBe($starting->provider)
+        ->and($failed->model)->toBe($starting->model);
+});
+
+test('every step event names the provider and model the step ran against', function (): void {
+    Event::fake();
+
+    MultiStepToolAgent::fake([
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+        'The number is 72019.',
+    ]);
+
+    (new MultiStepToolAgent)->prompt('Generate a number');
+
+    $starting = Event::dispatched(StartingStep::class)->first()[0];
+    $completed = Event::dispatched(StepCompleted::class)->first()[0];
+
+    // A consumer builds a span from whichever event it sees, so the identity is read the same way on all of them...
+    expect($completed->provider)->toBe($starting->provider)
+        ->and($completed->model)->toBe($starting->model)
+        ->and($completed->isFinalStep)->toBe($starting->isFinalStep)
+        ->and($completed->agent)->toBe($starting->agent);
+});
+
+test('step completed carries the wall time spent in the provider call', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake(['Hello!']);
+
+    (new AssistantAgent)->prompt('Hi');
+
+    $completed = Event::dispatched(StepCompleted::class)->first()[0];
+
+    expect($completed->time)->toBeFloat()->toBeGreaterThan(0.0);
+});
+
+test('step failed carries the wall time spent before the failure', function (): void {
+    Event::fake();
+
+    config(['ai.providers.only' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->push(status: 429);
+
+    expect(fn (): mixed => (new AssistantAgent)->prompt('Hi', provider: 'only'))
+        ->toThrow(RateLimitedException::class);
+
+    $failed = Event::dispatched(StepFailed::class)->first()[0];
+
+    expect($failed->time)->toBeFloat()->toBeGreaterThan(0.0);
 });

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -58,6 +58,34 @@ function fakeGroqResponse(string $text = 'Hello'): PromiseInterface
     ]);
 }
 
+function fakeGroqStreamResponse(string $text = 'Hello'): PromiseInterface
+{
+    $chunk = fn (array|object $delta, ?string $finishReason = null): array => [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion.chunk',
+        'model' => 'openai/gpt-oss-20b',
+        'choices' => [['index' => 0, 'delta' => $delta, 'finish_reason' => $finishReason]],
+    ];
+
+    $body = implode("\n\n", [
+        'data: '.json_encode($chunk(['role' => 'assistant', 'content' => $text])),
+        'data: '.json_encode($chunk((object) [], 'stop')),
+        'data: [DONE]',
+    ])."\n\n";
+
+    return Http::response($body, 200, ['Content-Type' => 'text/event-stream']);
+}
+
+function fakeGroqStreamErrorResponse(string $message = 'Upstream exploded.'): PromiseInterface
+{
+    $body = implode("\n\n", [
+        'data: '.json_encode(['error' => ['code' => 'server_error', 'message' => $message]]),
+        'data: [DONE]',
+    ])."\n\n";
+
+    return Http::response($body, 200, ['Content-Type' => 'text/event-stream']);
+}
+
 function fakeGroqToolCallResponse(string $name = 'FixedNumberGenerator', array $arguments = [], string $id = 'call_123'): PromiseInterface
 {
     return Http::response([


### PR DESCRIPTION
Part of the #848 stack. Base: #872. Purely additive.

`PromptingAgent` → `AgentPrompted` is a single flat pair, so a run that took five provider round-trips to resolve its tool calls looked exactly like a run that took one. Per-step `Usage` already existed on `AgentResponse->steps`, but only as a bulk payload on the terminal event and with no timing at all.

The loop now reports `StartingStep`, `StepCompleted`, and `StepFailed` around every round-trip on both the synchronous and streaming paths. `StartingStep` carries the messages and resolved options the step is sent with; `StepCompleted` carries the whole step response — so a listener never has to reconstruct either. Each end event carries the step’s wall time in milliseconds, matching `QueryExecuted::$time`.

### Note for queued listeners

`StartingStep` carries the run’s whole message history, so a `ShouldQueue` listener will serialize it along with any attachments. That is the intended trade — a listener that opens a span needs the request that step was sent with — but it is worth knowing before queueing one.