### PR TITLE
Keep the MCP request bound while converting generator results

### DIFF
--- a/src/Tools/McpServerTool.php
+++ b/src/Tools/McpServerTool.php
@@ -78,14 +78,12 @@ class McpServerTool implements Tool
         $container->instance(self::MCP_REQUEST, new (self::MCP_REQUEST)($request->toArray()));
 
         try {
-            $response = $container->call([$this->tool, 'handle']);
+            return $this->convertResponse($container->call([$this->tool, 'handle']));
         } finally {
             $previous !== null
                 ? $container->instance(self::MCP_REQUEST, $previous)
                 : $container->forgetInstance(self::MCP_REQUEST);
         }
-
-        return $this->convertResponse($response);
     }
 
     /**

--- a/tests/Unit/Tools/McpServerToolTest.php
+++ b/tests/Unit/Tools/McpServerToolTest.php
@@ -1,10 +1,13 @@
 <?php
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Tools\McpServerTool;
 use Laravel\Ai\Tools\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
 use Tests\Fixtures\Mcp\FakeArrayMcpServerTool;
 use Tests\Fixtures\Mcp\FakeErroringMcpServerTool;
 use Tests\Fixtures\Mcp\FakeMcpServerTool;
@@ -89,6 +92,24 @@ test('it returns only the final item from an array response', function (): void 
     $tool = new McpServerTool(new FakeArrayMcpServerTool);
 
     expect($tool->handle(new Request))->toBe('Third.');
+});
+
+test('lazily yielded responses still resolve the scoped mcp request', function (): void {
+    $tool = new McpServerTool(new class extends Tool
+    {
+        public function handle(Laravel\Mcp\Request $request): Generator
+        {
+            yield Response::text('First. ');
+            yield Response::text(Container::getInstance()->make(Laravel\Mcp\Request::class)->get('city'));
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    });
+
+    expect($tool->handle(new Request(['city' => 'Paris'])))->toBe('Paris');
 });
 
 test('the mcp request binding is cleared after the call', function (): void {


### PR DESCRIPTION
**What changed**

```php
// before
try {
    $response = $container->call([$this->tool, 'handle']);
} finally {
    // binding restored here
}

return $this->convertResponse($response);

// after
try {
    return $this->convertResponse($container->call([$this->tool, 'handle']));
} finally {
    // binding restored here
}
```

**Why it's needed**

MCP server tools can return a `Generator`. A generator doesn't run until something iterates it, and `convertResponse()` is what iterates it. Today that happens after the `finally` has already restored the previous `Laravel\Mcp\Request` binding.

**What happens without it**

Everything after the first `yield` runs outside the tool's request scope, so a streaming tool that resolves `Request` from the container gets the wrong one, or nothing at all:

```php
yield Response::text('working...');
yield Response::text(app(Request::class)->get('city')); // empty
```

Test added, it fails on the current code.