### PR TITLE
Emit citation events for xAI web search results while streaming

### DIFF
--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -276,6 +277,15 @@ trait HandlesTextStreaming
                     $responseUsage['input_tokens_details']['cached_tokens'] ?? 0,
                     $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
                 );
+
+                foreach ($this->extractCitations($response['output'] ?? []) as $citation) {
+                    yield (new CitationEvent(
+                        $this->generateEventId(),
+                        $messageId,
+                        $citation,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
             }
         }
 

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -41,6 +41,7 @@ trait HandlesTextStreaming
         $toolCalls = [];
         $pendingToolCalls = [];
         $reasoningItems = [];
+        $lastTextMessageId = null;
         $usage = null;
         $responseData = [];
 
@@ -107,6 +108,7 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
 
+                $lastTextMessageId = $messageId;
                 $textStartEmitted = false;
                 $messageId = $this->generateEventId();
 
@@ -281,7 +283,7 @@ trait HandlesTextStreaming
                 foreach ($this->extractCitations($response['output'] ?? []) as $citation) {
                     yield (new CitationEvent(
                         $this->generateEventId(),
-                        $messageId,
+                        $lastTextMessageId ?? $messageId,
                         $citation,
                         time(),
                     ))->withInvocationId($invocationId);

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
@@ -43,6 +44,32 @@ test('streaming emits text events', function (): void {
         ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
         ->and($events[4])->toBeInstanceOf(TextEnd::class)
         ->and($events[5])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming emits citation events from the completed response', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.created', 'response' => ['id' => 'resp_123', 'model' => 'grok-4-1-fast-reasoning']],
+                ['type' => 'response.output_text.delta', 'delta' => 'Here are sources'],
+                ['type' => 'response.output_text.done'],
+                ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'message', 'status' => 'completed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'Here are sources', 'annotations' => [
+                    ['type' => 'url_citation', 'url' => 'https://example.com/one', 'title' => 'Example One', 'start_index' => 0, 'end_index' => 10],
+                    ['type' => 'url_citation', 'url' => 'https://example.com/two', 'title' => 'Example Two', 'start_index' => 11, 'end_index' => 25],
+                ]]]]], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+
+    expect($citations)->toHaveCount(2)
+        ->and($citations[0]->citation->url)->toBe('https://example.com/one')
+        ->and($citations[0]->citation->title)->toBe('Example One')
+        ->and($citations[0]->citation->startIndex)->toBe(0)
+        ->and($citations[1]->citation->url)->toBe('https://example.com/two');
 });
 
 test('streaming starts a new text part after each text end in the same step', function (): void {

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -63,9 +63,13 @@ test('streaming emits citation events from the completed response', function ():
         ),
     ]);
 
-    $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+    $events = $this->collectStreamEvents();
+    $textStart = collect($events)->first(fn ($event): bool => $event instanceof TextStart);
+    $citations = array_values(array_filter($events, fn ($event): bool => $event instanceof CitationEvent));
 
     expect($citations)->toHaveCount(2)
+        ->and($citations[0]->messageId)->toBe($textStart->messageId)
+        ->and($citations[1]->messageId)->toBe($textStart->messageId)
         ->and($citations[0]->citation->url)->toBe('https://example.com/one')
         ->and($citations[0]->citation->title)->toBe('Example One')
         ->and($citations[0]->citation->startIndex)->toBe(0)


### PR DESCRIPTION
same gap as the openai one, on xai. web search citations never made it out of the streaming handler even though the non-streaming path surfaces them.

xai delivers these citations on the completed response (its own streaming docs read response.citations once the stream finishes), so this runs extractCitations on the completed response output and yields a CitationEvent per url_citation, matching anthropic (#892) and openrouter. the gateway already parses these same inline annotations on the non-streaming path.

added a streaming test, red before and green after.
