### PR TITLE
Added assertPromptedTimes test method

### DIFF
--- a/src/Concerns/InteractsWithFakeAgents.php
+++ b/src/Concerns/InteractsWithFakeAgents.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Concerns;
 
 use Closure;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Gateway\FakeTextGateway;
@@ -90,6 +91,25 @@ trait InteractsWithFakeAgents
         PHPUnit::assertTrue(
             (new Collection($prompts ?? $this->recordedPrompts[$agent] ?? []))->contains(fn ($prompt) => $callback($prompt)),
             $message ?? 'An expected prompt was not received.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that a certain number of prompts were received.
+     */
+    public function assertAgentWasPromptedTimes(string $agent, int $times = 1): self
+    {
+        $count = count($this->recordedPrompts[$agent] ?? []);
+
+        PHPUnit::assertSame(
+            $times, $count,
+            sprintf(
+                "Received {$count} %s instead of {$times} %s.",
+                Str::plural('prompt', $count),
+                Str::plural('prompt', $times),
+            ),
         );
 
         return $this;

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -427,6 +427,14 @@ trait Promptable
     }
 
     /**
+     * Assert that a certain number of prompts were received.
+     */
+    public static function assertPromptedTimes(int $times = 1): void
+    {
+        Ai::assertAgentWasPromptedTimes(static::class, $times);
+    }
+
+    /**
      * Assert that a prompt was not received matching a given truth test.
      */
     public static function assertNotPrompted(Closure|string $callback): void

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -47,6 +47,7 @@ describe('prompt responses', function (): void {
 
         // Assertion tests...
         AssistantAgent::assertPrompted('First prompt');
+        AssistantAgent::assertPromptedTimes(3);
         AssistantAgent::assertNotPrompted('Missing prompt');
 
         AssistantAgent::assertPrompted(fn (AgentPrompt $prompt): bool => $prompt->prompt === 'First prompt');


### PR DESCRIPTION
I have added the `assertPromptedTimes` test method to the `Promptable` trait, similar to how `Bus::assertDispatchedTimes` and `Notification::assertSentTimes` work.

## Example
```php
SalesCoach::assertPromptedTimes(3);
```