### PR TITLE
Add a voices listing API for audio generation

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -199,6 +199,11 @@ $audio = Audio::of('Hello from Laravel.')
     ->generate();
 
 $path = $audio->store();
+
+// List the voices available for audio generation (ElevenLabs, Mistral)
+$voices = Audio::voices(provider: 'eleven');
+
+$voices->first()->id; // Pass directly to ->voice(...)
 ```
 
 ### Transcription
@@ -384,6 +389,11 @@ Image::assertNothingGenerated();
 // Audio
 Audio::fake();
 Audio::assertGenerated(fn ($prompt) => $prompt->contains('Hello'));
+
+// Voices
+Audio::fakeVoices();
+Audio::assertVoicesListed('eleven');
+Audio::assertNoVoicesListed();
 
 // Transcription
 Transcription::fake(['Transcribed text.']);

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -14,6 +14,7 @@ use Laravel\Ai\Contracts\Providers\RerankingProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
 use Laravel\Ai\Gateway\Gemini\GeminiGateway;
@@ -47,6 +48,7 @@ class AiManager extends MultipleInstanceManager
     use Concerns\InteractsWithFakeReranking;
     use Concerns\InteractsWithFakeStores;
     use Concerns\InteractsWithFakeTranscriptions;
+    use Concerns\InteractsWithFakeVoices;
 
     /**
      * The key name of the "driver" equivalent configuration option.
@@ -80,6 +82,34 @@ class AiManager extends MultipleInstanceManager
 
         return $this->audioIsFaked()
             ? (clone $provider)->useAudioGateway($this->fakeAudioGateway())
+            : $provider;
+    }
+
+    /**
+     * Get a voice provider instance by name.
+     *
+     * @throws LogicException
+     */
+    public function voiceProvider(?string $name = null): VoiceProvider
+    {
+        return tap($this->instance($name), function ($instance): void {
+            if (! $instance instanceof VoiceProvider) {
+                throw new LogicException('Provider ['.$instance::class.'] does not support voice listing.');
+            }
+        });
+    }
+
+    /**
+     * Get a voice provider instance, using a fake gateway if voices are faked.
+     *
+     * @throws LogicException
+     */
+    public function fakeableVoiceProvider(?string $name = null): VoiceProvider
+    {
+        $provider = $this->voiceProvider($name);
+
+        return $this->voicesAreFaked()
+            ? (clone $provider)->useVoiceGateway($this->fakeVoiceGateway())
             : $provider;
     }
 

--- a/src/Audio.php
+++ b/src/Audio.php
@@ -5,7 +5,9 @@ namespace Laravel\Ai;
 use Closure;
 use InvalidArgumentException;
 use Laravel\Ai\Gateway\FakeAudioGateway;
+use Laravel\Ai\Gateway\FakeVoiceGateway;
 use Laravel\Ai\PendingResponses\PendingAudioGeneration;
+use Laravel\Ai\Responses\VoicesResponse;
 
 class Audio
 {
@@ -17,6 +19,48 @@ class Audio
     public static function of(string $text): PendingAudioGeneration
     {
         return new PendingAudioGeneration($text);
+    }
+
+    /**
+     * List the voices available for audio generation.
+     */
+    public static function voices(?string $provider = null, int $timeout = 30): VoicesResponse
+    {
+        return Ai::fakeableVoiceProvider(
+            $provider ?? config('ai.default_for_audio')
+        )->voices($timeout);
+    }
+
+    /**
+     * Fake voice listing.
+     */
+    public static function fakeVoices(Closure|array|null $voices = null): FakeVoiceGateway
+    {
+        return Ai::fakeVoices($voices);
+    }
+
+    /**
+     * Assert that voices were listed matching a given provider name or truth test.
+     */
+    public static function assertVoicesListed(Closure|string $callback): void
+    {
+        Ai::assertVoicesListed($callback);
+    }
+
+    /**
+     * Assert that voices were not listed matching a given provider name or truth test.
+     */
+    public static function assertVoicesNotListed(Closure|string $callback): void
+    {
+        Ai::assertVoicesNotListed($callback);
+    }
+
+    /**
+     * Assert that no voices were listed.
+     */
+    public static function assertNoVoicesListed(): void
+    {
+        Ai::assertNoVoicesListed();
     }
 
     /**

--- a/src/Concerns/InteractsWithFakeVoices.php
+++ b/src/Concerns/InteractsWithFakeVoices.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Laravel\Ai\Concerns;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Gateway\FakeVoiceGateway;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait InteractsWithFakeVoices
+{
+    /**
+     * The fake voice gateway instance.
+     */
+    protected ?FakeVoiceGateway $fakeVoiceGateway = null;
+
+    /**
+     * All of the recorded voice listings.
+     */
+    protected array $recordedVoiceListings = [];
+
+    /**
+     * Fake voice listing.
+     */
+    public function fakeVoices(Closure|array|null $voices = null): FakeVoiceGateway
+    {
+        return $this->fakeVoiceGateway = new FakeVoiceGateway($voices);
+    }
+
+    /**
+     * Record a voice listing.
+     */
+    public function recordVoiceListing(string $provider): self
+    {
+        $this->recordedVoiceListings[] = $provider;
+
+        return $this;
+    }
+
+    /**
+     * Assert that voices were listed matching a given provider name or truth test.
+     */
+    public function assertVoicesListed(Closure|string $callback): self
+    {
+        if (is_string($callback)) {
+            $provider = $callback;
+            $callback = fn (string $name): bool => $name === $provider;
+        }
+
+        PHPUnit::assertTrue(
+            (new Collection($this->recordedVoiceListings))->contains(fn (string $name) => $callback($name)),
+            'An expected voice listing was not recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that voices were not listed matching a given provider name or truth test.
+     */
+    public function assertVoicesNotListed(Closure|string $callback): self
+    {
+        if (is_string($callback)) {
+            $provider = $callback;
+            $callback = fn (string $name): bool => $name === $provider;
+        }
+
+        PHPUnit::assertTrue(
+            (new Collection($this->recordedVoiceListings))->doesntContain(fn (string $name) => $callback($name)),
+            'An unexpected voice listing was recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that no voices were listed.
+     */
+    public function assertNoVoicesListed(): self
+    {
+        PHPUnit::assertEmpty(
+            $this->recordedVoiceListings,
+            'Unexpected voice listings were recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Determine if voice listing is faked.
+     */
+    public function voicesAreFaked(): bool
+    {
+        return $this->fakeVoiceGateway !== null;
+    }
+
+    /**
+     * Get the fake voice gateway instance.
+     */
+    public function fakeVoiceGateway(): ?FakeVoiceGateway
+    {
+        return $this->fakeVoiceGateway;
+    }
+}

--- a/src/Contracts/Gateway/VoiceGateway.php
+++ b/src/Contracts/Gateway/VoiceGateway.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Gateway;
+
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
+use Laravel\Ai\Responses\VoicesResponse;
+
+interface VoiceGateway
+{
+    /**
+     * List the voices available for audio generation.
+     */
+    public function listVoices(
+        VoiceProvider $provider,
+        int $timeout = 30,
+    ): VoicesResponse;
+}

--- a/src/Contracts/Providers/VoiceProvider.php
+++ b/src/Contracts/Providers/VoiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Providers;
+
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
+use Laravel\Ai\Responses\VoicesResponse;
+
+interface VoiceProvider extends Provider
+{
+    /**
+     * List the voices available for audio generation.
+     */
+    public function voices(int $timeout = 30): VoicesResponse;
+
+    /**
+     * Get the provider's voice gateway.
+     */
+    public function voiceGateway(): VoiceGateway;
+
+    /**
+     * Set the provider's voice gateway.
+     */
+    public function useVoiceGateway(VoiceGateway $gateway): self;
+}

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -7,16 +7,20 @@ use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
 use Laravel\Ai\Files\Audio;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\Data\Voice;
 use Laravel\Ai\Responses\TranscriptionResponse;
+use Laravel\Ai\Responses\VoicesResponse;
 
-class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
+class ElevenLabsGateway implements AudioGateway, TranscriptionGateway, VoiceGateway
 {
     use Concerns\CreatesClient;
     use Concerns\HandlesFailoverErrors;
@@ -99,9 +103,30 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
     }
 
     /**
+     * List the voices available for audio generation.
+     */
+    public function listVoices(
+        VoiceProvider $provider,
+        int $timeout = 30,
+    ): VoicesResponse {
+        $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
+            ->get('voices')->throw());
+
+        $voices = (new Collection($response->json('voices') ?? []))
+            ->map(fn (array $voice): Voice => new Voice(
+                $voice['voice_id'],
+                $voice['name'] ?? $voice['voice_id'],
+                $voice['labels']['gender'] ?? null,
+                (new Collection($voice['verified_languages'] ?? []))->pluck('language')->filter()->unique()->values()->all(),
+            ))->all();
+
+        return new VoicesResponse($voices, new Meta($provider->name()));
+    }
+
+    /**
      * Get an HTTP client for the ElevenLabs API.
      */
-    protected function client(AudioProvider|TranscriptionProvider $provider, int $timeout = 30): PendingRequest
+    protected function client(AudioProvider|TranscriptionProvider|VoiceProvider $provider, int $timeout = 30): PendingRequest
     {
         return $this->createClient(
             $this->baseUrl($provider),
@@ -115,7 +140,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
     /**
      * Get the base URL for the ElevenLabs API.
      */
-    protected function baseUrl(AudioProvider|TranscriptionProvider $provider): string
+    protected function baseUrl(AudioProvider|TranscriptionProvider|VoiceProvider $provider): string
     {
         return rtrim($provider->additionalConfiguration()['url'] ?? 'https://api.elevenlabs.io/v1', '/');
     }

--- a/src/Gateway/FakeVoiceGateway.php
+++ b/src/Gateway/FakeVoiceGateway.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Closure;
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Voice;
+use Laravel\Ai\Responses\VoicesResponse;
+
+class FakeVoiceGateway implements VoiceGateway
+{
+    /**
+     * @param  Closure|array<int, Voice>|null  $voices
+     */
+    public function __construct(
+        protected Closure|array|null $voices = null,
+    ) {}
+
+    /**
+     * List the voices available for audio generation.
+     */
+    public function listVoices(
+        VoiceProvider $provider,
+        int $timeout = 30,
+    ): VoicesResponse {
+        $voices = $this->voices instanceof Closure
+            ? call_user_func($this->voices, $provider)
+            : $this->voices;
+
+        $voices ??= [
+            new Voice('fake-female-voice', 'Fake Female Voice', 'female', ['en']),
+            new Voice('fake-male-voice', 'Fake Male Voice', 'male', ['en']),
+        ];
+
+        return new VoicesResponse($voices, new Meta($provider->name()));
+    }
+}

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -7,9 +7,11 @@ use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
@@ -21,10 +23,12 @@ use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\Data\Voice;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
+use Laravel\Ai\Responses\VoicesResponse;
 
-class MistralGateway implements EmbeddingGateway, StepTextGateway, TranscriptionGateway
+class MistralGateway implements EmbeddingGateway, StepTextGateway, TranscriptionGateway, VoiceGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesMistralClient;
@@ -131,6 +135,45 @@ class MistralGateway implements EmbeddingGateway, StepTextGateway, Transcription
             ),
             new Meta($provider->name(), $model),
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listVoices(
+        VoiceProvider $provider,
+        int $timeout = 30,
+    ): VoicesResponse {
+        $voices = [];
+        $offset = 0;
+        $limit = 100;
+
+        do {
+            $response = $this->withErrorHandling(
+                $provider->name(),
+                fn () => $this->client($provider, $timeout)->get('audio/voices', ['limit' => $limit, 'offset' => $offset]),
+            );
+
+            $items = $response->json('items') ?? [];
+
+            foreach ($items as $voice) {
+                $voices[] = new Voice(
+                    $voice['slug'],
+                    $voice['name'] ?? $voice['slug'],
+                    $voice['gender'] ?? null,
+                    array_values(array_filter($voice['languages'] ?? [])),
+                );
+            }
+
+            $offset += count($items);
+            $total = $response->json('total');
+
+            $hasMore = $total !== null
+                ? $items !== [] && $offset < $total
+                : count($items) === $limit;
+        } while ($hasMore);
+
+        return new VoicesResponse($voices, new Meta($provider->name()));
     }
 
     /**

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -195,7 +195,11 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
         do {
             $response = $this->withErrorHandling(
                 $provider->name(),
-                fn () => $this->client($provider, $timeout)->get('audio/voices', ['limit' => $limit, 'offset' => $offset]),
+                fn () => $this->client($provider, $timeout)->get('audio/voices', [
+                    'limit' => $limit,
+                    'offset' => $offset,
+                    'type' => 'all',
+                ]),
             );
 
             $items = $response->json('items') ?? [];

--- a/src/Providers/Concerns/HasVoiceGateway.php
+++ b/src/Providers/Concerns/HasVoiceGateway.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
+
+trait HasVoiceGateway
+{
+    protected VoiceGateway $voiceGateway;
+
+    /**
+     * Get the provider's voice gateway.
+     */
+    public function voiceGateway(): VoiceGateway
+    {
+        return $this->voiceGateway ?? $this->gateway;
+    }
+
+    /**
+     * Set the provider's voice gateway.
+     */
+    public function useVoiceGateway(VoiceGateway $gateway): self
+    {
+        $this->voiceGateway = $gateway;
+
+        return $this;
+    }
+}

--- a/src/Providers/Concerns/ListsVoices.php
+++ b/src/Providers/Concerns/ListsVoices.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Responses\VoicesResponse;
+
+trait ListsVoices
+{
+    /**
+     * List the voices available for audio generation.
+     */
+    public function voices(int $timeout = 30): VoicesResponse
+    {
+        if (Ai::voicesAreFaked()) {
+            Ai::recordVoiceListing($this->name());
+        }
+
+        return $this->voiceGateway()->listVoices($this, $timeout);
+    }
+}

--- a/src/Providers/ElevenLabsProvider.php
+++ b/src/Providers/ElevenLabsProvider.php
@@ -5,16 +5,20 @@ namespace Laravel\Ai\Providers;
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
 use Laravel\Ai\Gateway\ElevenLabsGateway;
 
-class ElevenLabsProvider extends Provider implements AudioProvider, TranscriptionProvider
+class ElevenLabsProvider extends Provider implements AudioProvider, TranscriptionProvider, VoiceProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesTranscriptions;
     use Concerns\HasAudioGateway;
     use Concerns\HasTranscriptionGateway;
+    use Concerns\HasVoiceGateway;
+    use Concerns\ListsVoices;
 
     public function __construct(
         protected array $config,
@@ -26,6 +30,14 @@ class ElevenLabsProvider extends Provider implements AudioProvider, Transcriptio
     public function audioGateway(): AudioGateway
     {
         return $this->audioGateway ??= new ElevenLabsGateway;
+    }
+
+    /**
+     * Get the provider's voice gateway.
+     */
+    public function voiceGateway(): VoiceGateway
+    {
+        return $this->voiceGateway ??= new ElevenLabsGateway;
     }
 
     /**

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -6,12 +6,14 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Gateway\VoiceGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Contracts\Providers\VoiceProvider;
 use Laravel\Ai\Gateway\Mistral\MistralGateway;
 
-class MistralProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider
+class MistralProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider, VoiceProvider
 {
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
@@ -19,6 +21,8 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
+    use Concerns\HasVoiceGateway;
+    use Concerns\ListsVoices;
     use Concerns\StreamsText;
 
     protected ?MistralGateway $mistralGateway = null;
@@ -58,6 +62,14 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     public function transcriptionGateway(): TranscriptionGateway
     {
         return $this->transcriptionGateway ??= $this->mistralGateway();
+    }
+
+    /**
+     * Get the provider's voice gateway.
+     */
+    public function voiceGateway(): VoiceGateway
+    {
+        return $this->voiceGateway ??= $this->mistralGateway();
     }
 
     /**

--- a/src/Responses/Data/Voice.php
+++ b/src/Responses/Data/Voice.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Ai\Responses\Data;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class Voice implements Arrayable, JsonSerializable
+{
+    /**
+     * @param  array<int, string>  $languages
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $name,
+        public readonly ?string $gender = null,
+        public readonly array $languages = [],
+    ) {}
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'gender' => $this->gender,
+            'languages' => $this->languages,
+        ];
+    }
+
+    /**
+     * Convert the instance into something JSON serializable.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Responses/VoicesResponse.php
+++ b/src/Responses/VoicesResponse.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use Countable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+use IteratorAggregate;
+use JsonSerializable;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Voice;
+use Traversable;
+
+class VoicesResponse implements Arrayable, Countable, IteratorAggregate, JsonSerializable
+{
+    /**
+     * Create a new voices response instance.
+     *
+     * @param  array<int, Voice>  $voices
+     */
+    public function __construct(
+        public readonly array $voices,
+        public readonly Meta $meta,
+    ) {}
+
+    /**
+     * Get the first voice in the response.
+     */
+    public function first(): ?Voice
+    {
+        return $this->voices[0] ?? null;
+    }
+
+    /**
+     * Find a voice by its ID.
+     */
+    public function find(string $id): ?Voice
+    {
+        return $this->collect()->first(fn (Voice $voice): bool => $voice->id === $id);
+    }
+
+    /**
+     * Get the number of voices in the response.
+     */
+    public function count(): int
+    {
+        return count($this->voices);
+    }
+
+    /**
+     * Get the voices as a collection.
+     *
+     * @return Collection<int, Voice>
+     */
+    public function collect(): Collection
+    {
+        return new Collection($this->voices);
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'voices' => $this->voices,
+            'meta' => $this->meta,
+        ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the instance.
+     */
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Get an iterator for the voices.
+     *
+     * @return Traversable<int, Voice>
+     */
+    public function getIterator(): Traversable
+    {
+        foreach ($this->voices as $voice) {
+            yield $voice;
+        }
+    }
+}

--- a/tests/Feature/Providers/ElevenLabs/VoicesTest.php
+++ b/tests/Feature/Providers/ElevenLabs/VoicesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Responses\Data\Voice;
+
+beforeEach(function (): void {
+    config(['ai.providers.eleven' => [
+        ...config('ai.providers.eleven'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('voices request hits the voices endpoint with the api key header', function (): void {
+    Http::fake(['*' => fakeElevenVoicesResponse()]);
+
+    Audio::voices(provider: 'eleven');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.elevenlabs.io/v1/voices'
+        && $request->method() === 'GET'
+        && $request->hasHeader('xi-api-key', 'test-key'));
+});
+
+test('voices are mapped from the response', function (): void {
+    Http::fake(['*' => fakeElevenVoicesResponse()]);
+
+    $response = Audio::voices(provider: 'eleven');
+
+    expect($response)->toHaveCount(2)
+        ->and($response->first())->toBeInstanceOf(Voice::class)
+        ->and($response->first()->id)->toBe('21m00Tcm4TlvDq8ikWAM')
+        ->and($response->first()->name)->toBe('Rachel')
+        ->and($response->first()->gender)->toBe('female')
+        ->and($response->first()->languages)->toBe(['en'])
+        ->and($response->meta->provider)->toBe('eleven');
+});
+
+test('voices without labels or verified languages map to null gender and empty languages', function (): void {
+    Http::fake(['*' => Http::response(['voices' => [
+        ['voice_id' => 'cloned-voice-id', 'name' => 'My Clone'],
+    ]])]);
+
+    $voice = Audio::voices(provider: 'eleven')->first();
+
+    expect($voice->gender)->toBeNull()
+        ->and($voice->languages)->toBe([]);
+});
+
+test('voices can be found by id', function (): void {
+    Http::fake(['*' => fakeElevenVoicesResponse()]);
+
+    $response = Audio::voices(provider: 'eleven');
+
+    expect($response->find('onwK4e9ZLuTAKqWW03F9')?->name)->toBe('Daniel')
+        ->and($response->find('missing'))->toBeNull();
+});
+
+test('voices throws when the API returns an error', function (): void {
+    Http::fake(['*' => Http::response(['detail' => 'unauthorized'], 401)]);
+
+    Audio::voices(provider: 'eleven');
+})->throws(RequestException::class);
+
+function fakeElevenVoicesResponse()
+{
+    return Http::response(['voices' => [
+        [
+            'voice_id' => '21m00Tcm4TlvDq8ikWAM',
+            'name' => 'Rachel',
+            'labels' => ['accent' => 'American', 'gender' => 'female'],
+            'verified_languages' => [
+                ['language' => 'en', 'model_id' => 'eleven_multilingual_v2', 'locale' => 'en-US'],
+            ],
+        ],
+        [
+            'voice_id' => 'onwK4e9ZLuTAKqWW03F9',
+            'name' => 'Daniel',
+            'labels' => ['gender' => 'male'],
+            'verified_languages' => [
+                ['language' => 'en'],
+                ['language' => 'nl'],
+            ],
+        ],
+    ]]);
+}

--- a/tests/Feature/Providers/Mistral/VoicesTest.php
+++ b/tests/Feature/Providers/Mistral/VoicesTest.php
@@ -18,7 +18,7 @@ test('voices request hits the audio voices endpoint with a bearer token', functi
 
     Audio::voices(provider: 'mistral');
 
-    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.mistral.ai/v1/audio/voices?limit=100&offset=0'
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.mistral.ai/v1/audio/voices?limit=100&offset=0&type=all'
         && $request->method() === 'GET'
         && $request->hasHeader('Authorization', 'Bearer test-key'));
 });

--- a/tests/Feature/Providers/Mistral/VoicesTest.php
+++ b/tests/Feature/Providers/Mistral/VoicesTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Responses\Data\Voice;
+
+beforeEach(function (): void {
+    config(['ai.providers.mistral' => [
+        ...config('ai.providers.mistral'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('voices request hits the audio voices endpoint with a bearer token', function (): void {
+    Http::fake(['*' => fakeMistralVoicesResponse()]);
+
+    Audio::voices(provider: 'mistral');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.mistral.ai/v1/audio/voices?limit=100&offset=0'
+        && $request->method() === 'GET'
+        && $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('voices are mapped from the response with the slug as the voice id', function (): void {
+    Http::fake(['*' => fakeMistralVoicesResponse()]);
+
+    $response = Audio::voices(provider: 'mistral');
+
+    expect($response)->toHaveCount(2)
+        ->and($response->first())->toBeInstanceOf(Voice::class)
+        ->and($response->first()->id)->toBe('en_paul_neutral')
+        ->and($response->first()->name)->toBe('Paul - Neutral')
+        ->and($response->first()->gender)->toBe('male')
+        ->and($response->first()->languages)->toBe(['en_us'])
+        ->and($response->meta->provider)->toBe('mistral');
+});
+
+test('voices can be found by id', function (): void {
+    Http::fake(['*' => fakeMistralVoicesResponse()]);
+
+    expect(Audio::voices(provider: 'mistral')->find('gb_jane_neutral')?->name)->toBe('Jane - Neutral');
+});
+
+test('voices throws when the API returns an error', function (): void {
+    Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
+
+    Audio::voices(provider: 'mistral');
+})->throws(RequestException::class);
+
+test('voices follows offset pagination until the full catalogue is collected', function (): void {
+    Http::fake(function (Request $request) {
+        parse_str(parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        $voices = collect(range(0, 149))->map(fn (int $i): array => [
+            'slug' => "voice_{$i}",
+            'name' => "Voice {$i}",
+            'gender' => 'female',
+            'languages' => ['en_us'],
+        ]);
+
+        return Http::response([
+            'items' => $voices->slice((int) $query['offset'], (int) $query['limit'])->values()->all(),
+            'total' => 150,
+            'page' => 1,
+            'page_size' => (int) $query['limit'],
+            'total_pages' => 2,
+        ]);
+    });
+
+    $response = Audio::voices(provider: 'mistral');
+
+    expect($response)->toHaveCount(150)
+        ->and($response->first()->id)->toBe('voice_0')
+        ->and($response->find('voice_149'))->not->toBeNull();
+
+    Http::assertSentCount(2);
+});
+
+function fakeMistralVoicesResponse()
+{
+    return Http::response(['items' => [
+        [
+            'slug' => 'en_paul_neutral',
+            'name' => 'Paul - Neutral',
+            'gender' => 'male',
+            'languages' => ['en_us'],
+            'id' => 'c69964a6-ab8b-4f8a-9465-ec0925096ec8',
+        ],
+        [
+            'slug' => 'gb_jane_neutral',
+            'name' => 'Jane - Neutral',
+            'gender' => 'female',
+            'languages' => ['en_gb'],
+            'id' => 'a0000000-0000-0000-0000-000000000000',
+        ],
+    ], 'total' => 2, 'page' => 1, 'page_size' => 100, 'total_pages' => 1]);
+}

--- a/tests/Feature/VoicesFakeTest.php
+++ b/tests/Feature/VoicesFakeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Responses\Data\Voice;
+use PHPUnit\Framework\AssertionFailedError;
+
+test('fake voices returns default voices without touching the network', function (): void {
+    Http::fake(fn () => throw new RuntimeException('Network should not be hit.'));
+
+    Audio::fakeVoices();
+
+    $response = Audio::voices(provider: 'eleven');
+
+    expect($response)->toHaveCount(2)
+        ->and($response->first()->gender)->toBe('female')
+        ->and($response->meta->provider)->toBe('eleven');
+
+    Audio::assertVoicesListed('eleven');
+});
+
+test('fake voices returns the given voices', function (): void {
+    Audio::fakeVoices([
+        new Voice('custom-voice', 'Custom Voice', 'female', ['nl']),
+    ]);
+
+    $response = Audio::voices(provider: 'mistral');
+
+    expect($response)->toHaveCount(1)
+        ->and($response->first()->id)->toBe('custom-voice');
+
+    Audio::assertVoicesListed(fn (string $provider): bool => $provider === 'mistral');
+});
+
+test('fake voices can resolve voices via closure', function (): void {
+    Audio::fakeVoices(fn ($provider): array => [
+        new Voice("voice-for-{$provider->name()}", 'Dynamic Voice'),
+    ]);
+
+    expect(Audio::voices(provider: 'eleven')->first()->id)->toBe('voice-for-eleven');
+});
+
+test('assert no voices listed passes without listings and fails after one', function (): void {
+    Audio::fakeVoices();
+
+    Audio::assertNoVoicesListed();
+
+    Audio::voices(provider: 'eleven');
+
+    expect(fn () => Audio::assertNoVoicesListed())->toThrow(AssertionFailedError::class);
+});
+
+test('fake voices with an explicit empty catalogue stays empty', function (): void {
+    Audio::fakeVoices(fn (): array => []);
+
+    expect(Audio::voices(provider: 'eleven'))->toHaveCount(0);
+});
+
+test('voices resolves the default audio provider when none is given', function (): void {
+    config(['ai.default_for_audio' => 'eleven']);
+
+    Audio::fakeVoices();
+
+    expect(Audio::voices()->meta->provider)->toBe('eleven');
+
+    Audio::assertVoicesListed('eleven');
+});
+
+test('assert voices not listed passes for other providers and fails for the listed one', function (): void {
+    Audio::fakeVoices();
+
+    Audio::voices(provider: 'eleven');
+
+    Audio::assertVoicesNotListed('mistral');
+
+    expect(fn () => Audio::assertVoicesNotListed('eleven'))->toThrow(AssertionFailedError::class);
+});
+
+test('voices throws for providers that do not support voice listing', function (): void {
+    Audio::voices(provider: 'openai');
+})->throws(LogicException::class, 'does not support voice listing');


### PR DESCRIPTION
The SDK can generate speech with a chosen `voice`, but it gives applications no way to discover which voices exist. Anyone building a voice picker, or validating a stored voice id, has to hand-roll HTTP calls per provider today. This adds a small listing API for the two supported providers with a dynamic voice catalogue: ElevenLabs (`GET /v1/voices`) and Mistral (`GET /v1/audio/voices`).

Every returned `Voice->id` can be passed directly to the audio builder's `voice()` method. That holds for ElevenLabs voice ids and Mistral voice slugs, both checked against the live APIs.

## Usage

```php
use Laravel\Ai\Audio;

$voices = Audio::voices(provider: 'eleven');

foreach ($voices as $voice) {
    $voice->id;        // 'gb_jane_neutral', pass straight to ->voice(...)
    $voice->name;      // 'Jane - Neutral'
    $voice->gender;    // 'female', or null when the provider does not expose it
    $voice->languages; // ['en_gb']
}

$voices->find('gb_jane_neutral');

// Without an explicit provider, the default audio provider is used:
$voices = Audio::voices();
```

## Design notes

`VoiceProvider` is a new opt-in contract rather than an addition to `AudioProvider`. Extending `AudioProvider` would break OpenAI, Gemini, and OpenRouter, which have no voices endpoint, and providers with a fixed documented voice list gain nothing from an HTTP round-trip.

The plumbing mirrors the Files feature: a `VoiceGateway` contract, `HasVoiceGateway` and `ListsVoices` provider concerns, `AiManager::voiceProvider()` / `fakeableVoiceProvider()` with the same `LogicException` guard, and shared gateway instances (Mistral reuses its memoized gateway across all capabilities).

Two things worth calling out:

- Mistral caps `limit` at 100 and paginates via `offset`. The documented `page` parameter is ignored server-side (confirmed with live requests: `page=2` returns the first page, `offset=10` returns the second). The gateway follows `offset` until the reported `total` is collected, and if `total` is ever absent it continues while pages come back full.
- `VoicesResponse` follows the `RerankingResponse` idiom (iterable, countable, `first()`, `find()`, `collect()`). Its `Meta` carries the provider and a `null` model, since a listing has no model — `Meta` already supports this. And `Audio::voices()` takes the provider as a direct argument because a listing has no builder step; without one it resolves `config('ai.default_for_audio')`, matching `Audio::of(...)->generate()`.

## Testing

```php
Audio::fakeVoices(); // two default voices, zero-config

Audio::fakeVoices([new Voice('custom-voice', 'Custom Voice', 'female', ['nl'])]);

Audio::fakeVoices(fn ($provider) => [...]); // per-provider

Audio::assertVoicesListed('eleven');
Audio::assertVoicesNotListed('mistral');
Audio::assertNoVoicesListed();
```

`assertVoicesListed` and `assertVoicesNotListed` accept a provider-name string as shorthand for the closure form, following `assertFileDeleted`.

18 tests cover request mapping and auth per provider, null-safe field mapping for voices without labels or languages, `find()`, error propagation, a 150-voice two-request pagination case, default-provider resolution, the fake layer (defaults, explicit voices, closure, an explicitly empty catalogue), and the `LogicException` for providers without voice support. Full suite green, Pint and PHPStan clean. The `resources/boost/skills` doc is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
