### PR TITLE
Allow the caller to supply an agent invocation id

### DIFF
--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -40,6 +40,38 @@ trait Promptable
     use SerializesModels;
 
     /**
+     * The invocation id supplied by the caller for the agent's next run, if any.
+     */
+    protected ?string $pendingInvocationId = null;
+
+    /**
+     * Use the given invocation id for the agent's next run instead of a generated one.
+     *
+     * The id identifies the run in every event it dispatches, so a caller that
+     * already records its own work may reuse that record's identifier here.
+     */
+    public function withInvocationId(string $invocationId): static
+    {
+        $this->pendingInvocationId = $invocationId;
+
+        return $this;
+    }
+
+    /**
+     * Get the invocation id for a run, consuming any the caller supplied.
+     */
+    protected function resolveInvocationId(): string
+    {
+        $invocationId = $this->pendingInvocationId ?? (string) Str::uuid7();
+
+        // Consumed rather than retained, so a reused agent instance cannot
+        // silently stamp a later run with an earlier run's identifier.
+        $this->pendingInvocationId = null;
+
+        return $invocationId;
+    }
+
+    /**
      * Create a new instance of the agent.
      */
     public static function make(...$arguments): static
@@ -63,7 +95,7 @@ trait Promptable
     {
         [$text, $approvalDecisions] = $this->extractPromptInput($prompt);
 
-        $invocationId = (string) Str::uuid7();
+        $invocationId = $this->resolveInvocationId();
 
         $providers = $approvalDecisions !== null
             ? $this->providersForApprovalContinuation($provider, $model)
@@ -127,7 +159,7 @@ trait Promptable
             : $this->getProvidersAndModelsForFailover($provider, $model);
         $resolvedTimeout = $this->getTimeout($timeout);
 
-        $invocationId = (string) Str::uuid7();
+        $invocationId = $this->resolveInvocationId();
 
         [$parentInvocationId, $parentToolInvocationId] = ParentInvocation::current();
 

--- a/tests/Feature/AgentEventsTest.php
+++ b/tests/Feature/AgentEventsTest.php
@@ -940,3 +940,61 @@ test('a single provider synchronous failure reports the prompt the middleware pr
     Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->prompt->prompt === $prompted->prompt->prompt
         && $event->prompt->prompt === 'Revised by middleware.');
 });
+
+test('a caller supplied invocation id is threaded through the run and its events', function (): void {
+    Event::fake();
+
+    AssistantAgent::fake(['Hello!']);
+
+    $response = (new AssistantAgent)->withInvocationId('run-1-step-2')->prompt('Hi');
+
+    expect($response->invocationId)->toBe('run-1-step-2');
+
+    Event::assertDispatched(PromptingAgent::class, fn (PromptingAgent $event): bool => $event->invocationId === 'run-1-step-2'
+        && $event->prompt->invocationId === 'run-1-step-2');
+
+    Event::assertDispatched(StepCompleted::class, fn (StepCompleted $event): bool => $event->invocationId === 'run-1-step-2');
+
+    Event::assertDispatched(AgentPrompted::class, fn (AgentPrompted $event): bool => $event->invocationId === 'run-1-step-2');
+});
+
+test('a run that throws still reports the caller supplied invocation id', function (): void {
+    Event::fake();
+
+    ToolUsingAgent::fake([
+        new ToolCall('call_1', 'FixedNumberGenerator', []),
+        ['number' => 5],
+    ]);
+
+    // Nothing is returned to the caller here, so the id it supplied is the only
+    // thing tying the dispatched events back to the work it was doing...
+    expect(fn (): mixed => (new ToolUsingAgent(fixed: true, toolThrowsException: true))
+        ->withInvocationId('run-1-step-3')
+        ->prompt('Generate'))->toThrow(Exception::class, 'Forced to throw exception.');
+
+    Event::assertDispatched(AgentFailed::class, fn (AgentFailed $event): bool => $event->invocationId === 'run-1-step-3');
+
+    Event::assertDispatched(ToolFailed::class, fn (ToolFailed $event): bool => $event->invocationId === 'run-1-step-3');
+});
+
+test('a supplied invocation id belongs to a single run', function (): void {
+    AssistantAgent::fake(['First', 'Second']);
+
+    $agent = new AssistantAgent;
+
+    $first = $agent->withInvocationId('run-1-step-4')->prompt('Hi');
+    $second = $agent->prompt('Hi again');
+
+    expect($first->invocationId)->toBe('run-1-step-4')
+        ->and($second->invocationId)->not->toBe('run-1-step-4');
+});
+
+test('a streamed run uses the caller supplied invocation id', function (): void {
+    AssistantAgent::fake(['Hello!']);
+
+    $response = (new AssistantAgent)->withInvocationId('run-1-step-5')->stream('Hi');
+
+    $response->each(fn (): true => true);
+
+    expect($response->invocationId)->toBe('run-1-step-5');
+});


### PR DESCRIPTION
`Promptable::prompt()` generates the invocation id internally and only hands it back on the response. When a run throws there is no response, so the caller never learns the id of the run it started, even though each event it dispatched, including `AgentFailed`, carries it.

`AgentPrompt` already accepts an `invocationId`, so this is only the entry point. This adds `withInvocationId()` to `Promptable`, following the fluent style of `continue()` and `forParticipant()`. The id is consumed by one run, so a reused agent instance can't stamp a later run with an earlier id. `Contracts\Agent` is unchanged.

Use case: a queued job that prompts an agent and keeps its own record of the work can pass that record's id in, so the run's events arrive already labelled with it instead of being reconciled after the fact.