### PR TITLE
Add file search support to the xAI provider

### DIFF
--- a/src/Gateway/Xai/Concerns/MapsTools.php
+++ b/src/Gateway/Xai/Concerns/MapsTools.php
@@ -3,10 +3,12 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Laravel\Ai\Tools\ToolNameResolver;
@@ -40,9 +42,25 @@ trait MapsTools
     protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
     {
         return match (true) {
+            $tool instanceof FileSearch => $this->mapFileSearchTool($tool, $provider),
             $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
             default => [],
         };
+    }
+
+    /**
+     * Map a file search tool to an xAI file search definition.
+     */
+    protected function mapFileSearchTool(FileSearch $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsFileSearch) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support file search.');
+        }
+
+        return [
+            'type' => 'file_search',
+            ...$provider->fileSearchToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -6,14 +6,16 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Xai\XaiGateway;
 use Laravel\Ai\Gateway\Xai\XaiImageGateway;
+use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class XaiProvider extends Provider implements ImageProvider, SupportsWebSearch, TextProvider
+class XaiProvider extends Provider implements ImageProvider, SupportsFileSearch, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
@@ -25,6 +27,16 @@ class XaiProvider extends Provider implements ImageProvider, SupportsWebSearch, 
         protected array $config,
         protected Dispatcher $events,
     ) {}
+
+    /**
+     * Get the file search tool options for the provider.
+     */
+    public function fileSearchToolOptions(FileSearch $search): array
+    {
+        return array_filter([
+            'vector_store_ids' => $search->ids(),
+        ]) + $search->providerOptions(Lab::xAI);
+    }
 
     /**
      * Get the web search tool options for the provider.

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
@@ -33,6 +34,10 @@ class XaiProvider extends Provider implements ImageProvider, SupportsFileSearch,
      */
     public function fileSearchToolOptions(FileSearch $search): array
     {
+        if (filled($search->filters)) {
+            throw new InvalidArgumentException('xAI does not support file search metadata filters.');
+        }
+
         return array_filter([
             'vector_store_ids' => $search->ids(),
         ]) + $search->providerOptions(Lab::xAI);

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
@@ -146,6 +147,13 @@ test('file search tool sends file_search with vector store ids', function (): vo
 
         return data_get($tool, 'vector_store_ids') === ['collection-id'];
     });
+});
+
+test('file search metadata filters throw an exception', function (): void {
+    $search = new FileSearch(['collection-id'], where: ['company' => 'laravel']);
+
+    expect(fn () => Ai::textProvider('xai')->fileSearchToolOptions($search))
+        ->toThrow(InvalidArgumentException::class, 'xAI does not support file search metadata filters.');
 });
 
 test('file search tool forwards xai provider options into the tool payload', function (): void {

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -135,10 +135,40 @@ test('web search tool forwards xai provider options into the tool payload', func
     });
 });
 
+test('file search tool sends file_search with vector store ids', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [new FileSearch(['collection-id'])])->prompt('Search my docs', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'file_search');
+
+        return data_get($tool, 'vector_store_ids') === ['collection-id'];
+    });
+});
+
+test('file search tool forwards xai provider options into the tool payload', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [
+        (new FileSearch(['collection-id']))->withProviderOptions([
+            'max_num_results' => 5,
+        ]),
+    ])->prompt('Search my docs', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'file_search');
+
+        return data_get($tool, 'max_num_results') === 5;
+    });
+});
+
 test('unsupported provider tools are omitted from the tools payload', function (): void {
     Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
 
-    agent(tools: [new WebFetch, new FileSearch(['store-id']), new WebSearch])
+    agent(tools: [new WebFetch, new WebSearch])
         ->prompt('Search', provider: 'xai');
 
     Http::assertSent(function (Request $request): bool {


### PR DESCRIPTION
xAI exposes collections search as `file_search` with `vector_store_ids`: 
https://docs.x.ai/developers/tools/collections-search

This PR adds `SupportsFileSearch` to `XaiProvider` and a `file_search` to the gateway's tool mapping. Tested against the live API on a collection and it's working.

Metadata filters (`$where`) aren't mapped. xAI uses AIP-160 filter strings rather than the structured array, so that's a bigger change.
