### PR TITLE
Read Cohere Bedrock embeddings input token count from response header

### DIFF
--- a/src/Gateway/Bedrock/BedrockTextGateway.php
+++ b/src/Gateway/Bedrock/BedrockTextGateway.php
@@ -576,10 +576,13 @@ class BedrockTextGateway implements EmbeddingGateway, StepTextGateway
             throw BedrockException::toAiException($throwable, $provider->name(), $model);
         }
 
-        // Cohere's Bedrock responses carry no usage, so no input token count is available.
+        // Cohere's Bedrock response body carries no usage, but the input token
+        // count is reported in the `x-amzn-bedrock-input-token-count` header.
+        $inputTokens = (int) ($response->get('@metadata')['headers']['x-amzn-bedrock-input-token-count'] ?? 0);
+
         return new EmbeddingsResponse(
             $this->parseCohereEmbeddings($result['embeddings'] ?? []),
-            0,
+            $inputTokens,
             new Meta($provider->name(), $model),
         );
     }

--- a/tests/Feature/Providers/Bedrock/BedrockHelpers.php
+++ b/tests/Feature/Providers/Bedrock/BedrockHelpers.php
@@ -29,6 +29,14 @@ trait BedrockHelpers
         ])]);
     }
 
+    protected function fakeBedrockInvokeWithHeaders(array $body, array $headers): BedrockRuntimeClient
+    {
+        return $this->bedrockClient(new MockHandler([new Result([
+            'body' => Utils::streamFor(json_encode($body)),
+            '@metadata' => ['headers' => $headers],
+        ])]));
+    }
+
     protected function fakeBedrockStream(array $events): BedrockRuntimeClient
     {
         return $this->bedrockClient(new MockHandler([

--- a/tests/Feature/Providers/Bedrock/EmbeddingTest.php
+++ b/tests/Feature/Providers/Bedrock/EmbeddingTest.php
@@ -63,6 +63,22 @@ describe('cohere embeddings', function () {
         expect($response->embeddings)->toBe([]);
     });
 
+    test('reports the input token count from the response header', function () {
+        $client = $this->fakeBedrockInvokeWithHeaders(
+            ['embeddings' => [[0.1, 0.2, 0.3]]],
+            ['x-amzn-bedrock-input-token-count' => '7'],
+        );
+
+        $response = $this->gatewayWithClient($client)->generateEmbeddings(
+            $this->bedrockProvider(),
+            'cohere.embed-v4:0',
+            ['The quick brown fox.'],
+            1024,
+        );
+
+        expect($response->tokens)->toBe(7);
+    });
+
     test('sends the Cohere request shape rather than the Titan one', function () {
         $mock = $this->bedrockInvokeMock(['embeddings' => ['float' => [[0.1, 0.2, 0.3]]]]);
 


### PR DESCRIPTION
Cohere's Bedrock `invoke_model` response body carries no usage data for embeddings, so the gateway currently always reports 0 input tokens for Cohere embeddings on Bedrock. AWS does report the count, in the `x-amzn-bedrock-input-token-count` response header, so this reads it from there instead of hardcoding 0.

Claude assisted with this change; I reviewed, tested, and understand it.