### PR TITLE
Report a run's terminal failure

### DIFF
--- a/src/Events/AgentFailed.php
+++ b/src/Events/AgentFailed.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Ai\Events;
+
+use Laravel\Ai\Prompts\AgentPrompt;
+use Throwable;
+
+class AgentFailed
+{
+    public function __construct(
+        public string $invocationId,
+        public AgentPrompt $prompt,
+        public Throwable $exception,
+    ) {}
+}

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -71,15 +71,21 @@ trait Promptable
 
         [$parentInvocationId, $parentToolInvocationId] = ParentInvocation::current();
 
-        $run = fn (TextProvider $provider, string $model): AgentResponse => $provider->prompt(
-            new AgentPrompt(
-                $this, $text, $attachments, $provider, $model, $this->getTimeout($timeout),
-                invocationId: $invocationId,
-                approvalDecisions: $approvalDecisions,
-                parentInvocationId: $parentInvocationId,
-                parentToolInvocationId: $parentToolInvocationId,
-            )
-        );
+        $run = function (TextProvider $provider, string $model, bool $isFinalAttempt = true) use (
+            $text, $attachments, $timeout, $invocationId, $approvalDecisions,
+            $parentInvocationId, $parentToolInvocationId
+        ): AgentResponse {
+            return $provider->prompt(
+                new AgentPrompt(
+                    $this, $text, $attachments, $provider, $model, $this->getTimeout($timeout),
+                    invocationId: $invocationId,
+                    approvalDecisions: $approvalDecisions,
+                    parentInvocationId: $parentInvocationId,
+                    parentToolInvocationId: $parentToolInvocationId,
+                    isFinalAttempt: $isFinalAttempt,
+                )
+            );
+        };
 
         if ($approvalDecisions !== null) {
             [$provider, $model] = $this->iterateProvidersWithFailover($providers)->current();
@@ -147,7 +153,7 @@ trait Promptable
             function () use ($providers, $prompt, $approvalDecisions, $attachments, $resolvedTimeout, $invocationId, $parentInvocationId, $parentToolInvocationId, &$outer) {
                 $lastException = null;
 
-                foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
+                foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model, $isFinalAttempt]) {
                     $innerResponse = null;
 
                     try {
@@ -158,6 +164,7 @@ trait Promptable
                                 approvalDecisions: $approvalDecisions,
                                 parentInvocationId: $parentInvocationId,
                                 parentToolInvocationId: $parentToolInvocationId,
+                                isFinalAttempt: $isFinalAttempt,
                             )
                         );
 
@@ -173,7 +180,9 @@ trait Promptable
                             throw $e;
                         }
 
-                        $lastException = $this->recordAgentFailover($invocationId, $provider, $model, $e);
+                        $lastException = $isFinalAttempt
+                            ? $e
+                            : $this->recordAgentFailover($invocationId, $provider, $model, $e);
                     }
                 }
 
@@ -265,11 +274,13 @@ trait Promptable
     {
         $lastException = null;
 
-        foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model]) {
+        foreach ($this->iterateProvidersWithFailover($providers) as [$provider, $model, $isFinalAttempt]) {
             try {
-                return $callback($provider, $model);
+                return $callback($provider, $model, $isFinalAttempt);
             } catch (FailoverableException $e) {
-                $lastException = $this->recordAgentFailover($invocationId, $provider, $model, $e);
+                $lastException = $isFinalAttempt
+                    ? $e
+                    : $this->recordAgentFailover($invocationId, $provider, $model, $e);
             }
         }
 
@@ -299,17 +310,19 @@ trait Promptable
     }
 
     /**
-     * Iterate the configured provider / model pairs.
+     * Iterate the configured provider / model pairs, flagging the attempt that has no provider left to fall back to.
      *
      * @param  array<string, string|null>  $providers
-     * @return Generator<int, array{TextProvider, string}>
+     * @return Generator<int, array{TextProvider, string, bool}>
      */
     private function iterateProvidersWithFailover(array $providers): Generator
     {
+        $remaining = count($providers);
+
         foreach ($providers as $provider => $model) {
             $provider = Ai::textProviderFor($this, $provider);
 
-            yield [$provider, $model ?? $this->getDefaultModelFor($provider)];
+            yield [$provider, $model ?? $this->getDefaultModelFor($provider), --$remaining === 0];
         }
     }
 

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -22,6 +22,14 @@ class AgentPrompt extends Prompt
 
     public readonly ?string $parentToolInvocationId;
 
+    // Internal failover bookkeeping, deliberately not part of the prompt's public surface. It rides on the prompt
+    // because the provider catches the failure but only the caller knows whether another provider is queued, and
+    // moving the dispatch up to the caller would lose the prompt the middleware produced...
+    protected readonly bool $isFinalAttempt;
+
+    /**
+     * @param  bool  $isFinalAttempt  whether the caller has run out of providers to retry this prompt against, so a failoverable exception is terminal
+     */
     public function __construct(
         Agent $agent,
         string $prompt,
@@ -33,6 +41,7 @@ class AgentPrompt extends Prompt
         ?Decisions $approvalDecisions = null,
         ?string $parentInvocationId = null,
         ?string $parentToolInvocationId = null,
+        bool $isFinalAttempt = true,
     ) {
         parent::__construct($prompt, $provider, $model, $approvalDecisions);
 
@@ -42,6 +51,17 @@ class AgentPrompt extends Prompt
         $this->invocationId = $invocationId;
         $this->parentInvocationId = $parentInvocationId;
         $this->parentToolInvocationId = $parentToolInvocationId;
+        $this->isFinalAttempt = $isFinalAttempt;
+    }
+
+    /**
+     * Determine whether the caller has run out of providers to retry this prompt against.
+     *
+     * @internal
+     */
+    public function isFinalAttempt(): bool
+    {
+        return $this->isFinalAttempt;
     }
 
     /**
@@ -92,6 +112,7 @@ class AgentPrompt extends Prompt
             $this->approvalDecisions,
             $this->parentInvocationId,
             $this->parentToolInvocationId,
+            $this->isFinalAttempt,
         );
     }
 

--- a/src/Prompts/AgentPrompt.php
+++ b/src/Prompts/AgentPrompt.php
@@ -22,13 +22,10 @@ class AgentPrompt extends Prompt
 
     public readonly ?string $parentToolInvocationId;
 
-    // Internal failover bookkeeping, deliberately not part of the prompt's public surface. It rides on the prompt
-    // because the provider catches the failure but only the caller knows whether another provider is queued, and
-    // moving the dispatch up to the caller would lose the prompt the middleware produced...
     protected readonly bool $isFinalAttempt;
 
     /**
-     * @param  bool  $isFinalAttempt  whether the caller has run out of providers to retry this prompt against, so a failoverable exception is terminal
+     * @param  bool  $isFinalAttempt  Whether the caller has run out of providers to retry this prompt against.
      */
     public function __construct(
         Agent $agent,
@@ -52,16 +49,6 @@ class AgentPrompt extends Prompt
         $this->parentInvocationId = $parentInvocationId;
         $this->parentToolInvocationId = $parentToolInvocationId;
         $this->isFinalAttempt = $isFinalAttempt;
-    }
-
-    /**
-     * Determine whether the caller has run out of providers to retry this prompt against.
-     *
-     * @internal
-     */
-    public function isFinalAttempt(): bool
-    {
-        return $this->isFinalAttempt;
     }
 
     /**
@@ -130,5 +117,15 @@ class AgentPrompt extends Prompt
     public function provider(): TextProvider
     {
         return $this->provider;
+    }
+
+    /**
+     * Determine whether the caller has run out of providers to retry this prompt against.
+     *
+     * @internal
+     */
+    public function isFinalAttempt(): bool
+    {
+        return $this->isFinalAttempt;
     }
 }

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -14,11 +14,13 @@ use Laravel\Ai\Contracts\HasMiddleware;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\ToolApprovalRequested;
 use Laravel\Ai\Events\ToolApprovalResolved;
 use Laravel\Ai\Exceptions\ApprovalNotResumableException;
+use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\UserMessage;
@@ -32,6 +34,7 @@ use Laravel\Ai\Responses\TextResponse;
 use Laravel\Ai\Tools\AgentTool;
 use Laravel\Ai\Tools\McpServerTool;
 use Laravel\Ai\Tools\McpTool;
+use Throwable;
 
 use function Laravel\Ai\pipeline;
 
@@ -49,60 +52,66 @@ trait GeneratesText
         $processedPrompt = null;
         $resolvedApprovalResults = null;
 
-        $response = pipeline()
-            ->send($prompt)
-            ->through($this->gatherMiddlewareFor($prompt->agent))
-            ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt, &$resolvedApprovalResults): TextResponse {
-                $processedPrompt = $prompt;
+        try {
+            $response = pipeline()
+                ->send($prompt)
+                ->through($this->gatherMiddlewareFor($prompt->agent))
+                ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt, &$resolvedApprovalResults): TextResponse {
+                    $processedPrompt = $prompt;
 
-                $this->events->dispatch(new PromptingAgent($invocationId, $prompt));
+                    $this->events->dispatch(new PromptingAgent($invocationId, $prompt));
 
-                $agent = $prompt->agent;
+                    $agent = $prompt->agent;
 
-                $messages = $this->withoutForeignProviderContentBlocks([
-                    ...($agent instanceof Conversational ? $agent->messages() : []),
-                ]);
+                    $messages = $this->withoutForeignProviderContentBlocks([
+                        ...($agent instanceof Conversational ? $agent->messages() : []),
+                    ]);
 
-                if (! $prompt->hasApprovalDecisions()) {
-                    $messages[] = new UserMessage($prompt->prompt, $prompt->attachments->all());
-                }
+                    if (! $prompt->hasApprovalDecisions()) {
+                        $messages[] = new UserMessage($prompt->prompt, $prompt->attachments->all());
+                    }
 
-                $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
+                    $schema = $agent instanceof HasStructuredOutput ? $agent->schema(new JsonSchemaTypeFactory) : null;
 
-                $response = $this->textGenerationLoop()->generate(
-                    $this,
-                    $prompt->model,
-                    (string) $agent->instructions(),
-                    $messages,
-                    $this->resolveTools($agent),
-                    $schema,
-                    TextGenerationOptions::forAgent($agent),
-                    $prompt->timeout,
-                    $this->resumableApprovalFor($prompt),
-                    $this->approvalResultRecorderFor($prompt, $resolvedApprovalResults),
-                    $this->runContextFor($invocationId, $prompt),
-                );
+                    $response = $this->textGenerationLoop()->generate(
+                        $this,
+                        $prompt->model,
+                        (string) $agent->instructions(),
+                        $messages,
+                        $this->resolveTools($agent),
+                        $schema,
+                        TextGenerationOptions::forAgent($agent),
+                        $prompt->timeout,
+                        $this->resumableApprovalFor($prompt),
+                        $this->approvalResultRecorderFor($prompt, $resolvedApprovalResults),
+                        $this->runContextFor($invocationId, $prompt),
+                    );
 
-                if ($response->hasPendingApprovals()) {
-                    $this->throwIfNotResumable($agent);
-                }
+                    if ($response->hasPendingApprovals()) {
+                        $this->throwIfNotResumable($agent);
+                    }
 
-                $agentResponse = $response instanceof StructuredTextResponse
-                    ? (new StructuredAgentResponse($invocationId, $response->structured, $response->text, $response->usage, $response->meta))
-                        ->withMessages($response->messages)
-                        ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
-                        ->withSteps($response->steps)
-                        ->withRawResponse($response->raw)
-                    : (new AgentResponse($invocationId, $response->text, $response->usage, $response->meta))
-                        ->withMessages($response->messages)
-                        ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
-                        ->withSteps($response->steps)
-                        ->withRawResponse($response->raw);
+                    $agentResponse = $response instanceof StructuredTextResponse
+                        ? (new StructuredAgentResponse($invocationId, $response->structured, $response->text, $response->usage, $response->meta))
+                            ->withMessages($response->messages)
+                            ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
+                            ->withSteps($response->steps)
+                            ->withRawResponse($response->raw)
+                        : (new AgentResponse($invocationId, $response->text, $response->usage, $response->meta))
+                            ->withMessages($response->messages)
+                            ->withToolCallsAndResults($response->toolCalls, $response->toolResults)
+                            ->withSteps($response->steps)
+                            ->withRawResponse($response->raw);
 
-                $agentResponse->withPendingApprovals($response->pendingApprovals);
+                    $agentResponse->withPendingApprovals($response->pendingApprovals);
 
-                return $agentResponse;
-            });
+                    return $agentResponse;
+                });
+        } catch (Throwable $exception) {
+            $this->recordAgentFailure($invocationId, $prompt, $exception, $processedPrompt);
+
+            throw $exception;
+        }
 
         $this->events->dispatch(
             new AgentPrompted($invocationId, $processedPrompt ?? $prompt, $response)
@@ -184,11 +193,27 @@ trait GeneratesText
     }
 
     /**
-     * Build the context that identifies this run and reports its tool events.
+     * Build the context that identifies this run and reports its step and tool events.
      */
     protected function runContextFor(string $invocationId, AgentPrompt $prompt): RunContext
     {
         return new RunContext($invocationId, $prompt->agent, $this, $prompt->model, $this->events);
+    }
+
+    /**
+     * Dispatch the terminal failure event for a run, unless the caller may still retry it against another provider.
+     *
+     * Terminality is read from the prompt the caller handed us, since middleware that builds a new prompt
+     * by hand rather than revising ours would not carry the attempt bookkeeping forward...
+     */
+    protected function recordAgentFailure(string $invocationId, AgentPrompt $prompt, Throwable $exception, ?AgentPrompt $processedPrompt = null, bool $retryable = true): void
+    {
+        // A failoverable exception is only terminal once the caller has run out of providers to try...
+        if ($retryable && ! $prompt->isFinalAttempt() && $exception instanceof FailoverableException) {
+            return;
+        }
+
+        $this->events->dispatch(new AgentFailed($invocationId, $processedPrompt ?? $prompt, $exception));
     }
 
     /**

--- a/src/Providers/Concerns/GeneratesText.php
+++ b/src/Providers/Concerns/GeneratesText.php
@@ -202,18 +202,19 @@ trait GeneratesText
 
     /**
      * Dispatch the terminal failure event for a run, unless the caller may still retry it against another provider.
-     *
-     * Terminality is read from the prompt the caller handed us, since middleware that builds a new prompt
-     * by hand rather than revising ours would not carry the attempt bookkeeping forward...
      */
     protected function recordAgentFailure(string $invocationId, AgentPrompt $prompt, Throwable $exception, ?AgentPrompt $processedPrompt = null, bool $retryable = true): void
     {
         // A failoverable exception is only terminal once the caller has run out of providers to try...
-        if ($retryable && ! $prompt->isFinalAttempt() && $exception instanceof FailoverableException) {
+        if ($retryable &&
+            ! $prompt->isFinalAttempt() &&
+            $exception instanceof FailoverableException) {
             return;
         }
 
-        $this->events->dispatch(new AgentFailed($invocationId, $processedPrompt ?? $prompt, $exception));
+        $this->events->dispatch(
+            new AgentFailed($invocationId, $processedPrompt ?? $prompt, $exception)
+        );
     }
 
     /**

--- a/src/Providers/Concerns/StreamsText.php
+++ b/src/Providers/Concerns/StreamsText.php
@@ -17,6 +17,7 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
+use Throwable;
 
 use function Laravel\Ai\pipeline;
 
@@ -31,93 +32,115 @@ trait StreamsText
     {
         $invocationId = $prompt->invocationId ?? (string) Str::uuid7();
 
+        // Held under its own name because the pipeline hands the middleware's prompt to the callback as $prompt...
+        $originalPrompt = $prompt;
+
         $processedPrompt = null;
         $resolvedApprovalResults = null;
 
-        return pipeline()
-            ->send($prompt)
-            ->through($this->gatherMiddlewareFor($prompt->agent))
-            ->then(function (AgentPrompt $prompt) use ($invocationId, &$processedPrompt, &$resolvedApprovalResults): StreamableAgentResponse {
-                $processedPrompt = $prompt;
+        try {
+            $response = pipeline()
+                ->send($prompt)
+                ->through($this->gatherMiddlewareFor($prompt->agent))
+                ->then(function (AgentPrompt $prompt) use ($invocationId, $originalPrompt, &$processedPrompt, &$resolvedApprovalResults): StreamableAgentResponse {
+                    $processedPrompt = $prompt;
 
-                $agent = $prompt->agent;
+                    $agent = $prompt->agent;
 
-                if ($agent instanceof HasStructuredOutput) {
-                    throw new InvalidArgumentException('Streaming structured output is not currently supported.');
-                }
+                    if ($agent instanceof HasStructuredOutput) {
+                        throw new InvalidArgumentException('Streaming structured output is not currently supported.');
+                    }
 
-                $meta = new Meta($this->name(), $prompt->model);
+                    $meta = new Meta($this->name(), $prompt->model);
 
-                $messages = $this->withoutForeignProviderContentBlocks([
-                    ...($agent instanceof Conversational ? $agent->messages() : []),
-                ]);
+                    $messages = $this->withoutForeignProviderContentBlocks([
+                        ...($agent instanceof Conversational ? $agent->messages() : []),
+                    ]);
 
-                if (! $prompt->hasApprovalDecisions()) {
-                    $messages[] = new UserMessage($prompt->prompt, $prompt->attachments->all());
-                }
+                    if (! $prompt->hasApprovalDecisions()) {
+                        $messages[] = new UserMessage($prompt->prompt, $prompt->attachments->all());
+                    }
 
-                $tools = $this->resolveTools($agent);
-                $approval = $this->resumableApprovalFor($prompt);
-                $recordApprovalResults = $this->approvalResultRecorderFor($prompt, $resolvedApprovalResults);
+                    $tools = $this->resolveTools($agent);
+                    $approval = $this->resumableApprovalFor($prompt);
+                    $recordApprovalResults = $this->approvalResultRecorderFor($prompt, $resolvedApprovalResults);
 
-                // Validate eagerly so a mismatch throws before the stream begins, then thread the result into stream() so it isn't re-validated there...
-                $validatedApproval = $approval !== null
-                    ? $this->textGenerationLoop()->validateApproval($approval, $messages, $tools)
-                    : null;
+                    // Validate eagerly so a mismatch throws before the stream begins, then thread the result into stream() so it isn't re-validated there...
+                    $validatedApproval = $approval !== null
+                        ? $this->textGenerationLoop()->validateApproval($approval, $messages, $tools)
+                        : null;
 
-                return new StreamableAgentResponse(
-                    $invocationId,
-                    function () use ($invocationId, $prompt, $agent, $messages, $tools, $approval, $recordApprovalResults, $validatedApproval) {
-                        $this->events->dispatch(new StreamingAgent($invocationId, $prompt));
+                    $streamable = null;
 
-                        foreach ($this->textGenerationLoop()->stream(
-                            $invocationId,
-                            $this,
-                            $prompt->model,
-                            (string) $agent->instructions(),
-                            $messages,
-                            $tools,
-                            null,
-                            TextGenerationOptions::forAgent($agent),
-                            $prompt->timeout,
-                            $approval,
-                            $recordApprovalResults,
-                            $validatedApproval,
-                            $this->runContextFor($invocationId, $prompt),
-                        ) as $event) {
-                            if ($event instanceof ToolApprovalRequest) {
-                                $this->throwIfNotResumable($agent);
+                    // The response owns the "has anything reached the consumer" flag so this failure check and the caller's failover decision can never drift apart...
+                    $streamable = new StreamableAgentResponse(
+                        $invocationId,
+                        function () use ($invocationId, $prompt, $originalPrompt, $agent, $messages, $tools, $approval, $recordApprovalResults, $validatedApproval, &$streamable) {
+                            $this->events->dispatch(new StreamingAgent($invocationId, $prompt));
+
+                            try {
+                                foreach ($this->textGenerationLoop()->stream(
+                                    $invocationId,
+                                    $this,
+                                    $prompt->model,
+                                    (string) $agent->instructions(),
+                                    $messages,
+                                    $tools,
+                                    null,
+                                    TextGenerationOptions::forAgent($agent),
+                                    $prompt->timeout,
+                                    $approval,
+                                    $recordApprovalResults,
+                                    $validatedApproval,
+                                    $this->runContextFor($invocationId, $prompt),
+                                ) as $event) {
+                                    if ($event instanceof ToolApprovalRequest) {
+                                        $this->throwIfNotResumable($agent);
+                                    }
+
+                                    yield $event;
+                                }
+                            } catch (Throwable $exception) {
+                                $this->recordAgentFailure($invocationId, $originalPrompt, $exception, $prompt, retryable: ! $streamable->hasYielded());
+
+                                throw $exception;
                             }
+                        },
+                        $meta,
+                    );
 
-                            yield $event;
-                        }
-                    },
-                    $meta,
-                );
-            })->then(function (StreamedAgentResponse $response) use ($invocationId, $prompt, &$processedPrompt, &$resolvedApprovalResults): void {
-                $this->events->dispatch(
-                    new AgentStreamed($invocationId, $processedPrompt ?? $prompt, $response)
-                );
+                    return $streamable;
+                });
+        } catch (Throwable $exception) {
+            $this->recordAgentFailure($invocationId, $prompt, $exception, $processedPrompt);
 
-                if ($response->hasPendingApprovals()) {
-                    $this->events->dispatch(new ToolApprovalRequested(
-                        $invocationId,
-                        $prompt->agent,
-                        $response->pendingApprovals,
-                        $response->conversationId,
-                        $response->conversationUser,
-                    ));
-                }
+            throw $exception;
+        }
 
-                if ($resolvedApprovalResults !== null) {
-                    $this->events->dispatch(new ToolApprovalResolved(
-                        $invocationId,
-                        $prompt->agent,
-                        $resolvedApprovalResults,
-                        $response->conversationId,
-                        $response->conversationUser,
-                    ));
-                }
-            });
+        return $response->then(function (StreamedAgentResponse $response) use ($invocationId, $prompt, &$processedPrompt, &$resolvedApprovalResults): void {
+            $this->events->dispatch(
+                new AgentStreamed($invocationId, $processedPrompt ?? $prompt, $response)
+            );
+
+            if ($response->hasPendingApprovals()) {
+                $this->events->dispatch(new ToolApprovalRequested(
+                    $invocationId,
+                    $prompt->agent,
+                    $response->pendingApprovals,
+                    $response->conversationId,
+                    $response->conversationUser,
+                ));
+            }
+
+            if ($resolvedApprovalResults !== null) {
+                $this->events->dispatch(new ToolApprovalResolved(
+                    $invocationId,
+                    $prompt->agent,
+                    $resolvedApprovalResults,
+                    $response->conversationId,
+                    $response->conversationUser,
+                ));
+            }
+        });
     }
 }

--- a/src/Tools/AgentTool.php
+++ b/src/Tools/AgentTool.php
@@ -47,6 +47,7 @@ class AgentTool implements Tool
         try {
             return $this->agent->prompt((string) $request['task'])->text;
         } catch (Throwable $throwable) {
+            // Degraded to a result so the parent run survives; the failure surfaces as the sub-agent's own AgentFailed...
             return 'Agent failed: '.$throwable->getMessage();
         }
     }

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -6,13 +6,16 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Events\AgentFailedOver;
 use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
 use Laravel\Ai\Events\InvokingTool;
 use Laravel\Ai\Events\PromptingAgent;
 use Laravel\Ai\Events\StartingStep;
 use Laravel\Ai\Events\StepCompleted;
 use Laravel\Ai\Events\StepFailed;
+use Laravel\Ai\Events\StreamingAgent;
 use Laravel\Ai\Events\ToolFailed;
 use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Exceptions\RateLimitedException;
@@ -26,6 +29,7 @@ use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Tools\AgentTool;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\DelegatingAgent;
@@ -33,6 +37,7 @@ use Tests\Fixtures\Agents\DelegatingViaCustomToolAgent;
 use Tests\Fixtures\Agents\MiddleManagerAgent;
 use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\OrchestratorAgent;
+use Tests\Fixtures\Agents\RateLimitedToolAgent;
 use Tests\Fixtures\Agents\RememberingAssistantAgent;
 use Tests\Fixtures\Agents\RememberingThrowingApprovableAgent;
 use Tests\Fixtures\Agents\ResearchAgent;
@@ -384,6 +389,8 @@ test('a throwing tool dispatches tool failed and still propagates the exception'
 
     Event::assertNotDispatched(ToolInvoked::class);
 
+    Event::assertDispatched(AgentFailed::class);
+
     $invoking = Event::dispatched(InvokingTool::class)->first()[0];
     $failed = Event::dispatched(ToolFailed::class)->first()[0];
 
@@ -437,6 +444,7 @@ test('a tool that fails while resuming an approval reports the failure once and 
     // The resume path turns the failure into a tool result, so the run survives but still reports the failure exactly once...
     Event::assertDispatchedTimes(ToolFailed::class, 1);
     Event::assertNotDispatched(ToolInvoked::class);
+    Event::assertNotDispatched(AgentFailed::class);
 
     expect($resumed->text)->toBe('The tool could not run.');
 
@@ -540,4 +548,395 @@ test('the parent invocation never travels outside the current process', function
     // Queued jobs serialize the log context, so the delegating pair must never be stored there...
     expect($insideDehydratedContext)->toBeNull()
         ->and(ParentInvocation::current())->toBe([null, null]);
+});
+
+test('a recoverable failover does not report the run as failed', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->pushResponse(fakeGroqResponse('Hello from the backup.'));
+
+    $response = (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']);
+
+    expect($response->text)->toBe('Hello from the backup.');
+
+    // The recoverable attempt is reported through the per-step event, not the terminal one...
+    Event::assertDispatched(StepFailed::class, fn (StepFailed $event): bool => $event->invocationId === $response->invocationId);
+    Event::assertDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentPrompted::class);
+    Event::assertNotDispatched(AgentFailed::class);
+});
+
+test('a recoverable failover does not report the streamed run as failed', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->pushResponse(fakeGroqStreamResponse('Hello from the backup.'));
+
+    $response = (new AssistantAgent)->stream('Hi', provider: ['primary', 'backup']);
+
+    foreach ($response as $event) {
+        //
+    }
+
+    Event::assertDispatched(StepFailed::class);
+    Event::assertDispatched(AgentFailedOver::class);
+    Event::assertDispatched(AgentStreamed::class);
+    Event::assertNotDispatched(AgentFailed::class);
+});
+
+test('a run that exhausts every provider reports the failure once', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(status: 429);
+
+    expect(fn (): mixed => (new AssistantAgent)->prompt('Hi', provider: ['primary', 'backup']))
+        ->toThrow(RateLimitedException::class);
+
+    Event::assertDispatchedTimes(AgentFailedOver::class, 1);
+    Event::assertDispatchedTimes(AgentFailed::class, 1);
+
+    $failed = Event::dispatched(AgentFailed::class)->first()[0];
+    $failedOver = Event::dispatched(AgentFailedOver::class)->first()[0];
+
+    expect($failed->invocationId)->toBe($failedOver->invocationId)
+        ->and($failed->prompt->prompt)->toBe('Hi');
+});
+
+test('a streamed run that exhausts every provider reports the failure once', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(status: 429);
+
+    $response = (new AssistantAgent)->stream('Hi', provider: ['primary', 'backup']);
+
+    expect(function () use ($response): void {
+        foreach ($response as $event) {
+            //
+        }
+    })->toThrow(RateLimitedException::class);
+
+    Event::assertDispatchedTimes(AgentFailedOver::class, 1);
+    Event::assertDispatchedTimes(AgentFailed::class, 1);
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId);
+});
+
+test('a single provider run with no failover still reports a failoverable failure', function (): void {
+    Event::fake();
+
+    config(['ai.providers.only' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->push(status: 429);
+
+    expect(fn (): mixed => (new AssistantAgent)->prompt('Hi', provider: 'only'))
+        ->toThrow(RateLimitedException::class);
+
+    Event::assertDispatchedTimes(AgentFailed::class, 1);
+    Event::assertNotDispatched(AgentFailedOver::class);
+});
+
+test('a single provider stream with no failover still reports a failoverable failure', function (): void {
+    Event::fake();
+
+    config(['ai.providers.only' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->push(status: 429);
+
+    $response = (new AssistantAgent)->stream('Hi', provider: 'only');
+
+    expect(function () use ($response): void {
+        foreach ($response as $event) {
+            //
+        }
+    })->toThrow(RateLimitedException::class);
+
+    Event::assertDispatchedTimes(AgentFailed::class, 1);
+    Event::assertNotDispatched(AgentFailedOver::class);
+});
+
+test('a failing gateway dispatches step failed and agent failed instead of agent prompted', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake([fn () => throw new RuntimeException('Provider exploded.')]);
+
+    expect(fn (): mixed => (new AssistantAgent)->prompt('Hi'))
+        ->toThrow(RuntimeException::class, 'Provider exploded.');
+
+    Event::assertDispatched(StepFailed::class, fn (StepFailed $event): bool => $event->stepNumber === 0
+        && $event->exception->getMessage() === 'Provider exploded.');
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->prompt->prompt === 'Hi'
+        && $event->exception->getMessage() === 'Provider exploded.');
+
+    Event::assertNotDispatched(AgentPrompted::class);
+
+    $stepFailed = Event::dispatched(StepFailed::class)->first()[0];
+    $agentFailed = Event::dispatched(AgentFailed::class)->first()[0];
+
+    expect($stepFailed->invocationId)->toBe($agentFailed->invocationId);
+});
+
+test('a failing stream dispatches agent failed instead of agent streamed', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake([fn () => throw new RuntimeException('Stream exploded.')]);
+
+    $response = (new AssistantAgent)->stream('Hi');
+
+    expect(function () use ($response): void {
+        foreach ($response as $event) {
+            //
+        }
+    })->toThrow(RuntimeException::class, 'Stream exploded.');
+
+    Event::assertDispatched(StepFailed::class);
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === $response->invocationId
+        && $event->exception->getMessage() === 'Stream exploded.');
+
+    Event::assertNotDispatched(AgentStreamed::class);
+});
+
+test('a provider error inside the stream closes the step it opened', function (): void {
+    Event::fake();
+
+    config(['ai.providers.only' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->pushResponse(fakeGroqStreamErrorResponse('Upstream exploded.'));
+
+    $response = (new AssistantAgent)->stream('Hi', provider: 'only');
+
+    expect(function () use ($response): void {
+        foreach ($response as $event) {
+            //
+        }
+    })->toThrow('Upstream exploded.');
+
+    // The provider reported the error in the stream rather than throwing, but the step still has to close...
+    Event::assertDispatchedTimes(StartingStep::class, 1);
+    Event::assertDispatchedTimes(StepFailed::class, 1);
+    Event::assertNotDispatched(StepCompleted::class);
+    Event::assertDispatched(AgentFailed::class);
+    Event::assertNotDispatched(AgentStreamed::class);
+
+    $starting = Event::dispatched(StartingStep::class)->first()[0];
+    $failed = Event::dispatched(StepFailed::class)->first()[0];
+
+    expect($failed->invocationId)->toBe($starting->invocationId)
+        ->and($failed->stepNumber)->toBe($starting->stepNumber)
+        ->and($failed->exception)->toBeInstanceOf(StreamErrorException::class)
+        ->and($failed->exception->getMessage())->toBe('Upstream exploded.');
+
+    // The provider's own classification rides on the exception, so a listener never loses the error's type or metadata...
+    expect($failed->exception->error)->toBeInstanceOf(Error::class)
+        ->and($failed->exception->error->message)->toBe('Upstream exploded.')
+        ->and($failed->exception->error->type)->toBe('server_error');
+});
+
+test('a failure after failover reports the prompt the middleware produced', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(status: 429);
+
+    $agent = (new AssistantAgent)->withMiddleware([
+        fn (AgentPrompt $prompt, Closure $next) => $next($prompt->revise('Revised by middleware.')),
+    ]);
+
+    expect(fn (): mixed => $agent->prompt('Hi', provider: ['primary', 'backup']))
+        ->toThrow(RateLimitedException::class);
+
+    $prompted = Event::dispatched(PromptingAgent::class)->first()[0];
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->prompt->prompt === $prompted->prompt->prompt
+        && $event->prompt->prompt === 'Revised by middleware.');
+});
+
+test('middleware that builds its own prompt does not turn a recoverable failover into a failure', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->pushResponse(fakeGroqResponse('Hello from the backup.'));
+
+    // A hand built prompt cannot carry the attempt bookkeeping forward, so terminality must be read from ours...
+    $agent = (new AssistantAgent)->withMiddleware([
+        fn (AgentPrompt $prompt, Closure $next) => $next(new AgentPrompt(
+            $prompt->agent,
+            'Rebuilt by middleware.',
+            $prompt->attachments,
+            $prompt->provider,
+            $prompt->model,
+            invocationId: $prompt->invocationId,
+        )),
+    ]);
+
+    $response = $agent->prompt('Hi', provider: ['primary', 'backup']);
+
+    expect($response->text)->toBe('Hello from the backup.');
+
+    Event::assertDispatched(AgentFailedOver::class);
+    Event::assertNotDispatched(AgentFailed::class);
+});
+
+test('a streamed failure after the stream started reports the run as failed', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->pushResponse(fakeGroqStreamToolCallResponse('RateLimitedNumberGenerator'));
+
+    $response = (new RateLimitedToolAgent)->stream('Generate', provider: ['primary', 'backup']);
+
+    $seen = 0;
+
+    // The stream had already reached the consumer, so the run can no longer be replayed against the backup...
+    expect(function () use ($response, &$seen): void {
+        foreach ($response as $event) {
+            $seen++;
+        }
+    })->toThrow(RateLimitedException::class, 'Rate limited while running the tool.');
+
+    expect($seen)->toBeGreaterThan(0);
+
+    Event::assertDispatchedTimes(AgentFailed::class, 1);
+    Event::assertNotDispatched(AgentFailedOver::class);
+});
+
+test('a streamed failure after failover reports the prompt the middleware produced', function (): void {
+    Event::fake();
+
+    config([
+        'ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key'],
+        'ai.providers.backup' => ['driver' => 'groq', 'key' => 'test-key'],
+    ]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()
+        ->push(status: 429)
+        ->push(status: 429);
+
+    $agent = (new AssistantAgent)->withMiddleware([
+        fn (AgentPrompt $prompt, Closure $next) => $next($prompt->revise('Revised by middleware.')),
+    ]);
+
+    expect(function () use ($agent): void {
+        foreach ($agent->stream('Hi', provider: ['primary', 'backup']) as $event) {
+            //
+        }
+    })->toThrow(RateLimitedException::class);
+
+    $streaming = Event::dispatched(StreamingAgent::class)->first()[0];
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->prompt->prompt === $streaming->prompt->prompt
+        && $event->prompt->prompt === 'Revised by middleware.');
+});
+
+test('a single provider streamed failure reports the prompt the middleware produced', function (): void {
+    Event::fake();
+
+    config(['ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->push(status: 429);
+
+    $agent = (new AssistantAgent)->withMiddleware([
+        fn (AgentPrompt $prompt, Closure $next) => $next($prompt->revise('Revised by middleware.')),
+    ]);
+
+    expect(function () use ($agent): void {
+        foreach ($agent->stream('Hi', provider: 'primary') as $event) {
+            //
+        }
+    })->toThrow(RateLimitedException::class);
+
+    $streaming = Event::dispatched(StreamingAgent::class)->first()[0];
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->prompt->prompt === $streaming->prompt->prompt
+        && $event->prompt->prompt === 'Revised by middleware.');
+});
+
+test('a single provider synchronous failure reports the prompt the middleware produced', function (): void {
+    Event::fake();
+
+    config(['ai.providers.primary' => ['driver' => 'groq', 'key' => 'test-key']]);
+
+    Http::preventStrayRequests();
+
+    Http::fakeSequence()->push(status: 429);
+
+    $agent = (new AssistantAgent)->withMiddleware([
+        fn (AgentPrompt $prompt, Closure $next) => $next($prompt->revise('Revised by middleware.')),
+    ]);
+
+    expect(fn (): mixed => $agent->prompt('Hi', provider: 'primary'))
+        ->toThrow(RateLimitedException::class);
+
+    $prompted = Event::dispatched(PromptingAgent::class)->first()[0];
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->prompt->prompt === $prompted->prompt->prompt
+        && $event->prompt->prompt === 'Revised by middleware.');
 });

--- a/tests/Fixtures/Agents/RateLimitedToolAgent.php
+++ b/tests/Fixtures/Agents/RateLimitedToolAgent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\RateLimitedNumberGenerator;
+
+class RateLimitedToolAgent implements Agent, HasTools
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that generates numbers using the tool available to you.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     */
+    public function tools(): iterable
+    {
+        return [new RateLimitedNumberGenerator];
+    }
+}

--- a/tests/Fixtures/Tools/RateLimitedNumberGenerator.php
+++ b/tests/Fixtures/Tools/RateLimitedNumberGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Fixtures\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Tools\Request;
+
+class RateLimitedNumberGenerator implements Tool
+{
+    /**
+     * Get the description of the tool's purpose.
+     */
+    public function description(): string
+    {
+        return 'This tool can be used to generate cryptographically secure random numbers.';
+    }
+
+    /**
+     * Execute the tool.
+     */
+    public function handle(Request $request): string
+    {
+        throw new RateLimitedException('Rate limited while running the tool.');
+    }
+
+    /**
+     * Get the tool's schema definition.
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -86,6 +86,33 @@ function fakeGroqStreamErrorResponse(string $message = 'Upstream exploded.'): Pr
     return Http::response($body, 200, ['Content-Type' => 'text/event-stream']);
 }
 
+function fakeGroqStreamToolCallResponse(string $name = 'FixedNumberGenerator', string $id = 'call_123'): PromiseInterface
+{
+    $chunk = fn (array|object $delta, ?string $finishReason = null): array => [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion.chunk',
+        'model' => 'openai/gpt-oss-20b',
+        'choices' => [['index' => 0, 'delta' => $delta, 'finish_reason' => $finishReason]],
+    ];
+
+    $body = implode("\n\n", [
+        'data: '.json_encode($chunk(['role' => 'assistant', 'tool_calls' => [[
+            'index' => 0,
+            'id' => $id,
+            'type' => 'function',
+            'function' => ['name' => $name, 'arguments' => ''],
+        ]]])),
+        'data: '.json_encode($chunk(['tool_calls' => [[
+            'index' => 0,
+            'function' => ['arguments' => '{}'],
+        ]]])),
+        'data: '.json_encode($chunk((object) [], 'tool_calls')),
+        'data: [DONE]',
+    ])."\n\n";
+
+    return Http::response($body, 200, ['Content-Type' => 'text/event-stream']);
+}
+
 function fakeGroqToolCallResponse(string $name = 'FixedNumberGenerator', array $arguments = [], string $id = 'call_123'): PromiseInterface
 {
     return Http::response([


### PR DESCRIPTION
Top of the #848 stack. Base: #875. **This is the layer with the open design question — everything below it merges independently of how this one lands.**

Every span-closing event in the package was on the happy path: if the gateway threw, `AgentPrompted` was never reached and nothing at all was dispatched. A listener watching a run had no way to learn it had died — precisely the case anyone instrumenting a run cares most about.

`AgentFailed` reports that once per run, and only once the run is really over. With failover configured, the first provider throwing a `FailoverableException` is not terminal, so someone has to decide terminality.

## The design question

The dispatch happens inside the provider (`GeneratesText::prompt()`, `StreamsText::stream()`), which cannot know how many providers the caller queued. Only `Promptable`’s failover loops know. So as implemented here, the answer is shipped *downward* on the prompt:

`iterateProvidersWithFailover()` yields `--$remaining === 0` → threaded into `new AgentPrompt(..., isFinalAttempt:)` at three sites → stored as a `protected readonly bool` with an `@internal` accessor → passed positionally through `revise()` → read back by `recordAgentFailure()` → and overridden again by `StreamsText` as `retryable: ! $streamable->hasYielded()`.

That is two sources of truth for one predicate, and the flag rides on the middleware-facing value object. Because middleware may build a fresh `AgentPrompt` rather than calling `revise()`, and `isFinalAttempt` defaults to `true`, two defensive workarounds exist: `GeneratesText` deliberately reads the *original* prompt, and `StreamsText` holds `$originalPrompt` under a separate name.

**The alternative:** dispatch from `Promptable`’s failover loops, where `$isFinalAttempt` is already the loop variable. That deletes the flag, the `@internal` accessor, and the `retryable:` parameter. It needs `streamPrompt()`’s single-provider fast path wrapped in `StreamableAgentResponse` so both stream paths share one catch site. The cost is that `AgentFailed` would carry the caller’s prompt rather than the middleware-processed one — acceptable, since `PromptingAgent` already fires earlier with the processed prompt under the same `invocationId`.

I lean toward the alternative. Happy to push it here if you agree.

### Behaviour change

`AgentFailedOver` no longer fires for the final provider. That attempt has nothing to fall back to, so it is reported as the run’s failure instead of as a failover. Previously `recordAgentFailover()` was called unconditionally in every catch, including the last.