### PR TITLE
Strip markdown code fences from OpenAI-compatible structured output

### DIFF
--- a/src/Gateway/Concerns/DecodesStructuredOutput.php
+++ b/src/Gateway/Concerns/DecodesStructuredOutput.php
@@ -9,28 +9,30 @@ trait DecodesStructuredOutput
      */
     protected function decodeStructuredOutput(?string $text): array
     {
-        if ($text === null || trim($text) === '') {
+        $trimmed = trim((string) $text);
+
+        if ($trimmed === '') {
             return [];
         }
 
-        $payload = $this->stripJsonCodeFence($text);
+        $decoded = json_decode($trimmed, true);
 
-        $decoded = json_decode((string) $payload, true);
+        if (! is_array($decoded)) {
+            $decoded = json_decode($this->extractJsonCodeFence($trimmed) ?? '', true);
+        }
 
         return is_array($decoded) ? $decoded : [];
     }
 
     /**
-     * Strip a wrapping markdown code fence from the payload, if present.
+     * Extract the contents of a markdown code fence from the payload, if present.
      */
-    private function stripJsonCodeFence(string $text): string
+    private function extractJsonCodeFence(string $text): ?string
     {
-        $trimmed = trim($text);
-
-        if (preg_match('/^```(?:json)?\s*(.*?)\s*```$/si', $trimmed, $matches) === 1) {
+        if (preg_match('/```(?:json)?\s*(.*?)\s*```/si', $text, $matches) === 1) {
             return trim($matches[1]);
         }
 
-        return $trimmed;
+        return null;
     }
 }

--- a/src/Gateway/OpenAiCompatible/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAiCompatible/Concerns/ParsesTextResponses.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenAiCompatible\Concerns;
 
 use Laravel\Ai\Exceptions\AiException;
+use Laravel\Ai\Gateway\Concerns\DecodesStructuredOutput;
 use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\FinishReason;
@@ -12,6 +13,8 @@ use Laravel\Ai\Responses\Data\Usage;
 
 trait ParsesTextResponses
 {
+    use DecodesStructuredOutput;
+
     /**
      * Validate the OpenAI-compatible response data.
      *
@@ -56,7 +59,7 @@ trait ParsesTextResponses
             finishReason: $this->extractFinishReason($choice),
             usage: $this->extractUsage($data),
             meta: new Meta($provider->name(), $model),
-            structured: $structured ? (json_decode($text, true) ?? []) : null,
+            structured: $structured ? $this->decodeStructuredOutput($text) : null,
         );
     }
 

--- a/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
@@ -102,6 +102,22 @@ test('structured output defaults to json schema response format', function (): v
     });
 });
 
+test('structured response is correctly parsed', function (): void {
+    Http::fake(['*' => fakeOpenAiCompatibleResponse('{"symbol": "Au"}')]);
+
+    $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openai-compatible');
+
+    expect($response->structured['symbol'])->toBe('Au');
+});
+
+test('structured response tolerates a markdown code fence', function (): void {
+    Http::fake(['*' => fakeOpenAiCompatibleResponse("```json\n".'{"symbol": "Au"}'."\n```")]);
+
+    $response = (new StructuredAgent)->prompt('What is the symbol for Gold?', provider: 'openai-compatible');
+
+    expect($response->structured['symbol'])->toBe('Au');
+});
+
 test('required tool choice forces the model to call a tool', function (): void {
     Http::fake(['*' => fakeOpenAiCompatibleResponse('42')]);
 

--- a/tests/Unit/Gateway/Concerns/DecodesStructuredOutputTest.php
+++ b/tests/Unit/Gateway/Concerns/DecodesStructuredOutputTest.php
@@ -61,6 +61,15 @@ test('handles mixed-case json fence language tag', function (): void {
         ->and($host->decode("```jSoN\n{\"ok\":true}\n```"))->toBe(['ok' => true]);
 });
 
+test('strips a fence wrapped in conversational prose', function (): void {
+    $host = decoderHost();
+
+    expect($host->decode("Here's the JSON you asked for:\n\n```json\n{\"symbol\":\"Au\"}\n```"))
+        ->toBe(['symbol' => 'Au'])
+        ->and($host->decode("```json\n{\"symbol\":\"Au\"}\n```\n\nHope that helps!"))
+        ->toBe(['symbol' => 'Au']);
+});
+
 test('returns empty array for invalid JSON', function (): void {
     $host = decoderHost();
 


### PR DESCRIPTION
the openai-compatible gateway decodes structured output with a raw `json_decode`, its the only text gateway that doesnt go through the `DecodesStructuredOutput` trait (10 others do). so if the backend wraps its json in a markdown code fence the decode returns null and the structured output silently comes back as `[]`.

local backends (vLLM / LM Studio / llama.cpp etc) do this a lot, a bunch of them dont actually honor `response_format: json_schema` and just emit fenced json in the content.

fix routes it through the same `decodeStructuredOutput` helper every sibling uses (strips the fence then decodes). added a structured-response parse test for the compat provider since it only had a request-format one before, plus a fenced variant that was red before the change.
