### PR TITLE
Exclude cached tokens from the reported prompt token count on the Groq and OpenAI-compatible providers

### DIFF
--- a/src/Gateway/Groq/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Groq/Concerns/ParsesTextResponses.php
@@ -75,7 +75,7 @@ trait ParsesTextResponses
         $completionDetails = $usage['completion_tokens_details'] ?? [];
 
         return new Usage(
-            promptTokens: $usage['prompt_tokens'] ?? 0,
+            promptTokens: ($usage['prompt_tokens'] ?? 0) - ($promptDetails['cached_tokens'] ?? 0),
             completionTokens: $usage['completion_tokens'] ?? 0,
             cacheReadInputTokens: $promptDetails['cached_tokens'] ?? 0,
             reasoningTokens: $completionDetails['reasoning_tokens'] ?? 0,

--- a/src/Gateway/OpenAiCompatible/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenAiCompatible/Concerns/ParsesTextResponses.php
@@ -73,7 +73,7 @@ trait ParsesTextResponses
         $completionDetails = $usage['completion_tokens_details'] ?? [];
 
         return new Usage(
-            promptTokens: $usage['prompt_tokens'] ?? 0,
+            promptTokens: ($usage['prompt_tokens'] ?? 0) - ($promptDetails['cached_tokens'] ?? 0),
             completionTokens: $usage['completion_tokens'] ?? 0,
             cacheReadInputTokens: $promptDetails['cached_tokens'] ?? 0,
             reasoningTokens: $completionDetails['reasoning_tokens'] ?? 0,

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -287,7 +287,7 @@ test('response usage includes cached prompt tokens', function (): void {
 
     $response = agent()->prompt('Hello', provider: 'groq');
 
-    expect($response->usage->promptTokens)->toBe(4641)
+    expect($response->usage->promptTokens)->toBe(33)
         ->and($response->usage->completionTokens)->toBe(1817)
         ->and($response->usage->cacheReadInputTokens)->toBe(4608);
 });

--- a/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
@@ -186,7 +186,7 @@ test('response usage is parsed using the openai standard shape', function (): vo
 
     $response = agent()->prompt('Hello', provider: 'openai-compatible');
 
-    expect($response->usage->promptTokens)->toBe(100)
+    expect($response->usage->promptTokens)->toBe(60)
         ->and($response->usage->completionTokens)->toBe(50)
         ->and($response->usage->cacheReadInputTokens)->toBe(40)
         ->and($response->usage->reasoningTokens)->toBe(10);


### PR DESCRIPTION
follow-up to #896, same bug on the two remaining openai-standard chat gateways. groq and openai-compatible both drop the raw prompt_tokens into promptTokens while also reporting the cached slice in cacheReadInputTokens. prompt_tokens already includes the cached tokens (openai and groq both document prompt_tokens_details.cached_tokens as a subset of the prompt), so cached tokens get counted twice.

this subtracts the cached tokens back out of promptTokens, same one-liner as the deepseek fix and the native openai gateway (#846), so promptTokens + cacheReadInputTokens lines up with the real prompt total again.

both gateways share extractUsage between streaming and non-streaming so it covers both paths. the groq fixture already had cached tokens in it (prompt_tokens 4641 / cached 4608) so i just corrected the assertion, same for openai-compatible.

left openrouter out on purpose, its web tools carry a cache-write dimension i couldnt confirm is a subset, same reason i scoped #896 to deepseek.
