### PR TITLE
Add withProviderOptions support to the image builder

### DIFF
--- a/src/Contracts/Gateway/ImageGateway.php
+++ b/src/Contracts/Gateway/ImageGateway.php
@@ -13,6 +13,7 @@ interface ImageGateway
      *
      * @param  array<Image>  $attachments
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateImage(
         ImageProvider $provider,
@@ -22,5 +23,6 @@ interface ImageGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse;
 }

--- a/src/Contracts/Providers/ImageProvider.php
+++ b/src/Contracts/Providers/ImageProvider.php
@@ -13,6 +13,7 @@ interface ImageProvider extends Provider
      *
      * @param  array<Image>  $attachments
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function image(
         string $prompt,
@@ -21,6 +22,7 @@ interface ImageProvider extends Provider
         ?string $quality = null,
         ?string $model = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse;
 
     /**

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -128,6 +128,7 @@ class AnthropicGateway implements Gateway, StepTextGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         throw new LogicException('Anthropic does not support image generation.');
     }

--- a/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiGateway.php
@@ -77,6 +77,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, StepTextGate
      * @param  array<Image>  $attachments
      * @param  '3:2'|'2:3'|'1:1'|null  $size
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      *
      * @throws LogicException if attachments are passed; Azure OpenAI does not support image edits.
      */
@@ -88,6 +89,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, StepTextGate
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         if (filled($attachments)) {
             throw new LogicException('Azure OpenAI does not support image editing.');
@@ -96,6 +98,7 @@ class AzureOpenAiGateway implements EmbeddingGateway, ImageGateway, StepTextGate
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout ?? 120)->post('images/generations', [
+                ...$providerOptions,
                 'model' => $model,
                 'prompt' => $prompt,
                 'moderation' => 'low',

--- a/src/Gateway/Bedrock/BedrockImageGateway.php
+++ b/src/Gateway/Bedrock/BedrockImageGateway.php
@@ -47,7 +47,7 @@ class BedrockImageGateway implements ImageGateway
                     'modelId' => $model,
                     'contentType' => 'application/json',
                     'accept' => 'application/json',
-                    'body' => json_encode(array_merge($providerOptions, $this->prepareImageRequestBody($model, $prompt, $size, $options))),
+                    'body' => json_encode(array_replace_recursive($providerOptions, $this->prepareImageRequestBody($model, $prompt, $size, $options))),
                 ]),
             );
         } catch (Throwable $throwable) {

--- a/src/Gateway/Bedrock/BedrockImageGateway.php
+++ b/src/Gateway/Bedrock/BedrockImageGateway.php
@@ -25,6 +25,7 @@ class BedrockImageGateway implements ImageGateway
      * @param  array<Image>  $attachments
      * @param  '3:2'|'2:3'|'1:1'|null  $size
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateImage(
         ImageProvider $provider,
@@ -34,6 +35,7 @@ class BedrockImageGateway implements ImageGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         $client = $this->createBedrockClient($provider, $timeout);
         $options = $provider->defaultImageOptions($size, $quality);
@@ -45,7 +47,7 @@ class BedrockImageGateway implements ImageGateway
                     'modelId' => $model,
                     'contentType' => 'application/json',
                     'accept' => 'application/json',
-                    'body' => json_encode($this->prepareImageRequestBody($model, $prompt, $size, $options)),
+                    'body' => json_encode(array_merge($providerOptions, $this->prepareImageRequestBody($model, $prompt, $size, $options))),
                 ]),
             );
         } catch (Throwable $throwable) {

--- a/src/Gateway/FakeImageGateway.php
+++ b/src/Gateway/FakeImageGateway.php
@@ -29,6 +29,7 @@ class FakeImageGateway implements ImageGateway
      *
      * @param  array<Image>  $attachments
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateImage(
         ImageProvider $provider,
@@ -38,8 +39,9 @@ class FakeImageGateway implements ImageGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
-        $imagePrompt = new ImagePrompt($prompt, $attachments, $size, $quality, $provider, $model);
+        $imagePrompt = new ImagePrompt($prompt, $attachments, $size, $quality, $provider, $model, $providerOptions);
 
         return $this->nextResponse($provider, $model, $imagePrompt);
     }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -111,6 +111,7 @@ class GeminiGateway implements Gateway, StepTextGateway
      * @param  array<ImageFile>  $attachments
      * @param  '3:2'|'2:3'|'1:1'|null  $size
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateImage(
         ImageProvider $provider,
@@ -120,6 +121,7 @@ class GeminiGateway implements Gateway, StepTextGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         $parts = [['text' => $prompt]];
 
@@ -129,7 +131,7 @@ class GeminiGateway implements Gateway, StepTextGateway
 
         $imageOptions = $provider->defaultImageOptions($size, $quality);
 
-        $body = [
+        $body = array_merge($providerOptions, [
             'contents' => [['role' => 'user', 'parts' => $parts]],
             'generationConfig' => array_filter([
                 'responseModalities' => ['IMAGE', 'TEXT'],
@@ -138,7 +140,7 @@ class GeminiGateway implements Gateway, StepTextGateway
                     'aspectRatio' => $imageOptions['aspect_ratio'] ?? null,
                 ]),
             ]),
-        ];
+        ]);
 
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -133,13 +133,13 @@ class GeminiGateway implements Gateway, StepTextGateway
 
         $body = array_merge($providerOptions, [
             'contents' => [['role' => 'user', 'parts' => $parts]],
-            'generationConfig' => array_filter([
+            'generationConfig' => array_replace_recursive($providerOptions['generationConfig'] ?? [], array_filter([
                 'responseModalities' => ['IMAGE', 'TEXT'],
                 'imageConfig' => array_filter([
                     'imageSize' => $imageOptions['image_size'] ?? null,
                     'aspectRatio' => $imageOptions['aspect_ratio'] ?? null,
                 ]),
-            ]),
+            ])),
         ]);
 
         $response = $this->withErrorHandling(

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -56,6 +56,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
      * @param  array<Image>  $attachments
      * @param  '3:2'|'2:3'|'1:1'|null  $size
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateImage(
         ImageProvider $provider,
@@ -65,14 +66,15 @@ class OpenAiGateway implements Gateway, StepTextGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         $hasAttachments = filled($attachments);
 
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $hasAttachments
-                ? $this->sendImageEditRequest($provider, $model, $prompt, $attachments, $size, $quality, $timeout)
-                : $this->sendImageGenerationRequest($provider, $model, $prompt, $size, $quality, $timeout),
+                ? $this->sendImageEditRequest($provider, $model, $prompt, $attachments, $size, $quality, $timeout, $providerOptions)
+                : $this->sendImageGenerationRequest($provider, $model, $prompt, $size, $quality, $timeout, $providerOptions),
         );
 
         $data = $response->json();
@@ -89,6 +91,8 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
     /**
      * Send an image generation request.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     protected function sendImageGenerationRequest(
         ImageProvider $provider,
@@ -97,8 +101,10 @@ class OpenAiGateway implements Gateway, StepTextGateway
         ?string $size,
         ?string $quality,
         ?int $timeout,
+        array $providerOptions = [],
     ) {
         return $this->client($provider, $timeout ?? 120)->post('images/generations', [
+            ...$providerOptions,
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),
@@ -110,6 +116,8 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
     /**
      * Send an image edit request with attachments.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     protected function sendImageEditRequest(
         ImageProvider $provider,
@@ -119,6 +127,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
         ?string $size,
         ?string $quality,
         ?int $timeout,
+        array $providerOptions = [],
     ) {
         $request = $this->client($provider, $timeout ?? 120);
 
@@ -143,6 +152,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
         }
 
         return $request->post('images/edits', array_filter([
+            ...$providerOptions,
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -151,15 +151,14 @@ class OpenAiGateway implements Gateway, StepTextGateway
             $request = $request->attach($field, $content, 'image.png');
         }
 
-        return $request->post('images/edits', array_filter([
-            ...$providerOptions,
+        return $request->post('images/edits', array_merge($providerOptions, array_filter([
             'model' => $model,
             'prompt' => $prompt,
             ...$provider->defaultImageOptions($size, $quality),
             ...($isGptImage
                 ? ['moderation' => 'low']
                 : ['response_format' => 'b64_json']),
-        ]));
+        ])));
     }
 
     /**

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -120,13 +120,12 @@ class OpenRouterGateway implements Gateway, StepTextGateway
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout ?? 120)
-                ->post('chat/completions', array_filter([
-                    ...$providerOptions,
+                ->post('chat/completions', array_merge($providerOptions, array_filter([
                     'model' => $model,
                     'messages' => $this->buildImageMessages($prompt, $attachments),
                     'modalities' => ['image'],
                     'image_config' => $imageConfig ?: null,
-                ]))
+                ])))
         );
 
         $data = $response->json();

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -108,6 +108,7 @@ class OpenRouterGateway implements Gateway, StepTextGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         $imageOptions = $provider->defaultImageOptions($size, $quality);
 
@@ -120,6 +121,7 @@ class OpenRouterGateway implements Gateway, StepTextGateway
             $provider->name(),
             fn () => $this->client($provider, $timeout ?? 120)
                 ->post('chat/completions', array_filter([
+                    ...$providerOptions,
                     'model' => $model,
                     'messages' => $this->buildImageMessages($prompt, $attachments),
                     'modalities' => ['image'],

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -110,6 +110,7 @@ class XaiGateway implements Gateway, StepTextGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         throw new LogicException('Use XaiImageGateway for image generation.');
     }

--- a/src/Gateway/Xai/XaiImageGateway.php
+++ b/src/Gateway/Xai/XaiImageGateway.php
@@ -22,6 +22,7 @@ class XaiImageGateway implements ImageGateway
      *
      * @param  array<Image>  $attachments
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateImage(
         ImageProvider $provider,
@@ -31,13 +32,14 @@ class XaiImageGateway implements ImageGateway
         ?string $size = null,
         ?string $quality = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         $options = $provider->defaultImageOptions($size, $quality);
 
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout ?? 120)
-                ->post('images/generations', array_merge(array_filter([
+                ->post('images/generations', array_merge($providerOptions, array_filter([
                     'model' => $model,
                     'prompt' => $prompt,
                     'response_format' => 'b64_json',

--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -12,6 +12,7 @@ use Laravel\Ai\Files\Image;
 use Laravel\Ai\Files\LocalImage;
 use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Jobs\GenerateImage;
+use Laravel\Ai\PendingResponses\Concerns\ResolvesProviderOptions;
 use Laravel\Ai\Prompts\QueuedImagePrompt;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\ImageResponse;
@@ -21,6 +22,7 @@ use LogicException;
 class PendingImageGeneration
 {
     use Conditionable;
+    use ResolvesProviderOptions;
 
     public array $attachments = [];
 
@@ -131,7 +133,7 @@ class PendingImageGeneration
 
             try {
                 return $provider->image(
-                    $this->prompt, $this->attachments, $this->size, $this->quality, $model, $this->timeout
+                    $this->prompt, $this->attachments, $this->size, $this->quality, $model, $this->timeout, $this->resolveProviderOptions($provider)
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -162,7 +164,8 @@ class PendingImageGeneration
                     $this->size,
                     $this->quality,
                     $provider,
-                    $model
+                    $model,
+                    is_array($this->providerOptions) ? $this->providerOptions : [],
                 )
             );
         }

--- a/src/Prompts/ImagePrompt.php
+++ b/src/Prompts/ImagePrompt.php
@@ -10,6 +10,9 @@ class ImagePrompt
 {
     public readonly Collection $attachments;
 
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $prompt,
         Collection|array $attachments,
@@ -17,6 +20,7 @@ class ImagePrompt
         public readonly ?string $quality,
         public readonly ImageProvider $provider,
         public readonly string $model,
+        public readonly array $providerOptions = [],
     ) {
         $this->attachments = Collection::make($attachments);
     }

--- a/src/Prompts/QueuedImagePrompt.php
+++ b/src/Prompts/QueuedImagePrompt.php
@@ -10,6 +10,9 @@ class QueuedImagePrompt
 {
     public readonly Collection $attachments;
 
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $prompt,
         Collection|array $attachments,
@@ -17,6 +20,7 @@ class QueuedImagePrompt
         public readonly ?string $quality,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
+        public readonly array $providerOptions = [],
     ) {
         $this->attachments = Collection::make($attachments);
     }

--- a/src/Providers/Concerns/GeneratesImages.php
+++ b/src/Providers/Concerns/GeneratesImages.php
@@ -17,6 +17,7 @@ trait GeneratesImages
      *
      * @param  array<Image>  $attachments
      * @param  'low'|'medium'|'high'|null  $quality
+     * @param  array<string, mixed>  $providerOptions
      */
     public function image(
         string $prompt,
@@ -25,12 +26,13 @@ trait GeneratesImages
         ?string $quality = null,
         ?string $model = null,
         ?int $timeout = null,
+        array $providerOptions = [],
     ): ImageResponse {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultImageModel();
 
-        $prompt = new ImagePrompt($prompt, $attachments, $size, $quality, $this, $model);
+        $prompt = new ImagePrompt($prompt, $attachments, $size, $quality, $this, $model, $providerOptions);
 
         if (Ai::imagesAreFaked()) {
             Ai::recordImageGeneration($prompt);
@@ -41,7 +43,7 @@ trait GeneratesImages
         ));
 
         return tap($this->imageGateway()->generateImage(
-            $this, $model, $prompt->prompt, $prompt->attachments->all(), $prompt->size, $prompt->quality, $timeout,
+            $this, $model, $prompt->prompt, $prompt->attachments->all(), $prompt->size, $prompt->quality, $timeout, $prompt->providerOptions,
         ), function (ImageResponse $response) use ($invocationId, $prompt, $model): void {
             $this->events->dispatch(new ImageGenerated(
                 $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/ImageProviderOptionsTest.php
+++ b/tests/Feature/ImageProviderOptionsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Image;
+use Laravel\Ai\Prompts\QueuedImagePrompt;
+use Laravel\Ai\Providers\Provider;
+
+beforeEach(function (): void {
+    config(['ai.providers.openai' => [...config('ai.providers.openai'), 'key' => 'test-key']]);
+});
+
+test('flat provider options are sent on the image request', function (): void {
+    Http::fake(['*' => Http::response(['data' => [['b64_json' => base64_encode('fake-image')]]])]);
+
+    Image::of('A red apple')
+        ->withProviderOptions(['background' => 'transparent'])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['background'] === 'transparent');
+});
+
+test('provider options may not override the core image request payload', function (): void {
+    Http::fake(['*' => Http::response(['data' => [['b64_json' => base64_encode('fake-image')]]])]);
+
+    Image::of('A red apple')
+        ->withProviderOptions(['model' => 'hijacked', 'prompt' => 'hijacked'])
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'gpt-image-1' && $body['prompt'] === 'A red apple';
+    });
+});
+
+test('closure provider options receive the resolved image provider', function (): void {
+    Http::fake(['*' => Http::response(['data' => [['b64_json' => base64_encode('fake-image')]]])]);
+
+    $seen = [];
+
+    Image::of('A red apple')
+        ->withProviderOptions(function (Provider $provider) use (&$seen): array {
+            $seen[] = $provider->driver();
+
+            return ['background' => 'transparent'];
+        })
+        ->generate(provider: 'openai', model: 'gpt-image-1');
+
+    expect($seen)->toBe(['openai']);
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['background'] === 'transparent');
+});
+
+test('flat provider options are recorded on the queued image prompt fake', function (): void {
+    Image::fake();
+
+    Image::of('A red apple')
+        ->withProviderOptions(['background' => 'transparent'])
+        ->queue(provider: 'openai');
+
+    Image::assertQueued(
+        fn (QueuedImagePrompt $prompt): bool => $prompt->providerOptions === ['background' => 'transparent'],
+    );
+});

--- a/tests/Feature/ImageProviderOptionsTest.php
+++ b/tests/Feature/ImageProviderOptionsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Image;
+use Laravel\Ai\Jobs\GenerateImage;
 use Laravel\Ai\Prompts\QueuedImagePrompt;
 use Laravel\Ai\Providers\Provider;
 
@@ -62,4 +63,18 @@ test('flat provider options are recorded on the queued image prompt fake', funct
     Image::assertQueued(
         fn (QueuedImagePrompt $prompt): bool => $prompt->providerOptions === ['background' => 'transparent'],
     );
+});
+
+test('closure provider options survive queue serialization round-trip', function (): void {
+    Http::fake(['*' => Http::response(['data' => [['b64_json' => base64_encode('fake-image')]]])]);
+
+    $job = new GenerateImage(
+        Image::of('A red apple')->withProviderOptions(fn (Provider $provider): array => ['background' => 'transparent']),
+        'openai',
+        'gpt-image-1',
+    );
+
+    unserialize(serialize($job))->handle();
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['background'] === 'transparent');
 });

--- a/tests/Feature/Providers/Bedrock/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Bedrock/ImageGenerationTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Aws\BedrockRuntime\BedrockRuntimeClient;
+use Laravel\Ai\Gateway\Bedrock\BedrockImageGateway;
+use Laravel\Ai\Providers\Provider;
+
+test('nested provider options are merged beneath the core image body', function (): void {
+    $mock = $this->bedrockInvokeMock(['images' => [base64_encode('fake-image')]]);
+
+    $gateway = new class($this->bedrockClient($mock)) extends BedrockImageGateway
+    {
+        public function __construct(private BedrockRuntimeClient $stub) {}
+
+        protected function createBedrockClient(Provider $provider, ?int $timeout = null): BedrockRuntimeClient
+        {
+            return $this->stub;
+        }
+    };
+
+    $gateway->generateImage(
+        $this->bedrockProvider(),
+        'amazon.titan-image-generator-v2:0',
+        'A red apple',
+        providerOptions: ['imageGenerationConfig' => ['seed' => 42, 'numberOfImages' => 5]],
+    );
+
+    $body = json_decode($mock->getLastCommand()['body'], true);
+
+    expect($body['imageGenerationConfig']['seed'])->toBe(42)
+        ->and($body['imageGenerationConfig']['numberOfImages'])->toBe(1)
+        ->and($body['textToImageParams']['text'])->toBe('A red apple');
+});

--- a/tests/Feature/Providers/Gemini/ImageGenerationTest.php
+++ b/tests/Feature/Providers/Gemini/ImageGenerationTest.php
@@ -322,3 +322,17 @@ test('image response is empty when candidate is blocked with no content parts', 
 
     expect($response->images)->toHaveCount(0);
 });
+
+test('nested generation config provider options are merged beneath the core config', function (): void {
+    Http::fake(['generativelanguage.googleapis.com/*' => fakeGeminiImageResponse()]);
+
+    Image::of('A red apple')
+        ->withProviderOptions(['generationConfig' => ['temperature' => 0.1, 'responseModalities' => ['TEXT']]])
+        ->generate(provider: 'gemini', model: 'gemini-3.1-flash-image-preview');
+
+    Http::assertSent(function (Request $request): bool {
+        $config = json_decode($request->body(), true)['generationConfig'];
+
+        return $config['temperature'] === 0.1 && $config['responseModalities'] === ['IMAGE', 'TEXT'];
+    });
+});

--- a/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
+++ b/tests/Feature/Providers/OpenRouter/ImageGenerationTest.php
@@ -234,3 +234,13 @@ test('image http error response throws request exception', function (): void {
 
     Image::of('A blue circle')->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
 })->throws(RequestException::class);
+
+test('falsy provider options are not filtered out of the image request', function (): void {
+    Http::fake(['openrouter.ai/*' => fakeOpenRouterImageResponse()]);
+
+    Image::of('A blue circle')
+        ->withProviderOptions(['stream' => false])
+        ->generate(provider: 'openrouter', model: 'google/gemini-2.5-flash-image');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['stream'] === false);
+});


### PR DESCRIPTION
Currently there isn't a way to send provider specific keys on an image request, so things like OpenAI's `background` or a Bedrock model's own fields are out of reach. `Embeddings` and `Transcription` already have `withProviderOptions()`, images did not.

```php
use Laravel\Ai\Image;

$response = Image::of('A red apple')
    ->withProviderOptions(['background' => 'transparent'])
    ->generate(provider: 'openai', model: 'gpt-image-1');
```

Pass a closure to scope the options per provider:

```php
use Laravel\Ai\Providers\Provider;

Image::of('A red apple')
    ->withProviderOptions(fn (Provider $provider): array => $provider->driver() === 'openai'
        ? ['background' => 'transparent']
        : ['negative_prompt' => 'blurry'])
    ->generate();
```

Options merge underneath the core payload, so `model`, `prompt`, size and quality can't be overridden. They also land on `ImagePrompt` and `QueuedImagePrompt` so fakes can assert on them.

BC break for anyone implementing `ImageGateway` or `ImageProvider` outside the package, both gained a trailing `array $providerOptions = []` parameter.

First of three stacked PRs (image, then audio, then reranking).