### PR TITLE
Align the Vercel UI message stream with the data stream protocol

### DIFF
--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Responses\Concerns;
 
 use Generator;
+use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
@@ -25,7 +26,7 @@ trait CanStreamUsingVercelProtocol
 
             public array $toolCalls = [];
 
-            public ?array $lastStreamEndEvent = null;
+            public ?StreamEnd $lastStreamEnd = null;
         };
 
         return response()->stream(function () use ($state) {
@@ -64,9 +65,14 @@ trait CanStreamUsingVercelProtocol
                     continue;
                 }
 
-                // Save the last stream end event until the very end...
+                // Save the last stream end event until the very end, combining usage across steps...
                 if ($event instanceof StreamEnd) {
-                    $state->lastStreamEndEvent = $event->toVercelProtocolArray();
+                    $state->lastStreamEnd = new StreamEnd(
+                        $event->id,
+                        $event->reason,
+                        ($state->lastStreamEnd?->usage ?? new Usage)->add($event->usage),
+                        $event->timestamp,
+                    );
 
                     continue;
                 }
@@ -78,8 +84,8 @@ trait CanStreamUsingVercelProtocol
                 yield from $this->toVercelProtocolPart($state, $data);
             }
 
-            if ($state->lastStreamEndEvent) {
-                yield 'data: '.json_encode($state->lastStreamEndEvent)."\n\n";
+            if ($state->lastStreamEnd) {
+                yield 'data: '.json_encode($state->lastStreamEnd->toVercelProtocolArray())."\n\n";
             }
 
             yield "data: [DONE]\n\n";

--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Responses\Concerns;
 
 use Generator;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
@@ -28,14 +29,19 @@ trait CanStreamUsingVercelProtocol
             public array $toolCalls = [];
 
             public ?StreamEnd $lastStreamEnd = null;
+
+            public bool $errored = false;
         };
 
         return response()->stream(function () use ($state) {
             try {
                 foreach ($this as $event) {
-                    // Send one stream start event...
+                    // Send one stream start event, wrapping each subsequent provider step in step parts...
                     if ($event instanceof StreamStart) {
                         if ($state->streamStarted) {
+                            yield 'data: '.json_encode(['type' => 'finish-step'])."\n\n";
+                            yield 'data: '.json_encode(['type' => 'start-step'])."\n\n";
+
                             continue;
                         }
 
@@ -45,6 +51,10 @@ trait CanStreamUsingVercelProtocol
                     // Track tool calls initiated within this stream.
                     if ($event instanceof ToolCall) {
                         $state->toolCalls[$event->toolCall->id] = true;
+                    }
+
+                    if ($event instanceof Error) {
+                        $state->errored = true;
                     }
 
                     // A result without a local call is valid only when continuing the client message that contains the call...
@@ -86,6 +96,10 @@ trait CanStreamUsingVercelProtocol
                     yield from $this->toVercelProtocolPart($state, $data);
                 }
 
+                if ($state->streamStarted && ! $state->errored) {
+                    yield 'data: '.json_encode(['type' => 'finish-step'])."\n\n";
+                }
+
                 if ($state->lastStreamEnd) {
                     yield 'data: '.json_encode($state->lastStreamEnd->toVercelProtocolArray())."\n\n";
                 }
@@ -118,8 +132,13 @@ trait CanStreamUsingVercelProtocol
             $state->streamStarted = true;
 
             yield 'data: '.json_encode(['type' => 'start', 'messageId' => $this->vercelProtocolMessageId ?? $this->invocationId])."\n\n";
+            yield 'data: '.json_encode(['type' => 'start-step'])."\n\n";
         }
 
         yield 'data: '.json_encode($data)."\n\n";
+
+        if ($data['type'] === 'start') {
+            yield 'data: '.json_encode(['type' => 'start-step'])."\n\n";
+        }
     }
 }

--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -30,6 +30,8 @@ trait CanStreamUsingVercelProtocol
 
             public ?StreamEnd $lastStreamEnd = null;
 
+            public ?Usage $usage = null;
+
             public bool $errored = false;
         };
 
@@ -37,15 +39,11 @@ trait CanStreamUsingVercelProtocol
             try {
                 foreach ($this as $event) {
                     // Send one stream start event, wrapping each subsequent provider step in step parts...
-                    if ($event instanceof StreamStart) {
-                        if ($state->streamStarted) {
-                            yield 'data: '.json_encode(['type' => 'finish-step'])."\n\n";
-                            yield 'data: '.json_encode(['type' => 'start-step'])."\n\n";
+                    if ($event instanceof StreamStart && $state->streamStarted) {
+                        yield $this->toVercelProtocolLine(['type' => 'finish-step']);
+                        yield $this->toVercelProtocolLine(['type' => 'start-step']);
 
-                            continue;
-                        }
-
-                        $state->streamStarted = true;
+                        continue;
                     }
 
                     // Track tool calls initiated within this stream.
@@ -79,12 +77,8 @@ trait CanStreamUsingVercelProtocol
 
                     // Save the last stream end event until the very end, combining usage across steps...
                     if ($event instanceof StreamEnd) {
-                        $state->lastStreamEnd = new StreamEnd(
-                            $event->id,
-                            $event->reason,
-                            ($state->lastStreamEnd?->usage ?? new Usage)->add($event->usage),
-                            $event->timestamp,
-                        );
+                        $state->lastStreamEnd = $event;
+                        $state->usage = ($state->usage ?? new Usage)->add($event->usage);
 
                         continue;
                     }
@@ -97,20 +91,27 @@ trait CanStreamUsingVercelProtocol
                 }
 
                 if ($state->streamStarted && ! $state->errored) {
-                    yield 'data: '.json_encode(['type' => 'finish-step'])."\n\n";
-                }
+                    yield $this->toVercelProtocolLine(['type' => 'finish-step']);
 
-                if ($state->lastStreamEnd) {
-                    yield 'data: '.json_encode($state->lastStreamEnd->toVercelProtocolArray())."\n\n";
+                    if ($state->lastStreamEnd) {
+                        yield $this->toVercelProtocolLine((new StreamEnd(
+                            $state->lastStreamEnd->id,
+                            $state->lastStreamEnd->reason,
+                            $state->usage,
+                            $state->lastStreamEnd->timestamp,
+                        ))->toVercelProtocolArray());
+                    }
                 }
             } catch (Throwable $e) {
-                // The response is already streaming, so surface the failure as a terminal error part instead of re-throwing...
-                report($e);
+                // The response is already streaming, so surface a masked terminal error part instead of re-throwing, unless an error part was already sent...
+                if (! $state->errored) {
+                    report($e);
 
-                yield from $this->toVercelProtocolPart($state, [
-                    'type' => 'error',
-                    'errorText' => $e->getMessage(),
-                ]);
+                    yield from $this->toVercelProtocolPart($state, [
+                        'type' => 'error',
+                        'errorText' => 'An error occurred.',
+                    ]);
+                }
             }
 
             yield "data: [DONE]\n\n";
@@ -127,18 +128,28 @@ trait CanStreamUsingVercelProtocol
     protected function toVercelProtocolPart(object $state, array $data): Generator
     {
         if ($data['type'] === 'start') {
-            $data['messageId'] = $this->vercelProtocolMessageId ?? $data['messageId'];
-        } elseif (! $state->streamStarted) {
             $state->streamStarted = true;
 
-            yield 'data: '.json_encode(['type' => 'start', 'messageId' => $this->vercelProtocolMessageId ?? $this->invocationId])."\n\n";
-            yield 'data: '.json_encode(['type' => 'start-step'])."\n\n";
+            $data['messageId'] = $this->vercelProtocolMessageId ?? $data['messageId'];
+
+            yield $this->toVercelProtocolLine($data);
+            yield $this->toVercelProtocolLine(['type' => 'start-step']);
+
+            return;
         }
 
-        yield 'data: '.json_encode($data)."\n\n";
-
-        if ($data['type'] === 'start') {
-            yield 'data: '.json_encode(['type' => 'start-step'])."\n\n";
+        if (! $state->streamStarted) {
+            yield from $this->toVercelProtocolPart($state, ['type' => 'start', 'messageId' => $this->invocationId]);
         }
+
+        yield $this->toVercelProtocolLine($data);
+    }
+
+    /**
+     * Encode the given protocol part as a server-sent event line.
+     */
+    protected function toVercelProtocolLine(array $data): string
+    {
+        return 'data: '.json_encode($data)."\n\n";
     }
 }

--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Responses\Concerns;
 
 use Generator;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
@@ -40,8 +41,8 @@ trait CanStreamUsingVercelProtocol
                 foreach ($this as $event) {
                     // Send one stream start event, wrapping each subsequent provider step in step parts...
                     if ($event instanceof StreamStart && $state->streamStarted) {
-                        yield $this->toVercelProtocolLine(['type' => 'finish-step']);
-                        yield $this->toVercelProtocolLine(['type' => 'start-step']);
+                        yield $this->toVercelProtocolFormat(['type' => 'finish-step']);
+                        yield $this->toVercelProtocolFormat(['type' => 'start-step']);
 
                         continue;
                     }
@@ -91,10 +92,10 @@ trait CanStreamUsingVercelProtocol
                 }
 
                 if ($state->streamStarted && ! $state->errored) {
-                    yield $this->toVercelProtocolLine(['type' => 'finish-step']);
+                    yield $this->toVercelProtocolFormat(['type' => 'finish-step']);
 
                     if ($state->lastStreamEnd) {
-                        yield $this->toVercelProtocolLine((new StreamEnd(
+                        yield $this->toVercelProtocolFormat((new StreamEnd(
                             $state->lastStreamEnd->id,
                             $state->lastStreamEnd->reason,
                             $state->usage,
@@ -103,10 +104,13 @@ trait CanStreamUsingVercelProtocol
                     }
                 }
             } catch (Throwable $e) {
+                // A stream error exception carries a provider error the stream already surfaced, so only report anything else...
+                if (! $e instanceof StreamErrorException) {
+                    report($e);
+                }
+
                 // The response is already streaming, so surface a masked terminal error part instead of re-throwing, unless an error part was already sent...
                 if (! $state->errored) {
-                    report($e);
-
                     yield from $this->toVercelProtocolPart($state, [
                         'type' => 'error',
                         'errorText' => 'An error occurred.',
@@ -132,8 +136,8 @@ trait CanStreamUsingVercelProtocol
 
             $data['messageId'] = $this->vercelProtocolMessageId ?? $data['messageId'];
 
-            yield $this->toVercelProtocolLine($data);
-            yield $this->toVercelProtocolLine(['type' => 'start-step']);
+            yield $this->toVercelProtocolFormat($data);
+            yield $this->toVercelProtocolFormat(['type' => 'start-step']);
 
             return;
         }
@@ -142,13 +146,13 @@ trait CanStreamUsingVercelProtocol
             yield from $this->toVercelProtocolPart($state, ['type' => 'start', 'messageId' => $this->invocationId]);
         }
 
-        yield $this->toVercelProtocolLine($data);
+        yield $this->toVercelProtocolFormat($data);
     }
 
     /**
      * Encode the given protocol part as a server-sent event line.
      */
-    protected function toVercelProtocolLine(array $data): string
+    protected function toVercelProtocolFormat(array $data): string
     {
         return 'data: '.json_encode($data)."\n\n";
     }

--- a/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
+++ b/src/Responses/Concerns/CanStreamUsingVercelProtocol.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 trait CanStreamUsingVercelProtocol
 {
@@ -30,62 +31,72 @@ trait CanStreamUsingVercelProtocol
         };
 
         return response()->stream(function () use ($state) {
-            foreach ($this as $event) {
-                // Send one stream start event...
-                if ($event instanceof StreamStart) {
-                    if ($state->streamStarted) {
+            try {
+                foreach ($this as $event) {
+                    // Send one stream start event...
+                    if ($event instanceof StreamStart) {
+                        if ($state->streamStarted) {
+                            continue;
+                        }
+
+                        $state->streamStarted = true;
+                    }
+
+                    // Track tool calls initiated within this stream.
+                    if ($event instanceof ToolCall) {
+                        $state->toolCalls[$event->toolCall->id] = true;
+                    }
+
+                    // A result without a local call is valid only when continuing the client message that contains the call...
+                    if ($event instanceof ToolResult
+                        && ! isset($state->toolCalls[$event->toolResult->id])
+                        && $this->vercelProtocolMessageId === null) {
                         continue;
                     }
 
-                    $state->streamStarted = true;
-                }
+                    if ($event instanceof ToolApprovalRequest) {
+                        foreach ($event->pendingApprovals as $pendingApproval) {
+                            yield from $this->toVercelProtocolPart($state, [
+                                'type' => 'tool-approval-request',
+                                'toolCallId' => $pendingApproval->id,
+                                'approvalId' => $pendingApproval->id,
+                                'reason' => $pendingApproval->reason,
+                            ]);
+                        }
 
-                // Track tool calls initiated within this stream.
-                if ($event instanceof ToolCall) {
-                    $state->toolCalls[$event->toolCall->id] = true;
-                }
-
-                // A result without a local call is valid only when continuing the client message that contains the call...
-                if ($event instanceof ToolResult
-                    && ! isset($state->toolCalls[$event->toolResult->id])
-                    && $this->vercelProtocolMessageId === null) {
-                    continue;
-                }
-
-                if ($event instanceof ToolApprovalRequest) {
-                    foreach ($event->pendingApprovals as $pendingApproval) {
-                        yield from $this->toVercelProtocolPart($state, [
-                            'type' => 'tool-approval-request',
-                            'toolCallId' => $pendingApproval->id,
-                            'approvalId' => $pendingApproval->id,
-                            'reason' => $pendingApproval->reason,
-                        ]);
+                        continue;
                     }
 
-                    continue;
+                    // Save the last stream end event until the very end, combining usage across steps...
+                    if ($event instanceof StreamEnd) {
+                        $state->lastStreamEnd = new StreamEnd(
+                            $event->id,
+                            $event->reason,
+                            ($state->lastStreamEnd?->usage ?? new Usage)->add($event->usage),
+                            $event->timestamp,
+                        );
+
+                        continue;
+                    }
+
+                    if (empty($data = $event->toVercelProtocolArray())) {
+                        continue;
+                    }
+
+                    yield from $this->toVercelProtocolPart($state, $data);
                 }
 
-                // Save the last stream end event until the very end, combining usage across steps...
-                if ($event instanceof StreamEnd) {
-                    $state->lastStreamEnd = new StreamEnd(
-                        $event->id,
-                        $event->reason,
-                        ($state->lastStreamEnd?->usage ?? new Usage)->add($event->usage),
-                        $event->timestamp,
-                    );
-
-                    continue;
+                if ($state->lastStreamEnd) {
+                    yield 'data: '.json_encode($state->lastStreamEnd->toVercelProtocolArray())."\n\n";
                 }
+            } catch (Throwable $e) {
+                // The response is already streaming, so surface the failure as a terminal error part instead of re-throwing...
+                report($e);
 
-                if (empty($data = $event->toVercelProtocolArray())) {
-                    continue;
-                }
-
-                yield from $this->toVercelProtocolPart($state, $data);
-            }
-
-            if ($state->lastStreamEnd) {
-                yield 'data: '.json_encode($state->lastStreamEnd->toVercelProtocolArray())."\n\n";
+                yield from $this->toVercelProtocolPart($state, [
+                    'type' => 'error',
+                    'errorText' => $e->getMessage(),
+                ]);
             }
 
             yield "data: [DONE]\n\n";

--- a/src/Streaming/Events/Citation.php
+++ b/src/Streaming/Events/Citation.php
@@ -42,11 +42,13 @@ class Citation extends StreamEvent
     public function toVercelProtocolArray(): ?array
     {
         return match (true) {
-            $this->citation instanceof UrlCitation => [
+            $this->citation instanceof UrlCitation => array_filter([
                 'type' => 'source-url',
                 'sourceId' => $this->citation->url,
                 'url' => $this->citation->url,
-            ],
+                'title' => $this->citation->title,
+            ]),
+            default => null,
         };
     }
 }

--- a/src/Streaming/Events/Citation.php
+++ b/src/Streaming/Events/Citation.php
@@ -47,7 +47,7 @@ class Citation extends StreamEvent
                 'sourceId' => $this->citation->url,
                 'url' => $this->citation->url,
                 'title' => $this->citation->title,
-            ]),
+            ], fn ($value) => $value !== null),
             default => null,
         };
     }

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -59,6 +59,7 @@ class StreamEnd extends StreamEvent
                 'length' => 'length',
                 'content_filter' => 'content-filter',
                 'error' => 'error',
+                'unknown' => 'unknown',
                 default => 'other',
             },
             'messageMetadata' => [

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -63,7 +63,13 @@ class StreamEnd extends StreamEvent
                 default => 'other',
             },
             'messageMetadata' => [
-                'usage' => $this->usage->toArray(),
+                'usage' => [
+                    'inputTokens' => $this->usage->promptTokens,
+                    'outputTokens' => $this->usage->completionTokens,
+                    'totalTokens' => $this->usage->promptTokens + $this->usage->completionTokens,
+                    'reasoningTokens' => $this->usage->reasoningTokens,
+                    'cachedInputTokens' => $this->usage->cacheReadInputTokens,
+                ],
             ],
         ];
     }

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -53,6 +53,17 @@ class StreamEnd extends StreamEvent
     {
         return [
             'type' => 'finish',
+            'finishReason' => match ($this->reason) {
+                'stop' => 'stop',
+                'tool_calls' => 'tool-calls',
+                'length' => 'length',
+                'content_filter' => 'content-filter',
+                'error' => 'error',
+                default => 'other',
+            },
+            'messageMetadata' => [
+                'usage' => $this->usage->toArray(),
+            ],
         ];
     }
 }

--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -67,9 +67,11 @@ test('a text stream emits start, delta, and end parts for the message', function
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'text-start', 'id' => 'msg-1'],
         ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hello.'],
         ['type' => 'text-end', 'id' => 'msg-1'],
+        ['type' => 'finish-step'],
         vercelFinishPart(),
         ['type' => 'done'],
     ]);
@@ -86,9 +88,11 @@ test('a reasoning stream emits start, delta, and end parts for the reasoning blo
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'reasoning-start', 'id' => 'reasoning-1'],
         ['type' => 'reasoning-delta', 'id' => 'reasoning-1', 'delta' => 'Considering the options.'],
         ['type' => 'reasoning-end', 'id' => 'reasoning-1'],
+        ['type' => 'finish-step'],
         vercelFinishPart(),
         ['type' => 'done'],
     ]);
@@ -106,10 +110,12 @@ test('a cited text stream emits a source url part for the cited page', function 
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'text-start', 'id' => 'msg-1'],
         ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Laravel is a PHP framework.'],
-        ['type' => 'source-url', 'sourceId' => 'https://laravel.com/docs', 'url' => 'https://laravel.com/docs'],
+        ['type' => 'source-url', 'sourceId' => 'https://laravel.com/docs', 'url' => 'https://laravel.com/docs', 'title' => 'Laravel Documentation'],
         ['type' => 'text-end', 'id' => 'msg-1'],
+        ['type' => 'finish-step'],
         vercelFinishPart(),
         ['type' => 'done'],
     ]);
@@ -124,6 +130,7 @@ test('a failed stream emits an error part instead of a finish part', function ()
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'text-start', 'id' => 'msg-1'],
         ['type' => 'error', 'errorText' => 'Overloaded'],
         ['type' => 'done'],
@@ -142,8 +149,10 @@ test('a paused stream emits an approval request part for each pending approval',
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'tool-input-available', 'toolCallId' => 'call-1', 'toolName' => 'DeleteFile', 'input' => ['path' => 'a.txt']],
         ['type' => 'tool-approval-request', 'toolCallId' => 'call-1', 'approvalId' => 'call-1', 'reason' => 'Destructive operation.'],
+        ['type' => 'finish-step'],
         vercelFinishPart('tool-calls'),
         ['type' => 'done'],
     ]);
@@ -159,8 +168,12 @@ test('a resumed stream emits the approved tool output for the prior turn tool ca
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'client-message-1'],
+        ['type' => 'start-step'],
         ['type' => 'tool-output-available', 'toolCallId' => 'call-1', 'output' => 'deleted'],
+        ['type' => 'finish-step'],
+        ['type' => 'start-step'],
         ['type' => 'text-delta', 'id' => 'msg-2', 'delta' => 'Done.'],
+        ['type' => 'finish-step'],
         vercelFinishPart(),
         ['type' => 'done'],
     ]);
@@ -185,7 +198,9 @@ test('a rejected approval streams as a denied tool output', function () {
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'client-message-1'],
+        ['type' => 'start-step'],
         ['type' => 'tool-output-denied', 'toolCallId' => 'call-1'],
+        ['type' => 'finish-step'],
         vercelFinishPart(),
         ['type' => 'done'],
     ]);
@@ -211,7 +226,7 @@ test('an unexecuted tool call streams as a tool output error', function () {
         new StreamEnd('event-3', 'stop', new Usage, time()),
     ]);
 
-    expect($parts[2])->toBe([
+    expect($parts[3])->toBe([
         'type' => 'tool-output-error',
         'toolCallId' => 'call-1',
         'errorText' => 'The agent reached its maximum number of steps without running this tool call.',
@@ -226,7 +241,7 @@ test('a failed tool call without an error message streams a default error text',
         new StreamEnd('event-3', 'stop', new Usage, time()),
     ]);
 
-    expect($parts[2])->toBe([
+    expect($parts[3])->toBe([
         'type' => 'tool-output-error',
         'toolCallId' => 'call-1',
         'errorText' => 'The tool call failed.',
@@ -265,6 +280,11 @@ test('a multi-step stream emits one finish part with combined usage and the fina
 
     expect(collect($parts)->where('type', 'finish')->values()->all())->toBe([
         vercelFinishPart('stop', new Usage(promptTokens: 30, completionTokens: 20)),
+    ])->and(collect($parts)->pluck('type')->all())->toBe([
+        'start', 'start-step',
+        'tool-input-available', 'tool-output-available', 'finish-step',
+        'start-step', 'text-delta', 'finish-step',
+        'finish', 'done',
     ]);
 });
 
@@ -280,6 +300,7 @@ test('an exception mid-stream is reported and emitted as a terminal error part',
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hel'],
         ['type' => 'error', 'errorText' => 'Provider connection lost.'],
         ['type' => 'done'],
@@ -298,8 +319,10 @@ test('a tool executed within the stream emits its input and output parts', funct
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
         ['type' => 'tool-input-available', 'toolCallId' => 'call-1', 'toolName' => 'GetWeather', 'input' => ['city' => 'Lisbon']],
         ['type' => 'tool-output-available', 'toolCallId' => 'call-1', 'output' => 'sunny'],
+        ['type' => 'finish-step'],
         vercelFinishPart(),
         ['type' => 'done'],
     ]);

--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Exceptions;
 use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\Usage;
@@ -265,6 +266,26 @@ test('a multi-step stream emits one finish part with combined usage and the fina
     expect(collect($parts)->where('type', 'finish')->values()->all())->toBe([
         vercelFinishPart('stop', new Usage(promptTokens: 30, completionTokens: 20)),
     ]);
+});
+
+test('an exception mid-stream is reported and emitted as a terminal error part', function () {
+    Exceptions::fake();
+
+    $parts = vercelProtocolParts(function () {
+        yield new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time());
+        yield new TextDelta('event-1', 'msg-1', 'Hel', time());
+
+        throw new RuntimeException('Provider connection lost.');
+    });
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hel'],
+        ['type' => 'error', 'errorText' => 'Provider connection lost.'],
+        ['type' => 'done'],
+    ]);
+
+    Exceptions::assertReported(RuntimeException::class);
 });
 
 test('a tool executed within the stream emits its input and output parts', function () {

--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -18,9 +18,11 @@ use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
 
-function vercelProtocolParts(array $events, ?string $messageId = null): array
+function vercelProtocolParts(array|Closure $events, ?string $messageId = null): array
 {
-    $response = (new StreamableAgentResponse('invocation-1', fn () => yield from $events, new Data\Meta('anthropic', 'claude-sonnet-4-6')))
+    $stream = $events instanceof Closure ? $events : fn () => yield from $events;
+
+    $response = (new StreamableAgentResponse('invocation-1', $stream, new Data\Meta('anthropic', 'claude-sonnet-4-6')))
         ->usingVercelDataProtocol(messageId: $messageId)
         ->toResponse(request());
 
@@ -42,6 +44,17 @@ function vercelProtocolParts(array $events, ?string $messageId = null): array
         ->all();
 }
 
+function vercelFinishPart(string $reason = 'stop', ?Usage $usage = null): array
+{
+    return [
+        'type' => 'finish',
+        'finishReason' => $reason,
+        'messageMetadata' => [
+            'usage' => ($usage ?? new Usage)->toArray(),
+        ],
+    ];
+}
+
 test('a text stream emits start, delta, and end parts for the message', function () {
     $parts = vercelProtocolParts([
         new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
@@ -56,7 +69,7 @@ test('a text stream emits start, delta, and end parts for the message', function
         ['type' => 'text-start', 'id' => 'msg-1'],
         ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hello.'],
         ['type' => 'text-end', 'id' => 'msg-1'],
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -75,7 +88,7 @@ test('a reasoning stream emits start, delta, and end parts for the reasoning blo
         ['type' => 'reasoning-start', 'id' => 'reasoning-1'],
         ['type' => 'reasoning-delta', 'id' => 'reasoning-1', 'delta' => 'Considering the options.'],
         ['type' => 'reasoning-end', 'id' => 'reasoning-1'],
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -96,7 +109,7 @@ test('a cited text stream emits a source url part for the cited page', function 
         ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Laravel is a PHP framework.'],
         ['type' => 'source-url', 'sourceId' => 'https://laravel.com/docs', 'url' => 'https://laravel.com/docs'],
         ['type' => 'text-end', 'id' => 'msg-1'],
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -130,7 +143,7 @@ test('a paused stream emits an approval request part for each pending approval',
         ['type' => 'start', 'messageId' => 'msg-1'],
         ['type' => 'tool-input-available', 'toolCallId' => 'call-1', 'toolName' => 'DeleteFile', 'input' => ['path' => 'a.txt']],
         ['type' => 'tool-approval-request', 'toolCallId' => 'call-1', 'approvalId' => 'call-1', 'reason' => 'Destructive operation.'],
-        ['type' => 'finish'],
+        vercelFinishPart('tool-calls'),
         ['type' => 'done'],
     ]);
 });
@@ -147,7 +160,7 @@ test('a resumed stream emits the approved tool output for the prior turn tool ca
         ['type' => 'start', 'messageId' => 'client-message-1'],
         ['type' => 'tool-output-available', 'toolCallId' => 'call-1', 'output' => 'deleted'],
         ['type' => 'text-delta', 'id' => 'msg-2', 'delta' => 'Done.'],
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -172,7 +185,7 @@ test('a rejected approval streams as a denied tool output', function () {
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'client-message-1'],
         ['type' => 'tool-output-denied', 'toolCallId' => 'call-1'],
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -184,7 +197,7 @@ test('a tool result without a prior call or existing message is skipped', functi
     ]);
 
     expect($parts)->toBe([
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -219,6 +232,41 @@ test('a failed tool call without an error message streams a default error text',
     ]);
 });
 
+test('the finish part carries the stream usage and finish reason as message metadata', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new TextDelta('event-1', 'msg-1', 'Hello.', time()),
+        new StreamEnd('event-2', 'length', new Usage(promptTokens: 10, completionTokens: 20), time()),
+    ]);
+
+    expect($parts[count($parts) - 2])->toBe(vercelFinishPart('length', new Usage(promptTokens: 10, completionTokens: 20)));
+});
+
+test('finish reasons outside the Vercel enum emit as other', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new StreamEnd('event-1', 'unknown', new Usage, time()),
+    ]);
+
+    expect($parts[count($parts) - 2])->toBe(vercelFinishPart('other'));
+});
+
+test('a multi-step stream emits one finish part with combined usage and the final reason', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new ToolCall('event-1', new Data\ToolCall('call-1', 'GetWeather', ['city' => 'Lisbon']), time()),
+        new StreamEnd('event-2', 'tool_calls', new Usage(promptTokens: 10, completionTokens: 5), time()),
+        new ToolResult('event-3', new Data\ToolResult('call-1', 'GetWeather', ['city' => 'Lisbon'], 'sunny'), true, null, time()),
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new TextDelta('event-4', 'msg-1', 'Sunny.', time()),
+        new StreamEnd('event-5', 'stop', new Usage(promptTokens: 20, completionTokens: 15), time()),
+    ]);
+
+    expect(collect($parts)->where('type', 'finish')->values()->all())->toBe([
+        vercelFinishPart('stop', new Usage(promptTokens: 30, completionTokens: 20)),
+    ]);
+});
+
 test('a tool executed within the stream emits its input and output parts', function () {
     $parts = vercelProtocolParts([
         new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
@@ -231,7 +279,7 @@ test('a tool executed within the stream emits its input and output parts', funct
         ['type' => 'start', 'messageId' => 'msg-1'],
         ['type' => 'tool-input-available', 'toolCallId' => 'call-1', 'toolName' => 'GetWeather', 'input' => ['city' => 'Lisbon']],
         ['type' => 'tool-output-available', 'toolCallId' => 'call-1', 'output' => 'sunny'],
-        ['type' => 'finish'],
+        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });

--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -48,11 +48,19 @@ function vercelProtocolParts(array|Closure $events, ?string $messageId = null): 
 
 function vercelFinishPart(string $reason = 'stop', ?Usage $usage = null): array
 {
+    $usage ??= new Usage;
+
     return [
         'type' => 'finish',
         'finishReason' => $reason,
         'messageMetadata' => [
-            'usage' => ($usage ?? new Usage)->toArray(),
+            'usage' => [
+                'inputTokens' => $usage->promptTokens,
+                'outputTokens' => $usage->completionTokens,
+                'totalTokens' => $usage->promptTokens + $usage->completionTokens,
+                'reasoningTokens' => $usage->reasoningTokens,
+                'cachedInputTokens' => $usage->cacheReadInputTokens,
+            ],
         ],
     ];
 }
@@ -371,6 +379,21 @@ test('a provider stream error followed by the loop exception emits a single erro
     ]);
 
     Exceptions::assertNothingReported();
+});
+
+test('an unexpected exception after an error part is still reported', function () {
+    Exceptions::fake();
+
+    $parts = vercelProtocolParts(function () {
+        yield new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time());
+        yield new Error('event-1', 'overloaded_error', 'Overloaded', false, time());
+
+        throw new RuntimeException('Broken pipe');
+    });
+
+    expect(collect($parts)->where('type', 'error')->count())->toBe(1);
+
+    Exceptions::assertReported(RuntimeException::class);
 });
 
 test('a stream end after an error does not emit finish parts', function () {

--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Exceptions;
 use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamableAgentResponse;
@@ -121,6 +122,36 @@ test('a cited text stream emits a source url part for the cited page', function 
     ]);
 });
 
+test('a url citation without a title omits only the title from the source url part', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new Citation('event-1', 'msg-1', new Data\UrlCitation('https://laravel.com/docs'), time()),
+        new StreamEnd('event-2', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts[2])->toBe([
+        'type' => 'source-url',
+        'sourceId' => 'https://laravel.com/docs',
+        'url' => 'https://laravel.com/docs',
+    ]);
+});
+
+test('an unknown citation type is skipped instead of ending the stream', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new Citation('event-1', 'msg-1', new class extends Data\Citation {}, time()),
+        new StreamEnd('event-2', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
+        ['type' => 'finish-step'],
+        vercelFinishPart(),
+        ['type' => 'done'],
+    ]);
+});
+
 test('a failed stream emits an error part instead of a finish part', function () {
     $parts = vercelProtocolParts([
         new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
@@ -213,7 +244,6 @@ test('a tool result without a prior call or existing message is skipped', functi
     ]);
 
     expect($parts)->toBe([
-        vercelFinishPart(),
         ['type' => 'done'],
     ]);
 });
@@ -261,10 +291,19 @@ test('the finish part carries the stream usage and finish reason as message meta
 test('finish reasons outside the Vercel enum emit as other', function () {
     $parts = vercelProtocolParts([
         new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
-        new StreamEnd('event-1', 'unknown', new Usage, time()),
+        new StreamEnd('event-1', 'continue', new Usage, time()),
     ]);
 
     expect($parts[count($parts) - 2])->toBe(vercelFinishPart('other'));
+});
+
+test('an unknown finish reason is preserved', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new StreamEnd('event-1', 'unknown', new Usage, time()),
+    ]);
+
+    expect($parts[count($parts) - 2])->toBe(vercelFinishPart('unknown'));
 });
 
 test('a multi-step stream emits one finish part with combined usage and the final reason', function () {
@@ -288,25 +327,65 @@ test('a multi-step stream emits one finish part with combined usage and the fina
     ]);
 });
 
-test('an exception mid-stream is reported and emitted as a terminal error part', function () {
+test('an exception mid-stream is reported and emitted as a masked terminal error part', function () {
     Exceptions::fake();
 
     $parts = vercelProtocolParts(function () {
         yield new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time());
         yield new TextDelta('event-1', 'msg-1', 'Hel', time());
 
-        throw new RuntimeException('Provider connection lost.');
+        throw new RuntimeException('SQLSTATE[HY000] [2002] Connection refused');
     });
 
     expect($parts)->toBe([
         ['type' => 'start', 'messageId' => 'msg-1'],
         ['type' => 'start-step'],
         ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hel'],
-        ['type' => 'error', 'errorText' => 'Provider connection lost.'],
+        ['type' => 'error', 'errorText' => 'An error occurred.'],
         ['type' => 'done'],
     ]);
 
     Exceptions::assertReported(RuntimeException::class);
+});
+
+test('a provider stream error followed by the loop exception emits a single error part', function () {
+    Exceptions::fake();
+
+    $parts = vercelProtocolParts(function () {
+        yield new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time());
+        yield new TextDelta('event-1', 'msg-1', 'Hel', time());
+
+        $error = new Error('event-2', 'overloaded_error', 'Overloaded', false, time());
+
+        yield $error;
+
+        throw new StreamErrorException($error);
+    });
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
+        ['type' => 'text-delta', 'id' => 'msg-1', 'delta' => 'Hel'],
+        ['type' => 'error', 'errorText' => 'Overloaded'],
+        ['type' => 'done'],
+    ]);
+
+    Exceptions::assertNothingReported();
+});
+
+test('a stream end after an error does not emit finish parts', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
+        new Error('event-1', 'overloaded_error', 'Overloaded', false, time()),
+        new StreamEnd('event-2', 'error', new Usage, time()),
+    ]);
+
+    expect($parts)->toBe([
+        ['type' => 'start', 'messageId' => 'msg-1'],
+        ['type' => 'start-step'],
+        ['type' => 'error', 'errorText' => 'Overloaded'],
+        ['type' => 'done'],
+    ]);
 });
 
 test('a tool executed within the stream emits its input and output parts', function () {


### PR DESCRIPTION
Currently the Vercel protocol stream drops information the AI SDK client is built to consume. A completed run looks like this on the wire:

```
data: {"type":"start","messageId":"019..."}
data: {"type":"text-delta","id":"msg_1","delta":"Hello."}
data: {"type":"finish"}   // usage and finish reason are thrown away
data: [DONE]
```

And when a provider fails after streaming has started, the connection just drops, so `useChat` sits on a dead spinner with no error state.

After this PR, the same run emits every part the client processes, validated field by field against the `UIMessageChunk` schema in `vercel/ai`:

```
data: {"type":"start","messageId":"019..."}
data: {"type":"start-step"}
data: {"type":"text-delta","id":"msg_1","delta":"Hello."}
data: {"type":"finish-step"}
data: {"type":"finish","finishReason":"stop","messageMetadata":{"usage":{"prompt_tokens":10,...}}}
data: [DONE]
```

On the client that means `message.metadata.usage` is populated, `finishReason` lands in the chat state, and multi-step tool runs get proper step boundaries (`start-step` also makes the client insert its `step-start` parts, and `finish-step` resets its active text and reasoning state between steps, which guards against text block id reuse across steps).

A mid-stream failure now closes the stream properly instead of severing it:

```
data: {"type":"start","messageId":"019..."}
data: {"type":"text-delta","id":"msg_1","delta":"Hel"}
data: {"type":"error","errorText":"Provider connection lost."}   // client renders its error state
data: [DONE]
```

The exception is still reported to the handler, it just no longer escapes into an already-open response.