### PR TITLE
Add withProviderOptions support to the audio builder

### DIFF
--- a/src/Contracts/Gateway/AudioGateway.php
+++ b/src/Contracts/Gateway/AudioGateway.php
@@ -9,6 +9,8 @@ interface AudioGateway
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -17,5 +19,6 @@ interface AudioGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse;
 }

--- a/src/Contracts/Providers/AudioProvider.php
+++ b/src/Contracts/Providers/AudioProvider.php
@@ -9,6 +9,8 @@ interface AudioProvider extends Provider
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function audio(
         string $text,
@@ -16,6 +18,7 @@ interface AudioProvider extends Provider
         ?string $instructions = null,
         ?string $model = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse;
 
     /**

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -145,6 +145,7 @@ class AnthropicGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         throw new LogicException('Anthropic does not support audio generation.');
     }

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -23,6 +23,8 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -31,6 +33,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'onwK4e9ZLuTAKqWW03F9',
@@ -39,10 +42,10 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         };
 
         $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
-            ->post('text-to-speech/'.$voice, [
+            ->post('text-to-speech/'.$voice, array_merge($providerOptions, [
                 'model_id' => $model,
                 'text' => $text,
-            ])->throw());
+            ]))->throw());
 
         return new AudioResponse(
             base64_encode((string) $response),

--- a/src/Gateway/FakeAudioGateway.php
+++ b/src/Gateway/FakeAudioGateway.php
@@ -22,6 +22,8 @@ class FakeAudioGateway implements AudioGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -30,8 +32,9 @@ class FakeAudioGateway implements AudioGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
-        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout);
+        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout, $providerOptions);
 
         return $this->nextResponse($provider, $model, $audioPrompt);
     }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -226,7 +226,7 @@ class GeminiGateway implements Gateway, StepTextGateway
                             : $text,
                     ]],
                 ]],
-                'generationConfig' => [
+                'generationConfig' => array_replace_recursive($providerOptions['generationConfig'] ?? [], [
                     'responseModalities' => ['AUDIO'],
                     'speechConfig' => [
                         'voiceConfig' => [
@@ -239,7 +239,7 @@ class GeminiGateway implements Gateway, StepTextGateway
                             ],
                         ],
                     ],
-                ],
+                ]),
             ])),
         );
 

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -226,8 +226,7 @@ class GeminiGateway implements Gateway, StepTextGateway
                             : $text,
                     ]],
                 ]],
-                'generationConfig' => array_replace_recursive($providerOptions['generationConfig'] ?? [], [
-                    'responseModalities' => ['AUDIO'],
+                'generationConfig' => array_merge(array_replace_recursive($providerOptions['generationConfig'] ?? [], [
                     'speechConfig' => [
                         'voiceConfig' => [
                             'prebuiltVoiceConfig' => [
@@ -239,7 +238,7 @@ class GeminiGateway implements Gateway, StepTextGateway
                             ],
                         ],
                     ],
-                ]),
+                ]), ['responseModalities' => ['AUDIO']]),
             ])),
         );
 

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -202,6 +202,8 @@ class GeminiGateway implements Gateway, StepTextGateway
     /**
      * Generate audio from the given text.
      *
+     * @param  array<string, mixed>  $providerOptions
+     *
      * @throws RuntimeException if Gemini returns no audio data or invalid base64 audio.
      */
     public function generateAudio(
@@ -211,10 +213,11 @@ class GeminiGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", [
+            fn () => $this->client($provider, $timeout)->post("models/{$model}:generateContent", array_merge($providerOptions, [
                 'contents' => [[
                     'role' => 'user',
                     'parts' => [[
@@ -237,7 +240,7 @@ class GeminiGateway implements Gateway, StepTextGateway
                         ],
                     ],
                 ],
-            ]),
+            ])),
         );
 
         $data = $response->json();

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -183,15 +183,14 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
-                ...$providerOptions,
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $voice,
                 'response_format' => 'mp3',
                 'speed' => 1.0,
                 'instructions' => $instructions,
-            ])),
+            ]))),
         );
 
         return new AudioResponse(

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -163,6 +163,8 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -171,6 +173,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'ash',
@@ -181,6 +184,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
+                ...$providerOptions,
                 'model' => $model,
                 'input' => $text,
                 'voice' => $voice,

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -183,12 +183,11 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge($providerOptions, array_filter([
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge(['speed' => 1.0], $providerOptions, array_filter([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $voice,
                 'response_format' => 'mp3',
-                'speed' => 1.0,
                 'instructions' => $instructions,
             ]))),
         );

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -170,6 +170,8 @@ class OpenRouterGateway implements Gateway, StepTextGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -178,12 +180,14 @@ class OpenRouterGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $format = $this->audioResponseFormat($model);
 
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
+                ...$providerOptions,
                 'model' => $model,
                 'input' => $text,
                 'voice' => $this->resolveVoice($model, $voice),

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -186,15 +186,14 @@ class OpenRouterGateway implements Gateway, StepTextGateway
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
-                ...$providerOptions,
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $this->resolveVoice($model, $voice),
                 'response_format' => $format,
                 'speed' => 1.0,
                 'instructions' => $instructions,
-            ])),
+            ]))),
         );
 
         return new AudioResponse(

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -186,12 +186,11 @@ class OpenRouterGateway implements Gateway, StepTextGateway
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge($providerOptions, array_filter([
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge(['speed' => 1.0], $providerOptions, array_filter([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $this->resolveVoice($model, $voice),
                 'response_format' => $format,
-                'speed' => 1.0,
                 'instructions' => $instructions,
             ]))),
         );

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -125,6 +125,7 @@ class XaiGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         throw new LogicException('xAI does not support audio generation.');
     }

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Jobs\GenerateAudio;
+use Laravel\Ai\PendingResponses\Concerns\ResolvesProviderOptions;
 use Laravel\Ai\Prompts\QueuedAudioPrompt;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AudioResponse;
@@ -18,6 +19,7 @@ use Laravel\Ai\Responses\QueuedAudioResponse;
 class PendingAudioGeneration
 {
     use Conditionable;
+    use ResolvesProviderOptions;
 
     protected string $voice = 'default-female';
 
@@ -103,7 +105,7 @@ class PendingAudioGeneration
 
             try {
                 return $provider->audio(
-                    $this->text, $this->voice, $this->instructions, $model, $this->timeout
+                    $this->text, $this->voice, $this->instructions, $model, $this->timeout, $this->resolveProviderOptions($provider)
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -131,6 +133,7 @@ class PendingAudioGeneration
                     $provider,
                     $model,
                     $this->timeout,
+                    is_array($this->providerOptions) ? $this->providerOptions : [],
                 )
             );
         }

--- a/src/Prompts/AudioPrompt.php
+++ b/src/Prompts/AudioPrompt.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Contracts\Providers\AudioProvider;
 
 class AudioPrompt
 {
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $text,
         public readonly string $voice,
@@ -14,6 +17,7 @@ class AudioPrompt
         public readonly AudioProvider $provider,
         public readonly string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Prompts/QueuedAudioPrompt.php
+++ b/src/Prompts/QueuedAudioPrompt.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Enums\Lab;
 
 class QueuedAudioPrompt
 {
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $text,
         public readonly string $voice,
@@ -14,6 +17,7 @@ class QueuedAudioPrompt
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesAudio.php
+++ b/src/Providers/Concerns/GeneratesAudio.php
@@ -13,6 +13,8 @@ trait GeneratesAudio
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function audio(
         string $text,
@@ -20,12 +22,13 @@ trait GeneratesAudio
         ?string $instructions = null,
         ?string $model = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultAudioModel();
 
-        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout);
+        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout, $providerOptions);
 
         if (Ai::audioIsFaked()) {
             Ai::recordAudioGeneration($prompt);
@@ -36,7 +39,7 @@ trait GeneratesAudio
         ));
 
         return tap($this->audioGateway()->generateAudio(
-            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout,
+            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout, $prompt->providerOptions,
         ), function (AudioResponse $response) use ($invocationId, $model, $prompt): void {
             $this->events->dispatch(new AudioGenerated(
                 $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/AudioProviderOptionsTest.php
+++ b/tests/Feature/AudioProviderOptionsTest.php
@@ -15,13 +15,13 @@ test('provider options may not override the core audio request payload', functio
     Http::fake(['*' => Http::response('fake-audio-bytes')]);
 
     Audio::of('Hello world')
-        ->withProviderOptions(['model' => 'hijacked', 'stream_format' => 'sse'])
+        ->withProviderOptions(['model' => 'hijacked', 'speed' => 0.8])
         ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
 
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);
 
-        return $body['model'] === 'gpt-4o-mini-tts' && $body['stream_format'] === 'sse';
+        return $body['model'] === 'gpt-4o-mini-tts' && $body['speed'] === 0.8;
     });
 });
 
@@ -34,24 +34,24 @@ test('closure provider options receive the resolved audio provider', function ()
         ->withProviderOptions(function (Provider $provider) use (&$seen): array {
             $seen[] = $provider->driver();
 
-            return ['stream_format' => 'sse'];
+            return ['speed' => 0.8];
         })
         ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
 
     expect($seen)->toBe(['openai']);
 
-    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['stream_format'] === 'sse');
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['speed'] === 0.8);
 });
 
 test('flat provider options are recorded on the queued audio prompt fake', function (): void {
     Audio::fake();
 
     Audio::of('Hello world')
-        ->withProviderOptions(['stream_format' => 'sse'])
+        ->withProviderOptions(['speed' => 0.8])
         ->queue(provider: 'openai');
 
     Audio::assertQueued(
-        fn (QueuedAudioPrompt $prompt): bool => $prompt->providerOptions === ['stream_format' => 'sse'],
+        fn (QueuedAudioPrompt $prompt): bool => $prompt->providerOptions === ['speed' => 0.8],
     );
 });
 
@@ -73,12 +73,12 @@ test('closure provider options survive queue serialization round-trip', function
     Http::fake(['*' => Http::response('fake-audio-bytes')]);
 
     $job = new GenerateAudio(
-        Audio::of('Hello world')->withProviderOptions(fn (Provider $provider): array => ['stream_format' => 'sse']),
+        Audio::of('Hello world')->withProviderOptions(fn (Provider $provider): array => ['speed' => 0.8]),
         'openai',
         'gpt-4o-mini-tts',
     );
 
     unserialize(serialize($job))->handle();
 
-    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['stream_format'] === 'sse');
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['speed'] === 0.8);
 });

--- a/tests/Feature/AudioProviderOptionsTest.php
+++ b/tests/Feature/AudioProviderOptionsTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Audio;
+use Laravel\Ai\Jobs\GenerateAudio;
 use Laravel\Ai\Prompts\QueuedAudioPrompt;
 use Laravel\Ai\Providers\Provider;
 
@@ -52,4 +53,32 @@ test('flat provider options are recorded on the queued audio prompt fake', funct
     Audio::assertQueued(
         fn (QueuedAudioPrompt $prompt): bool => $prompt->providerOptions === ['stream_format' => 'sse'],
     );
+});
+
+test('falsy provider options are not dropped from the audio request', function (): void {
+    Http::fake(['*' => Http::response('fake-audio-bytes')]);
+
+    Audio::of('Hello world')
+        ->withProviderOptions(['stream' => false])
+        ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return array_key_exists('stream', $body) && $body['stream'] === false;
+    });
+});
+
+test('closure provider options survive queue serialization round-trip', function (): void {
+    Http::fake(['*' => Http::response('fake-audio-bytes')]);
+
+    $job = new GenerateAudio(
+        Audio::of('Hello world')->withProviderOptions(fn (Provider $provider): array => ['stream_format' => 'sse']),
+        'openai',
+        'gpt-4o-mini-tts',
+    );
+
+    unserialize(serialize($job))->handle();
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['stream_format'] === 'sse');
 });

--- a/tests/Feature/AudioProviderOptionsTest.php
+++ b/tests/Feature/AudioProviderOptionsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Prompts\QueuedAudioPrompt;
+use Laravel\Ai\Providers\Provider;
+
+beforeEach(function (): void {
+    config(['ai.providers.openai' => [...config('ai.providers.openai'), 'key' => 'test-key']]);
+});
+
+test('provider options may not override the core audio request payload', function (): void {
+    Http::fake(['*' => Http::response('fake-audio-bytes')]);
+
+    Audio::of('Hello world')
+        ->withProviderOptions(['model' => 'hijacked', 'stream_format' => 'sse'])
+        ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'gpt-4o-mini-tts' && $body['stream_format'] === 'sse';
+    });
+});
+
+test('closure provider options receive the resolved audio provider', function (): void {
+    Http::fake(['*' => Http::response('fake-audio-bytes')]);
+
+    $seen = [];
+
+    Audio::of('Hello world')
+        ->withProviderOptions(function (Provider $provider) use (&$seen): array {
+            $seen[] = $provider->driver();
+
+            return ['stream_format' => 'sse'];
+        })
+        ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    expect($seen)->toBe(['openai']);
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['stream_format'] === 'sse');
+});
+
+test('flat provider options are recorded on the queued audio prompt fake', function (): void {
+    Audio::fake();
+
+    Audio::of('Hello world')
+        ->withProviderOptions(['stream_format' => 'sse'])
+        ->queue(provider: 'openai');
+
+    Audio::assertQueued(
+        fn (QueuedAudioPrompt $prompt): bool => $prompt->providerOptions === ['stream_format' => 'sse'],
+    );
+});

--- a/tests/Feature/Providers/Gemini/AudioTest.php
+++ b/tests/Feature/Providers/Gemini/AudioTest.php
@@ -102,6 +102,30 @@ test('audio uses default model when none specified', function (): void {
     Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'models/gemini-2.5-flash-preview-tts:generateContent'));
 });
 
+test('nested generation config provider options are merged beneath the core config', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => fakeGeminiAudioResponse(),
+    ]);
+
+    Audio::of('Hello world')
+        ->voice('Kore')
+        ->withProviderOptions(['generationConfig' => [
+            'temperature' => 0.1,
+            'responseModalities' => ['TEXT'],
+            'speechConfig' => ['languageCode' => 'en-US'],
+        ]])
+        ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');
+
+    Http::assertSent(function (Request $request): bool {
+        $config = $request->data()['generationConfig'];
+
+        return $config['temperature'] === 0.1
+            && $config['responseModalities'] === ['AUDIO']
+            && $config['speechConfig']['languageCode'] === 'en-US'
+            && $config['speechConfig']['voiceConfig']['prebuiltVoiceConfig']['voiceName'] === 'Kore';
+    });
+});
+
 function fakeGeminiAudioResponse(string $pcm = "\x00\x00"): PromiseInterface
 {
     return Http::response([

--- a/tests/Feature/Providers/Gemini/AudioTest.php
+++ b/tests/Feature/Providers/Gemini/AudioTest.php
@@ -111,7 +111,7 @@ test('nested generation config provider options are merged beneath the core conf
         ->voice('Kore')
         ->withProviderOptions(['generationConfig' => [
             'temperature' => 0.1,
-            'responseModalities' => ['TEXT'],
+            'responseModalities' => ['TEXT', 'IMAGE'],
             'speechConfig' => ['languageCode' => 'en-US'],
         ]])
         ->generate(provider: 'gemini', model: 'gemini-2.5-flash-preview-tts');


### PR DESCRIPTION
Same gap as #899, this time for speech. There was no way to reach the knobs a TTS provider exposes but the builder doesn't model, like ElevenLabs voice settings or OpenAI's `stream_format`.

```php
use Laravel\Ai\Audio;

$response = Audio::of('Hello world')
    ->withProviderOptions(['voice_settings' => ['stability' => 0.4]])
    ->generate(provider: 'elevenlabs');
```

Closure form works the same way:

```php
use Laravel\Ai\Providers\Provider;

Audio::of('Hello world')
    ->withProviderOptions(fn (Provider $provider): array => $provider->driver() === 'elevenlabs'
        ? ['voice_settings' => ['stability' => 0.4]]
        : ['stream_format' => 'sse'])
    ->generate();
```

Core payload keys still win, and the options are recorded on `AudioPrompt` and `QueuedAudioPrompt` for fake assertions.

BC break for external implementations of `AudioGateway` or `AudioProvider`, both gained a trailing `array $providerOptions = []` parameter.

Stacked on #899.