### PR TITLE
Exclude cached tokens from the reported prompt token count on the OpenRouter provider

### DIFF
--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -94,12 +94,15 @@ trait ParsesTextResponses
     protected function extractUsage(array $data): Usage
     {
         $usage = $data['usage'] ?? [];
+        $promptDetails = $usage['prompt_tokens_details'] ?? [];
+        $cachedTokens = $promptDetails['cached_tokens'] ?? 0;
+        $cacheWriteTokens = $promptDetails['cache_write_tokens'] ?? 0;
 
         return new Usage(
-            ($usage['prompt_tokens'] ?? 0) - ($usage['prompt_tokens_details']['cached_tokens'] ?? 0),
+            ($usage['prompt_tokens'] ?? 0) - $cachedTokens - $cacheWriteTokens,
             $usage['completion_tokens'] ?? 0,
-            cacheWriteInputTokens: $usage['prompt_tokens_details']['cache_write_tokens'] ?? 0,
-            cacheReadInputTokens: $usage['prompt_tokens_details']['cached_tokens'] ?? 0,
+            cacheWriteInputTokens: $cacheWriteTokens,
+            cacheReadInputTokens: $cachedTokens,
             reasoningTokens: $usage['completion_tokens_details']['reasoning_tokens'] ?? 0,
         );
     }

--- a/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/OpenRouter/Concerns/ParsesTextResponses.php
@@ -96,7 +96,7 @@ trait ParsesTextResponses
         $usage = $data['usage'] ?? [];
 
         return new Usage(
-            $usage['prompt_tokens'] ?? 0,
+            ($usage['prompt_tokens'] ?? 0) - ($usage['prompt_tokens_details']['cached_tokens'] ?? 0),
             $usage['completion_tokens'] ?? 0,
             cacheWriteInputTokens: $usage['prompt_tokens_details']['cache_write_tokens'] ?? 0,
             cacheReadInputTokens: $usage['prompt_tokens_details']['cached_tokens'] ?? 0,

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -259,7 +259,7 @@ test('response usage includes cache and reasoning tokens', function (): void {
 
     $response = agent()->prompt('Hello', provider: 'openrouter');
 
-    expect($response->usage->promptTokens)->toBe(100)
+    expect($response->usage->promptTokens)->toBe(80)
         ->and($response->usage->completionTokens)->toBe(50)
         ->and($response->usage->cacheReadInputTokens)->toBe(20)
         ->and($response->usage->cacheWriteInputTokens)->toBe(80)

--- a/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
+++ b/tests/Feature/Providers/OpenRouter/RequestMappingTest.php
@@ -249,7 +249,7 @@ test('response usage includes cache and reasoning tokens', function (): void {
             'completion_tokens' => 50,
             'prompt_tokens_details' => [
                 'cached_tokens' => 20,
-                'cache_write_tokens' => 80,
+                'cache_write_tokens' => 30,
             ],
             'completion_tokens_details' => [
                 'reasoning_tokens' => 10,
@@ -259,10 +259,10 @@ test('response usage includes cache and reasoning tokens', function (): void {
 
     $response = agent()->prompt('Hello', provider: 'openrouter');
 
-    expect($response->usage->promptTokens)->toBe(80)
+    expect($response->usage->promptTokens)->toBe(50)
         ->and($response->usage->completionTokens)->toBe(50)
         ->and($response->usage->cacheReadInputTokens)->toBe(20)
-        ->and($response->usage->cacheWriteInputTokens)->toBe(80)
+        ->and($response->usage->cacheWriteInputTokens)->toBe(30)
         ->and($response->usage->reasoningTokens)->toBe(10);
 });
 

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -182,6 +182,28 @@ test('streaming captures usage from final chunk', function (): void {
         ->and($streamEnd[0]->usage->completionTokens)->toBe(3);
 });
 
+test('streaming excludes cached tokens from the prompt token count', function (): void {
+    Http::fake([
+        '*' => Http::response($this->ssePayload([
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 100, 'completion_tokens' => 5, 'prompt_tokens_details' => ['cached_tokens' => 20, 'cache_write_tokens' => 80]]],
+        ])),
+    ]);
+
+    $events = [];
+    foreach (agent()->stream('Hi', provider: 'openrouter') as $event) {
+        $events[] = $event;
+    }
+
+    $streamEnd = array_values(array_filter($events, fn ($e): bool => $e instanceof StreamEnd));
+    expect($streamEnd)->toHaveCount(1)
+        ->and($streamEnd[0]->usage->promptTokens)->toBe(80)
+        ->and($streamEnd[0]->usage->completionTokens)->toBe(5)
+        ->and($streamEnd[0]->usage->cacheReadInputTokens)->toBe(20)
+        ->and($streamEnd[0]->usage->cacheWriteInputTokens)->toBe(80);
+});
+
 test('streaming finish reason maps correctly', function (string $apiReason, $expected): void {
     Http::fake([
         '*' => Http::response($this->ssePayload([

--- a/tests/Feature/Providers/OpenRouter/StreamingTest.php
+++ b/tests/Feature/Providers/OpenRouter/StreamingTest.php
@@ -187,7 +187,7 @@ test('streaming excludes cached tokens from the prompt token count', function ()
         '*' => Http::response($this->ssePayload([
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => ['role' => 'assistant', 'content' => 'Hi'], 'finish_reason' => null]]],
             ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [['index' => 0, 'delta' => [], 'finish_reason' => 'stop']]],
-            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 100, 'completion_tokens' => 5, 'prompt_tokens_details' => ['cached_tokens' => 20, 'cache_write_tokens' => 80]]],
+            ['id' => 'chatcmpl-1', 'object' => 'chat.completion.chunk', 'model' => 'anthropic/claude-sonnet-4.6', 'choices' => [], 'usage' => ['prompt_tokens' => 100, 'completion_tokens' => 5, 'prompt_tokens_details' => ['cached_tokens' => 20, 'cache_write_tokens' => 30]]],
         ])),
     ]);
 
@@ -198,10 +198,10 @@ test('streaming excludes cached tokens from the prompt token count', function ()
 
     $streamEnd = array_values(array_filter($events, fn ($e): bool => $e instanceof StreamEnd));
     expect($streamEnd)->toHaveCount(1)
-        ->and($streamEnd[0]->usage->promptTokens)->toBe(80)
+        ->and($streamEnd[0]->usage->promptTokens)->toBe(50)
         ->and($streamEnd[0]->usage->completionTokens)->toBe(5)
         ->and($streamEnd[0]->usage->cacheReadInputTokens)->toBe(20)
-        ->and($streamEnd[0]->usage->cacheWriteInputTokens)->toBe(80);
+        ->and($streamEnd[0]->usage->cacheWriteInputTokens)->toBe(30);
 });
 
 test('streaming finish reason maps correctly', function (string $apiReason, $expected): void {


### PR DESCRIPTION
OpenRouter drops raw `prompt_tokens` into `promptTokens` but also reports the cached portion in `cacheReadInputTokens`, so cache-read tokens get counted twice. Every other OpenAI-family provider already excludes them (OpenAI, DeepSeek in #896, Gemini, and Groq + OpenAI-compatible in #909), so OpenRouter is the last one still double-counting.

checked it against real OpenRouter responses: `cached_tokens` is a subset of `prompt_tokens` (e.g. `prompt_tokens` 10339 with `cached_tokens` 10318, and `total_tokens` = prompt + completion). cache write tokens are separate and not part of `prompt_tokens`, so this subtracts only `cached_tokens` and leaves `cacheWriteInputTokens` alone.

one line in the shared `extractUsage`, so streaming gets it too. flipped the existing usage assertion to the right value and added a streaming test that carries cache tokens.
