### PR TITLE
Fail over on Anthropic transient gateway and Cloudflare errors

### DIFF
--- a/src/Gateway/Anthropic/AnthropicFileGateway.php
+++ b/src/Gateway/Anthropic/AnthropicFileGateway.php
@@ -91,6 +91,7 @@ class AnthropicFileGateway implements FileGateway
      */
     protected function overloadedStatusCodes(): array
     {
-        return [529];
+        // 529 is Anthropic's own "overloaded" status, plus the shared transient gateway and Cloudflare codes.
+        return [529, 502, 503, 504, 520, 522, 524];
     }
 }

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -186,7 +186,8 @@ class AnthropicGateway implements Gateway, StepTextGateway
      */
     protected function overloadedStatusCodes(): array
     {
-        return [529];
+        // 529 is Anthropic's own "overloaded" status, plus the shared transient gateway and Cloudflare codes.
+        return [529, 502, 503, 504, 520, 522, 524];
     }
 
     /**

--- a/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Anthropic/ErrorHandlingTest.php
@@ -99,3 +99,20 @@ test('529 overloaded response throws provider overloaded exception', function ()
         provider: 'anthropic',
     );
 })->throws(ProviderOverloadedException::class);
+
+test('transient upstream errors fail over as overloaded', function (int $status): void {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'type' => 'error',
+            'error' => [
+                'type' => 'api_error',
+                'message' => 'The service is temporarily unavailable.',
+            ],
+        ], $status),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'anthropic',
+    );
+})->with([502, 503, 504, 520, 522, 524])->throws(ProviderOverloadedException::class);


### PR DESCRIPTION
#810 widened the base `overloadedStatusCodes` to `[502,503,504,520,522,524]` so transient gateway + cloudflare errors fail over. but `AnthropicGateway` (and `AnthropicFileGateway`) override that method and return `[529]`, which replaces the base list instead of extending it, so anthropic never picked up the new codes.

so every other provider fails over on a 520/522/524 (cloudflare) or 502/504 (gateway), but anthropic doesnt, even though api.anthropic.com is cloudflare fronted. a failover setup with anthropic as primary just hard fails on those.

fix returns `[529, 502, 503, 504, 520, 522, 524]` in both anthropic gateways (529 is anthropics own overloaded code, the rest are the shared transient set). added the same parametrized test the gemini side already has, it was red for anthropic before this.
