### PR TITLE
Surface Anthropic web fetch citations on the response

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -155,6 +155,17 @@ trait HandlesTextStreaming
                         time(),
                     ))->withInvocationId($invocationId);
                 } elseif ($this->isProviderToolResultBlock($blockType)) {
+                    $fetchResult = $data['content_block']['content'] ?? [];
+
+                    if ($blockType === 'web_fetch_tool_result' && ($fetchResult['type'] ?? '') === 'web_fetch_result' && filled($fetchResult['url'] ?? null)) {
+                        yield (new CitationEvent(
+                            $this->generateEventId(),
+                            $messageId,
+                            new UrlCitation($fetchResult['url'], $fetchResult['content']['title'] ?? null),
+                            time(),
+                        ))->withInvocationId($invocationId);
+                    }
+
                     yield (new ProviderToolEvent(
                         $this->generateEventId(),
                         $data['content_block']['tool_use_id'] ?? $data['content_block']['id'] ?? '',

--- a/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Anthropic/Concerns/ParsesTextResponses.php
@@ -141,6 +141,17 @@ trait ParsesTextResponses
                 }
             }
 
+            if ($blockType === 'web_fetch_tool_result') {
+                $result = $block['content'] ?? [];
+
+                if (($result['type'] ?? '') === 'web_fetch_result' && filled($result['url'] ?? null)) {
+                    $citations->push(new UrlCitation(
+                        $result['url'],
+                        $result['content']['title'] ?? null,
+                    ));
+                }
+            }
+
             if ($blockType === 'text') {
                 foreach ($block['citations'] ?? [] as $citation) {
                     if (($citation['type'] ?? '') === 'web_search_result_location') {

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -197,6 +198,7 @@ describe('thinking blocks', function (): void {
         expect($providerEvents)->not->toBeEmpty()
             ->and($providerEvents[0])->status->toBe('result_received')->type->toBe('web_search_tool_result');
     });
+
 });
 
 describe('pause_turn', function (): void {
@@ -409,4 +411,62 @@ describe('usage tracking', function (): void {
         'refusal maps to ContentFilter' => ['refusal', FinishReason::ContentFilter],
         'tool_use without tool blocks normalizes to Stop (StreamEnd still emitted)' => ['tool_use', FinishReason::Stop],
     ]);
+});
+
+describe('provider tool citations', function (): void {
+    test('streaming emits a citation for a fetched url', function (): void {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, [
+                        'type' => 'web_fetch_tool_result',
+                        'tool_use_id' => 'srvtoolu_1',
+                        'content' => [
+                            'type' => 'web_fetch_result',
+                            'url' => 'https://example.com/article',
+                            'content' => ['type' => 'document', 'title' => 'Article Title'],
+                        ],
+                    ]),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(1, ['type' => 'text_delta', 'text' => 'The article argues X.']),
+                    $this->contentBlockStop(1),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $citations = array_values(array_filter($events, fn ($e): bool => $e instanceof CitationEvent));
+
+        expect($citations)->toHaveCount(1)
+            ->and($citations[0]->citation)->url->toBe('https://example.com/article')->title->toBe('Article Title');
+    });
+
+    test('streaming skips citations for a failed fetch', function (): void {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, [
+                        'type' => 'web_fetch_tool_result',
+                        'tool_use_id' => 'srvtoolu_1',
+                        'content' => ['type' => 'web_fetch_tool_result_error', 'error_code' => 'url_not_accessible'],
+                    ]),
+                    $this->contentBlockStop(0),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $citations = array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent);
+
+        expect($citations)->toBeEmpty();
+    });
 });

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -175,6 +175,51 @@ test('web fetch tool forwards provider options', function () {
     });
 });
 
+test('web fetch tool result surfaces the fetched url as a citation', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_fetch_1',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [
+                ['type' => 'text', 'text' => "I'll fetch that."],
+                [
+                    'type' => 'server_tool_use',
+                    'id' => 'srvtoolu_1',
+                    'name' => 'web_fetch',
+                    'input' => (object) ['url' => 'https://example.com/article'],
+                ],
+                [
+                    'type' => 'web_fetch_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => [
+                        'type' => 'web_fetch_result',
+                        'url' => 'https://example.com/article',
+                        'content' => [
+                            'type' => 'document',
+                            'source' => ['type' => 'text', 'media_type' => 'text/plain', 'data' => 'Full text.'],
+                            'title' => 'Article Title',
+                            'citations' => ['enabled' => true],
+                        ],
+                        'retrieved_at' => '2026-08-17T10:30:00Z',
+                    ],
+                ],
+                ['type' => 'text', 'text' => 'The article argues X.'],
+            ],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = agent(tools: [(new WebFetch)->withProviderOptions(['citations' => ['enabled' => true]])])
+        ->prompt('Fetch it', provider: 'anthropic');
+
+    expect($response->meta->citations)->toHaveCount(1)
+        ->and($response->meta->citations[0]->url)->toBe('https://example.com/article')
+        ->and($response->meta->citations[0]->title)->toBe('Article Title');
+});
+
 test('web fetch tool forwards a custom max_uses', function () {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse('ok'),

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -220,6 +220,31 @@ test('web fetch tool result surfaces the fetched url as a citation', function ()
         ->and($response->meta->citations[0]->title)->toBe('Article Title');
 });
 
+test('web fetch tool result skips citations for a failed fetch', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'id' => 'msg_fetch_2',
+            'type' => 'message',
+            'role' => 'assistant',
+            'model' => 'claude-sonnet-4-6',
+            'content' => [
+                [
+                    'type' => 'web_fetch_tool_result',
+                    'tool_use_id' => 'srvtoolu_1',
+                    'content' => ['type' => 'web_fetch_tool_result_error', 'error_code' => 'url_not_accessible'],
+                ],
+                ['type' => 'text', 'text' => "I couldn't reach that page."],
+            ],
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $response = agent(tools: [new WebFetch])->prompt('Fetch it', provider: 'anthropic');
+
+    expect($response->meta->citations)->toBeEmpty();
+});
+
 test('web fetch tool forwards a custom max_uses', function () {
     Http::fake([
         'api.anthropic.com/*' => $this->fakeTextResponse('ok'),


### PR DESCRIPTION
enabling citations on Anthropic's web_fetch tool (`->withProviderOptions(['citations' => ['enabled' => true]])`) returns an empty `$response->meta->citations`. `extractCitations` only handles `web_search_tool_result` blocks, so `web_fetch_tool_result` gets dropped.

this adds a `web_fetch_tool_result` branch mirroring the web_search one, pushing the fetched `content.url` + title as a `UrlCitation` (guarded on `web_fetch_result`, so error blocks are skipped). non-streaming only: web_fetch's streaming citations come as `char_location`/`page_location` deltas with no url to map onto `UrlCitation`.

test included, red before the branch and green after.
