### PR TITLE
Exclude DeepSeek cache-hit tokens from the reported prompt token count

### DIFF
--- a/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/DeepSeek/Concerns/ParsesTextResponses.php
@@ -83,7 +83,7 @@ trait ParsesTextResponses
         $details = $usage['completion_tokens_details'] ?? [];
 
         return new Usage(
-            promptTokens: $usage['prompt_tokens'] ?? 0,
+            promptTokens: ($usage['prompt_tokens'] ?? 0) - ($usage['prompt_cache_hit_tokens'] ?? 0),
             completionTokens: $usage['completion_tokens'] ?? 0,
             cacheReadInputTokens: $usage['prompt_cache_hit_tokens'] ?? 0,
             reasoningTokens: $details['reasoning_tokens'] ?? 0,

--- a/tests/Feature/Providers/DeepSeek/RequestMappingTest.php
+++ b/tests/Feature/Providers/DeepSeek/RequestMappingTest.php
@@ -254,7 +254,7 @@ test('response usage includes cache hit and reasoning tokens', function (): void
 
     $response = agent()->prompt('What is 2+2?', provider: 'deepseek', model: 'deepseek-reasoner');
 
-    expect($response->usage->promptTokens)->toBe(100)
+    expect($response->usage->promptTokens)->toBe(80)
         ->and($response->usage->completionTokens)->toBe(50)
         ->and($response->usage->cacheReadInputTokens)->toBe(20)
         ->and($response->usage->cacheWriteInputTokens)->toBe(0)

--- a/tests/Feature/Providers/DeepSeek/StreamingTest.php
+++ b/tests/Feature/Providers/DeepSeek/StreamingTest.php
@@ -186,7 +186,7 @@ test('streaming captures cache hit and reasoning tokens', function (): void {
 
     $streamEnd = array_values(array_filter($events, fn ($e): bool => $e instanceof StreamEnd))[0];
 
-    expect($streamEnd->usage->promptTokens)->toBe(100)
+    expect($streamEnd->usage->promptTokens)->toBe(70)
         ->and($streamEnd->usage->completionTokens)->toBe(50)
         ->and($streamEnd->usage->cacheReadInputTokens)->toBe(30)
         ->and($streamEnd->usage->cacheWriteInputTokens)->toBe(0)


### PR DESCRIPTION
deepseek reports prompt_tokens with the cached part baked in (their docs say prompt_tokens = prompt_cache_hit_tokens + prompt_cache_miss_tokens), but the gateway was dropping that raw prompt_tokens straight into promptTokens and also putting the cached part into cacheReadInputTokens. so cached tokens got counted twice.

this subtracts the cache-hit tokens back out of promptTokens, same as the native openai gateway does it (input_tokens - cached_tokens, from #846), so promptTokens + cacheReadInputTokens lines up with the real prompt total again.

the other chat-completion gateways (openrouter, groq, openai-compatible) have the same shape, but i scoped this to deepseek since it's the one with a documented subset relationship and no cache-write ambiguity. happy to do the rest if you want them.

both the non-streaming and streaming tests already had cache-hit fixtures, so i updated those. one-line change, red before and green after.
