### PR TITLE
Preserve multi-round tool call boundaries in stored conversations

### DIFF
--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -213,13 +213,17 @@ class DatabaseConversationStore implements ConversationStore
         if (! $response->hasPendingApprovals()) {
             $toolCallRounds = $response->steps
                 ->filter(fn ($step): bool => $step instanceof Step && filled($step->toolCalls))
-                ->map(fn (Step $step): array => array_values(array_map(
-                    fn (ToolCall $toolCall): string => $toolCall->id,
-                    $step->toolCalls,
-                )))
+                ->map(fn (Step $step): array => [
+                    'text' => $step->text,
+                    'tool_call_ids' => array_values(array_map(
+                        fn (ToolCall $toolCall): string => $toolCall->id,
+                        $step->toolCalls,
+                    )),
+                ])
                 ->values();
 
-            if ($toolCallRounds->count() > 1) {
+            if ($toolCallRounds->count() > 1
+                || $toolCallRounds->contains(fn (array $round): bool => filled($round['text']))) {
                 $meta['tool_call_rounds'] = $toolCallRounds->all();
             }
         }
@@ -364,7 +368,7 @@ class DatabaseConversationStore implements ConversationStore
     }
 
     /**
-     * Rebuild a completed multi-round tool turn from its persisted call ID grouping.
+     * Rebuild a completed tool turn from its persisted call ID grouping.
      *
      * @param  array<mixed>  $rounds
      * @param  Collection<int, array<string, mixed>>  $toolCalls
@@ -373,7 +377,7 @@ class DatabaseConversationStore implements ConversationStore
      */
     protected function reconstructToolCallRounds(array $rounds, Collection $toolCalls, Collection $toolResults, string $content): ?array
     {
-        if (! array_is_list($rounds) || count($rounds) < 2) {
+        if (! array_is_list($rounds) || $rounds === []) {
             return null;
         }
 
@@ -393,13 +397,17 @@ class DatabaseConversationStore implements ConversationStore
         $messages = [];
 
         foreach ($rounds as $round) {
-            if (! is_array($round) || ! array_is_list($round) || $round === []) {
+            if (! is_array($round)
+                || ! is_string($round['text'] ?? null)
+                || ! is_array($round['tool_call_ids'] ?? null)
+                || ! array_is_list($round['tool_call_ids'])
+                || $round['tool_call_ids'] === []) {
                 return null;
             }
 
             $roundIds = [];
 
-            foreach ($round as $id) {
+            foreach ($round['tool_call_ids'] as $id) {
                 if (! is_string($id) || $id === '' || isset($groupedIds[$id]) || ! $callsById->has($id) || ! $resultsById->has($id)) {
                     return null;
                 }
@@ -408,7 +416,7 @@ class DatabaseConversationStore implements ConversationStore
                 $roundIds[] = $id;
             }
 
-            $messages[] = new AssistantMessage('', collect($roundIds)->map(
+            $messages[] = new AssistantMessage($round['text'], collect($roundIds)->map(
                 fn (string $id): ToolCall => ToolCall::fromArray($callsById->get($id)),
             ));
             $messages[] = new ToolResultMessage(collect($roundIds)->map(

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -16,6 +16,7 @@ use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 
@@ -209,6 +210,20 @@ class DatabaseConversationStore implements ConversationStore
             $meta['provider_content_blocks'] = $blocks;
         }
 
+        if (! $response->hasPendingApprovals()) {
+            $toolCallRounds = $response->steps
+                ->filter(fn ($step): bool => $step instanceof Step && filled($step->toolCalls))
+                ->map(fn (Step $step): array => array_values(array_map(
+                    fn (ToolCall $toolCall): string => $toolCall->id,
+                    $step->toolCalls,
+                )))
+                ->values();
+
+            if ($toolCallRounds->count() > 1) {
+                $meta['tool_call_rounds'] = $toolCallRounds->all();
+            }
+        }
+
         return $meta;
     }
 
@@ -315,6 +330,19 @@ class DatabaseConversationStore implements ConversationStore
             return $messages;
         }
 
+        if (! $isPause && $priorResults->isEmpty() && is_array($meta['tool_call_rounds'] ?? null)) {
+            $roundMessages = $this->reconstructToolCallRounds(
+                $meta['tool_call_rounds'],
+                $toolCalls,
+                $toolResults,
+                $record->content,
+            );
+
+            if ($roundMessages !== null) {
+                return $roundMessages;
+            }
+        }
+
         // Calls already answered this turn are replayed with their results...
         if ($resolvedCalls->isNotEmpty()) {
             $messages[] = new AssistantMessage('', $resolvedCalls->map(ToolCall::fromArray(...))->values());
@@ -330,6 +358,70 @@ class DatabaseConversationStore implements ConversationStore
             $messages[] = new AssistantMessage($record->content, $keptCalls->map(ToolCall::fromArray(...))->values());
         } elseif (filled($record->content)) {
             $messages[] = new AssistantMessage($record->content);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Rebuild a completed multi-round tool turn from its persisted call ID grouping.
+     *
+     * @param  array<mixed>  $rounds
+     * @param  Collection<int, array<string, mixed>>  $toolCalls
+     * @param  Collection<int, array<string, mixed>>  $toolResults
+     * @return array<int, Message>|null
+     */
+    protected function reconstructToolCallRounds(array $rounds, Collection $toolCalls, Collection $toolResults, string $content): ?array
+    {
+        if (! array_is_list($rounds) || count($rounds) < 2) {
+            return null;
+        }
+
+        if ($toolCalls->contains(fn ($toolCall): bool => ! is_array($toolCall) || ! is_string($toolCall['id'] ?? null))
+            || $toolResults->contains(fn ($toolResult): bool => ! is_array($toolResult) || ! is_string($toolResult['id'] ?? null))) {
+            return null;
+        }
+
+        $callsById = $toolCalls->keyBy('id');
+        $resultsById = $toolResults->keyBy('id');
+
+        if ($callsById->count() !== $toolCalls->count() || $resultsById->count() !== $toolResults->count()) {
+            return null;
+        }
+
+        $groupedIds = [];
+        $messages = [];
+
+        foreach ($rounds as $round) {
+            if (! is_array($round) || ! array_is_list($round) || $round === []) {
+                return null;
+            }
+
+            $roundIds = [];
+
+            foreach ($round as $id) {
+                if (! is_string($id) || $id === '' || isset($groupedIds[$id]) || ! $callsById->has($id) || ! $resultsById->has($id)) {
+                    return null;
+                }
+
+                $groupedIds[$id] = true;
+                $roundIds[] = $id;
+            }
+
+            $messages[] = new AssistantMessage('', collect($roundIds)->map(
+                fn (string $id): ToolCall => ToolCall::fromArray($callsById->get($id)),
+            ));
+            $messages[] = new ToolResultMessage(collect($roundIds)->map(
+                fn (string $id): ToolResult => ToolResult::fromArray($resultsById->get($id)),
+            ));
+        }
+
+        if (count($groupedIds) !== $toolCalls->count() || count($groupedIds) !== $toolResults->count()) {
+            return null;
+        }
+
+        if (filled($content)) {
+            $messages[] = new AssistantMessage($content);
         }
 
         return $messages;

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -19,7 +19,9 @@ use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
@@ -266,6 +268,56 @@ test('it replays stored tool conversations before the final assistant response',
         ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
         ->and($messages[2]->content)->toBe('The order has shipped.')
         ->and($messages[2]->toolCalls)->toBeEmpty();
+});
+
+test('it preserves multiple tool call round boundaries when replaying a stored assistant turn', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $firstCall = new ToolCall('call-1', 'lookup_order', ['id' => 1]);
+    $firstResult = new ToolResult('call-1', 'lookup_order', ['id' => 1], ['status' => 'shipped']);
+    $secondCall = new ToolCall('call-2', 'lookup_carrier', ['id' => 1]);
+    $secondResult = new ToolResult('call-2', 'lookup_carrier', ['id' => 1], ['carrier' => 'UPS']);
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = (new AgentResponse('invocation-id', 'The order has shipped with UPS.', new Usage, new Meta))
+        ->withMessages(collect([
+            new AssistantMessage('', collect([$firstCall])),
+            new ToolResultMessage(collect([$firstResult])),
+            new AssistantMessage('', collect([$secondCall])),
+            new ToolResultMessage(collect([$secondResult])),
+            new AssistantMessage('The order has shipped with UPS.'),
+        ]))
+        ->withSteps(collect([
+            new Step('', [$firstCall], [$firstResult], FinishReason::ToolCalls, new Usage, new Meta),
+            new Step('', [$secondCall], [$secondResult], FinishReason::ToolCalls, new Usage, new Meta),
+            new Step('The order has shipped with UPS.', [], [], FinishReason::Stop, new Usage, new Meta),
+        ]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($meta)->toHaveKey('tool_call_rounds', [['call-1'], ['call-2']])
+        ->and($messages)->toHaveCount(5)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2'])
+        ->and($messages[3])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[3]->toolResults->pluck('id')->all())->toBe(['call-2'])
+        ->and($messages[4])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[4]->content)->toBe('The order has shipped with UPS.');
 });
 
 test('it drops unresolved tool calls on an unmarked legacy row keeping the final assistant text', function (): void {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -289,14 +289,14 @@ test('it preserves multiple tool call round boundaries when replaying a stored a
 
     $response = (new AgentResponse('invocation-id', 'The order has shipped with UPS.', new Usage, new Meta))
         ->withMessages(collect([
-            new AssistantMessage('', collect([$firstCall])),
+            new AssistantMessage('Sure, I will check.', collect([$firstCall])),
             new ToolResultMessage(collect([$firstResult])),
             new AssistantMessage('', collect([$secondCall])),
             new ToolResultMessage(collect([$secondResult])),
             new AssistantMessage('The order has shipped with UPS.'),
         ]))
         ->withSteps(collect([
-            new Step('', [$firstCall], [$firstResult], FinishReason::ToolCalls, new Usage, new Meta),
+            new Step('Sure, I will check.', [$firstCall], [$firstResult], FinishReason::ToolCalls, new Usage, new Meta),
             new Step('', [$secondCall], [$secondResult], FinishReason::ToolCalls, new Usage, new Meta),
             new Step('The order has shipped with UPS.', [], [], FinishReason::Stop, new Usage, new Meta),
         ]));
@@ -306,9 +306,13 @@ test('it preserves multiple tool call round boundaries when replaying a stored a
     $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
     $messages = $store->getLatestConversationMessages($conversationId, 10);
 
-    expect($meta)->toHaveKey('tool_call_rounds', [['call-1'], ['call-2']])
+    expect($meta)->toHaveKey('tool_call_rounds', [
+        ['text' => 'Sure, I will check.', 'tool_call_ids' => ['call-1']],
+        ['text' => '', 'tool_call_ids' => ['call-2']],
+    ])
         ->and($messages)->toHaveCount(5)
         ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->content)->toBe('Sure, I will check.')
         ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
         ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
@@ -318,6 +322,53 @@ test('it preserves multiple tool call round boundaries when replaying a stored a
         ->and($messages[3]->toolResults->pluck('id')->all())->toBe(['call-2'])
         ->and($messages[4])->toBeInstanceOf(AssistantMessage::class)
         ->and($messages[4]->content)->toBe('The order has shipped with UPS.');
+});
+
+test('it preserves assistant text before tool calls when replaying a stored turn', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    $orderCall = new ToolCall('call-1', 'lookup_order', ['id' => 1]);
+    $orderResult = new ToolResult('call-1', 'lookup_order', ['id' => 1], ['status' => 'shipped']);
+    $carrierCall = new ToolCall('call-2', 'lookup_carrier', ['id' => 1]);
+    $carrierResult = new ToolResult('call-2', 'lookup_carrier', ['id' => 1], ['carrier' => 'UPS']);
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'Check my order status.',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = (new AgentResponse('invocation-id', 'Here you go, the order has shipped with UPS.', new Usage, new Meta))
+        ->withMessages(collect([
+            new AssistantMessage('Sure, I will check.', collect([$orderCall, $carrierCall])),
+            new ToolResultMessage(collect([$orderResult, $carrierResult])),
+            new AssistantMessage('Here you go, the order has shipped with UPS.'),
+        ]))
+        ->withSteps(collect([
+            new Step('Sure, I will check.', [$orderCall, $carrierCall], [$orderResult, $carrierResult], FinishReason::ToolCalls, new Usage, new Meta),
+            new Step('Here you go, the order has shipped with UPS.', [], [], FinishReason::Stop, new Usage, new Meta),
+        ]));
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($meta)->toHaveKey('tool_call_rounds', [[
+        'text' => 'Sure, I will check.',
+        'tool_call_ids' => ['call-1', 'call-2'],
+    ]])
+        ->and($messages)->toHaveCount(3)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->content)->toBe('Sure, I will check.')
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1', 'call-2'])
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1', 'call-2'])
+        ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[2]->content)->toBe('Here you go, the order has shipped with UPS.');
 });
 
 test('it drops unresolved tool calls on an unmarked legacy row keeping the final assistant text', function (): void {


### PR DESCRIPTION
Fixes #402.

`DatabaseConversationStore` previously flattened tool calls and results from multiple rounds into a single assistant/tool-result pair. This produced invalid conversation history for providers that require interleaved tool messages.

This change stores the tool-call IDs from each completed step in the existing message metadata and uses that grouping when reconstructing the conversation.

Legacy or malformed records fall back to the existing behavior. Approval-paused turns remain unchanged.

No database migration or public API change is required.