### PR TITLE
Add support for the OpenRouter web fetch server tool

### DIFF
--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -12,6 +12,7 @@ use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
@@ -23,6 +24,7 @@ use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Providers\Tools\ProviderTool;
+use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
@@ -58,10 +60,33 @@ class OpenRouterGateway implements Gateway, StepTextGateway
      */
     protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
     {
-        if (! $tool instanceof WebSearch) {
-            throw new RuntimeException('OpenRouter does not support ['.class_basename($tool).'] provider tools.');
+        return match (true) {
+            $tool instanceof WebFetch => $this->mapWebFetchTool($tool, $provider),
+            $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
+            default => throw new RuntimeException('OpenRouter does not support ['.class_basename($tool).'] provider tools.'),
+        };
+    }
+
+    /**
+     * Map a web fetch tool to an OpenRouter server tool definition.
+     */
+    protected function mapWebFetchTool(WebFetch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsWebFetch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support web fetch.');
         }
 
+        return [
+            'type' => 'openrouter:web_fetch',
+            ...$provider->webFetchToolOptions($tool),
+        ];
+    }
+
+    /**
+     * Map a web search tool to an OpenRouter server tool definition.
+     */
+    protected function mapWebSearchTool(WebSearch $tool, Provider $provider): array
+    {
         if (! $provider instanceof SupportsWebSearch) {
             throw new RuntimeException('Provider ['.$provider->name().'] does not support web search.');
         }

--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -27,11 +27,11 @@ class AnthropicProvider extends Provider implements FileProvider, SupportsToolSe
     public function webFetchToolOptions(WebFetch $fetch): array
     {
         return array_filter([
-            'max_uses' => $fetch->maxSearches ?? 10,
+            'max_uses' => $fetch->maxSearches,
             'allowed_domains' => $fetch->allowedDomains === []
                 ? null
                 : $fetch->allowedDomains,
-        ]);
+        ]) + $fetch->providerOptions(Lab::Anthropic);
     }
 
     /**

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -11,14 +11,16 @@ use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\OpenRouter\OpenRouterGateway;
+use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, SupportsWebSearch, TextProvider, TranscriptionProvider
+class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingProvider, ImageProvider, SupportsWebFetch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
@@ -35,6 +37,23 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
     public function __construct(protected array $config, protected Dispatcher $events)
     {
         //
+    }
+
+    /**
+     * Get the web fetch tool options for the provider.
+     */
+    public function webFetchToolOptions(WebFetch $fetch): array
+    {
+        $options = $fetch->providerOptions(Lab::OpenRouter);
+
+        $parameters = array_filter([
+            'max_uses' => $fetch->maxSearches,
+            'allowed_domains' => filled($fetch->allowedDomains) ? $fetch->allowedDomains : null,
+        ]) + $options;
+
+        return array_filter([
+            'parameters' => filled($parameters) ? $parameters : null,
+        ]);
     }
 
     /**

--- a/src/Providers/OpenRouterProvider.php
+++ b/src/Providers/OpenRouterProvider.php
@@ -44,16 +44,7 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
      */
     public function webFetchToolOptions(WebFetch $fetch): array
     {
-        $options = $fetch->providerOptions(Lab::OpenRouter);
-
-        $parameters = array_filter([
-            'max_uses' => $fetch->maxSearches,
-            'allowed_domains' => filled($fetch->allowedDomains) ? $fetch->allowedDomains : null,
-        ]) + $options;
-
-        return array_filter([
-            'parameters' => filled($parameters) ? $parameters : null,
-        ]);
+        return $this->serverToolOptions($fetch);
     }
 
     /**
@@ -61,15 +52,19 @@ class OpenRouterProvider extends Provider implements AudioProvider, EmbeddingPro
      */
     public function webSearchToolOptions(WebSearch $search): array
     {
-        $options = $search->providerOptions(Lab::OpenRouter);
+        return $this->serverToolOptions($search);
+    }
 
-        $parameters = array_filter([
-            'max_results' => $search->maxSearches,
-            'allowed_domains' => filled($search->allowedDomains) ? $search->allowedDomains : null,
-        ]) + $options;
-
+    /**
+     * Get the parameters for an OpenRouter server tool.
+     */
+    protected function serverToolOptions(WebFetch|WebSearch $tool): array
+    {
         return array_filter([
-            'parameters' => filled($parameters) ? $parameters : null,
+            'parameters' => array_filter([
+                'max_uses' => $tool->maxSearches,
+                'allowed_domains' => $tool->allowedDomains,
+            ]) + $tool->providerOptions(Lab::OpenRouter),
         ]);
     }
 

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -141,7 +141,7 @@ test('web fetch tool sends allowed_domains', function () {
     });
 });
 
-test('web fetch tool defaults max_uses to ten', function () {
+test('web fetch tool omits max_uses when none is set', function () {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
     ]);
@@ -151,7 +151,27 @@ test('web fetch tool defaults max_uses to ten', function () {
     Http::assertSent(function ($request) {
         $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_fetch');
 
-        return data_get($tool, 'max_uses') === 10;
+        return $tool !== null && ! array_key_exists('max_uses', $tool);
+    });
+});
+
+test('web fetch tool forwards provider options', function () {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    $fetch = (new WebFetch)->withProviderOptions([
+        'citations' => ['enabled' => true],
+        'max_content_tokens' => 50000,
+    ]);
+
+    agent(tools: [$fetch])->prompt('Fetch', provider: 'anthropic');
+
+    Http::assertSent(function ($request) {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'web_fetch');
+
+        return data_get($tool, 'citations.enabled') === true
+            && data_get($tool, 'max_content_tokens') === 50000;
     });
 });
 

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -164,7 +164,7 @@ test('web search tool is sent as openrouter:web_search type', function (): void 
     });
 });
 
-test('web search tool sends max_results when maxSearches is set', function (): void {
+test('web search tool sends max_uses when maxSearches is set', function (): void {
     Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
     agent(tools: [(new WebSearch)->max(5)])->prompt('Search the web', provider: 'openrouter');
@@ -173,7 +173,23 @@ test('web search tool sends max_results when maxSearches is set', function (): v
         $body = json_decode($request->body(), true);
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
 
-        return data_get($tool, 'parameters.max_results') === 5;
+        return data_get($tool, 'parameters.max_uses') === 5;
+    });
+});
+
+test('web search tool forwards max_results through provider options', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    $search = (new WebSearch)->max(3)->withProviderOptions(['max_results' => 10]);
+
+    agent(tools: [$search])->prompt('Search the web', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_search');
+
+        return data_get($tool, 'parameters.max_uses') === 3
+            && data_get($tool, 'parameters.max_results') === 10;
     });
 });
 

--- a/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/ToolMappingTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Responses\AgentResponse;
@@ -73,8 +74,81 @@ test('tool parameters are not wrapped in schema definition', function (): void {
 test('unsupported provider tools throw runtime exception', function (): void {
     Http::fake(['*' => fakeOpenRouterResponse('done')]);
 
-    expect(fn (): AgentResponse => agent(tools: [new WebFetch])->prompt('Search', provider: 'openrouter'))
-        ->toThrow(RuntimeException::class, 'OpenRouter does not support [WebFetch] provider tools.');
+    expect(fn (): AgentResponse => agent(tools: [new FileSearch(['store'])])->prompt('Search', provider: 'openrouter'))
+        ->toThrow(RuntimeException::class, 'OpenRouter does not support [FileSearch] provider tools.');
+});
+
+test('web fetch tool is sent as openrouter:web_fetch type', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [new WebFetch])->prompt('Read https://laravel.com', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_fetch');
+
+        return $tool !== null && ! array_key_exists('parameters', $tool);
+    });
+});
+
+test('web fetch tool sends max_uses when maxSearches is set', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [(new WebFetch)->max(5)])->prompt('Read https://laravel.com', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_fetch');
+
+        return data_get($tool, 'parameters.max_uses') === 5;
+    });
+});
+
+test('web fetch tool sends allowed_domains', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [(new WebFetch)->allow(['example.com', 'laravel.com'])])->prompt('Read the docs', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_fetch');
+
+        return data_get($tool, 'parameters.allowed_domains') === ['example.com', 'laravel.com'];
+    });
+});
+
+test('web fetch tool forwards provider options into parameters', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    $fetch = (new WebFetch)->withProviderOptions([
+        'engine' => 'exa',
+        'max_content_tokens' => 50000,
+        'blocked_domains' => ['private.example.com'],
+    ]);
+
+    agent(tools: [$fetch])->prompt('Read the docs', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'openrouter:web_fetch');
+
+        return data_get($tool, 'parameters.engine') === 'exa'
+            && data_get($tool, 'parameters.max_content_tokens') === 50000
+            && data_get($tool, 'parameters.blocked_domains') === ['private.example.com'];
+    });
+});
+
+test('web fetch and web search can be used together', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('done')]);
+
+    agent(tools: [new WebSearch, new WebFetch])->prompt('Research this', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $types = collect(data_get(json_decode($request->body(), true), 'tools'))->pluck('type')->all();
+
+        return in_array('openrouter:web_search', $types, true)
+            && in_array('openrouter:web_fetch', $types, true);
+    });
 });
 
 test('web search tool is sent as openrouter:web_search type', function (): void {


### PR DESCRIPTION
OpenRouter serves `openrouter:web_fetch` as a server tool next to `openrouter:web_search` ([docs](https://openrouter.ai/docs/guides/features/server-tools/web-fetch)) — the model asks for a URL, OpenRouter fetches and extracts the page (or PDF) and hands the text back.

`WebFetch` could not reach it: `OpenRouterGateway::mapProviderTool()` threw for every provider tool that was not a `WebSearch`, so on OpenRouter the tool was simply unavailable. Anthropic and Gemini both map it already (`web_fetch_20250910` and `url_context`), so this brings the third provider that supports it in line.

## Changes

- `OpenRouterProvider` implements `SupportsWebFetch`. `maxSearches` maps to `max_uses` and `allowedDomains` to `allowed_domains`, both nested under `parameters` — the same shape `webSearchToolOptions()` already builds, and the shape the API documents. Provider options merge in, so `engine`, `max_content_tokens` and `blocked_domains` are reachable without further changes here.
- `OpenRouterGateway::mapProviderTool()` becomes a `match` over `WebFetch`/`WebSearch` (mirroring `Gateway\Anthropic\Concerns\MapsTools`), still throwing for anything else.
- The test that pinned the old refusal now uses `FileSearch`, which OpenRouter genuinely does not support, so the "unsupported tool throws" case stays covered.

## Verified

The emitted body was checked against the live API — this request returns `"Example Domain"`, so the payload is accepted and the fetch really happens:

```json
{
  "model": "google/gemini-3.5-flash-lite",
  "messages": [{"role": "user", "content": "Fetch https://example.com and quote its exact page title."}],
  "tools": [{"type": "openrouter:web_fetch", "parameters": {"max_uses": 2, "allowed_domains": ["example.com"]}}]
}
```

New tests cover the tool type, `max_uses`, `allowed_domains`, provider-option forwarding, and web fetch alongside web search. `vendor/bin/pest` is green (2155 passed, 260 skipped) and Pint is clean.