### PR TITLE
Add withProviderOptions support to the reranking builder

### DIFF
--- a/src/Contracts/Gateway/RerankingGateway.php
+++ b/src/Contracts/Gateway/RerankingGateway.php
@@ -11,12 +11,14 @@ interface RerankingGateway
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
     public function rerank(
         RerankingProvider $provider,
         string $model,
         array $documents,
         string $query,
-        ?int $limit = null
+        ?int $limit = null,
+        array $providerOptions = [],
     ): RerankingResponse;
 }

--- a/src/Contracts/Providers/RerankingProvider.php
+++ b/src/Contracts/Providers/RerankingProvider.php
@@ -11,8 +11,9 @@ interface RerankingProvider extends Provider
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
-    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null): RerankingResponse;
+    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null, array $providerOptions = []): RerankingResponse;
 
     /**
      * Get the provider's reranking gateway.

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -63,22 +63,24 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
     public function rerank(
         RerankingProvider $provider,
         string $model,
         array $documents,
         string $query,
-        ?int $limit = null
+        ?int $limit = null,
+        array $providerOptions = [],
     ): RerankingResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('/rerank', array_filter([
+            fn () => $this->client($provider)->post('/rerank', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'query' => $query,
                 'documents' => $documents,
                 'top_n' => $limit,
-            ])),
+            ]))),
         );
 
         $data = $response->json();

--- a/src/Gateway/FakeRerankingGateway.php
+++ b/src/Gateway/FakeRerankingGateway.php
@@ -26,15 +26,17 @@ class FakeRerankingGateway implements RerankingGateway
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
     public function rerank(
         RerankingProvider $provider,
         string $model,
         array $documents,
         string $query,
-        ?int $limit = null
+        ?int $limit = null,
+        array $providerOptions = [],
     ): RerankingResponse {
-        $prompt = new RerankingPrompt($documents, $query, $limit, $provider, $model);
+        $prompt = new RerankingPrompt($documents, $query, $limit, $provider, $model, $providerOptions);
 
         return $this->nextResponse($provider, $model, $prompt);
     }

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -61,22 +61,24 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
     public function rerank(
         RerankingProvider $provider,
         string $model,
         array $documents,
         string $query,
-        ?int $limit = null
+        ?int $limit = null,
+        array $providerOptions = [],
     ): RerankingResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('/rerank', array_filter([
+            fn () => $this->client($provider)->post('/rerank', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'query' => $query,
                 'documents' => $documents,
                 'top_n' => $limit,
-            ])),
+            ]))),
         );
 
         $data = $response->json();

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -54,22 +54,24 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
     public function rerank(
         RerankingProvider $provider,
         string $model,
         array $documents,
         string $query,
-        ?int $limit = null
+        ?int $limit = null,
+        array $providerOptions = [],
     ): RerankingResponse {
         $data = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('/rerank', array_filter([
+            fn () => $this->client($provider)->post('/rerank', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'query' => $query,
                 'documents' => $documents,
                 'top_k' => $limit,
-            ])),
+            ]))),
         )->json();
 
         return new RerankingResponse(

--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -8,12 +8,14 @@ use Laravel\Ai\Ai;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
+use Laravel\Ai\PendingResponses\Concerns\ResolvesProviderOptions;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\RerankingResponse;
 
 class PendingReranking
 {
     use Conditionable;
+    use ResolvesProviderOptions;
 
     protected ?int $limit = null;
 
@@ -71,7 +73,7 @@ class PendingReranking
             $model ??= $provider->defaultRerankingModel();
 
             try {
-                return $provider->rerank($this->documents, $query, $this->limit, $model);
+                return $provider->rerank($this->documents, $query, $this->limit, $model, $this->resolveProviderOptions($provider));
             } catch (FailoverableException $e) {
                 $lastException = $e;
 

--- a/src/Prompts/RerankingPrompt.php
+++ b/src/Prompts/RerankingPrompt.php
@@ -12,6 +12,7 @@ class RerankingPrompt implements Countable
      * Create a new reranking prompt instance.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
     public function __construct(
         public readonly array $documents,
@@ -19,6 +20,7 @@ class RerankingPrompt implements Countable
         public readonly ?int $limit,
         public readonly RerankingProvider $provider,
         public readonly string $model,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Providers/Concerns/Reranks.php
+++ b/src/Providers/Concerns/Reranks.php
@@ -15,14 +15,15 @@ trait Reranks
      * Rerank the given documents based on their relevance to the query.
      *
      * @param  array<int, string>  $documents
+     * @param  array<string, mixed>  $providerOptions
      */
-    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null): RerankingResponse
+    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null, array $providerOptions = []): RerankingResponse
     {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultRerankingModel();
 
-        $prompt = new RerankingPrompt($documents, $query, $limit, $this, $model);
+        $prompt = new RerankingPrompt($documents, $query, $limit, $this, $model, $providerOptions);
 
         if (Ai::rerankingIsFaked()) {
             Ai::recordReranking($prompt);
@@ -37,7 +38,8 @@ trait Reranks
             $model,
             $documents,
             $query,
-            $limit
+            $limit,
+            $providerOptions,
         ), fn (RerankingResponse $response) => $this->events->dispatch(new Reranked(
             $invocationId, $this, $model, $prompt, $response,
         )));

--- a/tests/Feature/RerankingProviderOptionsTest.php
+++ b/tests/Feature/RerankingProviderOptionsTest.php
@@ -6,7 +6,10 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Reranking;
 
 beforeEach(function (): void {
-    config(['ai.providers.cohere' => [...config('ai.providers.cohere'), 'key' => 'test-key']]);
+    config([
+        'ai.providers.cohere' => [...config('ai.providers.cohere'), 'key' => 'test-key'],
+        'ai.providers.voyageai' => [...config('ai.providers.voyageai'), 'key' => 'test-key'],
+    ]);
 });
 
 function fakeRerankingResponse(): array
@@ -67,5 +70,20 @@ test('falsy provider options are not dropped from the reranking request', functi
         $body = json_decode($request->body(), true);
 
         return array_key_exists('return_documents', $body) && $body['return_documents'] === false;
+    });
+});
+
+test('the limit still wins over a voyage top_k provider option', function (): void {
+    Http::fake(['*' => Http::response(['data' => [['index' => 0, 'relevance_score' => 0.9]]])]);
+
+    Reranking::of(['Laravel is a PHP framework'])
+        ->limit(1)
+        ->withProviderOptions(['top_k' => 99, 'truncation' => false])
+        ->rerank('What is Laravel?', provider: 'voyageai', model: 'rerank-2.5-lite');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['top_k'] === 1 && $body['truncation'] === false;
     });
 });

--- a/tests/Feature/RerankingProviderOptionsTest.php
+++ b/tests/Feature/RerankingProviderOptionsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Reranking;
+
+beforeEach(function (): void {
+    config(['ai.providers.cohere' => [...config('ai.providers.cohere'), 'key' => 'test-key']]);
+});
+
+function fakeRerankingResponse(): array
+{
+    return ['results' => [['index' => 0, 'relevance_score' => 0.9]]];
+}
+
+test('flat provider options are sent on the reranking request', function (): void {
+    Http::fake(['*' => Http::response(fakeRerankingResponse())]);
+
+    Reranking::of(['Laravel is a PHP framework'])
+        ->withProviderOptions(['max_tokens_per_doc' => 512])
+        ->rerank('What is Laravel?', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['max_tokens_per_doc'] === 512);
+});
+
+test('provider options may not override the core reranking request payload', function (): void {
+    Http::fake(['*' => Http::response(fakeRerankingResponse())]);
+
+    Reranking::of(['Laravel is a PHP framework'])
+        ->withProviderOptions(['model' => 'hijacked', 'query' => 'hijacked'])
+        ->rerank('What is Laravel?', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['model'] === 'rerank-v3.5' && $body['query'] === 'What is Laravel?';
+    });
+});
+
+test('closure provider options receive the resolved reranking provider', function (): void {
+    Http::fake(['*' => Http::response(fakeRerankingResponse())]);
+
+    $seen = [];
+
+    Reranking::of(['Laravel is a PHP framework'])
+        ->withProviderOptions(function (Provider $provider) use (&$seen): array {
+            $seen[] = $provider->driver();
+
+            return ['max_tokens_per_doc' => 512];
+        })
+        ->rerank('What is Laravel?', provider: 'cohere', model: 'rerank-v3.5');
+
+    expect($seen)->toBe(['cohere']);
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['max_tokens_per_doc'] === 512);
+});

--- a/tests/Feature/RerankingProviderOptionsTest.php
+++ b/tests/Feature/RerankingProviderOptionsTest.php
@@ -55,3 +55,17 @@ test('closure provider options receive the resolved reranking provider', functio
 
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['max_tokens_per_doc'] === 512);
 });
+
+test('falsy provider options are not dropped from the reranking request', function (): void {
+    Http::fake(['*' => Http::response(fakeRerankingResponse())]);
+
+    Reranking::of(['Laravel is a PHP framework'])
+        ->withProviderOptions(['return_documents' => false])
+        ->rerank('What is Laravel?', provider: 'cohere', model: 'rerank-v3.5');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return array_key_exists('return_documents', $body) && $body['return_documents'] === false;
+    });
+});


### PR DESCRIPTION
Last of the three (see #899 and #900). Cohere, Jina and Voyage all accept options the reranking builder doesn't model, like `max_tokens_per_doc` or `truncation`, and there was no way to send them.

```php
use Laravel\Ai\Reranking;

$response = Reranking::of($documents)
    ->withProviderOptions(['max_tokens_per_doc' => 512])
    ->rerank('What is Laravel?', provider: 'cohere');
```

Closure form for per-provider options:

```php
use Laravel\Ai\Providers\Provider;

Reranking::of($documents)
    ->withProviderOptions(fn (Provider $provider): array => $provider->driver() === 'cohere'
        ? ['max_tokens_per_doc' => 512]
        : ['truncation' => true])
    ->rerank('What is Laravel?');
```

`model`, `query`, `documents` and the limit still win over anything passed here. Options are recorded on `RerankingPrompt` for fake assertions. Reranking has no queued prompt, so there was nothing to thread there.

BC break for external implementations of `RerankingGateway` or `RerankingProvider`, both gained a trailing `array $providerOptions = []` parameter.