### PR TITLE
Add Laravel Pulse cards for AI token usage and step latency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "driftingly/rector-laravel": "^2.5",
         "laravel/mcp": "^0.8",
         "laravel/pint": "^1.26",
+        "laravel/pulse": "^1.4",
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^10.6|^11.0",
         "pestphp/pest": "^3.0|^4.0",
@@ -36,7 +37,8 @@
         "rector/rector": "^2.5"
     },
     "suggest": {
-        "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+        "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents.",
+        "laravel/pulse": "Required to display the AI token usage and step latency cards on the Pulse dashboard."
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,9 @@
         <testsuite name="Integration">
             <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
+        <testsuite name="Pulse">
+            <directory suffix="Test.php">./tests/Pulse</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/resources/views/pulse/step-latency.blade.php
+++ b/resources/views/pulse/step-latency.blade.php
@@ -1,0 +1,59 @@
+<x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
+    <x-pulse::card-header
+        name="AI Step Latency"
+        x-bind:title="`Time: {{ number_format($time) }}ms; Run at: ${formatDate('{{ $runAt }}')};`"
+        details="past {{ $this->periodForHumans() }}"
+    >
+        <x-slot:icon>
+            <x-pulse::icons.clock />
+        </x-slot:icon>
+    </x-pulse::card-header>
+
+    <x-pulse::scroll :expand="$expand" wire:poll.5s="">
+        @if ($models->isEmpty())
+            <x-pulse::no-results />
+        @else
+            <x-pulse::table>
+                <colgroup>
+                    <col width="100%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                </colgroup>
+                <x-pulse::thead>
+                    <tr>
+                        <x-pulse::th>Model</x-pulse::th>
+                        <x-pulse::th class="text-right">Steps</x-pulse::th>
+                        <x-pulse::th class="text-right">Average</x-pulse::th>
+                        <x-pulse::th class="text-right">Slowest</x-pulse::th>
+                    </tr>
+                </x-pulse::thead>
+                <tbody>
+                    @foreach ($models->take(100) as $model)
+                        <tr wire:key="{{ md5($model->key) }}-spacer" class="h-2 first:h-0"></tr>
+                        <tr wire:key="{{ md5($model->key) }}-row">
+                            <x-pulse::td class="max-w-[1px]">
+                                <code class="block text-xs text-gray-900 dark:text-gray-100 truncate" title="{{ $model->key }}">
+                                    {{ $model->key }}
+                                </code>
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300 font-bold">
+                                {{ number_format($model->count) }}
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                                <strong>{{ number_format($model->avg) ?: '<1' }}</strong> ms
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                                <strong>{{ number_format($model->max) ?: '<1' }}</strong> ms
+                            </x-pulse::td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </x-pulse::table>
+        @endif
+
+        @if ($models->count() > 100)
+            <div class="mt-2 text-xs text-gray-400 text-center">Limited to 100 entries</div>
+        @endif
+    </x-pulse::scroll>
+</x-pulse::card>

--- a/resources/views/pulse/token-usage.blade.php
+++ b/resources/views/pulse/token-usage.blade.php
@@ -1,0 +1,59 @@
+<x-pulse::card :cols="$cols" :rows="$rows" :class="$class">
+    <x-pulse::card-header
+        name="AI Token Usage"
+        x-bind:title="`Time: {{ number_format($time) }}ms; Run at: ${formatDate('{{ $runAt }}')};`"
+        details="past {{ $this->periodForHumans() }}"
+    >
+        <x-slot:icon>
+            <x-pulse::icons.sparkles />
+        </x-slot:icon>
+    </x-pulse::card-header>
+
+    <x-pulse::scroll :expand="$expand" wire:poll.5s="">
+        @if ($models->isEmpty())
+            <x-pulse::no-results />
+        @else
+            <x-pulse::table>
+                <colgroup>
+                    <col width="100%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                    <col width="0%" />
+                </colgroup>
+                <x-pulse::thead>
+                    <tr>
+                        <x-pulse::th>Model</x-pulse::th>
+                        <x-pulse::th class="text-right">Input</x-pulse::th>
+                        <x-pulse::th class="text-right">Output</x-pulse::th>
+                        <x-pulse::th class="text-right">Cached</x-pulse::th>
+                    </tr>
+                </x-pulse::thead>
+                <tbody>
+                    @foreach ($models->take(100) as $model)
+                        <tr wire:key="{{ md5($model->key) }}-spacer" class="h-2 first:h-0"></tr>
+                        <tr wire:key="{{ md5($model->key) }}-row">
+                            <x-pulse::td class="max-w-[1px]">
+                                <code class="block text-xs text-gray-900 dark:text-gray-100 truncate" title="{{ $model->key }}">
+                                    {{ $model->key }}
+                                </code>
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300 font-bold">
+                                {{ number_format($model->ai_prompt_tokens ?? 0) }}
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300 font-bold">
+                                {{ number_format($model->ai_completion_tokens ?? 0) }}
+                            </x-pulse::td>
+                            <x-pulse::td numeric class="text-gray-700 dark:text-gray-300">
+                                {{ number_format($model->ai_cached_tokens ?? 0) }}
+                            </x-pulse::td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </x-pulse::table>
+        @endif
+
+        @if ($models->count() > 100)
+            <div class="mt-2 text-xs text-gray-400 text-center">Limited to 100 entries</div>
+        @endif
+    </x-pulse::scroll>
+</x-pulse::card>

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -16,6 +16,10 @@ use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Laravel\Ai\Telemetry\Pulse\Livewire\StepLatency;
+use Laravel\Ai\Telemetry\Pulse\Livewire\TokenUsage;
+use Laravel\Pulse\Pulse;
+use Livewire\LivewireManager;
 
 class AiServiceProvider extends ServiceProvider
 {
@@ -43,6 +47,8 @@ class AiServiceProvider extends ServiceProvider
             $this->registerCommands();
             $this->registerPublishing();
         }
+
+        $this->registerPulseCards();
 
         // Embeddings macro...
         Stringable::macro('toEmbeddings', function (
@@ -142,6 +148,24 @@ class AiServiceProvider extends ServiceProvider
             return (new Collection($response->results))->map(
                 fn ($result): mixed => $this->values()[$result->index]
             );
+        });
+    }
+
+    /**
+     * Register the package's Laravel Pulse cards.
+     */
+    protected function registerPulseCards(): void
+    {
+        if (! class_exists(Pulse::class) || ! class_exists(LivewireManager::class)) {
+            return;
+        }
+
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'ai');
+
+        // Deferred so the cards register only once Livewire itself has booted, which never happens on a console-only app...
+        $this->callAfterResolving(LivewireManager::class, function (LivewireManager $livewire): void {
+            $livewire->component('ai.pulse.token-usage', TokenUsage::class);
+            $livewire->component('ai.pulse.step-latency', StepLatency::class);
         });
     }
 

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -162,7 +162,6 @@ class AiServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'ai');
 
-        // Deferred so the cards register only once Livewire itself has booted, which never happens on a console-only app...
         $this->callAfterResolving(LivewireManager::class, function (LivewireManager $livewire): void {
             $livewire->component('ai.pulse.token-usage', TokenUsage::class);
             $livewire->component('ai.pulse.step-latency', StepLatency::class);

--- a/src/Telemetry/Pulse/Livewire/StepLatency.php
+++ b/src/Telemetry/Pulse/Livewire/StepLatency.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Ai\Telemetry\Pulse\Livewire;
+
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Facades\View;
+use Laravel\Pulse\Livewire\Card;
+use Livewire\Attributes\Lazy;
+
+#[Lazy]
+class StepLatency extends Card
+{
+    /**
+     * Render the card.
+     */
+    public function render(): Renderable
+    {
+        [$models, $time, $runAt] = $this->remember(
+            fn () => $this->aggregate('ai_step_duration', ['max', 'avg', 'count'], 'max'),
+        );
+
+        return View::make('ai::pulse.step-latency', [
+            'models' => $models,
+            'time' => $time,
+            'runAt' => $runAt,
+        ]);
+    }
+}

--- a/src/Telemetry/Pulse/Livewire/TokenUsage.php
+++ b/src/Telemetry/Pulse/Livewire/TokenUsage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Ai\Telemetry\Pulse\Livewire;
+
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Facades\View;
+use Laravel\Pulse\Livewire\Card;
+use Livewire\Attributes\Lazy;
+
+#[Lazy]
+class TokenUsage extends Card
+{
+    /**
+     * Render the card.
+     */
+    public function render(): Renderable
+    {
+        [$models, $time, $runAt] = $this->remember(fn () => $this->aggregateTypes([
+            'ai_prompt_tokens',
+            'ai_completion_tokens',
+            'ai_cached_tokens',
+        ], 'sum'));
+
+        return View::make('ai::pulse.token-usage', [
+            'models' => $models,
+            'time' => $time,
+            'runAt' => $runAt,
+        ]);
+    }
+}

--- a/src/Telemetry/Pulse/Recorders/AgentUsage.php
+++ b/src/Telemetry/Pulse/Recorders/AgentUsage.php
@@ -37,12 +37,9 @@ class AgentUsage
 
         $usage = $event->response->usage;
 
-        // Counted here rather than on every type so the step count is not multiplied by the number of token buckets...
         Pulse::record('ai_prompt_tokens', $key, $usage->promptTokens)->sum()->count();
         Pulse::record('ai_completion_tokens', $key, $usage->completionTokens)->sum();
         Pulse::record('ai_cached_tokens', $key, $usage->cacheReadInputTokens)->sum();
-
-        // Pulse only aggregates integers, and sub-millisecond provider calls do not exist...
         Pulse::record('ai_step_duration', $key, (int) round($event->time))->avg()->max()->count();
     }
 

--- a/src/Telemetry/Pulse/Recorders/AgentUsage.php
+++ b/src/Telemetry/Pulse/Recorders/AgentUsage.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Ai\Telemetry\Pulse\Recorders;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Ai\Events\StepCompleted;
+use Laravel\Pulse\Facades\Pulse;
+use Laravel\Pulse\Recorders\Concerns\Sampling;
+
+class AgentUsage
+{
+    use Sampling;
+
+    /**
+     * The events to listen for.
+     *
+     * @var array<int, class-string>
+     */
+    public array $listen = [
+        StepCompleted::class,
+    ];
+
+    /**
+     * Record the token usage and latency of a completed generation step.
+     */
+    public function record(StepCompleted $event): void
+    {
+        if (! $this->shouldSample()) {
+            return;
+        }
+
+        $key = $event->provider->name().':'.$event->model;
+
+        if ($this->shouldIgnore($key)) {
+            return;
+        }
+
+        $usage = $event->response->usage;
+
+        // Counted here rather than on every type so the step count is not multiplied by the number of token buckets...
+        Pulse::record('ai_prompt_tokens', $key, $usage->promptTokens)->sum()->count();
+        Pulse::record('ai_completion_tokens', $key, $usage->completionTokens)->sum();
+        Pulse::record('ai_cached_tokens', $key, $usage->cacheReadInputTokens)->sum();
+
+        // Pulse only aggregates integers, and sub-millisecond provider calls do not exist...
+        Pulse::record('ai_step_duration', $key, (int) round($event->time))->avg()->max()->count();
+    }
+
+    /**
+     * Determine whether the given provider and model should not be recorded.
+     */
+    protected function shouldIgnore(string $key): bool
+    {
+        foreach (Config::get('pulse.recorders.'.static::class.'.ignore', []) as $pattern) {
+            if (preg_match($pattern, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Telemetry/Pulse/Recorders/AgentUsage.php
+++ b/src/Telemetry/Pulse/Recorders/AgentUsage.php
@@ -2,14 +2,13 @@
 
 namespace Laravel\Ai\Telemetry\Pulse\Recorders;
 
-use Illuminate\Support\Facades\Config;
 use Laravel\Ai\Events\StepCompleted;
 use Laravel\Pulse\Facades\Pulse;
-use Laravel\Pulse\Recorders\Concerns\Sampling;
+use Laravel\Pulse\Recorders\Concerns\Ignores;
 
 class AgentUsage
 {
-    use Sampling;
+    use Ignores;
 
     /**
      * The events to listen for.
@@ -25,10 +24,6 @@ class AgentUsage
      */
     public function record(StepCompleted $event): void
     {
-        if (! $this->shouldSample()) {
-            return;
-        }
-
         $key = $event->provider->name().':'.$event->model;
 
         if ($this->shouldIgnore($key)) {
@@ -37,23 +32,9 @@ class AgentUsage
 
         $usage = $event->response->usage;
 
-        Pulse::record('ai_prompt_tokens', $key, $usage->promptTokens)->sum()->count();
+        Pulse::record('ai_prompt_tokens', $key, $usage->promptTokens)->sum();
         Pulse::record('ai_completion_tokens', $key, $usage->completionTokens)->sum();
         Pulse::record('ai_cached_tokens', $key, $usage->cacheReadInputTokens)->sum();
         Pulse::record('ai_step_duration', $key, (int) round($event->time))->avg()->max()->count();
-    }
-
-    /**
-     * Determine whether the given provider and model should not be recorded.
-     */
-    protected function shouldIgnore(string $key): bool
-    {
-        foreach (Config::get('pulse.recorders.'.static::class.'.ignore', []) as $pattern) {
-            if (preg_match($pattern, $key)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -10,6 +10,7 @@ use Tests\Feature\Providers\Ollama\OllamaHelpers;
 use Tests\Feature\Providers\OpenAi\OpenAiHelpers;
 use Tests\Feature\Providers\OpenRouter\OpenRouterHelpers;
 use Tests\Feature\Providers\Xai\XaiHelpers;
+use Tests\PulseTestCase;
 use Tests\TestCase;
 
 require __DIR__.'/Expectations.php';
@@ -18,6 +19,7 @@ require_once __DIR__.'/Helpers.php';
 Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env', '.env.testing'])->safeLoad();
 
 pest()->extend(TestCase::class)->in('Feature', 'Integration');
+pest()->extend(PulseTestCase::class)->in('Pulse');
 pest()->use(AnthropicHelpers::class)->group('provider-anthropic')->in('Feature/Providers/Anthropic');
 pest()->use(AzureOpenAiHelpers::class)->group('provider-azure')->in('Feature/Providers/AzureOpenAi');
 pest()->use(BedrockHelpers::class)->group('provider-bedrock')->in('Feature/Providers/Bedrock');

--- a/tests/Pulse/AgentUsageRecorderTest.php
+++ b/tests/Pulse/AgentUsageRecorderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Events\StepCompleted;
+use Laravel\Ai\Gateway\StepResponse;
+use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Telemetry\Pulse\Recorders\AgentUsage;
+use Laravel\Pulse\Entry;
+use Laravel\Pulse\Facades\Pulse;
+
+function stepCompleted(Usage $usage, float $time = 1234.6, string $provider = 'groq', string $model = 'llama-3.3-70b'): StepCompleted
+{
+    $textProvider = Mockery::mock(TextProvider::class);
+    $textProvider->shouldReceive('name')->andReturn($provider);
+
+    return new StepCompleted(
+        'inv_1',
+        1,
+        Mockery::mock(Agent::class),
+        $textProvider,
+        $model,
+        true,
+        new StepResponse('text', [], FinishReason::Stop, $usage, new Meta),
+        $time,
+    );
+}
+
+/**
+ * Capture the entries the recorder hands to Pulse, keyed by type.
+ *
+ * @return array<string, Entry>
+ */
+function recordedEntries(StepCompleted $event): array
+{
+    $entries = [];
+
+    Pulse::shouldReceive('record')->andReturnUsing(
+        function (string $type, string $key, ?int $value = null) use (&$entries): Entry {
+            return $entries[$type] = new Entry(timestamp: 0, type: $type, key: $key, value: $value);
+        }
+    );
+
+    (new AgentUsage)->record($event);
+
+    return $entries;
+}
+
+test('it records the token usage of a completed step against the provider and model', function (): void {
+    $entries = recordedEntries(stepCompleted(new Usage(
+        promptTokens: 900,
+        completionTokens: 120,
+        cacheReadInputTokens: 640,
+    )));
+
+    expect($entries['ai_prompt_tokens']->key)->toBe('groq:llama-3.3-70b')
+        ->and($entries['ai_prompt_tokens']->value)->toBe(900)
+        ->and($entries['ai_completion_tokens']->value)->toBe(120)
+        ->and($entries['ai_cached_tokens']->value)->toBe(640);
+});
+
+test('it counts steps once rather than once per token bucket', function (): void {
+    $entries = recordedEntries(stepCompleted(new Usage(promptTokens: 10, completionTokens: 5)));
+
+    expect($entries['ai_prompt_tokens']->isCount())->toBeTrue()
+        ->and($entries['ai_completion_tokens']->isCount())->toBeFalse()
+        ->and($entries['ai_cached_tokens']->isCount())->toBeFalse();
+});
+
+test('it records the step duration as whole milliseconds', function (): void {
+    $entries = recordedEntries(stepCompleted(new Usage, time: 1234.6));
+
+    expect($entries['ai_step_duration']->value)->toBe(1235)
+        ->and($entries['ai_step_duration']->isAvg())->toBeTrue()
+        ->and($entries['ai_step_duration']->isMax())->toBeTrue()
+        ->and($entries['ai_step_duration']->isCount())->toBeTrue();
+});
+
+test('it does not record models matching an ignore pattern', function (): void {
+    config()->set('pulse.recorders.'.AgentUsage::class.'.ignore', ['#^groq:#']);
+
+    expect(recordedEntries(stepCompleted(new Usage(promptTokens: 10))))->toBe([]);
+});

--- a/tests/Pulse/AgentUsageRecorderTest.php
+++ b/tests/Pulse/AgentUsageRecorderTest.php
@@ -61,10 +61,11 @@ test('it records the token usage of a completed step against the provider and mo
         ->and($entries['ai_cached_tokens']->value)->toBe(640);
 });
 
-test('it counts steps once rather than once per token bucket', function (): void {
+test('it counts steps on the duration alone so the token types do not each carry a duplicate count', function (): void {
     $entries = recordedEntries(stepCompleted(new Usage(promptTokens: 10, completionTokens: 5)));
 
-    expect($entries['ai_prompt_tokens']->isCount())->toBeTrue()
+    expect($entries['ai_step_duration']->isCount())->toBeTrue()
+        ->and($entries['ai_prompt_tokens']->isCount())->toBeFalse()
         ->and($entries['ai_completion_tokens']->isCount())->toBeFalse()
         ->and($entries['ai_cached_tokens']->isCount())->toBeFalse();
 });

--- a/tests/Pulse/CardsTest.php
+++ b/tests/Pulse/CardsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Telemetry\Pulse\Livewire\StepLatency;
+use Laravel\Ai\Telemetry\Pulse\Livewire\TokenUsage;
+use Laravel\Pulse\Contracts\Storage;
+use Livewire\Livewire;
+
+function fakePulseStorage(string $method, Collection $rows): void
+{
+    // The cards are lazy, so without this a test only ever sees the placeholder...
+    Livewire::withoutLazyLoading();
+
+    $storage = Mockery::mock(Storage::class);
+    $storage->shouldReceive($method)->andReturn($rows);
+    $storage->shouldIgnoreMissing(new Collection);
+
+    app()->instance(Storage::class, $storage);
+}
+
+test('the token usage card lists each model with its input, output, and cached tokens', function (): void {
+    fakePulseStorage('aggregateTypes', new Collection([
+        (object) [
+            'key' => 'groq:llama-3.3-70b',
+            'ai_prompt_tokens' => 1200,
+            'ai_completion_tokens' => 340,
+            'ai_cached_tokens' => 900,
+        ],
+    ]));
+
+    Livewire::test(TokenUsage::class)
+        ->assertOk()
+        ->assertSee('AI Token Usage')
+        ->assertSee('groq:llama-3.3-70b')
+        ->assertSee('1,200')
+        ->assertSee('340')
+        ->assertSee('900');
+});
+
+test('the step latency card lists each model with its step count, average, and slowest step', function (): void {
+    fakePulseStorage('aggregate', new Collection([
+        (object) [
+            'key' => 'openai:gpt-5',
+            'count' => 42,
+            'avg' => 1500,
+            'max' => 9100,
+        ],
+    ]));
+
+    Livewire::test(StepLatency::class)
+        ->assertOk()
+        ->assertSee('AI Step Latency')
+        ->assertSee('openai:gpt-5')
+        ->assertSee('42')
+        ->assertSee('1,500')
+        ->assertSee('9,100');
+});
+
+test('the cards render an empty state when nothing has been recorded', function (): void {
+    fakePulseStorage('aggregateTypes', new Collection);
+
+    Livewire::test(TokenUsage::class)->assertOk()->assertSee('No results');
+});

--- a/tests/PulseTestCase.php
+++ b/tests/PulseTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests;
+
+use Laravel\Pulse\PulseServiceProvider;
+use Livewire\LivewireServiceProvider;
+
+abstract class PulseTestCase extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ...parent::getPackageProviders($app),
+            LivewireServiceProvider::class,
+            PulseServiceProvider::class,
+        ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        // Livewire encrypts its component snapshots, so rendering a card needs a key...
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+    }
+}


### PR DESCRIPTION
Adds an optional [Laravel Pulse](https://laravel.com/docs/pulse) integration with two cards, driven entirely by the `StepCompleted` event that landed in #873.

## Setup

```php
// config/pulse.php
'recorders' => [
    Laravel\Ai\Telemetry\Pulse\Recorders\AgentUsage::class => [
        'enabled' => env('PULSE_AGENT_USAGE_ENABLED', true),
        'ignore' => [
            // '#^ollama:#',
        ],
    ],
],
```

```blade
{{-- resources/views/vendor/pulse/dashboard.blade.php --}}
<livewire:ai.pulse.token-usage cols="6" />
<livewire:ai.pulse.step-latency cols="6" />
```

## The cards

**AI Token Usage** — input, output, and cached-read tokens per `provider:model`.

Cached reads get their own column deliberately: it is the number that tells you whether prompt caching is actually working.

**AI Step Latency** — step count, average, and slowest provider round-trip per `provider:model`.

This is per *step*, not per run — one provider round-trip. A multi-step tool-using run appears as several rows.

## Implementation

One recorder on one event. `StepCompleted` already carries usage, timing, provider, and model, so nothing new is threaded through the gateway and there is no per-run state to keep — which matters, since a recorder that accumulated across events would break under queues and Octane.

```php
Pulse::record('ai_prompt_tokens', $key, $usage->promptTokens)->sum();
Pulse::record('ai_completion_tokens', $key, $usage->completionTokens)->sum();
Pulse::record('ai_cached_tokens', $key, $usage->cacheReadInputTokens)->sum();
Pulse::record('ai_step_duration', $key, (int) round($event->time))->avg()->max()->count();
```

The step count sits on the duration type alone, so it is not duplicated across the three token types. Durations are rounded because `Pulse::record()` takes `?int`.

**No sampling.** Pulse's sampling concern scales recorded values down, and every core recorder that uses it pairs it with `~value * (1 / sample_rate)` extrapolation in the card. Without that, a sampled dashboard reports a fraction of real token usage as if it were the total — and agent steps are seconds apart, so there is nothing worth sampling away. `ignore` reuses Pulse's own `Ignores` concern.

## Pulse stays optional

`laravel/pulse` is a `suggest` and a `require-dev`, never a hard dependency. The cards register only when both Pulse and Livewire are installed, and registration is deferred via `callAfterResolving(LivewireManager::class)` so a console-only application never resolves Livewire at all.

## Notes for review

- **No cost card.** `Pulse::record()` takes an int and the pricing table is deferred, so this reports tokens, not spend.
- **No run-level latency.** `AgentPrompted` carries no duration, so "slowest agent runs" is not buildable today. Adding `float $time` to that event would unlock it, but it changes an existing public event signature and belongs in its own PR.
- **Packaging.** This puts Livewire components and Blade views in an SDK package. Reasonable per D1 in `plan.md` (one package, one release cycle), but a `laravel/ai-pulse` split is the alternative and is easier to do now than later.
- **Raw entries are kept** (no `onlyBuckets()`). Pulse reserves that for its high-frequency pollers, `Queues` and `Servers`; every `max()`/`count()` recorder shaped like this one — `SlowQueries`, `SlowJobs`, `SlowRequests`, `Exceptions` — keeps them, because dropping them costs the partial-bucket tail at the oldest edge of the window.
- Pulse tests live in their own `tests/Pulse` suite because they need Pulse's and Livewire's service providers, which Pest will not let a single file opt into.
