### PR TITLE
Report tool failures and how long a tool ran

### DIFF
--- a/src/Events/ToolFailed.php
+++ b/src/Events/ToolFailed.php
@@ -10,7 +10,7 @@ class ToolFailed
 {
     /**
      * @param  array<string, mixed>  $arguments
-     * @param  float  $time  wall time spent in the tool's handler before it threw, in milliseconds
+     * @param  float  $time  Wall time spent in the tool's handler before it threw, in milliseconds.
      */
     public function __construct(
         public string $invocationId,

--- a/src/Events/ToolFailed.php
+++ b/src/Events/ToolFailed.php
@@ -4,12 +4,13 @@ namespace Laravel\Ai\Events;
 
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Tool;
+use Throwable;
 
-class ToolInvoked
+class ToolFailed
 {
     /**
      * @param  array<string, mixed>  $arguments
-     * @param  float  $time  wall time spent in the tool's handler, in milliseconds
+     * @param  float  $time  wall time spent in the tool's handler before it threw, in milliseconds
      */
     public function __construct(
         public string $invocationId,
@@ -17,7 +18,7 @@ class ToolInvoked
         public Agent $agent,
         public Tool $tool,
         public array $arguments,
-        public mixed $result,
+        public Throwable $exception,
         public float $time,
     ) {}
 }

--- a/src/Events/ToolInvoked.php
+++ b/src/Events/ToolInvoked.php
@@ -9,7 +9,7 @@ class ToolInvoked
 {
     /**
      * @param  array<string, mixed>  $arguments
-     * @param  float  $time  wall time spent in the tool's handler, in milliseconds
+     * @param  float  $time  Wall time spent in the tool's handler, in milliseconds.
      */
     public function __construct(
         public string $invocationId,

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -8,9 +8,12 @@ use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Laravel\Ai\Tools\Request;
 use Laravel\Ai\Tools\ToolNameResolver;
+use Throwable;
 
 trait InvokesTools
 {
+    use MeasuresDuration;
+
     /**
      * Execute the given tool with the given arguments.
      *
@@ -22,9 +25,18 @@ trait InvokesTools
 
         $context?->invokingTool($tool, $arguments, $toolInvocationId);
 
-        $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
+        $startedAt = hrtime(true);
 
-        $context?->toolInvoked($tool, $arguments, $result, $toolInvocationId);
+        // Only the handler itself may fail the tool call, so a listener that throws is never reported as a tool failure...
+        try {
+            $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
+        } catch (Throwable $exception) {
+            $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
+
+            throw $exception;
+        }
+
+        $context?->toolInvoked($tool, $arguments, $result, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 
         return (string) $result;
     }

--- a/src/Gateway/RunContext.php
+++ b/src/Gateway/RunContext.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\StartingStep;
 use Laravel\Ai\Events\StepCompleted;
 use Laravel\Ai\Events\StepFailed;
+use Laravel\Ai\Events\ToolFailed;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Messages\Message;
 use Throwable;
@@ -76,10 +77,22 @@ class RunContext
      *
      * @param  array<string, mixed>  $arguments
      */
-    public function toolInvoked(Tool $tool, array $arguments, mixed $result, string $toolInvocationId): void
+    public function toolInvoked(Tool $tool, array $arguments, mixed $result, string $toolInvocationId, float $time): void
     {
         $this->events->dispatch(new ToolInvoked(
-            $this->invocationId, $toolInvocationId, $this->agent, $tool, $arguments, $result,
+            $this->invocationId, $toolInvocationId, $this->agent, $tool, $arguments, $result, $time,
+        ));
+    }
+
+    /**
+     * Report that a tool's handler threw.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    public function toolFailed(Tool $tool, array $arguments, Throwable $exception, string $toolInvocationId, float $time): void
+    {
+        $this->events->dispatch(new ToolFailed(
+            $this->invocationId, $toolInvocationId, $this->agent, $tool, $arguments, $exception, $time,
         ));
     }
 }

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentPrompted;
@@ -10,6 +12,7 @@ use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\StartingStep;
 use Laravel\Ai\Events\StepCompleted;
 use Laravel\Ai\Events\StepFailed;
+use Laravel\Ai\Events\ToolFailed;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Exceptions\StreamErrorException;
@@ -27,8 +30,11 @@ use Tests\Fixtures\Agents\MiddleManagerAgent;
 use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\OrchestratorAgent;
 use Tests\Fixtures\Agents\RememberingAssistantAgent;
+use Tests\Fixtures\Agents\RememberingThrowingApprovableAgent;
 use Tests\Fixtures\Agents\ResearchAgent;
+use Tests\Fixtures\Agents\ToolUsingAgent;
 use Tests\Fixtures\FakeConversationStore;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
 
 test('a synchronous prompt threads one invocation id through the prompt and its events', function (): void {
     Event::fake();
@@ -356,4 +362,98 @@ test('step failed carries the wall time spent before the failure', function (): 
     $failed = Event::dispatched(StepFailed::class)->first()[0];
 
     expect($failed->time)->toBeFloat()->toBeGreaterThan(0.0);
+});
+
+test('a throwing tool dispatches tool failed and still propagates the exception', function (): void {
+    Event::fake();
+
+    ToolUsingAgent::fake([
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+        ['number' => 5],
+    ]);
+
+    expect(fn (): mixed => (new ToolUsingAgent(fixed: true, toolThrowsException: true))->prompt('Generate'))
+        ->toThrow(Exception::class, 'Forced to throw exception.');
+
+    Event::assertDispatched(ToolFailed::class, fn (ToolFailed $event): bool => $event->tool instanceof FixedNumberGenerator
+        && $event->exception->getMessage() === 'Forced to throw exception.');
+
+    Event::assertNotDispatched(ToolInvoked::class);
+
+    $invoking = Event::dispatched(InvokingTool::class)->first()[0];
+    $failed = Event::dispatched(ToolFailed::class)->first()[0];
+
+    expect($failed->toolInvocationId)->toBe($invoking->toolInvocationId)
+        ->and($failed->invocationId)->toBe($invoking->invocationId);
+});
+
+test('a tool that fails while resuming an approval reports the failure once and continues the run', function (): void {
+    Event::fake();
+
+    Config::set('ai.conversations.generate_title', false);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'msg_tool_1',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [[
+                    'type' => 'tool_use',
+                    'id' => 'toolu_1',
+                    'name' => 'ThrowingApprovableGenerator',
+                    'input' => (object) [],
+                ]],
+                'stop_reason' => 'tool_use',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            Http::response([
+                'id' => 'msg_2',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [['type' => 'text', 'text' => 'The tool could not run.']],
+                'stop_reason' => 'end_turn',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingThrowingApprovableAgent)->forUser($user)->prompt('Generate a number', provider: 'anthropic');
+
+    expect($paused->hasPendingApprovals())->toBeTrue();
+
+    $resumed = (new RememberingThrowingApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_1' => true]), provider: 'anthropic');
+
+    // The resume path turns the failure into a tool result, so the run survives but still reports the failure exactly once...
+    Event::assertDispatchedTimes(ToolFailed::class, 1);
+    Event::assertNotDispatched(ToolInvoked::class);
+
+    expect($resumed->text)->toBe('The tool could not run.');
+
+    $failed = Event::dispatched(ToolFailed::class)->first()[0];
+    $invoking = Event::dispatched(InvokingTool::class)->first()[0];
+
+    expect($failed->exception->getMessage())->toBe('Forced to throw exception.')
+        ->and($failed->toolInvocationId)->toBe($invoking->toolInvocationId);
+});
+
+test('tool events carry the wall time spent in the tool', function (): void {
+    Event::fake();
+
+    MultiStepToolAgent::fake([
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+        'The number is 72019.',
+    ]);
+
+    (new MultiStepToolAgent)->prompt('Generate a number');
+
+    $invoked = Event::dispatched(ToolInvoked::class)->first()[0];
+
+    expect($invoked->time)->toBeFloat()->toBeGreaterThan(0.0);
 });

--- a/tests/Fixtures/Agents/RememberingThrowingApprovableAgent.php
+++ b/tests/Fixtures/Agents/RememberingThrowingApprovableAgent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\ThrowingApprovableGenerator;
+
+class RememberingThrowingApprovableAgent implements Agent, Conversational, HasTools
+{
+    use Promptable;
+    use RemembersConversations;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that always uses the available tool to generate a number.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     */
+    public function tools(): iterable
+    {
+        return [new ThrowingApprovableGenerator];
+    }
+}

--- a/tests/Fixtures/Tools/ThrowingApprovableGenerator.php
+++ b/tests/Fixtures/Tools/ThrowingApprovableGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Concerns\InteractsWithApprovals;
+use Laravel\Ai\Contracts\Approvable;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+
+class ThrowingApprovableGenerator implements Approvable, Tool
+{
+    use InteractsWithApprovals;
+
+    public function description(): string
+    {
+        return 'Generates a number, but requires human approval first and always fails.';
+    }
+
+    public function handle(Request $request): string
+    {
+        throw new \Exception('Forced to throw exception.');
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Gateway/InvokesToolsTest.php
+++ b/tests/Unit/Gateway/InvokesToolsTest.php
@@ -7,6 +7,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolFailed;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\RunContext;
@@ -39,7 +40,7 @@ function stubTool(string $name, Closure $handler): Tool
             return $this->name;
         }
 
-        public function handle(Request $request): string
+        public function handle(Request $request): Stringable|string
         {
             return call_user_func($this->handler, $request);
         }
@@ -122,6 +123,93 @@ test('the invoking and invoked events share a tool invocation id', function (): 
 
     expect($ids)->toHaveCount(2)
         ->and($ids[0])->toBe($ids[1]);
+});
+
+test('only the tool handler itself can fail a tool invocation', function (): void {
+    $invoked = 0;
+    $failed = 0;
+
+    $events = new Dispatcher;
+    $events->listen(ToolInvoked::class, function () use (&$invoked): void {
+        $invoked++;
+    });
+    $events->listen(ToolFailed::class, function () use (&$failed): void {
+        $failed++;
+    });
+
+    $tool = stubTool('unstringable', fn (): Stringable => new class implements Stringable
+    {
+        public function __toString(): string
+        {
+            throw new RuntimeException('Stringify exploded.');
+        }
+    });
+
+    expect(fn (): string => toolInvokingGateway()->invoke($tool, context: stubRunContext($events)))
+        ->toThrow(RuntimeException::class, 'Stringify exploded.');
+
+    // The handler succeeded, so the invocation is reported once and never as a failure...
+    expect($invoked)->toBe(1)
+        ->and($failed)->toBe(0);
+});
+
+test('a listener that throws is not reported as a tool failure', function (): void {
+    $failed = 0;
+
+    $events = new Dispatcher;
+    $events->listen(ToolInvoked::class, function (): void {
+        throw new RuntimeException('Listener exploded.');
+    });
+    $events->listen(ToolFailed::class, function () use (&$failed): void {
+        $failed++;
+    });
+
+    $tool = stubTool('fine', fn (): string => 'result');
+
+    expect(fn (): string => toolInvokingGateway()->invoke($tool, context: stubRunContext($events)))
+        ->toThrow(RuntimeException::class, 'Listener exploded.');
+
+    expect($failed)->toBe(0);
+});
+
+test('a failing tool handler is reported as a tool failure and rethrown', function (): void {
+    $failure = null;
+
+    $events = new Dispatcher;
+    $events->listen(ToolFailed::class, function (ToolFailed $event) use (&$failure): void {
+        $failure = $event;
+    });
+
+    $tool = stubTool('exploding', function (): string {
+        throw new RuntimeException('Handler exploded.');
+    });
+
+    expect(fn (): string => toolInvokingGateway()->invoke($tool, ['a' => 1], stubRunContext($events)))
+        ->toThrow(RuntimeException::class, 'Handler exploded.');
+
+    expect($failure)->toBeInstanceOf(ToolFailed::class)
+        ->and($failure->invocationId)->toBe('inv_1')
+        ->and($failure->arguments)->toBe(['a' => 1])
+        ->and($failure->exception->getMessage())->toBe('Handler exploded.');
+});
+
+test('tool events carry the wall time spent in the handler', function (): void {
+    $invoked = null;
+
+    $events = new Dispatcher;
+    $events->listen(ToolInvoked::class, function (ToolInvoked $event) use (&$invoked): void {
+        $invoked = $event;
+    });
+
+    $tool = stubTool('slow', function (): string {
+        usleep(2000);
+
+        return 'result';
+    });
+
+    toolInvokingGateway()->invoke($tool, context: stubRunContext($events));
+
+    expect($invoked->time)->toBeFloat()->toBeGreaterThan(1.0);
 });
 
 test('a tool invocation without a run context is silent', function (): void {


### PR DESCRIPTION
Part of the #848 stack. Base: #873.

`executeTool()` had no `catch`, so a tool whose handler threw propagated straight out of the generation loop: the invocation never reported an end at all, and the run aborted with no record of which tool caused it.

`ToolFailed` now reports the failure, carrying the same tool invocation id as the `InvokingTool` that opened it, and the exception is rethrown so existing behaviour is unchanged. Only the handler call is guarded — a listener that throws is never misreported as a tool failure, and neither is a `Stringable` result that throws while being cast.

### Breaking change

`ToolInvoked` gains a required `float $time` (wall time in the handler, in milliseconds to match `QueryExecuted::$time`). Anything constructing that event by hand needs updating; listeners are unaffected.