### PR TITLE
Accept every storable image type in OpenAI image edits

### DIFF
--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -5,8 +5,8 @@ namespace Laravel\Ai\Gateway\OpenAi;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\Gateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
@@ -16,8 +16,6 @@ use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image;
-use Laravel\Ai\Files\LocalImage;
-use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
@@ -133,8 +131,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
             }
 
             $content = match (true) {
-                $attachment instanceof LocalImage => file_get_contents($attachment->path),
-                $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
+                $attachment instanceof StorableFile => $attachment->content(),
                 $attachment instanceof UploadedFile => $attachment->get(),
                 default => throw new InvalidArgumentException('Unsupported image attachment type ['.$attachment::class.']'),
             };

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -14,7 +14,6 @@ use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
-use Laravel\Ai\Files\File;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
@@ -124,16 +123,10 @@ class OpenAiGateway implements Gateway, StepTextGateway
         $field = $isGptImage ? 'image[]' : 'image';
 
         foreach ($attachments as $attachment) {
-            if (! $attachment instanceof File && ! $attachment instanceof UploadedFile) {
-                throw new InvalidArgumentException(
-                    'Unsupported attachment type ['.$attachment::class.']'
-                );
-            }
-
             $content = match (true) {
-                $attachment instanceof StorableFile => $attachment->content(),
+                $attachment instanceof Image && $attachment instanceof StorableFile => $attachment->content(),
                 $attachment instanceof UploadedFile => $attachment->get(),
-                default => throw new InvalidArgumentException('Unsupported image attachment type ['.$attachment::class.']'),
+                default => throw new InvalidArgumentException('Unsupported image attachment type ['.get_debug_type($attachment).']'),
             };
 
             $request = $request->attach($field, $content, 'image.png');

--- a/tests/Feature/Providers/OpenAi/ImageEditTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageEditTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\ProviderImage;
+use Laravel\Ai\Files\RemoteImage;
+use Laravel\Ai\Files\StoredImage;
+use Laravel\Ai\Image;
+
+beforeEach(function (): void {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'key' => 'test-key',
+    ]]);
+});
+
+function fakeOpenAiImageEditResponse(): PromiseInterface
+{
+    return Http::response([
+        'data' => [[
+            'b64_json' => base64_encode('edited-image'),
+        ]],
+    ]);
+}
+
+test('attachments send the request to the edits endpoint', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    Image::of('Make it brighter')
+        ->attachments([new Base64Image(base64_encode('source-bytes'), 'image/png')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => str_ends_with($request->url(), 'images/edits'));
+});
+
+test('a base64 image is sent as the image content', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    Image::of('Make it brighter')
+        ->attachments([new Base64Image(base64_encode('source-bytes'), 'image/png')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'source-bytes'));
+});
+
+test('a remote image is fetched and sent as the image content', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('remote-bytes'),
+        '*' => fakeOpenAiImageEditResponse(),
+    ]);
+
+    Image::of('Make it brighter')
+        ->attachments([new RemoteImage('https://example.com/source.png', 'image/png')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'remote-bytes'));
+});
+
+test('a local image is sent as the image content', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    $path = tempnam(sys_get_temp_dir(), 'ai').'.png';
+    file_put_contents($path, 'local-bytes');
+
+    Image::of('Make it brighter')
+        ->attachments([new LocalImage($path, 'image/png')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'local-bytes'));
+
+    unlink($path);
+});
+
+test('a stored image is sent as the image content', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    Storage::fake('images');
+    Storage::disk('images')->put('source.png', 'stored-bytes');
+
+    Image::of('Make it brighter')
+        ->attachments([new StoredImage('source.png', 'images')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'stored-bytes'));
+});
+
+test('an uploaded file is sent as the image content', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    $path = tempnam(sys_get_temp_dir(), 'ai').'.png';
+    file_put_contents($path, 'uploaded-bytes');
+
+    Image::of('Make it brighter')
+        ->attachments([new UploadedFile($path, 'source.png', 'image/png', null, true)])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'uploaded-bytes'));
+
+    unlink($path);
+});
+
+test('a provider image cannot be used for edits', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    Image::of('Make it brighter')
+        ->attachments([new ProviderImage('file-123')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+})->throws(InvalidArgumentException::class, 'Unsupported image attachment type');
+
+test('non gpt-image models send a single image field', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    Image::of('Make it brighter')
+        ->attachments([new Base64Image(base64_encode('source-bytes'), 'image/png')])
+        ->generate(provider: 'openai', model: 'dall-e-2');
+
+    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'name="image"')
+        && ! str_contains($request->body(), 'name="image[]"'));
+});

--- a/tests/Feature/Providers/OpenAi/ImageEditTest.php
+++ b/tests/Feature/Providers/OpenAi/ImageEditTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files\Base64Image;
+use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\ProviderImage;
 use Laravel\Ai\Files\RemoteImage;
@@ -28,24 +29,15 @@ function fakeOpenAiImageEditResponse(): PromiseInterface
     ]);
 }
 
-test('attachments send the request to the edits endpoint', function (): void {
+test('a base64 image is sent to the edits endpoint as the image content', function (): void {
     Http::fake(['*' => fakeOpenAiImageEditResponse()]);
 
     Image::of('Make it brighter')
         ->attachments([new Base64Image(base64_encode('source-bytes'), 'image/png')])
         ->generate(provider: 'openai', model: 'gpt-image-1');
 
-    Http::assertSent(fn (Request $request): bool => str_ends_with($request->url(), 'images/edits'));
-});
-
-test('a base64 image is sent as the image content', function (): void {
-    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
-
-    Image::of('Make it brighter')
-        ->attachments([new Base64Image(base64_encode('source-bytes'), 'image/png')])
-        ->generate(provider: 'openai', model: 'gpt-image-1');
-
-    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'source-bytes'));
+    Http::assertSent(fn (Request $request): bool => str_ends_with($request->url(), 'images/edits')
+        && $request->hasFile('image[]', 'source-bytes', 'image.png'));
 });
 
 test('a remote image is fetched and sent as the image content', function (): void {
@@ -58,7 +50,7 @@ test('a remote image is fetched and sent as the image content', function (): voi
         ->attachments([new RemoteImage('https://example.com/source.png', 'image/png')])
         ->generate(provider: 'openai', model: 'gpt-image-1');
 
-    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'remote-bytes'));
+    Http::assertSent(fn (Request $request): bool => $request->hasFile('image[]', 'remote-bytes'));
 });
 
 test('a local image is sent as the image content', function (): void {
@@ -71,7 +63,7 @@ test('a local image is sent as the image content', function (): void {
         ->attachments([new LocalImage($path, 'image/png')])
         ->generate(provider: 'openai', model: 'gpt-image-1');
 
-    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'local-bytes'));
+    Http::assertSent(fn (Request $request): bool => $request->hasFile('image[]', 'local-bytes'));
 
     unlink($path);
 });
@@ -86,7 +78,7 @@ test('a stored image is sent as the image content', function (): void {
         ->attachments([new StoredImage('source.png', 'images')])
         ->generate(provider: 'openai', model: 'gpt-image-1');
 
-    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'stored-bytes'));
+    Http::assertSent(fn (Request $request): bool => $request->hasFile('image[]', 'stored-bytes'));
 });
 
 test('an uploaded file is sent as the image content', function (): void {
@@ -99,7 +91,7 @@ test('an uploaded file is sent as the image content', function (): void {
         ->attachments([new UploadedFile($path, 'source.png', 'image/png', null, true)])
         ->generate(provider: 'openai', model: 'gpt-image-1');
 
-    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'uploaded-bytes'));
+    Http::assertSent(fn (Request $request): bool => $request->hasFile('image[]', 'uploaded-bytes'));
 
     unlink($path);
 });
@@ -112,6 +104,14 @@ test('a provider image cannot be used for edits', function (): void {
         ->generate(provider: 'openai', model: 'gpt-image-1');
 })->throws(InvalidArgumentException::class, 'Unsupported image attachment type');
 
+test('a document attachment cannot be used for edits', function (): void {
+    Http::fake(['*' => fakeOpenAiImageEditResponse()]);
+
+    Image::of('Make it brighter')
+        ->attachments([new LocalDocument('/tmp/source.pdf', 'application/pdf')])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+})->throws(InvalidArgumentException::class, 'Unsupported image attachment type');
+
 test('non gpt-image models send a single image field', function (): void {
     Http::fake(['*' => fakeOpenAiImageEditResponse()]);
 
@@ -119,6 +119,5 @@ test('non gpt-image models send a single image field', function (): void {
         ->attachments([new Base64Image(base64_encode('source-bytes'), 'image/png')])
         ->generate(provider: 'openai', model: 'dall-e-2');
 
-    Http::assertSent(fn (Request $request): bool => str_contains($request->body(), 'name="image"')
-        && ! str_contains($request->body(), 'name="image[]"'));
+    Http::assertSent(fn (Request $request): bool => $request->hasFile('image', 'source-bytes', 'image.png'));
 });


### PR DESCRIPTION
`sendImageEditRequest()` reimplemented content loading for two attachment types and threw for everything else:

```php
$content = match (true) {
    $attachment instanceof LocalImage => file_get_contents($attachment->path),
    $attachment instanceof StoredImage => Storage::disk($attachment->disk)->get($attachment->path),
    $attachment instanceof UploadedFile => $attachment->get(),
    default => throw new InvalidArgumentException('Unsupported image attachment type ['.$attachment::class.']'),
};
```

`Base64Image` and `RemoteImage` were rejected by that `default` arm even though both expose a working `content()` — `Base64Image` decodes its own payload, `RemoteImage` fetches through `HasRemoteContent`. So a source image that arrived as base64 or as a URL could not be edited without first writing it to disk.

This reads the content through the `StorableFile` contract, which extends `HasContent` and is implemented by exactly the four image types that carry their own bytes. `ProviderImage` still throws, since it is only a reference to a file already uploaded to the provider and has no local content.

The transcription path in this same gateway already does it this way (`$audio->content()` in `generateTranscription()`), as do the ElevenLabs, Groq and OpenAI-compatible gateways.

### Tests

There was no coverage on `images/edits`, so this adds the first: one test per attachment type, the `ProviderImage` rejection, that attachments route to the edits endpoint, and that non `gpt-image` models use the single `image` field rather than `image[]`.

Four of them fail on `0.x` and pass here; the other four cover the paths that already worked, to catch a regression.

Noticed while reading #880, and independent of the mask feature discussed there.
