### PR TITLE
Add MiniMax text-to-speech support

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -114,6 +114,12 @@ return [
             'key' => env('JINA_API_KEY'),
         ],
 
+        'minimax' => [
+            'driver' => 'minimax',
+            'key' => env('MINIMAX_API_KEY'),
+            'url' => env('MINIMAX_URL', 'https://api.minimax.io/v1'),
+        ],
+
         'mistral' => [
             'driver' => 'mistral',
             'key' => env('MISTRAL_API_KEY'),

--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -487,7 +487,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 | ---------- | --------------------------------------------------------------- |
 | Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter, OpenAI-compatible |
 | Images     | OpenAI, Gemini, xAI                                            |
-| TTS        | OpenAI, ElevenLabs                                              |
+| TTS        | OpenAI, ElevenLabs, MiniMax                                     |
 | STT        | OpenAI, ElevenLabs, Mistral, Groq, OpenAI-compatible            |
 | Embeddings | OpenAI, OpenAI-compatible, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI |
 | Reranking  | Cohere, Jina                                                    |

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -27,6 +27,7 @@ use Laravel\Ai\Providers\ElevenLabsProvider;
 use Laravel\Ai\Providers\GeminiProvider;
 use Laravel\Ai\Providers\GroqProvider;
 use Laravel\Ai\Providers\JinaProvider;
+use Laravel\Ai\Providers\MiniMaxProvider;
 use Laravel\Ai\Providers\MistralProvider;
 use Laravel\Ai\Providers\OllamaProvider;
 use Laravel\Ai\Providers\OpenAiCompatibleProvider;
@@ -375,6 +376,17 @@ class AiManager extends MultipleInstanceManager
     public function createJinaDriver(array $config): JinaProvider
     {
         return new JinaProvider(
+            $config,
+            $this->app->make(Dispatcher::class)
+        );
+    }
+
+    /**
+     * Create a MiniMax powered instance.
+     */
+    public function createMinimaxDriver(array $config): MiniMaxProvider
+    {
+        return new MiniMaxProvider(
             $config,
             $this->app->make(Dispatcher::class)
         );

--- a/src/Enums/Lab.php
+++ b/src/Enums/Lab.php
@@ -13,6 +13,7 @@ enum Lab: string
     case Gemini = 'gemini';
     case Groq = 'groq';
     case Jina = 'jina';
+    case MiniMax = 'minimax';
     case Mistral = 'mistral';
     case Ollama = 'ollama';
     case OpenAI = 'openai';

--- a/src/Gateway/MiniMaxGateway.php
+++ b/src/Gateway/MiniMaxGateway.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Illuminate\Http\Client\PendingRequest;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Responses\AudioResponse;
+use Laravel\Ai\Responses\Data\Meta;
+use RuntimeException;
+
+class MiniMaxGateway implements AudioGateway
+{
+    use Concerns\CreatesClient;
+    use Concerns\HandlesFailoverErrors;
+
+    /**
+     * Generate audio from the given text.
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
+            ->post('t2a_v2', [
+                'model' => $model,
+                'text' => $text,
+                'stream' => false,
+                'output_format' => 'hex',
+                'voice_setting' => [
+                    'voice_id' => match ($voice) {
+                        'default-male' => 'English_Persuasive_Man',
+                        'default-female' => 'English_Graceful_Lady',
+                        default => $voice,
+                    },
+                ],
+                'audio_setting' => [
+                    'format' => 'mp3',
+                ],
+            ])->throw());
+
+        $data = $response->json();
+
+        if ((int) ($data['base_resp']['status_code'] ?? 0) !== 0) {
+            throw new RuntimeException('MiniMax API returned an error: '.($data['base_resp']['status_msg'] ?? 'Unknown error.'));
+        }
+
+        $encodedAudio = $data['data']['audio'] ?? null;
+
+        if (! is_string($encodedAudio) || $encodedAudio === '') {
+            throw new RuntimeException('No audio data received from MiniMax API.');
+        }
+
+        if (strlen($encodedAudio) % 2 !== 0 || ! ctype_xdigit($encodedAudio)) {
+            throw new RuntimeException('MiniMax returned invalid audio data.');
+        }
+
+        return new AudioResponse(
+            base64_encode((string) hex2bin($encodedAudio)),
+            new Meta($provider->name(), $model),
+            'audio/mpeg',
+        );
+    }
+
+    /**
+     * Get an HTTP client for the MiniMax API.
+     */
+    protected function client(AudioProvider $provider, int $timeout = 30): PendingRequest
+    {
+        return $this->createClient(
+            $this->baseUrl($provider),
+            ['Authorization' => 'Bearer '.$provider->providerCredentials()['key']],
+            $provider->additionalConfiguration()['headers'] ?? [],
+            $timeout,
+            false,
+        );
+    }
+
+    /**
+     * Get the base URL for the MiniMax API.
+     */
+    protected function baseUrl(AudioProvider $provider): string
+    {
+        return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.minimax.io/v1', '/');
+    }
+}

--- a/src/Providers/MiniMaxProvider.php
+++ b/src/Providers/MiniMaxProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Ai\Providers;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Gateway\MiniMaxGateway;
+
+class MiniMaxProvider extends Provider implements AudioProvider
+{
+    use Concerns\GeneratesAudio;
+    use Concerns\HasAudioGateway;
+
+    public function __construct(
+        protected array $config,
+        protected Dispatcher $events) {}
+
+    /**
+     * Get the provider's audio gateway.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ??= new MiniMaxGateway;
+    }
+
+    /**
+     * Get the name of the default audio (TTS) model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return $this->config['models']['audio']['default'] ?? 'speech-2.8-hd';
+    }
+}

--- a/tests/Feature/Providers/MiniMax/AudioTest.php
+++ b/tests/Feature/Providers/MiniMax/AudioTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+
+beforeEach(function (): void {
+    config(['ai.providers.minimax' => [
+        ...config('ai.providers.minimax'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio request maps the model, text, voice, and audio settings', function (): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse()]);
+
+    Audio::of('Hello world')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'speech-2.8-hd'
+            && $body['text'] === 'Hello world'
+            && $body['stream'] === false
+            && $body['output_format'] === 'hex'
+            && $body['voice_setting']['voice_id'] === 'English_Graceful_Lady'
+            && $body['audio_setting']['format'] === 'mp3'
+            && $request->url() === 'https://api.minimax.io/v1/t2a_v2';
+    });
+});
+
+test('audio request resolves the default-male voice alias', function (): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse()]);
+
+    Audio::of('Hello')->male()->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_setting']['voice_id'] === 'English_Persuasive_Man');
+});
+
+test('audio request passes a custom voice id through unchanged', function (): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse()]);
+
+    Audio::of('Hello')->voice('English_expressive_narrator')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_setting']['voice_id'] === 'English_expressive_narrator');
+});
+
+test('audio request sends a bearer authorization header', function (): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(fn (Request $request): bool => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('audio request passes each speech model through unchanged', function (string $model): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: $model);
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['model'] === $model);
+})->with([
+    'speech-2.8-hd',
+    'speech-2.8-turbo',
+    'speech-2.6-hd',
+    'speech-2.6-turbo',
+    'speech-02-hd',
+    'speech-02-turbo',
+    'speech-01-hd',
+    'speech-01-turbo',
+]);
+
+test('audio uses the default model when none is specified', function (): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'minimax');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['model'] === 'speech-2.8-hd');
+});
+
+test('hex encoded audio is decoded and re-encoded as base64', function (): void {
+    Http::fake(['*' => fakeMiniMaxAudioResponse('raw-audio-bytes')]);
+
+    $response = Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    expect($response->audio)->toBe(base64_encode('raw-audio-bytes'))
+        ->and($response->content())->toBe('raw-audio-bytes')
+        ->and($response->mimeType())->toBe('audio/mpeg')
+        ->and($response->meta->provider)->toBe('minimax')
+        ->and($response->meta->model)->toBe('speech-2.8-hd');
+});
+
+test('audio throws when the payload reports a failing status code', function (): void {
+    Http::fake(['*' => Http::response([
+        'base_resp' => ['status_code' => 1004, 'status_msg' => 'authentication failed'],
+    ])]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+})->throws(RuntimeException::class, 'MiniMax API returned an error: authentication failed');
+
+test('audio throws when the payload contains no audio', function (): void {
+    Http::fake(['*' => Http::response([
+        'data' => ['status' => 2],
+        'base_resp' => ['status_code' => 0, 'status_msg' => 'success'],
+    ])]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+})->throws(RuntimeException::class, 'No audio data received from MiniMax API.');
+
+test('audio throws when the payload audio is not valid hex', function (): void {
+    Http::fake(['*' => Http::response([
+        'data' => ['audio' => 'not-hex', 'status' => 2],
+        'base_resp' => ['status_code' => 0, 'status_msg' => 'success'],
+    ])]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+})->throws(RuntimeException::class, 'MiniMax returned invalid audio data.');
+
+test('audio throws when the API returns an error', function (): void {
+    Http::fake(['*' => Http::response(['base_resp' => ['status_code' => 1004]], 401)]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+})->throws(RequestException::class);
+
+test('audio rate limit response throws rate limited exception', function (): void {
+    Http::fake(['api.minimax.io/*' => Http::response(['base_resp' => ['status_code' => 1002]], 429)]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+})->throws(RateLimitedException::class);
+
+test('audio overloaded response throws provider overloaded exception', function (): void {
+    Http::fake(['api.minimax.io/*' => Http::response(['base_resp' => ['status_code' => 1000]], 503)]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+})->throws(ProviderOverloadedException::class);
+
+function fakeMiniMaxAudioResponse(string $audio = 'fake-audio-bytes'): PromiseInterface
+{
+    return Http::response([
+        'data' => ['audio' => bin2hex($audio), 'status' => 2],
+        'extra_info' => ['audio_format' => 'mp3'],
+        'base_resp' => ['status_code' => 0, 'status_msg' => 'success'],
+    ]);
+}

--- a/tests/Feature/Providers/MiniMax/BaseUrlTest.php
+++ b/tests/Feature/Providers/MiniMax/BaseUrlTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+
+function fakeMiniMaxBaseUrlAudioResponse(): PromiseInterface
+{
+    return Http::response([
+        'data' => ['audio' => bin2hex('fake-audio-bytes'), 'status' => 2],
+        'base_resp' => ['status_code' => 0, 'status_msg' => 'success'],
+    ]);
+}
+
+test('minimax audio requests fall back to the global base url', function (): void {
+    config(['ai.providers.minimax' => array_diff_key(
+        [...config('ai.providers.minimax'), 'key' => 'test-key'],
+        ['url' => null],
+    )]);
+
+    Http::fake(['*' => fakeMiniMaxBaseUrlAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(fn (Request $r): bool => $r->url() === 'https://api.minimax.io/v1/t2a_v2');
+});
+
+test('minimax audio requests use the configured regional base url', function (): void {
+    config(['ai.providers.minimax' => [
+        ...config('ai.providers.minimax'),
+        'key' => 'test-key',
+        'url' => 'https://api.minimaxi.com/v1',
+    ]]);
+
+    Http::fake(['*' => fakeMiniMaxBaseUrlAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(fn (Request $r): bool => $r->url() === 'https://api.minimaxi.com/v1/t2a_v2');
+});
+
+test('minimax audio requests use the configured base url', function (): void {
+    config(['ai.providers.minimax' => [
+        ...config('ai.providers.minimax'),
+        'key' => 'test-key',
+        'url' => 'http://localhost:8080/v1',
+    ]]);
+
+    Http::fake(['*' => fakeMiniMaxBaseUrlAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'minimax', model: 'speech-2.8-hd');
+
+    Http::assertSent(fn (Request $r): bool => $r->url() === 'http://localhost:8080/v1/t2a_v2');
+});

--- a/tests/Feature/Providers/MiniMax/GatewayCachingTest.php
+++ b/tests/Feature/Providers/MiniMax/GatewayCachingTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Laravel\Ai\Ai;
+
+beforeEach(function (): void {
+    config(['ai.providers.minimax' => [
+        ...config('ai.providers.minimax'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio gateway is memoized across calls', function (): void {
+    $provider = Ai::audioProvider('minimax');
+
+    expect($provider->audioGateway())->toBe($provider->audioGateway());
+});


### PR DESCRIPTION
Reason: The audio generation pipeline had no MiniMax text-to-speech support, so MiniMax speech models could not be used through `Audio::of(...)`.

## Summary

Adds text-to-speech support to the existing audio generation pipeline via a new `minimax` provider. This is purely additive — no existing provider, contract, or public API changes behaviour.

The provider implements `AudioProvider` only (text-to-speech), so it plugs into `Audio::of(...)->generate(...)`, failover, faking, and queueing without any pipeline changes.

## Usage

```php
use Laravel\Ai\Audio;

// Default model and voice.
$response = Audio::of('Hello there!')->generate(provider: 'minimax');

// Explicit model, or a specific voice id.
$response = Audio::of('Hello there!')
    ->voice('English_expressive_narrator')
    ->generate(provider: 'minimax', model: 'speech-2.8-turbo');

$response->store('audio');
```

## Changes

- `src/Providers/MiniMaxProvider.php` — implements `AudioProvider`, memoizes its audio gateway, and defaults to the `speech-2.8-hd` model (overridable via `models.audio.default`).
- `src/Gateway/MiniMaxGateway.php` — implements `AudioGateway`:
  - `POST t2a_v2` with `model`, `text`, `stream`, `output_format`, `voice_setting.voice_id` and `audio_setting.format`.
  - `default-female` / `default-male` are mapped to voice ids; any other value is passed through as a voice id unchanged.
  - Response parsing: the returned audio is hex encoded, so it is decoded and re-encoded as base64 for `AudioResponse`, with an `audio/mpeg` MIME type.
  - Error handling: a non-zero `base_resp.status_code` is surfaced as an exception even when the HTTP status is 200, and malformed or missing audio payloads are rejected rather than returned as empty audio. HTTP-level failures continue to flow through the shared failover error handling.
  - Authorization uses a bearer token, and the base URL is configurable so both the global and China endpoints are supported.
- `config/ai.php` — adds the `minimax` connection with `MINIMAX_API_KEY` and a `MINIMAX_URL` override defaulting to the global endpoint. Set `MINIMAX_URL=https://api.minimaxi.com/v1` to use the China endpoint.
- `src/Enums/Lab.php`, `src/AiManager.php` — registers the `minimax` driver.
- `resources/boost/skills/ai-sdk-development/SKILL.md` — adds the provider to the TTS row of the provider support table.

## Tests

Added `tests/Feature/Providers/MiniMax/`, mirroring the existing dedicated audio provider tests:

- `AudioTest.php` — request mapping, both voice aliases, custom voice pass-through, bearer header, pass-through of each supported speech model, the default model, hex to base64 decoding of the response, and the failure paths (failing `base_resp.status_code`, missing audio, non-hex audio, error/rate limit/overloaded HTTP responses).
- `BaseUrlTest.php` — the global endpoint fallback, the China endpoint, and a custom base URL.
- `GatewayCachingTest.php` — audio gateway memoization.

## Checks

- `php -l` on every changed PHP file — no syntax errors.
- Exercised `MiniMaxGateway::generateAudio()` directly against stubbed HTTP responses (24 assertions) covering request mapping, voice resolution, every supported speech model, hex decoding, base URL resolution for both endpoints, and each error branch.

Note: `composer test`, `pint` and `phpstan` were not run locally because a PHP 8.3 toolchain was not available in my environment, so the new Pest tests have not been executed here — please let CI (or a maintainer) confirm them.
