### PR TITLE
Map Anthropic refusal and model_context_window_exceeded stop reasons

### DIFF
--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -180,7 +180,8 @@ trait ParsesTextResponses
             'end_turn', 'stop_sequence' => FinishReason::Stop,
             'tool_use' => FinishReason::ToolCalls,
             'pause_turn' => FinishReason::Continue,
-            'max_tokens' => FinishReason::Length,
+            'max_tokens', 'model_context_window_exceeded' => FinishReason::Length,
+            'refusal' => FinishReason::ContentFilter,
             default => FinishReason::Unknown,
         };
     }

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -330,6 +330,8 @@ describe('usage tracking', function (): void {
         'end_turn maps to Stop' => ['end_turn', FinishReason::Stop],
         'stop_sequence maps to Stop' => ['stop_sequence', FinishReason::Stop],
         'max_tokens maps to Length' => ['max_tokens', FinishReason::Length],
+        'model_context_window_exceeded maps to Length' => ['model_context_window_exceeded', FinishReason::Length],
+        'refusal maps to ContentFilter' => ['refusal', FinishReason::ContentFilter],
         'tool_use without tool blocks normalizes to Stop (StreamEnd still emitted)' => ['tool_use', FinishReason::Stop],
     ]);
 });


### PR DESCRIPTION
Anthropic's Messages API can end a turn with two stop reasons the Anthropic gateway does not currently map: `refusal` (the model aborts its own output for safety reasons) and `model_context_window_exceeded` (generation stops because input plus output hit the context window). Both currently fall through to `FinishReason::Unknown`.

The practical consequence is worse than an odd label: when a step ends with `Unknown` while a `tool_use` block is pending, `TextGenerationLoop::stepToolResults()` only executes tools for `FinishReason::ToolCalls`, so the pending tool call is silently discarded and the turn ends with empty text, no exception, and no error event. From the application's perspective the request succeeded (HTTP 200, usage recorded) but nothing came back, which makes this failure mode very hard to diagnose in production. We hit exactly this in a live app on 2026-08-13.

This PR maps:

- `refusal` to `FinishReason::ContentFilter`, consistent with the OpenAI-compatible gateways (`content_filter`), Gemini (`SAFETY` etc.), and Bedrock (`content_filtered` / `guardrail_intervened`)
- `model_context_window_exceeded` to `FinishReason::Length`, since generation stopped for size reasons, same family as `max_tokens`

Docs: https://docs.claude.com/en/api/handling-stop-reasons

Both mappings are covered by the existing streaming finish-reason dataset test, extended with the two new cases. The shared `extractFinishReason()` helper also covers the non-streaming path.

The Bedrock gateway is untouched: the Converse API uses its own `stopReason` vocabulary and already maps its filter reasons.