### PR TITLE
Reconstruct S3 document attachments in File::fromArray

### DIFF
--- a/src/Files/File.php
+++ b/src/Files/File.php
@@ -40,6 +40,7 @@ abstract class File implements HasName, HasProviderOptions
             'stored-document' => new StoredDocument(self::value($data, 'path', $type), $data['disk'] ?? null),
             'remote-document' => new RemoteDocument(self::value($data, 'url', $type), $data['mime'] ?? null),
             'provider-document' => new ProviderDocument(self::value($data, 'id', $type)),
+            's3-document' => new S3Document(self::value($data, 'url', $type), $data['bucket_owner'] ?? null, $data['mime'] ?? null),
             'base64-audio' => new Base64Audio(self::value($data, 'base64', $type), $data['mime'] ?? null),
             'local-audio' => new LocalAudio(self::value($data, 'path', $type), $data['mime'] ?? null),
             'stored-audio' => new StoredAudio(self::value($data, 'path', $type), $data['disk'] ?? null),

--- a/tests/Feature/FileFromArrayTest.php
+++ b/tests/Feature/FileFromArrayTest.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Files\RemoteAudio;
 use Laravel\Ai\Files\RemoteDocument;
 use Laravel\Ai\Files\RemoteImage;
 use Laravel\Ai\Files\RemoteVideo;
+use Laravel\Ai\Files\S3Document;
 use Laravel\Ai\Files\StoredAudio;
 use Laravel\Ai\Files\StoredDocument;
 use Laravel\Ai\Files\StoredImage;
@@ -31,6 +32,7 @@ dataset('attachment types', [
     'stored-document' => [fn (): StoredDocument => (new StoredDocument('docs/a.pdf', 'local'))->as('a.pdf'), StoredDocument::class, ['path' => 'docs/a.pdf', 'disk' => 'local']],
     'remote-document' => [fn (): RemoteDocument => (new RemoteDocument('https://x/y.pdf', 'application/pdf'))->as('y.pdf'), RemoteDocument::class, ['url' => 'https://x/y.pdf', 'mime' => 'application/pdf']],
     'provider-document' => [fn (): ProviderDocument => (new ProviderDocument('file_doc_1'))->as('doc.pdf'), ProviderDocument::class, ['id' => 'file_doc_1']],
+    's3-document' => [fn (): S3Document => (new S3Document('s3://my-bucket/report.pdf', '123456789012', 'application/pdf'))->as('report.pdf'), S3Document::class, ['url' => 's3://my-bucket/report.pdf', 'bucketOwner' => '123456789012', 'mime' => 'application/pdf']],
     'base64-audio' => [fn (): Base64Audio => (new Base64Audio('aGVsbG8=', 'audio/mpeg'))->as('a.mp3'), Base64Audio::class, ['base64' => 'aGVsbG8=', 'mime' => 'audio/mpeg']],
     'local-audio' => [fn (): LocalAudio => (new LocalAudio('/tmp/a.mp3', 'audio/mpeg'))->as('a.mp3'), LocalAudio::class, ['path' => '/tmp/a.mp3', 'mime' => 'audio/mpeg']],
     'stored-audio' => [fn (): StoredAudio => (new StoredAudio('clips/a.mp3', 'local'))->as('a.mp3'), StoredAudio::class, ['path' => 'clips/a.mp3', 'disk' => 'local']],
@@ -52,6 +54,7 @@ dataset('malformed attachment types', [
     'stored-document' => [['type' => 'stored-document'], 'path'],
     'remote-document' => [['type' => 'remote-document'], 'url'],
     'provider-document' => [['type' => 'provider-document'], 'id'],
+    's3-document' => [['type' => 's3-document'], 'url'],
     'base64-audio' => [['type' => 'base64-audio'], 'base64'],
     'local-audio' => [['type' => 'local-audio'], 'path'],
     'stored-audio' => [['type' => 'stored-audio'], 'path'],


### PR DESCRIPTION
`S3Document::toArray()` writes `type => 's3-document'` but `File::fromArray()` has no arm for it, so it hits `default => null`. every other attachment type has a case, s3-document is the only one that doesnt.

so if you attach an S3 document and the conversation gets persisted then reloaded (`RemembersConversations` / `DatabaseConversationStore`), the attachment rehydrates to null and gets filtered out. if it was the only attachment on that message, the message drops down to a plain no-attachment message so the doc is gone on every replayed turn. this bites Bedrock since thats the provider that takes S3 document refs.

fix is the one missing match arm. also added `s3-document` to the `FileFromArrayTest` round-trip and malformed datasets, it was the only type not covered there either.
