### PR TITLE
Honor the Strict attribute for structured output on the Groq, Mistral, OpenAI-compatible, and OpenRouter providers

### DIFF
--- a/src/Gateway/Groq/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Groq/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Groq\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\Concerns\ComposesSchemaInstructions;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
@@ -66,7 +67,7 @@ trait BuildsTextRequests
         );
 
         if (filled($schema) && ! $inlineSchema) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
+            $body['response_format'] = $this->buildResponseFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -90,9 +91,9 @@ trait BuildsTextRequests
     /**
      * Build the response format options for structured output.
      */
-    protected function buildResponseFormat(array $schema): array
+    protected function buildResponseFormat(array $schema, bool $strict): array
     {
-        $objectSchema = new ObjectSchema($schema);
+        $objectSchema = new ObjectSchema($schema, strict: $strict);
 
         $schemaArray = $objectSchema->toSchema();
 
@@ -101,7 +102,7 @@ trait BuildsTextRequests
             'json_schema' => [
                 'name' => $schemaArray['name'] ?? 'schema_definition',
                 'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
+                'strict' => $strict,
             ],
         ];
     }

--- a/src/Gateway/Mistral/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Mistral/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Mistral\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
@@ -52,7 +53,7 @@ trait BuildsTextRequests
         }
 
         if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
+            $body['response_format'] = $this->buildResponseFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -76,9 +77,9 @@ trait BuildsTextRequests
     /**
      * Build the response format options for structured output.
      */
-    protected function buildResponseFormat(array $schema): array
+    protected function buildResponseFormat(array $schema, bool $strict): array
     {
-        $objectSchema = new ObjectSchema($schema);
+        $objectSchema = new ObjectSchema($schema, strict: $strict);
 
         $schemaArray = $objectSchema->toSchema();
 
@@ -87,7 +88,7 @@ trait BuildsTextRequests
             'json_schema' => [
                 'name' => $schemaArray['name'] ?? 'schema_definition',
                 'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
+                'strict' => $strict,
             ],
         ];
     }

--- a/src/Gateway/OpenAiCompatible/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAiCompatible/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenAiCompatible\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -40,7 +41,7 @@ trait BuildsTextRequests
         $body['messages'] = $this->mapMessagesToChat($messages, $instructions);
 
         if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
+            $body['response_format'] = $this->buildResponseFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -64,16 +65,16 @@ trait BuildsTextRequests
     /**
      * Build the response format options for structured output.
      */
-    protected function buildResponseFormat(array $schema): array
+    protected function buildResponseFormat(array $schema, bool $strict): array
     {
-        $schemaArray = (new ObjectSchema($schema))->toSchema();
+        $schemaArray = (new ObjectSchema($schema, strict: $strict))->toSchema();
 
         return [
             'type' => 'json_schema',
             'json_schema' => [
                 'name' => $schemaArray['name'] ?? 'schema_definition',
                 'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
+                'strict' => $strict,
             ],
         ];
     }

--- a/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenRouter/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\OpenRouter\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\ObjectSchema;
@@ -56,7 +57,7 @@ trait BuildsTextRequests
         }
 
         if (filled($schema)) {
-            $body['response_format'] = $this->buildResponseFormat($schema);
+            $body['response_format'] = $this->buildResponseFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -80,9 +81,9 @@ trait BuildsTextRequests
     /**
      * Build the response format options for structured output.
      */
-    protected function buildResponseFormat(array $schema): array
+    protected function buildResponseFormat(array $schema, bool $strict): array
     {
-        $objectSchema = new ObjectSchema($schema);
+        $objectSchema = new ObjectSchema($schema, strict: $strict);
 
         $schemaArray = $objectSchema->toSchema();
 
@@ -91,7 +92,7 @@ trait BuildsTextRequests
             'json_schema' => [
                 'name' => $schemaArray['name'] ?? 'schema_definition',
                 'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
+                'strict' => $strict,
             ],
         ];
     }

--- a/src/Gateway/Xai/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Xai/Concerns/BuildsTextRequests.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\Support\Arr;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -90,7 +91,7 @@ trait BuildsTextRequests
         }
 
         if (filled($schema)) {
-            $body['text'] = $this->buildSchemaFormat($schema);
+            $body['text'] = $this->buildSchemaFormat($schema, Strict::isAppliedTo($options?->agent));
         }
 
         if (! is_null($options?->maxTokens)) {
@@ -152,9 +153,9 @@ trait BuildsTextRequests
     /**
      * Build the text format options for structured output.
      */
-    protected function buildSchemaFormat(array $schema): array
+    protected function buildSchemaFormat(array $schema, bool $strict): array
     {
-        $objectSchema = new ObjectSchema($schema);
+        $objectSchema = new ObjectSchema($schema, strict: $strict);
 
         $schemaArray = $objectSchema->toSchema();
 
@@ -163,7 +164,7 @@ trait BuildsTextRequests
                 'type' => 'json_schema',
                 'name' => $schemaArray['name'] ?? 'schema_definition',
                 'schema' => Arr::except($schemaArray, ['name']),
-                'strict' => true,
+                'strict' => $strict,
             ],
         ];
     }

--- a/src/Gateway/Xai/Concerns/MapsTools.php
+++ b/src/Gateway/Xai/Concerns/MapsTools.php
@@ -3,6 +3,7 @@
 namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Attributes\Strict;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
@@ -83,17 +84,19 @@ trait MapsTools
      */
     protected function mapTool(Tool $tool): array
     {
+        $strict = Strict::isAppliedTo($tool);
+
         $schema = $tool->schema(new JsonSchemaTypeFactory);
 
         $schemaArray = filled($schema)
-            ? (new ObjectSchema($schema))->toSchema()
+            ? (new ObjectSchema($schema, strict: $strict))->toSchema()
             : [];
 
         return [
             'type' => 'function',
             'name' => ToolNameResolver::resolve($tool),
             'description' => (string) $tool->description(),
-            'strict' => true,
+            'strict' => $strict,
             'parameters' => [
                 'type' => 'object',
                 'properties' => $schemaArray['properties'] ?? (object) [],

--- a/tests/Feature/Providers/Groq/RequestMappingTest.php
+++ b/tests/Feature/Providers/Groq/RequestMappingTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
+use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -147,6 +148,19 @@ test('structured output includes json schema response format', function (): void
             && isset($format['json_schema']['name'])
             && isset($format['json_schema']['schema'])
             && $format['json_schema']['strict'] === true;
+    });
+});
+
+test('structured output without Strict attribute sends strict false in response format', function (): void {
+    Http::fake(['*' => fakeGroqResponse('{"elements": []}')]);
+
+    (new NestedStructuredAgent)->prompt('List elements.', provider: 'groq');
+
+    Http::assertSent(function (Request $request): bool {
+        $format = data_get(json_decode($request->body(), true), 'response_format');
+
+        return $format['type'] === 'json_schema'
+            && $format['json_schema']['strict'] === false;
     });
 });
 

--- a/tests/Feature/Providers/Mistral/RequestMappingTest.php
+++ b/tests/Feature/Providers/Mistral/RequestMappingTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
+use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -147,6 +148,19 @@ test('structured output includes json schema response format', function (): void
             && isset($format['json_schema']['name'])
             && isset($format['json_schema']['schema'])
             && $format['json_schema']['strict'] === true;
+    });
+});
+
+test('structured output without Strict attribute sends strict false in response format', function (): void {
+    Http::fake(['*' => $this->fakeStructuredResponse('{"elements": []}')]);
+
+    (new NestedStructuredAgent)->prompt('List elements.', provider: 'mistral');
+
+    Http::assertSent(function (Request $request): bool {
+        $format = data_get(json_decode($request->body(), true), 'response_format');
+
+        return $format['type'] === 'json_schema'
+            && $format['json_schema']['strict'] === false;
     });
 });
 

--- a/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\AgentResponse;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
+use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
 
@@ -99,6 +100,19 @@ test('structured output defaults to json schema response format', function (): v
 
         return $format['type'] === 'json_schema'
             && $format['json_schema']['strict'] === true;
+    });
+});
+
+test('structured output without Strict attribute sends strict false in response format', function (): void {
+    Http::fake(['*' => fakeOpenAiCompatibleResponse('{"elements": []}')]);
+
+    (new NestedStructuredAgent)->prompt('List elements.', provider: 'openai-compatible');
+
+    Http::assertSent(function (Request $request): bool {
+        $format = data_get(json_decode($request->body(), true), 'response_format');
+
+        return $format['type'] === 'json_schema'
+            && $format['json_schema']['strict'] === false;
     });
 });
 

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
+use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -147,6 +148,19 @@ test('structured output includes json schema response format', function (): void
             && isset($format['json_schema']['name'])
             && isset($format['json_schema']['schema'])
             && $format['json_schema']['strict'] === true;
+    });
+});
+
+test('structured output without Strict attribute sends strict false in response format', function (): void {
+    Http::fake(['*' => fakeOpenRouterResponse('{"elements": []}')]);
+
+    (new NestedStructuredAgent)->prompt('List elements.', provider: 'openrouter');
+
+    Http::assertSent(function (Request $request): bool {
+        $format = data_get(json_decode($request->body(), true), 'response_format');
+
+        return $format['type'] === 'json_schema'
+            && $format['json_schema']['strict'] === false;
     });
 });
 

--- a/tests/Feature/Providers/Xai/RequestMappingTest.php
+++ b/tests/Feature/Providers/Xai/RequestMappingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
+use Tests\Fixtures\Agents\NestedStructuredAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
@@ -149,6 +150,19 @@ test('structured output includes json schema text format', function (): void {
             && isset($format['name'])
             && isset($format['schema'])
             && $format['strict'] === true;
+    });
+});
+
+test('structured output without Strict attribute sends strict false in text format', function (): void {
+    Http::fake(['*' => fakeXaiRequestMappingResponse('{"elements": []}')]);
+
+    (new NestedStructuredAgent)->prompt('List elements.', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $format = data_get(json_decode($request->body(), true), 'text.format');
+
+        return $format['type'] === 'json_schema'
+            && $format['strict'] === false;
     });
 });
 

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
+use Tests\Fixtures\Tools\NonStrictTool;
 use Tests\Fixtures\Tools\RandomNumberGenerator;
 
 use function Laravel\Ai\agent;
@@ -37,6 +38,23 @@ test('tool with parameters includes correct schema', function (): void {
             && in_array('min', $tool['parameters']['required'])
             && in_array('max', $tool['parameters']['required'])
             && $tool['parameters']['additionalProperties'] === false;
+    });
+});
+
+test('tool without Strict attribute sends strict false and honors developer-declared required fields', function (): void {
+    Http::fake([
+        '*' => fakeXaiToolMappingResponse('ok'),
+    ]);
+
+    agent(tools: [new NonStrictTool])->prompt('Hi', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'function');
+
+        return $tool['strict'] === false
+            && $tool['parameters']['required'] === ['query']
+            && array_key_exists('limit', $tool['parameters']['properties']);
     });
 });
 

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -41,7 +41,7 @@ test('tool with parameters includes correct schema', function (): void {
     });
 });
 
-test('tool without Strict attribute sends strict false and honors developer-declared required fields', function (): void {
+test('tool without Strict attribute sends strict false', function (): void {
     Http::fake([
         '*' => fakeXaiToolMappingResponse('ok'),
     ]);


### PR DESCRIPTION
#530 wired the `#[Strict]` opt-in into the OpenAI provider, but the other providers that send a structured-output `strict` flag still hardcode `strict: true`, so they ignore the attribute.

same thing #506 was about: with `strict: true`, a schema that has any field without `->required()` gets a 400, since strict mode wants every property listed in `required`. so a user who never added `#[Strict]` still gets it forced on.

this threads `Strict::isAppliedTo($options?->agent)` into the response format for Groq, Mistral, OpenAI-compatible, and OpenRouter, same as the OpenAI fix. default is `strict: false` now (best-effort), `#[Strict]` turns it back on. added a without-attribute test per provider asserting strict false, the existing `#[Strict]` tests still assert true.
