### PR TITLE
Fix Vercel provider tool events and finish reasons

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -153,6 +153,7 @@ trait HandlesTextStreaming
                         $data['content_block'] ?? [],
                         'started',
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
                 } elseif ($this->isProviderToolResultBlock($blockType)) {
                     $fetchResult = $data['content_block']['content'] ?? [];
@@ -173,6 +174,7 @@ trait HandlesTextStreaming
                         $data['content_block'] ?? [],
                         'result_received',
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
                 }
 
@@ -310,6 +312,7 @@ trait HandlesTextStreaming
                         $responseContent[$index] ?? [],
                         'completed',
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
                 }
 

--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -166,6 +166,7 @@ trait HandlesTextGeneration
                         $data['item'] ?? [],
                         'completed',
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
 
                     continue;
@@ -183,6 +184,7 @@ trait HandlesTextGeneration
                         $data,
                         $parts[2],
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
 
                     continue;

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -167,6 +167,7 @@ trait HandlesTextStreaming
                         $data['item'] ?? [],
                         'completed',
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
 
                     continue;
@@ -184,6 +185,7 @@ trait HandlesTextStreaming
                         $data,
                         $parts[2],
                         time(),
+                        provider: $provider->name(),
                     ))->withInvocationId($invocationId);
 
                     continue;

--- a/src/Streaming/Events/ProviderToolEvent.php
+++ b/src/Streaming/Events/ProviderToolEvent.php
@@ -14,6 +14,7 @@ class ProviderToolEvent extends StreamEvent
         public array $data,
         public string $status,
         public int $timestamp,
+        public ?string $provider = null,
     ) {}
 
     /**
@@ -28,6 +29,27 @@ class ProviderToolEvent extends StreamEvent
             'data' => $this->data,
             'status' => $this->status,
             'timestamp' => $this->timestamp,
+            'provider' => $this->provider,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toVercelProtocolArray(): ?array
+    {
+        $provider = $this->provider ?? 'laravel';
+
+        return [
+            'type' => 'custom',
+            'kind' => $provider.'.'.$this->type,
+            'providerMetadata' => [
+                $provider => [
+                    'itemId' => $this->itemId,
+                    'status' => $this->status,
+                    'data' => $this->data,
+                ],
+            ],
         ];
     }
 }

--- a/src/Streaming/Events/StreamEnd.php
+++ b/src/Streaming/Events/StreamEnd.php
@@ -59,7 +59,7 @@ class StreamEnd extends StreamEvent
                 'length' => 'length',
                 'content_filter' => 'content-filter',
                 'error' => 'error',
-                'unknown' => 'unknown',
+                'unknown' => 'other',
                 default => 'other',
             },
             'messageMetadata' => [

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -171,6 +171,7 @@ describe('thinking blocks', function (): void {
 
         expect($providerEvents)->toHaveCount(2)
             ->and($providerEvents[0])->status->toBe('started')->itemId->toBe('srvtoolu_1')
+            ->and($providerEvents[0]->provider)->toBe('anthropic')
             ->and($providerEvents[1]->status)->toBe('completed');
     });
 

--- a/tests/Feature/VercelProtocolStreamTest.php
+++ b/tests/Feature/VercelProtocolStreamTest.php
@@ -8,6 +8,7 @@ use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Streaming\Events\Citation;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
@@ -305,13 +306,33 @@ test('finish reasons outside the Vercel enum emit as other', function () {
     expect($parts[count($parts) - 2])->toBe(vercelFinishPart('other'));
 });
 
-test('an unknown finish reason is preserved', function () {
+test('an unknown finish reason emits as other', function () {
     $parts = vercelProtocolParts([
         new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
         new StreamEnd('event-1', 'unknown', new Usage, time()),
     ]);
 
-    expect($parts[count($parts) - 2])->toBe(vercelFinishPart('unknown'));
+    expect($parts[count($parts) - 2])->toBe(vercelFinishPart('other'));
+});
+
+test('a provider tool event emits as a custom provider part', function () {
+    $parts = vercelProtocolParts([
+        new StreamStart('msg-1', 'openai', 'gpt-5', time()),
+        new ProviderToolEvent('event-1', 'search-1', 'web_search_call', ['query' => 'Laravel'], 'in_progress', time(), 'openai'),
+        new StreamEnd('event-2', 'stop', new Usage, time()),
+    ]);
+
+    expect($parts[2])->toBe([
+        'type' => 'custom',
+        'kind' => 'openai.web_search_call',
+        'providerMetadata' => [
+            'openai' => [
+                'itemId' => 'search-1',
+                'status' => 'in_progress',
+                'data' => ['query' => 'Laravel'],
+            ],
+        ],
+    ]);
 });
 
 test('a multi-step stream emits one finish part with combined usage and the final reason', function () {


### PR DESCRIPTION
Currently Vercel protocol streams drop provider tool activity, while unknown finish reasons emit a value rejected by AI SDK clients:

```text
// ProviderToolEvent is omitted
data: {\"type\":\"finish\",\"finishReason\":\"unknown\"} // rejected by the AI SDK
```

Provider tool events now retain their provider identity:

```php
new ProviderToolEvent(
    // ...
    provider: $provider->name(),
);
```

They serialize as custom protocol parts, and unknown reasons use the protocol fallback:

```text
data: {\"type\":\"custom\",\"kind\":\"openai.web_search_call\",\"providerMetadata\":{\"openai\":{\"itemId\":\"search-1\",\"status\":\"in_progress\",\"data\":{\"query\":\"Laravel\"}}}}
data: {\"type\":\"finish\",\"finishReason\":\"other\"}
```