### PR TITLE
Add audio (TTS) support to the Mistral provider

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -487,7 +487,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 | ---------- | --------------------------------------------------------------- |
 | Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter, OpenAI-compatible |
 | Images     | OpenAI, Gemini, xAI                                            |
-| TTS        | OpenAI, ElevenLabs                                              |
+| TTS        | OpenAI, ElevenLabs, Mistral                                     |
 | STT        | OpenAI, ElevenLabs, Mistral, Groq, OpenAI-compatible            |
 | Embeddings | OpenAI, OpenAI-compatible, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI |
 | Reranking  | Cohere, Jina                                                    |

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -4,9 +4,11 @@ namespace Laravel\Ai\Gateway\Mistral;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
@@ -18,13 +20,15 @@ use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
+use RuntimeException;
 
-class MistralGateway implements EmbeddingGateway, StepTextGateway, TranscriptionGateway
+class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway, TranscriptionGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesMistralClient;
@@ -57,6 +61,46 @@ class MistralGateway implements EmbeddingGateway, StepTextGateway, Transcription
         StepContext $stepContext,
     ): array {
         return $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        $voice = match ($voice) {
+            'default-male' => 'en_paul_neutral',
+            'default-female' => 'gb_jane_neutral',
+            default => $voice,
+        };
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('audio/speech', [
+                'model' => $model,
+                'input' => $text,
+                'voice_id' => $voice,
+                'response_format' => 'mp3',
+            ]),
+        );
+
+        $encodedAudio = $response->json('audio_data');
+
+        if (! is_string($encodedAudio) || $encodedAudio === '') {
+            throw new RuntimeException('No audio data received from Mistral API.');
+        }
+
+        return new AudioResponse(
+            $encodedAudio,
+            new Meta($provider->name(), $model),
+            'audio/mpeg',
+        );
     }
 
     /**

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -3,19 +3,23 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Mistral\MistralGateway;
 
-class MistralProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider
+class MistralProvider extends Provider implements AudioProvider, EmbeddingProvider, TextProvider, TranscriptionProvider
 {
+    use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
     use Concerns\GeneratesTranscriptions;
+    use Concerns\HasAudioGateway;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
@@ -34,6 +38,14 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     protected function mistralGateway(): MistralGateway
     {
         return $this->mistralGateway ??= new MistralGateway($this->events);
+    }
+
+    /**
+     * Get the provider's audio gateway.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ??= $this->mistralGateway();
     }
 
     /**
@@ -82,6 +94,14 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     public function smartestTextModel(): string
     {
         return $this->config['models']['text']['smartest'] ?? 'mistral-large-latest';
+    }
+
+    /**
+     * Get the name of the default audio (TTS) model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return $this->config['models']['audio']['default'] ?? 'voxtral-mini-tts-2603';
     }
 
     /**

--- a/tests/Feature/Providers/Mistral/AudioTest.php
+++ b/tests/Feature/Providers/Mistral/AudioTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+
+beforeEach(function (): void {
+    config(['ai.providers.mistral' => [
+        ...config('ai.providers.mistral'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio request includes model, input, voice_id, and resolves default-female voice', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello world')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.mistral.ai/v1/audio/speech'
+            && $body['model'] === 'voxtral-mini-tts-2603'
+            && $body['input'] === 'Hello world'
+            && $body['voice_id'] === 'gb_jane_neutral'
+            && $body['response_format'] === 'mp3';
+    });
+});
+
+test('audio request resolves default-male voice alias', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->male()->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_id'] === 'en_paul_neutral');
+});
+
+test('audio request passes custom voice id through unchanged', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->voice('my-custom-voice-id')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_id'] === 'my-custom-voice-id');
+});
+
+test('audio request omits instructions since the Mistral API does not accept them', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->instructions('Speak warmly')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => ! str_contains($request->body(), 'Speak warmly')
+        && ! array_key_exists('instructions', json_decode($request->body(), true)));
+});
+
+test('audio request sends bearer token', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('audio response passes base64 audio data through with audio/mpeg mime type', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse(base64_encode('raw-audio-bytes'))]);
+
+    $response = Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    expect($response->audio)->toBe(base64_encode('raw-audio-bytes'))
+        ->and($response->mimeType())->toBe('audio/mpeg')
+        ->and($response->meta->provider)->toBe('mistral')
+        ->and($response->meta->model)->toBe('voxtral-mini-tts-2603');
+});
+
+test('audio uses default model when none specified', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'mistral');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['model'] === 'voxtral-mini-tts-2603');
+});
+
+test('audio throws when the response contains no audio data', function (): void {
+    Http::fake(['*' => Http::response(['audio_data' => null])]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(RuntimeException::class, 'No audio data received from Mistral API.');
+
+test('audio throws when the API returns an error', function (): void {
+    Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(RequestException::class);
+
+test('audio rate limit response throws rate limited exception', function (): void {
+    Http::fake(['api.mistral.ai/*' => Http::response(['message' => 'rate limit exceeded'], 429)]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(RateLimitedException::class);
+
+test('audio overloaded response throws provider overloaded exception', function (): void {
+    Http::fake(['api.mistral.ai/*' => Http::response(['message' => 'service unavailable'], 503)]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(ProviderOverloadedException::class);
+
+test('audio gateway is shared with the other Mistral gateways', function (): void {
+    $provider = Ai::audioProvider('mistral');
+
+    expect($provider->audioGateway())->toBe($provider->transcriptionGateway())
+        ->and($provider->audioGateway())->toBe($provider->embeddingGateway());
+});
+
+function fakeMistralAudioResponse(?string $audioData = null)
+{
+    return Http::response([
+        'audio_data' => $audioData ?? base64_encode('fake-audio-bytes'),
+    ]);
+}

--- a/tests/Feature/Providers/Mistral/BaseUrlTest.php
+++ b/tests/Feature/Providers/Mistral/BaseUrlTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
 
 use function Laravel\Ai\agent;
 
@@ -40,6 +41,19 @@ test('mistral requests fall back to the default base url', function (): void {
 
     Http::assertSentCount(1);
     mistralAssertRequestSent('POST', 'https://api.mistral.ai/v1/chat/completions');
+});
+
+test('mistral audio requests use the configured base url', function (): void {
+    configureMistralProvider($this->customUrl);
+
+    Http::fake([
+        '*' => Http::response(['audio_data' => base64_encode('fake-audio-bytes')]),
+    ]);
+
+    Audio::of('Hello')->generate(provider: 'mistral');
+
+    Http::assertSentCount(1);
+    mistralAssertRequestSent('POST', "{$this->customUrl}/audio/speech");
 });
 
 function configureMistralProvider(?string $url = null): void


### PR DESCRIPTION
Mistral released Voxtral TTS in March 2026 (`voxtral-mini-tts-2603`), but the SDK's Mistral provider only had text, embeddings, and transcription wired up — so Voxtral speech could not be used through `Audio::of(...)`. This adds audio (TTS) support to the existing provider. Purely additive: no new driver, no contract or config changes, and the existing `mistral` connection just gains the capability.

The endpoint is `POST /v1/audio/speech` with a JSON body, and the response returns the audio base64-encoded in an `audio_data` field (unlike the raw bytes OpenAI and ElevenLabs return), so the gateway passes it straight through to `AudioResponse`.

## Usage

```php
use Laravel\Ai\Audio;

// Default model and voice.
$response = Audio::of('Hello there!')->generate(provider: 'mistral');

// Explicit model, or a specific preset/custom voice id.
$response = Audio::of('Bonjour!')
    ->voice('fr_marie_neutral')
    ->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');

$response->store('audio');
```

## What's in it

- `MistralProvider` implements `AudioProvider`; the audio gateway reuses the shared, memoized `MistralGateway` instance like the other capabilities. Default model is `voxtral-mini-tts-2603` (overridable via `models.audio.default`) — Mistral documents no `-latest` alias for the TTS model, so the pinned name is used deliberately, unlike the aliased text/STT defaults.
- `MistralGateway` implements `AudioGateway` with `generateAudio()`:
  - `POST audio/speech` with `model`, `input`, `voice_id`, and `response_format: mp3` (returned as `audio/mpeg`).
  - `default-female` / `default-male` map to Mistral's `gb_jane_neutral` / `en_paul_neutral` presets (verified against the live voices endpoint); any other value passes through as a `voice_id` unchanged, so all 30 presets and custom (cloned) voices work.
  - A missing or empty `audio_data` throws instead of returning empty audio, mirroring the Gemini gateway. HTTP failures flow through the shared failover error handling.
  - `instructions` is deliberately not sent — the Mistral API has no such field (same as ElevenLabs); a test documents the omission.
- `resources/boost/skills/ai-sdk-development/SKILL.md` — adds Mistral to the TTS row of the provider support table.

Docs: https://docs.mistral.ai/capabilities/audio/text_to_speech

## Tests

12 cases in `tests/Feature/Providers/Mistral/AudioTest.php` covering request mapping, both default-voice aliases, custom voice pass-through, bearer auth, base64 pass-through + MIME/meta, the default model, the omitted-instructions contract, missing `audio_data`, and error/rate limit/overloaded responses — plus an audio case in the existing `BaseUrlTest.php` and a gateway-sharing assertion. Full suite green, Pint and PHPStan clean.

Also smoke-tested against the live API: both default presets return HTTP 200 with valid mp3 audio for exactly the request this gateway sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
