### PR TITLE
Fail over on Groq's flex tier capacity exceeded status code

### DIFF
--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -42,8 +42,8 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
      */
     protected function overloadedStatusCodes(): array
     {
-        // 498 is Groq's "flex tier capacity exceeded" status, plus the shared transient gateway and Cloudflare codes.
-        return [498, 502, 503, 504, 520, 522, 524];
+        // The status codes Groq documents as transient: 498 is "flex tier capacity exceeded", alongside 502 and 503.
+        return [498, 502, 503];
     }
 
     /**

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -36,6 +36,17 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
     public function __construct(protected Dispatcher $events) {}
 
     /**
+     * The status codes that indicate Groq is transiently unavailable and the request should fail over.
+     *
+     * @return list<int>
+     */
+    protected function overloadedStatusCodes(): array
+    {
+        // 498 is Groq's "flex tier capacity exceeded" status, plus the shared transient gateway and Cloudflare codes.
+        return [498, 502, 503, 504, 520, 522, 524];
+    }
+
+    /**
      * Generate text from the given audio.
      *
      * @param  array<string, mixed>  $providerOptions

--- a/tests/Feature/Providers/Groq/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Groq/ErrorHandlingTest.php
@@ -62,6 +62,22 @@ test('overloaded response throws provider overloaded exception', function (): vo
     );
 })->throws(ProviderOverloadedException::class);
 
+test('flex tier capacity exceeded response throws provider overloaded exception', function (): void {
+    Http::fake([
+        'api.groq.com/*' => Http::response([
+            'error' => [
+                'type' => 'capacity_exceeded',
+                'message' => 'Flex tier capacity exceeded. Please try again later.',
+            ],
+        ], 498),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'groq',
+    );
+})->throws(ProviderOverloadedException::class);
+
 test('error in 200 response throws ai exception', function (): void {
     Http::fake([
         'api.groq.com/*' => Http::response([

--- a/tests/Feature/Providers/Groq/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Groq/ErrorHandlingTest.php
@@ -78,6 +78,17 @@ test('flex tier capacity exceeded response throws provider overloaded exception'
     );
 })->throws(ProviderOverloadedException::class);
 
+test('undocumented gateway status code does not fail over', function (): void {
+    Http::fake([
+        'api.groq.com/*' => Http::response('gateway timeout', 524),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'groq',
+    );
+})->throws(RequestException::class);
+
 test('error in 200 response throws ai exception', function (): void {
     Http::fake([
         'api.groq.com/*' => Http::response([


### PR DESCRIPTION
Groq's `overloadedStatusCodes()` doesn't include `498`, its own "flex tier capacity exceeded" status. so when a flex-tier request hits a capacity spike, the classifier falls through to a raw `RequestException` (not a `FailoverableException`), `withModelFailover` never catches it, and failover silently doesn't happen. the caller gets a raw Guzzle exception instead.

Groq documents 498 as transient ("the flex tier is at capacity and the request won't be processed. You can try again later."), same category as the 503 it already handles. this adds an `overloadedStatusCodes()` override mirroring the Anthropic 529 one from #884, so 498 maps to `ProviderOverloadedException` and fails over. added a 498 test next to the existing 503 one.
