### PR TITLE
Emit citation events for OpenAI web search results while streaming

### DIFF
--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -8,7 +8,9 @@ use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -90,6 +92,26 @@ trait HandlesTextGeneration
                         $this->generateEventId(),
                         $messageId,
                         $textDelta,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
+
+                continue;
+            }
+
+            if ($type === 'response.output_text.annotation.added') {
+                $annotation = $data['annotation'] ?? [];
+
+                if (($annotation['type'] ?? '') === 'url_citation') {
+                    yield (new CitationEvent(
+                        $this->generateEventId(),
+                        $messageId,
+                        new UrlCitation(
+                            $annotation['url'] ?? '',
+                            $annotation['title'] ?? null,
+                            isset($annotation['start_index']) ? (int) $annotation['start_index'] : null,
+                            isset($annotation['end_index']) ? (int) $annotation['end_index'] : null,
+                        ),
                         time(),
                     ))->withInvocationId($invocationId);
                 }

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
@@ -45,6 +46,32 @@ test('streaming emits text events', function (): void {
         ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
         ->and($events[4])->toBeInstanceOf(TextEnd::class)
         ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming emits citation events for web search url citations', function (): void {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                $this->outputTextDelta('Here are sources'),
+                ['type' => 'response.output_text.annotation.added', 'item_id' => 'msg_1', 'output_index' => 0, 'content_index' => 0, 'annotation_index' => 0, 'annotation' => ['type' => 'url_citation', 'url' => 'https://example.com/one', 'title' => 'Example One', 'start_index' => 0, 'end_index' => 10]],
+                ['type' => 'response.output_text.annotation.added', 'item_id' => 'msg_1', 'output_index' => 0, 'content_index' => 0, 'annotation_index' => 1, 'annotation' => ['type' => 'url_citation', 'url' => 'https://example.com/two', 'title' => 'Example Two', 'start_index' => 11, 'end_index' => 25]],
+                $this->outputTextDone('Here are sources'),
+                $this->responseCompleted(10, 5),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+
+    expect($citations)->toHaveCount(2)
+        ->and($citations[0]->citation->url)->toBe('https://example.com/one')
+        ->and($citations[0]->citation->title)->toBe('Example One')
+        ->and($citations[0]->citation->startIndex)->toBe(0)
+        ->and($citations[0]->citation->endIndex)->toBe(10)
+        ->and($citations[1]->citation->url)->toBe('https://example.com/two');
 });
 
 test('streaming starts a new text part after each text end in the same step', function (): void {


### PR DESCRIPTION
the non-streaming path already surfaces web search citations (extractCitations parses the url_citation annotations), but the streaming handler never emitted them. so a web search prompt returns sources on prompt() and nothing on stream().

openai streams these as response.output_text.annotation.added events, one per citation, per the responses api streaming docs. this handles that event and yields a CitationEvent per url_citation, the same inline pattern openrouter already uses for its annotation deltas. anthropic (#892) does the equivalent on its side.

added a streaming test driven by real annotation.added events, red before and green after.
