### PR TITLE
Fetch and inline remote image, document, and audio attachments for the Gemini provider

### DIFF
--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -49,7 +49,7 @@ trait HasRemoteContent
      */
     protected function response(): Response
     {
-        return $this->response ??= Http::get($this->url);
+        return $this->response ??= Http::get($this->url)->throw();
     }
 
     public function __toString(): string

--- a/src/Gateway/Gemini/Concerns/MapsAttachments.php
+++ b/src/Gateway/Gemini/Concerns/MapsAttachments.php
@@ -156,11 +156,16 @@ trait MapsAttachments
                     ),
                 ],
             ],
-            $attachment instanceof RemoteVideo => [
+            $attachment instanceof RemoteVideo => $this->isYouTubeUrl($attachment->url) ? [
                 'fileData' => array_filter([
                     'mimeType' => $attachment->mime,
                     'fileUri' => $attachment->url,
                 ]),
+            ] : [
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'video/mp4',
+                    'data' => base64_encode($attachment->content()),
+                ],
             ],
             $attachment instanceof UploadedFile => [
                 'inlineData' => [
@@ -170,5 +175,15 @@ trait MapsAttachments
             ],
             default => throw new InvalidArgumentException('Unsupported attachment type ['.get_debug_type($attachment).']'),
         };
+    }
+
+    /**
+     * Determine if the given URL is a YouTube URL, which Gemini accepts as a file URI.
+     */
+    protected function isYouTubeUrl(string $url): bool
+    {
+        return in_array(strtolower((string) parse_url($url, PHP_URL_HOST)), [
+            'youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'www.youtu.be',
+        ], true);
     }
 }

--- a/src/Gateway/Gemini/Concerns/MapsAttachments.php
+++ b/src/Gateway/Gemini/Concerns/MapsAttachments.php
@@ -60,10 +60,10 @@ trait MapsAttachments
                 ],
             ],
             $attachment instanceof RemoteImage => [
-                'fileData' => array_filter([
-                    'mimeType' => $attachment->mime,
-                    'fileUri' => $attachment->url,
-                ]),
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'image/png',
+                    'data' => base64_encode($attachment->content()),
+                ],
             ],
             $attachment instanceof LocalImage => [
                 'inlineData' => [
@@ -97,10 +97,10 @@ trait MapsAttachments
                 ],
             ],
             $attachment instanceof RemoteDocument => [
-                'fileData' => array_filter([
-                    'mimeType' => $attachment->mime,
-                    'fileUri' => $attachment->url,
-                ]),
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'application/octet-stream',
+                    'data' => base64_encode($attachment->content()),
+                ],
             ],
             $attachment instanceof StoredDocument => [
                 'inlineData' => [
@@ -131,10 +131,10 @@ trait MapsAttachments
                 ],
             ],
             $attachment instanceof RemoteAudio => [
-                'fileData' => array_filter([
-                    'mimeType' => $attachment->mime,
-                    'fileUri' => $attachment->url,
-                ]),
+                'inlineData' => [
+                    'mimeType' => $attachment->mimeType() ?? 'audio/mp3',
+                    'data' => base64_encode($attachment->content()),
+                ],
             ],
             $attachment instanceof Base64Video => [
                 'inlineData' => [

--- a/tests/Feature/Files/RemoteFileTest.php
+++ b/tests/Feature/Files/RemoteFileTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Files\RemoteImage;
+
+test('mime type falls back to the response content type', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('bytes', 200, ['Content-Type' => 'image/webp; charset=binary']),
+    ]);
+
+    expect((new RemoteImage('https://example.com/photo'))->mimeType())->toBe('image/webp');
+});
+
+test('mime type is null when the response declares none', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('bytes', 200),
+    ]);
+
+    expect((new RemoteImage('https://example.com/photo'))->mimeType())->toBeNull();
+});
+
+test('declared mime type wins without fetching the url', function (): void {
+    Http::fake();
+
+    expect((new RemoteImage('https://example.com/photo', 'image/png'))->mimeType())->toBe('image/png');
+
+    Http::assertNothingSent();
+});
+
+test('a failed fetch throws instead of inlining the error body', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('Not Found', 404),
+    ]);
+
+    (new RemoteImage('https://example.com/missing.png'))->content();
+})->throws(RequestException::class);
+
+test('the remote url is only fetched once', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('bytes', 200, ['Content-Type' => 'image/png']),
+    ]);
+
+    $image = new RemoteImage('https://example.com/photo.png');
+
+    $image->mimeType();
+    $image->content();
+
+    Http::assertSentCount(1);
+});

--- a/tests/Feature/Providers/Gemini/MessageMappingTest.php
+++ b/tests/Feature/Providers/Gemini/MessageMappingTest.php
@@ -9,6 +9,9 @@ use Laravel\Ai\Files;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Base64Video;
 use Laravel\Ai\Files\LocalImage;
+use Laravel\Ai\Files\RemoteAudio;
+use Laravel\Ai\Files\RemoteDocument;
+use Laravel\Ai\Files\RemoteImage;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Messages\ToolResultMessage;
@@ -214,6 +217,84 @@ test('base64 video attachment maps to inline data', function (): void {
             if (isset($part['inlineData'])) {
                 return $part['inlineData']['mimeType'] === 'video/mp4'
                     && $part['inlineData']['data'] === base64_encode('fake-video-content');
+            }
+        }
+
+        return false;
+    });
+});
+
+test('remote image url is fetched and mapped to inline data', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('fake-image-bytes', 200, ['Content-Type' => 'image/png']),
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('I see an image'),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'What is in this image?',
+        attachments: [new RemoteImage('https://example.com/photo.png', 'image/png')],
+        provider: 'gemini',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $parts = data_get($request->data(), 'contents.0.parts', []);
+
+        foreach ($parts as $part) {
+            if (isset($part['inlineData'])) {
+                return $part['inlineData']['mimeType'] === 'image/png'
+                    && $part['inlineData']['data'] === base64_encode('fake-image-bytes');
+            }
+        }
+
+        return false;
+    });
+});
+
+test('remote pdf url is fetched and mapped to inline data', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('fake-pdf-bytes', 200, ['Content-Type' => 'application/pdf']),
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('I see a PDF'),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'What is in this PDF?',
+        attachments: [new RemoteDocument('https://example.com/report.pdf', 'application/pdf')],
+        provider: 'gemini',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $parts = data_get($request->data(), 'contents.0.parts', []);
+
+        foreach ($parts as $part) {
+            if (isset($part['inlineData'])) {
+                return $part['inlineData']['mimeType'] === 'application/pdf'
+                    && $part['inlineData']['data'] === base64_encode('fake-pdf-bytes');
+            }
+        }
+
+        return false;
+    });
+});
+
+test('remote audio url is fetched and mapped to inline data', function (): void {
+    Http::fake([
+        'example.com/*' => Http::response('fake-audio-bytes', 200, ['Content-Type' => 'audio/mp3']),
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('I hear audio'),
+    ]);
+
+    agent('You are helpful.')->prompt(
+        'What is in this audio?',
+        attachments: [new RemoteAudio('https://example.com/clip.mp3', 'audio/mp3')],
+        provider: 'gemini',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $parts = data_get($request->data(), 'contents.0.parts', []);
+
+        foreach ($parts as $part) {
+            if (isset($part['inlineData'])) {
+                return $part['inlineData']['mimeType'] === 'audio/mp3'
+                    && $part['inlineData']['data'] === base64_encode('fake-audio-bytes');
             }
         }
 


### PR DESCRIPTION
Gemini maps `Image::fromUrl()` / `Document::fromUrl()` / `Audio::fromUrl()` to a `fileData.fileUri` pointing at the raw public URL. but Gemini's `fileUri` only accepts a Files API URI (`files/...`) or a YouTube URL for video, so a public content URL just gets rejected. every other provider handles these `fromUrl` attachments fine.

this fetches the bytes and inlines them as base64 for the remote-URL image, document, and audio cases, matching what the Local/Stored arms already do and what the Anthropic gateway does for remote docs. remote video stays on `fileUri` since YouTube is the one case Gemini accepts there. added a per-type test.
