### PR TITLE
Link an agent invoked as a tool back to its parent

### DIFF
--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Gateway\Concerns;
 
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Gateway\ParentInvocation;
 use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Laravel\Ai\Tools\Request;
@@ -23,22 +24,25 @@ trait InvokesTools
     {
         $toolInvocationId = (string) Str::uuid7();
 
-        $context?->invokingTool($tool, $arguments, $toolInvocationId);
+        // Any agent prompted while this tool runs, however it was reached, is a child of this tool call...
+        return ParentInvocation::within($context?->invocationId, $toolInvocationId, function () use ($tool, $arguments, $toolCallId, $toolInvocationId, $context): string {
+            $context?->invokingTool($tool, $arguments, $toolInvocationId);
 
-        $startedAt = hrtime(true);
+            $startedAt = hrtime(true);
 
-        // Only the handler itself may fail the tool call, so a listener that throws is never reported as a tool failure...
-        try {
-            $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
-        } catch (Throwable $exception) {
-            $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
+            // Only the handler itself may fail the tool call, so a listener that throws is never reported as a tool failure...
+            try {
+                $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
+            } catch (Throwable $exception) {
+                $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 
-            throw $exception;
-        }
+                throw $exception;
+            }
 
-        $context?->toolInvoked($tool, $arguments, $result, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
+            $context?->toolInvoked($tool, $arguments, $result, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 
-        return (string) $result;
+            return (string) $result;
+        });
     }
 
     /**

--- a/src/Gateway/ParentInvocation.php
+++ b/src/Gateway/ParentInvocation.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Closure;
+
+class ParentInvocation
+{
+    /**
+     * The invocation and tool invocation the current run was delegated from.
+     *
+     * @var array{?string, ?string}
+     */
+    protected static array $current = [null, null];
+
+    /**
+     * Get the invocation and tool invocation the current run was delegated from.
+     *
+     * @return array{?string, ?string}
+     */
+    public static function current(): array
+    {
+        return static::$current;
+    }
+
+    /**
+     * Run the given callback with the given invocation and tool invocation as the delegating parent.
+     */
+    public static function within(?string $invocationId, string $toolInvocationId, Closure $callback): mixed
+    {
+        $previous = static::$current;
+
+        static::$current = [$invocationId, $toolInvocationId];
+
+        try {
+            return $callback();
+        } finally {
+            static::$current = $previous;
+        }
+    }
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -21,6 +21,7 @@ use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Gateway\FakeTextGateway;
+use Laravel\Ai\Gateway\ParentInvocation;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Jobs\InvokeAgent;
 use Laravel\Ai\Prompts\AgentPrompt;
@@ -68,11 +69,15 @@ trait Promptable
             ? $this->providersForApprovalContinuation($provider, $model)
             : $this->getProvidersAndModelsForFailover($provider, $model);
 
+        [$parentInvocationId, $parentToolInvocationId] = ParentInvocation::current();
+
         $run = fn (TextProvider $provider, string $model): AgentResponse => $provider->prompt(
             new AgentPrompt(
                 $this, $text, $attachments, $provider, $model, $this->getTimeout($timeout),
                 invocationId: $invocationId,
                 approvalDecisions: $approvalDecisions,
+                parentInvocationId: $parentInvocationId,
+                parentToolInvocationId: $parentToolInvocationId,
             )
         );
 
@@ -118,11 +123,19 @@ trait Promptable
 
         $invocationId = (string) Str::uuid7();
 
+        [$parentInvocationId, $parentToolInvocationId] = ParentInvocation::current();
+
         if (count($providers) === 1) {
             [$resolved, $resolvedModel] = $this->iterateProvidersWithFailover($providers)->current();
 
             return $resolved->stream(
-                new AgentPrompt($this, $prompt, $attachments, $resolved, $resolvedModel, $resolvedTimeout, $invocationId, $approvalDecisions)
+                new AgentPrompt(
+                    $this, $prompt, $attachments, $resolved, $resolvedModel, $resolvedTimeout,
+                    invocationId: $invocationId,
+                    approvalDecisions: $approvalDecisions,
+                    parentInvocationId: $parentInvocationId,
+                    parentToolInvocationId: $parentToolInvocationId,
+                )
             );
         }
 
@@ -131,7 +144,7 @@ trait Promptable
 
         $outer = new StreamableAgentResponse(
             $invocationId,
-            function () use ($providers, $prompt, $approvalDecisions, $attachments, $resolvedTimeout, $invocationId, &$outer) {
+            function () use ($providers, $prompt, $approvalDecisions, $attachments, $resolvedTimeout, $invocationId, $parentInvocationId, $parentToolInvocationId, &$outer) {
                 $lastException = null;
 
                 foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
@@ -139,7 +152,13 @@ trait Promptable
 
                     try {
                         $innerResponse = $provider->stream(
-                            new AgentPrompt($this, $prompt, $attachments, $provider, $model, $resolvedTimeout, $invocationId, $approvalDecisions)
+                            new AgentPrompt(
+                                $this, $prompt, $attachments, $provider, $model, $resolvedTimeout,
+                                invocationId: $invocationId,
+                                approvalDecisions: $approvalDecisions,
+                                parentInvocationId: $parentInvocationId,
+                                parentToolInvocationId: $parentToolInvocationId,
+                            )
                         );
 
                         $innerResponse->then(fn (StreamedAgentResponse $response): StreamableAgentResponse => $outer->adoptStateFrom($response));

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -18,6 +18,10 @@ class AgentPrompt extends Prompt
 
     public readonly ?string $invocationId;
 
+    public readonly ?string $parentInvocationId;
+
+    public readonly ?string $parentToolInvocationId;
+
     public function __construct(
         Agent $agent,
         string $prompt,
@@ -27,6 +31,8 @@ class AgentPrompt extends Prompt
         ?int $timeout = null,
         ?string $invocationId = null,
         ?Decisions $approvalDecisions = null,
+        ?string $parentInvocationId = null,
+        ?string $parentToolInvocationId = null,
     ) {
         parent::__construct($prompt, $provider, $model, $approvalDecisions);
 
@@ -34,6 +40,8 @@ class AgentPrompt extends Prompt
         $this->attachments = Collection::make($attachments);
         $this->timeout = $timeout;
         $this->invocationId = $invocationId;
+        $this->parentInvocationId = $parentInvocationId;
+        $this->parentToolInvocationId = $parentToolInvocationId;
     }
 
     /**
@@ -82,6 +90,8 @@ class AgentPrompt extends Prompt
             $this->timeout,
             $this->invocationId,
             $this->approvalDecisions,
+            $this->parentInvocationId,
+            $this->parentToolInvocationId,
         );
     }
 

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Approvals\Decisions;
@@ -16,6 +17,7 @@ use Laravel\Ai\Events\ToolFailed;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Exceptions\StreamErrorException;
+use Laravel\Ai\Gateway\ParentInvocation;
 use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -26,6 +28,8 @@ use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Tools\AgentTool;
 use Tests\Fixtures\Agents\AssistantAgent;
+use Tests\Fixtures\Agents\DelegatingAgent;
+use Tests\Fixtures\Agents\DelegatingViaCustomToolAgent;
 use Tests\Fixtures\Agents\MiddleManagerAgent;
 use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\OrchestratorAgent;
@@ -456,4 +460,84 @@ test('tool events carry the wall time spent in the tool', function (): void {
     $invoked = Event::dispatched(ToolInvoked::class)->first()[0];
 
     expect($invoked->time)->toBeFloat()->toBeGreaterThan(0.0);
+});
+
+test('a sub agent prompt is linked to the parent invocation and tool invocation', function (): void {
+    Event::fake();
+
+    DelegatingAgent::fake([
+        new ToolCall('call_123', 'research_agent', ['task' => 'Research Laravel']),
+        'Research delegated.',
+    ]);
+
+    ResearchAgent::fake(['Research result']);
+
+    $response = (new DelegatingAgent)->prompt('Delegate research about Laravel');
+
+    $invoking = Event::dispatched(InvokingTool::class)->first()[0];
+
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->prompt->agent instanceof ResearchAgent
+        && $event->prompt->parentInvocationId === $response->invocationId
+        && $event->prompt->parentToolInvocationId === $invoking->toolInvocationId);
+
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->prompt->agent instanceof DelegatingAgent
+        && $event->prompt->parentInvocationId === null
+        && $event->prompt->parentToolInvocationId === null);
+});
+
+test('an agent prompted from a hand written tool is linked to the parent invocation', function (): void {
+    Event::fake();
+
+    DelegatingViaCustomToolAgent::fake([
+        new ToolCall('call_1', 'AgentCallingTool', []),
+        'Done.',
+    ]);
+
+    ResearchAgent::fake(['Research result']);
+
+    $response = (new DelegatingViaCustomToolAgent)->prompt('Go');
+
+    $invoking = Event::dispatched(InvokingTool::class)->first()[0];
+
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->prompt->agent instanceof ResearchAgent
+        && $event->prompt->parentInvocationId === $response->invocationId
+        && $event->prompt->parentToolInvocationId === $invoking->toolInvocationId);
+});
+
+test('the parent invocation is restored once a tool call finishes', function (): void {
+    Event::fake();
+
+    DelegatingAgent::fake([
+        new ToolCall('call_1', 'research_agent', ['task' => 'Research Laravel']),
+        'Delegated.',
+    ]);
+
+    ResearchAgent::fake(['Research result']);
+
+    (new DelegatingAgent)->prompt('Delegate');
+
+    ResearchAgent::fake(['Standalone result']);
+
+    (new ResearchAgent)->prompt('Standalone');
+
+    $standalone = Event::dispatched(PromptingAgent::class)
+        ->map(fn (array $dispatched) => $dispatched[0]->prompt)
+        ->last(fn ($prompt): bool => $prompt->agent instanceof ResearchAgent);
+
+    expect($standalone->parentInvocationId)->toBeNull()
+        ->and($standalone->parentToolInvocationId)->toBeNull();
+});
+
+test('the parent invocation never travels outside the current process', function (): void {
+    $insideDehydratedContext = null;
+
+    ParentInvocation::within('inv_1', 'tool_1', function () use (&$insideDehydratedContext): void {
+        $insideDehydratedContext = Context::dehydrate();
+
+        expect(ParentInvocation::current())->toBe(['inv_1', 'tool_1']);
+    });
+
+    // Queued jobs serialize the log context, so the delegating pair must never be stored there...
+    expect($insideDehydratedContext)->toBeNull()
+        ->and(ParentInvocation::current())->toBe([null, null]);
 });

--- a/tests/Fixtures/Agents/DelegatingViaCustomToolAgent.php
+++ b/tests/Fixtures/Agents/DelegatingViaCustomToolAgent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\AgentCallingTool;
+
+class DelegatingViaCustomToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You delegate research using your tool.';
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new AgentCallingTool,
+        ];
+    }
+}

--- a/tests/Fixtures/Tools/AgentCallingTool.php
+++ b/tests/Fixtures/Tools/AgentCallingTool.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Tests\Fixtures\Agents\ResearchAgent;
+
+class AgentCallingTool implements Tool
+{
+    public function description(): string
+    {
+        return 'Delegates to a research agent from within the tool handler.';
+    }
+
+    public function handle(Request $request): string
+    {
+        return ResearchAgent::make()->prompt('Research Laravel')->text;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Part of the #848 stack. Base: #874. Additive and self-contained.

`AgentTool` prompted the delegated agent with no reference to the run or the tool call that reached it, so a sub-agent’s events looked like a separate, unrelated run. Nothing correlated the two.

A tool call now publishes its run and tool invocation ids for its own duration, and any agent prompted while it runs picks them up as `parentInvocationId` / `parentToolInvocationId` on its prompt. That covers a hand-written tool that prompts an agent itself, not just `AgentTool`.

The ids live in a plain static rather than `Context::addHidden()`, deliberately: it keeps the delegating invocation out of queued job payloads.

### Known ceiling

A prompt dispatched with `promptOnQueue()` from inside a tool starts its own unparented run — the link does not cross the queue boundary. Worth revisiting only if someone asks for it.