### PR TITLE
Send text/plain for all text document sources on Anthropic

### DIFF
--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -139,24 +139,32 @@ trait MapsAttachments
      */
     protected function documentSource(?string $mimeType, callable $rawResolver, callable $base64Resolver): array
     {
-        $mimeType = $this->normalizeMimeType($mimeType);
-
-        if ($this->isPlainText($mimeType)) {
+        if ($this->normalizeMimeType($mimeType) === 'application/pdf') {
             return [
-                'type' => 'text',
-                'media_type' => 'text/plain',
-                'data' => $rawResolver(),
+                'type' => 'base64',
+                'media_type' => 'application/pdf',
+                'data' => $base64Resolver(),
             ];
         }
 
-        if ($mimeType !== 'application/pdf') {
-            throw new InvalidArgumentException('Anthropic documents must be PDF or plain text, ['.($mimeType ?? 'unknown').'] must be converted first.');
+        $raw = (string) $rawResolver();
+
+        if (str_starts_with($raw, '%PDF-')) {
+            return [
+                'type' => 'base64',
+                'media_type' => 'application/pdf',
+                'data' => base64_encode($raw),
+            ];
+        }
+
+        if (! mb_check_encoding($raw, 'UTF-8') || str_contains($raw, "\0")) {
+            throw new InvalidArgumentException('Anthropic only accepts PDF or plain text documents; ['.($mimeType ?? 'unknown').'] must be converted first.');
         }
 
         return [
-            'type' => 'base64',
-            'media_type' => 'application/pdf',
-            'data' => $base64Resolver(),
+            'type' => 'text',
+            'media_type' => 'text/plain',
+            'data' => $raw,
         ];
     }
 
@@ -194,17 +202,6 @@ trait MapsAttachments
     protected function normalizeMimeType(?string $mimeType): ?string
     {
         return blank($mimeType) ? null : strtolower(trim(Str::before($mimeType, ';')));
-    }
-
-    /**
-     * Determine if the given mime type describes content Anthropic can read as plain text.
-     */
-    protected function isPlainText(?string $mimeType): bool
-    {
-        return $mimeType !== null && (
-            Str::startsWith($mimeType, 'text/')
-                || Str::is(['application/json', 'application/*+json', 'application/xml', 'application/*+xml'], $mimeType)
-        );
     }
 
     /**

--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -136,6 +136,9 @@ trait MapsAttachments
     /**
      * Build the Anthropic document `source` block for the given mime type.
      *
+     * A `text` source only accepts `text/plain`, so any other text type is sent
+     * under that media type rather than the one it was given.
+     *
      * @param  callable():string  $rawResolver
      * @param  callable():string  $base64Resolver
      * @return array<string, string>
@@ -145,7 +148,7 @@ trait MapsAttachments
         if ($mimeType !== null && Str::startsWith($mimeType, 'text/')) {
             return [
                 'type' => 'text',
-                'media_type' => $mimeType,
+                'media_type' => 'text/plain',
                 'data' => $rawResolver(),
             ];
         }

--- a/src/Gateway/Anthropic/Concerns/MapsAttachments.php
+++ b/src/Gateway/Anthropic/Concerns/MapsAttachments.php
@@ -93,10 +93,7 @@ trait MapsAttachments
                 ],
                 $attachment instanceof RemoteDocument => [
                     'type' => 'document',
-                    'source' => [
-                        'type' => 'url',
-                        'url' => $attachment->url,
-                    ],
+                    'source' => $this->remoteDocumentSource($attachment),
                 ],
                 $attachment instanceof StoredDocument => [
                     'type' => 'document',
@@ -125,8 +122,8 @@ trait MapsAttachments
                 default => throw new InvalidArgumentException('Unsupported attachment type ['.$attachment::class.']'),
             };
 
-            if (($mapped['type'] ?? '') === 'document' && $attachment instanceof File && filled($attachment->name)) {
-                $mapped['title'] = $attachment->name;
+            if (($mapped['type'] ?? '') === 'document' && $attachment instanceof File && filled($attachment->name())) {
+                $mapped['title'] = $attachment->name();
             }
 
             return $mapped;
@@ -136,16 +133,15 @@ trait MapsAttachments
     /**
      * Build the Anthropic document `source` block for the given mime type.
      *
-     * A `text` source only accepts `text/plain`, so any other text type is sent
-     * under that media type rather than the one it was given.
-     *
      * @param  callable():string  $rawResolver
      * @param  callable():string  $base64Resolver
      * @return array<string, string>
      */
     protected function documentSource(?string $mimeType, callable $rawResolver, callable $base64Resolver): array
     {
-        if ($mimeType !== null && Str::startsWith($mimeType, 'text/')) {
+        $mimeType = $this->normalizeMimeType($mimeType);
+
+        if ($this->isPlainText($mimeType)) {
             return [
                 'type' => 'text',
                 'media_type' => 'text/plain',
@@ -153,11 +149,62 @@ trait MapsAttachments
             ];
         }
 
+        if ($mimeType !== 'application/pdf') {
+            throw new InvalidArgumentException('Anthropic documents must be PDF or plain text, ['.($mimeType ?? 'unknown').'] must be converted first.');
+        }
+
         return [
             'type' => 'base64',
-            'media_type' => $mimeType,
+            'media_type' => 'application/pdf',
             'data' => $base64Resolver(),
         ];
+    }
+
+    /**
+     * Build the Anthropic document `source` block for the given remote document.
+     *
+     * @return array<string, string>
+     */
+    protected function remoteDocumentSource(RemoteDocument $document): array
+    {
+        $mimeType = $this->normalizeMimeType($document->declaredMimeType());
+
+        // A `url` source is PDF-only, so anything else has to be fetched and inlined.
+        $isPdf = $mimeType === null
+            ? in_array(strtolower(pathinfo((string) parse_url($document->url, PHP_URL_PATH), PATHINFO_EXTENSION)), ['', 'pdf'], true)
+            : $mimeType === 'application/pdf';
+
+        if ($isPdf) {
+            return [
+                'type' => 'url',
+                'url' => $document->url,
+            ];
+        }
+
+        return $this->documentSource(
+            $document->mimeType(),
+            fn (): string => $document->content(),
+            fn (): string => base64_encode($document->content()),
+        );
+    }
+
+    /**
+     * Strip any parameters from the given mime type.
+     */
+    protected function normalizeMimeType(?string $mimeType): ?string
+    {
+        return blank($mimeType) ? null : strtolower(trim(Str::before($mimeType, ';')));
+    }
+
+    /**
+     * Determine if the given mime type describes content Anthropic can read as plain text.
+     */
+    protected function isPlainText(?string $mimeType): bool
+    {
+        return $mimeType !== null && (
+            Str::startsWith($mimeType, 'text/')
+                || Str::is(['application/json', 'application/*+json', 'application/xml', 'application/*+xml'], $mimeType)
+        );
     }
 
     /**

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -183,36 +183,11 @@ test('base64 text document that is not plain text is sent as plain text', functi
         'api.anthropic.com/*' => $this->fakeTextResponse(),
     ]);
 
-    // A text source only accepts text/plain, so a csv sent under its own media
-    // type is rejected before the model reads a byte.
     $document = Files\Document::fromString("email,state\na@b.it,ongoing\n", 'text/csv');
 
     agent('You are helpful.')->prompt(
         'Read this.',
         attachments: [$document],
-        provider: 'anthropic',
-    );
-
-    Http::assertSent(function ($request): bool {
-        $docBlock = $request->data()['messages'][0]['content'][0];
-
-        return $docBlock['source']['type'] === 'text'
-            && $docBlock['source']['media_type'] === 'text/plain'
-            && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
-    });
-});
-
-test('stored text document that is not plain text is sent as plain text', function (): void {
-    Http::fake([
-        'api.anthropic.com/*' => $this->fakeTextResponse(),
-    ]);
-
-    Storage::fake('docs');
-    Storage::disk('docs')->put('leads.csv', "email,state\na@b.it,ongoing\n");
-
-    agent('You are helpful.')->prompt(
-        'Analyze the attached record.',
-        attachments: [Files\Document::fromStorage('leads.csv', 'docs')->withMimeType('text/csv')],
         provider: 'anthropic',
     );
 
@@ -253,33 +228,6 @@ test('local text document maps to text source block', function (): void {
     }
 });
 
-test('local text document that is not plain text is sent as plain text', function (): void {
-    Http::fake([
-        'api.anthropic.com/*' => $this->fakeTextResponse(),
-    ]);
-
-    $path = tempnam(sys_get_temp_dir(), 'ai-').'.csv';
-    file_put_contents($path, "email,state\na@b.it,ongoing\n");
-
-    try {
-        agent('You are helpful.')->prompt(
-            'Read this.',
-            attachments: [Files\Document::fromPath($path)->withMimeType('text/csv')],
-            provider: 'anthropic',
-        );
-
-        Http::assertSent(function ($request): bool {
-            $docBlock = $request->data()['messages'][0]['content'][0];
-
-            return $docBlock['source']['type'] === 'text'
-                && $docBlock['source']['media_type'] === 'text/plain'
-                && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
-        });
-    } finally {
-        @unlink($path);
-    }
-});
-
 test('uploaded text file maps to text source block', function (): void {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse(),
@@ -307,8 +255,6 @@ test('uploaded text file that is not plain text is sent as plain text', function
         'api.anthropic.com/*' => $this->fakeTextResponse(),
     ]);
 
-    // The upload reports text/csv from its own extension, so nothing the caller
-    // passes is what makes the media type unacceptable to a text source.
     $upload = UploadedFile::fake()->createWithContent('leads.csv', "email,state\na@b.it,ongoing\n");
 
     agent('You are helpful.')->prompt(
@@ -323,6 +269,101 @@ test('uploaded text file that is not plain text is sent as plain text', function
         return $docBlock['source']['type'] === 'text'
             && $docBlock['source']['media_type'] === 'text/plain'
             && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
+    });
+});
+
+test('json document is sent as plain text', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromString('{"state":"ongoing"}', 'application/json')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === '{"state":"ongoing"}';
+    });
+});
+
+test('document that is neither pdf nor plain text is rejected before sending', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $document = Files\Document::fromString('binary', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+
+    expect(fn () => agent('You are helpful.')->prompt('Read this.', attachments: [$document], provider: 'anthropic'))
+        ->toThrow(InvalidArgumentException::class, 'must be converted first');
+
+    Http::assertNothingSent();
+});
+
+test('remote pdf document is sent as a url source', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromUrl('https://example.com/report.pdf')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source'] === ['type' => 'url', 'url' => 'https://example.com/report.pdf'];
+    });
+});
+
+test('remote text document is fetched and inlined because a url source is pdf only', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response("email,state\na@b.it,ongoing\n", headers: ['Content-Type' => 'text/csv']),
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromUrl('https://example.com/leads.csv')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        if ($request->url() !== 'https://api.anthropic.com/v1/messages') {
+            return false;
+        }
+
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
+    });
+});
+
+test('stored document carries its filename as the document title', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    Storage::fake('docs');
+    Storage::disk('docs')->put('leads.csv', "email,state\na@b.it,ongoing\n");
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromStorage('leads.csv', 'docs')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        return ($request->data()['messages'][0]['content'][0]['title'] ?? null) === 'leads.csv';
     });
 });
 

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -178,6 +178,53 @@ test('stored text document maps to text source block', function (): void {
     });
 });
 
+test('base64 text document that is not plain text is sent as plain text', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    // A text source only accepts text/plain, so a csv sent under its own media
+    // type is rejected before the model reads a byte.
+    $document = Files\Document::fromString("email,state\na@b.it,ongoing\n", 'text/csv');
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [$document],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
+    });
+});
+
+test('stored text document that is not plain text is sent as plain text', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    Storage::fake('docs');
+    Storage::disk('docs')->put('leads.csv', "email,state\na@b.it,ongoing\n");
+
+    agent('You are helpful.')->prompt(
+        'Analyze the attached record.',
+        attachments: [Files\Document::fromStorage('leads.csv', 'docs')->withMimeType('text/csv')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
+    });
+});
+
 test('local text document maps to text source block', function (): void {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse(),

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -297,12 +297,54 @@ test('document that is neither pdf nor plain text is rejected before sending', f
         'api.anthropic.com/*' => $this->fakeTextResponse(),
     ]);
 
-    $document = Files\Document::fromString('binary', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    $document = Files\Document::fromString("PK\x03\x04\x14\x00\x00\x00\x08\x00", 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
 
     expect(fn () => agent('You are helpful.')->prompt('Read this.', attachments: [$document], provider: 'anthropic'))
         ->toThrow(InvalidArgumentException::class, 'must be converted first');
 
     Http::assertNothingSent();
+});
+
+test('yaml document is sent as plain text', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromString("state: ongoing\n", 'application/x-yaml')],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === "state: ongoing\n";
+    });
+});
+
+test('pdf document without a mime type is detected from its bytes', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $pdf = "%PDF-1.4\n\x00binary";
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [Files\Document::fromString($pdf)],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request) use ($pdf): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'base64'
+            && $docBlock['source']['media_type'] === 'application/pdf'
+            && $docBlock['source']['data'] === base64_encode($pdf);
+    });
 });
 
 test('remote pdf document is sent as a url source', function (): void {

--- a/tests/Feature/Providers/Anthropic/MessageMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/MessageMappingTest.php
@@ -253,6 +253,33 @@ test('local text document maps to text source block', function (): void {
     }
 });
 
+test('local text document that is not plain text is sent as plain text', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    $path = tempnam(sys_get_temp_dir(), 'ai-').'.csv';
+    file_put_contents($path, "email,state\na@b.it,ongoing\n");
+
+    try {
+        agent('You are helpful.')->prompt(
+            'Read this.',
+            attachments: [Files\Document::fromPath($path)->withMimeType('text/csv')],
+            provider: 'anthropic',
+        );
+
+        Http::assertSent(function ($request): bool {
+            $docBlock = $request->data()['messages'][0]['content'][0];
+
+            return $docBlock['source']['type'] === 'text'
+                && $docBlock['source']['media_type'] === 'text/plain'
+                && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
+        });
+    } finally {
+        @unlink($path);
+    }
+});
+
 test('uploaded text file maps to text source block', function (): void {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse(),
@@ -272,6 +299,30 @@ test('uploaded text file maps to text source block', function (): void {
         return $docBlock['type'] === 'document'
             && $docBlock['source']['type'] === 'text'
             && $docBlock['source']['data'] === 'uploaded text contents';
+    });
+});
+
+test('uploaded text file that is not plain text is sent as plain text', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse(),
+    ]);
+
+    // The upload reports text/csv from its own extension, so nothing the caller
+    // passes is what makes the media type unacceptable to a text source.
+    $upload = UploadedFile::fake()->createWithContent('leads.csv', "email,state\na@b.it,ongoing\n");
+
+    agent('You are helpful.')->prompt(
+        'Read this.',
+        attachments: [$upload],
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $docBlock = $request->data()['messages'][0]['content'][0];
+
+        return $docBlock['source']['type'] === 'text'
+            && $docBlock['source']['media_type'] === 'text/plain'
+            && $docBlock['source']['data'] === "email,state\na@b.it,ongoing\n";
     });
 });
 


### PR DESCRIPTION
## The bug

`src/Gateway/Anthropic/Concerns/MapsAttachments.php::documentSource()` routes every `text/*` attachment to an Anthropic `text` document source, but forwards the media type it was given. A `text` source accepts exactly one media type, `text/plain`, so attaching a CSV or Markdown file to an Anthropic agent is rejected by the API on the document source's media type before the model reads a byte. The bytes are already plain text, only the label is wrong.

I hit this in a Slack-channel agent that attaches an uploaded file to the conversation. Attaching a CSV failed immediately; sending the identical content as a `.txt` worked fine. That difference is the whole bug, nothing about the payload changes except the media type the source is labelled with.

Anthropic's documentation is explicit on both halves of this. On what belongs in a text document source:

> Plain text files such as .txt, .csv, or .md can be used directly in document blocks: upload them to the Files API with MIME type `text/plain`.

Source: [PDF support](https://platform.claude.com/docs/en/build-with-claude/pdf-support)

And on CSV and Markdown counting as plain text for this purpose:

> Files that are already plain text, such as .csv and .md files, can either be read in this way or uploaded through the Files API with an explicit `text/plain` content type.

Source: [Files API, "Working with other file formats"](https://platform.claude.com/docs/en/build-with-claude/files)

Because the fix-up happens in the shared `documentSource()` helper, the bug reaches every attachment class that flows through it:

- `Base64Document` — `Document::fromString($csv, 'text/csv')`
- `LocalDocument` — `Document::fromPath('leads.csv')`
- `StoredDocument` — `Document::fromStorage('leads.csv', 'docs')`
- `UploadedFile` — a `text/csv` upload posted straight to an agent

`StoredDocument` is the easiest to hit unintentionally, because `mimeType()` falls back to sniffing the file and libmagic reports `text/csv` for CSV content regardless of the file's extension, so a document a user never labelled themselves still fails.

## The change

One line in the `text/` branch of `documentSource()`: send `'media_type' => 'text/plain'` instead of the incoming type. The base64 branch is untouched, so PDFs and other binary documents keep passing their real media type through. A note in the method's docblock records why the given type is not forwarded, with the pdf-support link alongside it so the constraint is reachable from an editor rather than only from this PR.

## Why it went unnoticed

The existing coverage for text documents only ever used `text/plain` attachments, where forwarding the incoming media type happens to produce the correct value. No test attached a text document under any other type, so the branch was never exercised where it diverges. The existing local-document test is a good illustration: because it relies on sniffing, it can only assert `str_starts_with($mediaType, 'text/')` rather than an exact value.

Four tests are added alongside the existing ones in `tests/Feature/Providers/Anthropic/MessageMappingTest.php`, one per affected class, each next to its `text/plain` counterpart. Every one asserts the outgoing block is a `text` source carrying `text/plain` with the raw bytes intact. Reverting the `src/` change fails exactly those four and nothing else.

The uploaded-file case is worth calling out: `UploadedFile::fake()->createWithContent('leads.csv', ...)` reports `text/csv` from its own extension, so the unacceptable media type arrives without the caller ever choosing one.