### PR TITLE
Update Gemini default text model to gemini-3.7-flash

### DIFF
--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -93,7 +93,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function defaultTextModel(): string
     {
-        return $this->config['models']['text']['default'] ?? 'gemini-3.6-flash';
+        return $this->config['models']['text']['default'] ?? 'gemini-3.7-flash';
     }
 
     /**
@@ -109,7 +109,7 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
      */
     public function smartestTextModel(): string
     {
-        return $this->config['models']['text']['smartest'] ?? 'gemini-3.6-flash';
+        return $this->config['models']['text']['smartest'] ?? 'gemini-3.7-flash';
     }
 
     /**

--- a/tests/Feature/Providers/Gemini/GeminiHelpers.php
+++ b/tests/Feature/Providers/Gemini/GeminiHelpers.php
@@ -23,7 +23,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3.5-flash',
+            'modelVersion' => 'gemini-3.7-flash',
         ]);
     }
 
@@ -48,7 +48,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3.5-flash',
+            'modelVersion' => 'gemini-3.7-flash',
         ]);
     }
 
@@ -67,7 +67,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3.5-flash',
+            'modelVersion' => 'gemini-3.7-flash',
         ]);
     }
 
@@ -92,7 +92,7 @@ trait GeminiHelpers
                 'candidatesTokenCount' => 5,
                 'totalTokenCount' => 15,
             ],
-            'modelVersion' => 'gemini-3.5-flash',
+            'modelVersion' => 'gemini-3.7-flash',
         ]);
     }
 
@@ -140,7 +140,7 @@ trait GeminiHelpers
 
         return [
             'candidates' => [$candidate],
-            'modelVersion' => $modelVersion ?? 'gemini-3.5-flash',
+            'modelVersion' => $modelVersion ?? 'gemini-3.7-flash',
         ];
     }
 

--- a/tests/Feature/Providers/Gemini/RequestMappingTest.php
+++ b/tests/Feature/Providers/Gemini/RequestMappingTest.php
@@ -19,10 +19,10 @@ describe('request structure', function (): void {
         (new AssistantAgent)->prompt(
             'What is Laravel?',
             provider: 'gemini',
-            model: 'gemini-3.5-flash',
+            model: 'gemini-3.7-flash',
         );
 
-        Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'models/gemini-3.5-flash:generateContent')
+        Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'models/gemini-3.7-flash:generateContent')
             && $request->data()['contents'][0]['role'] === 'user'
             && $request->data()['contents'][0]['parts'][0]['text'] === 'What is Laravel?');
     });

--- a/tests/Feature/Providers/Gemini/TranscriptionTest.php
+++ b/tests/Feature/Providers/Gemini/TranscriptionTest.php
@@ -18,13 +18,13 @@ test('transcription request sends audio as inline data with correct mime type', 
     ]);
 
     Transcription::of(base64_encode('fake-audio'))
-        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
+        ->generate(provider: 'gemini', model: 'gemini-3.7-flash');
 
     Http::assertSent(function (Request $request): bool {
         $body = $request->data();
         $parts = $body['contents'][0]['parts'];
 
-        return str_contains($request->url(), 'models/gemini-3.5-flash:generateContent')
+        return str_contains($request->url(), 'models/gemini-3.7-flash:generateContent')
             && $parts[1]['inlineData']['mimeType'] === 'audio/mp3'
             && $parts[1]['inlineData']['data'] === base64_encode('fake-audio');
     });
@@ -37,7 +37,7 @@ test('transcription request includes language in prompt when specified', functio
 
     Transcription::of(base64_encode('fake-audio'))
         ->language('fr')
-        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
+        ->generate(provider: 'gemini', model: 'gemini-3.7-flash');
 
     Http::assertSent(fn (Request $request): bool => str_contains(
         (string) $request->data()['contents'][0]['parts'][0]['text'],
@@ -51,12 +51,12 @@ test('transcription response returns text with correct meta', function (): void 
     ]);
 
     $response = Transcription::of(base64_encode('fake-audio'))
-        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
+        ->generate(provider: 'gemini', model: 'gemini-3.7-flash');
 
     expect($response->text)->toBe('Hello world')
         ->and($response->segments)->toHaveCount(0)
         ->and($response->meta->provider)->toBe('gemini')
-        ->and($response->meta->model)->toBe('gemini-3.5-flash')
+        ->and($response->meta->model)->toBe('gemini-3.7-flash')
         ->and($response->usage->promptTokens)->toBe(10)
         ->and($response->usage->completionTokens)->toBe(5);
 });
@@ -78,7 +78,7 @@ test('diarized transcription request sends json schema in generation config', fu
 
     Transcription::of(base64_encode('fake-audio'))
         ->diarize()
-        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
+        ->generate(provider: 'gemini', model: 'gemini-3.7-flash');
 
     Http::assertSent(function (Request $request): bool {
         $body = $request->data();
@@ -97,7 +97,7 @@ test('diarized transcription response returns text and segments', function (): v
 
     $response = Transcription::of(base64_encode('fake-audio'))
         ->diarize()
-        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
+        ->generate(provider: 'gemini', model: 'gemini-3.7-flash');
 
     expect($response->text)->toBe('Hello world')
         ->and($response->segments)->toHaveCount(2)
@@ -121,7 +121,7 @@ test('diarized transcription parses srt and hour timestamp formats', function ()
 
     $response = Transcription::of(base64_encode('fake-audio'))
         ->diarize()
-        ->generate(provider: 'gemini', model: 'gemini-3.5-flash');
+        ->generate(provider: 'gemini', model: 'gemini-3.7-flash');
 
     expect($response->segments[0]->startSeconds)->toBe(1.5)
         ->and($response->segments[0]->endSeconds)->toBe(62.25)


### PR DESCRIPTION
Google released [Gemini 3.7 Flash](https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/), so this bumps the Gemini provider's default and smartest text model fallbacks from `gemini-3.6-flash` to `gemini-3.7-flash`. Gemini feature tests updated to use the new model as well.

The transcription default stays on `gemini-3.5-flash`, unchanged here.