### PR TITLE
[0.x] Add Realtime sessions for low-latency audio and voice agents

### DIFF
--- a/config/ai.php
+++ b/config/ai.php
@@ -19,6 +19,7 @@ return [
     'default_for_transcription' => 'openai',
     'default_for_embeddings' => 'openai',
     'default_for_reranking' => 'cohere',
+    'default_for_realtime' => 'openai',
 
     /*
     |--------------------------------------------------------------------------
@@ -64,6 +65,7 @@ return [
             'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
             'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
             'image_deployment' => env('AZURE_OPENAI_IMAGE_DEPLOYMENT', 'gpt-image-1'),
+            'realtime_deployment' => env('AZURE_OPENAI_REALTIME_DEPLOYMENT', 'gpt-4o-realtime'),
             'store' => env('AZURE_OPENAI_STORE', true),
         ],
 

--- a/src/AiManager.php
+++ b/src/AiManager.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
@@ -44,6 +45,7 @@ class AiManager extends MultipleInstanceManager
     use Concerns\InteractsWithFakeEmbeddings;
     use Concerns\InteractsWithFakeFiles;
     use Concerns\InteractsWithFakeImages;
+    use Concerns\InteractsWithFakeRealtime;
     use Concerns\InteractsWithFakeReranking;
     use Concerns\InteractsWithFakeStores;
     use Concerns\InteractsWithFakeTranscriptions;
@@ -80,6 +82,34 @@ class AiManager extends MultipleInstanceManager
 
         return $this->audioIsFaked()
             ? (clone $provider)->useAudioGateway($this->fakeAudioGateway())
+            : $provider;
+    }
+
+    /**
+     * Get a provider instance by name.
+     *
+     * @throws LogicException
+     */
+    public function realtimeProvider(?string $name = null): RealtimeProvider
+    {
+        return tap($this->instance($name), function ($instance): void {
+            if (! $instance instanceof RealtimeProvider) {
+                throw new LogicException('Provider ['.$instance::class.'] does not support realtime sessions.');
+            }
+        });
+    }
+
+    /**
+     * Get a realtime provider instance, using a fake gateway if realtime is faked.
+     *
+     * @throws LogicException
+     */
+    public function fakeableRealtimeProvider(?string $name = null): RealtimeProvider
+    {
+        $provider = $this->realtimeProvider($name);
+
+        return $this->realtimeIsFaked()
+            ? (clone $provider)->useRealtimeGateway($this->fakeRealtimeGateway())
             : $provider;
     }
 

--- a/src/Concerns/InteractsWithFakeRealtime.php
+++ b/src/Concerns/InteractsWithFakeRealtime.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Laravel\Ai\Concerns;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Laravel\Ai\Gateway\FakeRealtimeGateway;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait InteractsWithFakeRealtime
+{
+    /**
+     * The fake realtime gateway instance.
+     */
+    protected ?FakeRealtimeGateway $fakeRealtimeGateway = null;
+
+    /**
+     * All of the recorded realtime session creations.
+     */
+    protected array $recordedRealtimeSessions = [];
+
+    /**
+     * Fake realtime session creation.
+     */
+    public function fakeRealtime(Closure|array $responses = []): FakeRealtimeGateway
+    {
+        return $this->fakeRealtimeGateway = new FakeRealtimeGateway($responses);
+    }
+
+    /**
+     * Record a realtime session creation.
+     */
+    public function recordRealtimeSessionCreation(RealtimePrompt $prompt): self
+    {
+        $this->recordedRealtimeSessions[] = $prompt;
+
+        return $this;
+    }
+
+    /**
+     * Assert that a realtime session was created matching a given truth test.
+     */
+    public function assertRealtimeSessionCreated(Closure $callback): self
+    {
+        PHPUnit::assertTrue(
+            (new Collection($this->recordedRealtimeSessions))->contains(fn (RealtimePrompt $prompt) => $callback($prompt)),
+            'An expected realtime session creation was not recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that a realtime session was not created matching a given truth test.
+     */
+    public function assertRealtimeSessionNotCreated(Closure $callback): self
+    {
+        PHPUnit::assertTrue(
+            (new Collection($this->recordedRealtimeSessions))->doesntContain(fn (RealtimePrompt $prompt) => $callback($prompt)),
+            'An unexpected realtime session creation was recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that no realtime sessions were created.
+     */
+    public function assertNoRealtimeSessionCreated(): self
+    {
+        PHPUnit::assertEmpty(
+            $this->recordedRealtimeSessions,
+            'Unexpected realtime sessions were recorded.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Determine if realtime session creation is faked.
+     */
+    public function realtimeIsFaked(): bool
+    {
+        return $this->fakeRealtimeGateway !== null;
+    }
+
+    /**
+     * Get the fake realtime gateway.
+     */
+    public function fakeRealtimeGateway(): ?FakeRealtimeGateway
+    {
+        return $this->fakeRealtimeGateway;
+    }
+}

--- a/src/Contracts/Agent.php
+++ b/src/Contracts/Agent.php
@@ -7,6 +7,7 @@ use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\QueuedAgentResponse;
+use Laravel\Ai\Responses\RealtimeSession;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Stringable;
 
@@ -82,4 +83,26 @@ interface Agent
         Lab|array|string|null $provider = null,
         ?string $model = null
     ): QueuedAgentResponse;
+
+    /**
+     * Create an ephemeral realtime session for the agent.
+     */
+    public function realtime(
+        Lab|array|string|null $provider = null,
+        ?string $model = null,
+        ?string $voice = null,
+        array $options = [],
+        ?int $timeout = null,
+    ): RealtimeSession;
+
+    /**
+     * Create ephemeral client credentials for the agent.
+     */
+    public function clientCredentials(
+        Lab|array|string|null $provider = null,
+        ?string $model = null,
+        ?string $voice = null,
+        array $options = [],
+        ?int $timeout = null,
+    ): RealtimeSession;
 }

--- a/src/Contracts/Gateway/RealtimeGateway.php
+++ b/src/Contracts/Gateway/RealtimeGateway.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Gateway;
+
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Responses\RealtimeSession;
+
+interface RealtimeGateway
+{
+    /**
+     * Create an ephemeral realtime session.
+     */
+    public function createRealtimeSession(
+        RealtimeProvider $provider,
+        RealtimePrompt $prompt,
+    ): RealtimeSession;
+}

--- a/src/Contracts/Providers/RealtimeProvider.php
+++ b/src/Contracts/Providers/RealtimeProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Providers;
+
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Responses\RealtimeSession;
+
+interface RealtimeProvider extends Provider
+{
+    /**
+     * Create an ephemeral realtime session.
+     */
+    public function createRealtimeSession(RealtimePrompt $prompt): RealtimeSession;
+
+    /**
+     * Get the provider's realtime gateway.
+     */
+    public function realtimeGateway(): RealtimeGateway;
+
+    /**
+     * Set the provider's realtime gateway.
+     */
+    public function useRealtimeGateway(RealtimeGateway $gateway): self;
+
+    /**
+     * Get the name of the default realtime model.
+     */
+    public function defaultRealtimeModel(): string;
+
+    /**
+     * Get the name of the default realtime voice.
+     */
+    public function defaultRealtimeVoice(): string;
+}

--- a/src/Gateway/AzureOpenAi/AzureOpenAiRealtimeGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiRealtimeGateway.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Ai\Gateway\AzureOpenAi;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
+use Laravel\Ai\Gateway\AzureOpenAi\Concerns\CreatesAzureOpenAiClient;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
+use Laravel\Ai\Gateway\OpenAi\Concerns\MapsTools;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\RealtimeSession;
+
+class AzureOpenAiRealtimeGateway implements RealtimeGateway
+{
+    use CreatesAzureOpenAiClient;
+    use HandlesFailoverErrors;
+    use MapsTools;
+
+    /**
+     * Create an ephemeral realtime session.
+     */
+    public function createRealtimeSession(
+        RealtimeProvider $provider,
+        RealtimePrompt $prompt,
+    ): RealtimeSession {
+        $voice = match ($prompt->voice) {
+            'default-female' => 'alloy',
+            'default-male' => 'ash',
+            default => $prompt->voice,
+        };
+
+        $payload = array_filter([
+            'model' => $prompt->model,
+            'modalities' => $prompt->modalities,
+            'instructions' => $prompt->instructions,
+            'voice' => $voice,
+            'tools' => filled($prompt->tools) ? $this->mapTools($prompt->tools, $provider) : null,
+            'input_audio_format' => $prompt->options['input_audio_format'] ?? null,
+            'output_audio_format' => $prompt->options['output_audio_format'] ?? null,
+            'input_audio_transcription' => $prompt->options['input_audio_transcription'] ?? null,
+            'turn_detection' => $prompt->options['turn_detection'] ?? null,
+            'tool_choice' => $prompt->options['tool_choice'] ?? null,
+            'temperature' => $prompt->options['temperature'] ?? null,
+            'max_response_output_tokens' => $prompt->options['max_response_output_tokens'] ?? null,
+        ], fn ($value) => $value !== null);
+
+        $extraOptions = Arr::except($prompt->options, [
+            'model', 'modalities', 'instructions', 'voice', 'tools',
+            'input_audio_format', 'output_audio_format', 'input_audio_transcription',
+            'turn_detection', 'tool_choice', 'temperature', 'max_response_output_tokens',
+        ]);
+
+        $payload = array_merge($payload, $extraOptions);
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $prompt->timeout)->post('realtime/sessions', $payload),
+        );
+
+        $data = $response->json();
+
+        $clientSecret = is_array($data['client_secret'] ?? null)
+            ? ($data['client_secret']['value'] ?? '')
+            : ($data['client_secret'] ?? '');
+
+        $expiresAt = is_array($data['client_secret'] ?? null)
+            ? ($data['client_secret']['expires_at'] ?? 0)
+            : ($data['expires_at'] ?? 0);
+
+        return new RealtimeSession(
+            id: $data['id'] ?? '',
+            clientSecret: $clientSecret,
+            expiresAt: $expiresAt,
+            model: $data['model'] ?? $prompt->model,
+            meta: new Meta($provider->name(), $data['model'] ?? $prompt->model),
+            voice: $data['voice'] ?? $voice,
+            modalities: $data['modalities'] ?? $prompt->modalities,
+            raw: $data,
+        );
+    }
+}

--- a/src/Gateway/AzureOpenAi/AzureOpenAiRealtimeGateway.php
+++ b/src/Gateway/AzureOpenAi/AzureOpenAiRealtimeGateway.php
@@ -31,52 +31,79 @@ class AzureOpenAiRealtimeGateway implements RealtimeGateway
             default => $prompt->voice,
         };
 
-        $payload = array_filter([
+        $session = array_filter([
+            'type' => 'realtime',
             'model' => $prompt->model,
-            'modalities' => $prompt->modalities,
             'instructions' => $prompt->instructions,
-            'voice' => $voice,
+            'modalities' => $prompt->modalities,
             'tools' => filled($prompt->tools) ? $this->mapTools($prompt->tools, $provider) : null,
-            'input_audio_format' => $prompt->options['input_audio_format'] ?? null,
-            'output_audio_format' => $prompt->options['output_audio_format'] ?? null,
-            'input_audio_transcription' => $prompt->options['input_audio_transcription'] ?? null,
-            'turn_detection' => $prompt->options['turn_detection'] ?? null,
             'tool_choice' => $prompt->options['tool_choice'] ?? null,
             'temperature' => $prompt->options['temperature'] ?? null,
             'max_response_output_tokens' => $prompt->options['max_response_output_tokens'] ?? null,
         ], fn ($value) => $value !== null);
 
+        if ($voice !== null || isset($prompt->options['output_audio_format'])) {
+            $session['audio']['output'] = array_filter([
+                'voice' => $voice,
+                'format' => $prompt->options['output_audio_format'] ?? null,
+            ], fn ($value) => $value !== null);
+        }
+
+        if (isset($prompt->options['input_audio_format']) || isset($prompt->options['input_audio_transcription']) || isset($prompt->options['turn_detection'])) {
+            $session['audio']['input'] = array_filter([
+                'format' => $prompt->options['input_audio_format'] ?? null,
+                'transcription' => $prompt->options['input_audio_transcription'] ?? null,
+                'turn_detection' => $prompt->options['turn_detection'] ?? null,
+            ], fn ($value) => $value !== null);
+        }
+
         $extraOptions = Arr::except($prompt->options, [
             'model', 'modalities', 'instructions', 'voice', 'tools',
             'input_audio_format', 'output_audio_format', 'input_audio_transcription',
             'turn_detection', 'tool_choice', 'temperature', 'max_response_output_tokens',
+            'session',
         ]);
 
-        $payload = array_merge($payload, $extraOptions);
+        $session = array_merge($session, $prompt->options['session'] ?? [], $extraOptions);
+
+        $payload = [
+            'session' => $session,
+        ];
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $prompt->timeout)->post('realtime/sessions', $payload),
+            fn () => $this->client($provider, $prompt->timeout)->post('realtime/client_secrets', $payload),
         );
 
         $data = $response->json();
 
-        $clientSecret = is_array($data['client_secret'] ?? null)
-            ? ($data['client_secret']['value'] ?? '')
-            : ($data['client_secret'] ?? '');
+        $clientSecret = $data['value']
+            ?? (is_array($data['client_secret'] ?? null)
+                ? ($data['client_secret']['value'] ?? '')
+                : ($data['client_secret'] ?? ''));
 
-        $expiresAt = is_array($data['client_secret'] ?? null)
-            ? ($data['client_secret']['expires_at'] ?? 0)
-            : ($data['expires_at'] ?? 0);
+        $expiresAt = $data['expires_at']
+            ?? (is_array($data['client_secret'] ?? null)
+                ? ($data['client_secret']['expires_at'] ?? 0)
+                : 0);
+
+        $model = $data['session']['model']
+            ?? ($data['model'] ?? $prompt->model);
+
+        $resolvedVoice = $data['session']['audio']['output']['voice']
+            ?? ($data['session']['voice'] ?? ($data['voice'] ?? $voice));
+
+        $resolvedModalities = $data['session']['modalities']
+            ?? ($data['modalities'] ?? $prompt->modalities);
 
         return new RealtimeSession(
             id: $data['id'] ?? '',
             clientSecret: $clientSecret,
             expiresAt: $expiresAt,
-            model: $data['model'] ?? $prompt->model,
-            meta: new Meta($provider->name(), $data['model'] ?? $prompt->model),
-            voice: $data['voice'] ?? $voice,
-            modalities: $data['modalities'] ?? $prompt->modalities,
+            model: $model,
+            meta: new Meta($provider->name(), $model),
+            voice: $resolvedVoice,
+            modalities: $resolvedModalities,
             raw: $data,
         );
     }

--- a/src/Gateway/FakeRealtimeGateway.php
+++ b/src/Gateway/FakeRealtimeGateway.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Laravel\Ai\Gateway;
+
+use Closure;
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\RealtimeSession;
+use RuntimeException;
+
+class FakeRealtimeGateway implements RealtimeGateway
+{
+    protected int $currentResponseIndex = 0;
+
+    protected bool $preventStraySessions = false;
+
+    public function __construct(
+        protected Closure|array $responses = [],
+    ) {}
+
+    /**
+     * Create an ephemeral realtime session.
+     */
+    public function createRealtimeSession(
+        RealtimeProvider $provider,
+        RealtimePrompt $prompt,
+    ): RealtimeSession {
+        return $this->nextResponse($provider, $prompt);
+    }
+
+    /**
+     * Get the next response instance.
+     */
+    protected function nextResponse(RealtimeProvider $provider, RealtimePrompt $prompt): RealtimeSession
+    {
+        $response = is_array($this->responses)
+            ? ($this->responses[$this->currentResponseIndex] ?? null)
+            : call_user_func($this->responses, $prompt);
+
+        return tap($this->marshalResponse(
+            $response, $provider, $prompt
+        ), fn (): int => $this->currentResponseIndex++);
+    }
+
+    /**
+     * Marshal the given response into a full RealtimeSession instance.
+     */
+    protected function marshalResponse(
+        mixed $response,
+        RealtimeProvider $provider,
+        RealtimePrompt $prompt,
+    ): RealtimeSession {
+        if ($response instanceof Closure) {
+            $response = $response($prompt);
+        }
+
+        if (is_null($response)) {
+            if ($this->preventStraySessions) {
+                throw new RuntimeException('Attempted realtime session creation without a fake response.');
+            }
+
+            return new RealtimeSession(
+                id: 'sess_fake_'.uniqid(),
+                clientSecret: 'ek_fake_'.uniqid(),
+                expiresAt: time() + 3600,
+                model: $prompt->model,
+                meta: new Meta($provider->name(), $prompt->model),
+                voice: $prompt->voice,
+                modalities: $prompt->modalities,
+            );
+        }
+
+        if (is_array($response)) {
+            return new RealtimeSession(
+                id: $response['id'] ?? 'sess_fake_'.uniqid(),
+                clientSecret: $response['client_secret'] ?? ($response['token'] ?? 'ek_fake_'.uniqid()),
+                expiresAt: $response['expires_at'] ?? (time() + 3600),
+                model: $response['model'] ?? $prompt->model,
+                meta: new Meta($provider->name(), $response['model'] ?? $prompt->model),
+                voice: $response['voice'] ?? $prompt->voice,
+                modalities: $response['modalities'] ?? $prompt->modalities,
+                raw: $response,
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Indicate that an exception should be thrown if any realtime session is not faked.
+     */
+    public function preventStrayRealtime(bool $prevent = true): self
+    {
+        $this->preventStraySessions = $prevent;
+
+        return $this;
+    }
+}

--- a/src/Gateway/OpenAi/OpenAiRealtimeGateway.php
+++ b/src/Gateway/OpenAi/OpenAiRealtimeGateway.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Laravel\Ai\Gateway\OpenAi;
+
+use Illuminate\Support\Arr;
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
+use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
+use Laravel\Ai\Gateway\OpenAi\Concerns\CreatesOpenAiClient;
+use Laravel\Ai\Gateway\OpenAi\Concerns\MapsTools;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\RealtimeSession;
+
+class OpenAiRealtimeGateway implements RealtimeGateway
+{
+    use CreatesOpenAiClient;
+    use HandlesFailoverErrors;
+    use MapsTools;
+
+    /**
+     * Create an ephemeral realtime session.
+     */
+    public function createRealtimeSession(
+        RealtimeProvider $provider,
+        RealtimePrompt $prompt,
+    ): RealtimeSession {
+        $voice = match ($prompt->voice) {
+            'default-female' => 'alloy',
+            'default-male' => 'ash',
+            default => $prompt->voice,
+        };
+
+        $payload = array_filter([
+            'model' => $prompt->model,
+            'modalities' => $prompt->modalities,
+            'instructions' => $prompt->instructions,
+            'voice' => $voice,
+            'tools' => filled($prompt->tools) ? $this->mapTools($prompt->tools, $provider) : null,
+            'input_audio_format' => $prompt->options['input_audio_format'] ?? null,
+            'output_audio_format' => $prompt->options['output_audio_format'] ?? null,
+            'input_audio_transcription' => $prompt->options['input_audio_transcription'] ?? null,
+            'turn_detection' => $prompt->options['turn_detection'] ?? null,
+            'tool_choice' => $prompt->options['tool_choice'] ?? null,
+            'temperature' => $prompt->options['temperature'] ?? null,
+            'max_response_output_tokens' => $prompt->options['max_response_output_tokens'] ?? null,
+        ], fn ($value) => $value !== null);
+
+        $extraOptions = Arr::except($prompt->options, [
+            'model', 'modalities', 'instructions', 'voice', 'tools',
+            'input_audio_format', 'output_audio_format', 'input_audio_transcription',
+            'turn_detection', 'tool_choice', 'temperature', 'max_response_output_tokens',
+        ]);
+
+        $payload = array_merge($payload, $extraOptions);
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $prompt->timeout)->post('realtime/sessions', $payload),
+        );
+
+        $data = $response->json();
+
+        $clientSecret = is_array($data['client_secret'] ?? null)
+            ? ($data['client_secret']['value'] ?? '')
+            : ($data['client_secret'] ?? '');
+
+        $expiresAt = is_array($data['client_secret'] ?? null)
+            ? ($data['client_secret']['expires_at'] ?? 0)
+            : ($data['expires_at'] ?? 0);
+
+        return new RealtimeSession(
+            id: $data['id'] ?? '',
+            clientSecret: $clientSecret,
+            expiresAt: $expiresAt,
+            model: $data['model'] ?? $prompt->model,
+            meta: new Meta($provider->name(), $data['model'] ?? $prompt->model),
+            voice: $data['voice'] ?? $voice,
+            modalities: $data['modalities'] ?? $prompt->modalities,
+            raw: $data,
+        );
+    }
+}

--- a/src/Gateway/OpenAi/OpenAiRealtimeGateway.php
+++ b/src/Gateway/OpenAi/OpenAiRealtimeGateway.php
@@ -31,52 +31,79 @@ class OpenAiRealtimeGateway implements RealtimeGateway
             default => $prompt->voice,
         };
 
-        $payload = array_filter([
+        $session = array_filter([
+            'type' => 'realtime',
             'model' => $prompt->model,
-            'modalities' => $prompt->modalities,
             'instructions' => $prompt->instructions,
-            'voice' => $voice,
+            'modalities' => $prompt->modalities,
             'tools' => filled($prompt->tools) ? $this->mapTools($prompt->tools, $provider) : null,
-            'input_audio_format' => $prompt->options['input_audio_format'] ?? null,
-            'output_audio_format' => $prompt->options['output_audio_format'] ?? null,
-            'input_audio_transcription' => $prompt->options['input_audio_transcription'] ?? null,
-            'turn_detection' => $prompt->options['turn_detection'] ?? null,
             'tool_choice' => $prompt->options['tool_choice'] ?? null,
             'temperature' => $prompt->options['temperature'] ?? null,
             'max_response_output_tokens' => $prompt->options['max_response_output_tokens'] ?? null,
         ], fn ($value) => $value !== null);
 
+        if ($voice !== null || isset($prompt->options['output_audio_format'])) {
+            $session['audio']['output'] = array_filter([
+                'voice' => $voice,
+                'format' => $prompt->options['output_audio_format'] ?? null,
+            ], fn ($value) => $value !== null);
+        }
+
+        if (isset($prompt->options['input_audio_format']) || isset($prompt->options['input_audio_transcription']) || isset($prompt->options['turn_detection'])) {
+            $session['audio']['input'] = array_filter([
+                'format' => $prompt->options['input_audio_format'] ?? null,
+                'transcription' => $prompt->options['input_audio_transcription'] ?? null,
+                'turn_detection' => $prompt->options['turn_detection'] ?? null,
+            ], fn ($value) => $value !== null);
+        }
+
         $extraOptions = Arr::except($prompt->options, [
             'model', 'modalities', 'instructions', 'voice', 'tools',
             'input_audio_format', 'output_audio_format', 'input_audio_transcription',
             'turn_detection', 'tool_choice', 'temperature', 'max_response_output_tokens',
+            'session',
         ]);
 
-        $payload = array_merge($payload, $extraOptions);
+        $session = array_merge($session, $prompt->options['session'] ?? [], $extraOptions);
+
+        $payload = [
+            'session' => $session,
+        ];
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $prompt->timeout)->post('realtime/sessions', $payload),
+            fn () => $this->client($provider, $prompt->timeout)->post('realtime/client_secrets', $payload),
         );
 
         $data = $response->json();
 
-        $clientSecret = is_array($data['client_secret'] ?? null)
-            ? ($data['client_secret']['value'] ?? '')
-            : ($data['client_secret'] ?? '');
+        $clientSecret = $data['value']
+            ?? (is_array($data['client_secret'] ?? null)
+                ? ($data['client_secret']['value'] ?? '')
+                : ($data['client_secret'] ?? ''));
 
-        $expiresAt = is_array($data['client_secret'] ?? null)
-            ? ($data['client_secret']['expires_at'] ?? 0)
-            : ($data['expires_at'] ?? 0);
+        $expiresAt = $data['expires_at']
+            ?? (is_array($data['client_secret'] ?? null)
+                ? ($data['client_secret']['expires_at'] ?? 0)
+                : 0);
+
+        $model = $data['session']['model']
+            ?? ($data['model'] ?? $prompt->model);
+
+        $resolvedVoice = $data['session']['audio']['output']['voice']
+            ?? ($data['session']['voice'] ?? ($data['voice'] ?? $voice));
+
+        $resolvedModalities = $data['session']['modalities']
+            ?? ($data['modalities'] ?? $prompt->modalities);
 
         return new RealtimeSession(
             id: $data['id'] ?? '',
             clientSecret: $clientSecret,
             expiresAt: $expiresAt,
-            model: $data['model'] ?? $prompt->model,
-            meta: new Meta($provider->name(), $data['model'] ?? $prompt->model),
-            voice: $data['voice'] ?? $voice,
-            modalities: $data['modalities'] ?? $prompt->modalities,
+            model: $model,
+            meta: new Meta($provider->name(), $model),
+            voice: $resolvedVoice,
+            modalities: $resolvedModalities,
             raw: $data,
         );
     }

--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -16,19 +16,23 @@ use Laravel\Ai\Attributes\Timeout as TimeoutAttribute;
 use Laravel\Ai\Attributes\UseCheapestModel;
 use Laravel\Ai\Attributes\UseSmartestModel;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
+use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\AgentFailedOver;
+use Laravel\Ai\Events\ProviderFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Gateway\FakeTextGateway;
 use Laravel\Ai\Gateway\ParentInvocation;
 use Laravel\Ai\Jobs\BroadcastAgent;
 use Laravel\Ai\Jobs\InvokeAgent;
 use Laravel\Ai\Prompts\AgentPrompt;
+use Laravel\Ai\Prompts\RealtimePrompt;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\QueuedAgentResponse;
+use Laravel\Ai\Responses\RealtimeSession;
 use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
@@ -263,6 +267,70 @@ trait Promptable
         return new QueuedAgentResponse(
             BroadcastAgent::dispatch($this, $prompt, $channels, $attachments, $provider, $model)
         );
+    }
+
+    /**
+     * Create an ephemeral realtime session for the agent.
+     */
+    public function realtime(
+        Lab|array|string|null $provider = null,
+        ?string $model = null,
+        ?string $voice = null,
+        array $options = [],
+        ?int $timeout = null,
+    ): RealtimeSession {
+        $providers = Provider::formatProviderAndModelList(
+            $provider ?? config('ai.default_for_realtime', config('ai.default')), $model
+        );
+
+        $lastException = null;
+
+        foreach ($providers as $providerName => $providerModel) {
+            $realtimeProvider = Ai::fakeableRealtimeProvider($providerName);
+
+            $providerModel ??= $realtimeProvider->defaultRealtimeModel();
+            $resolvedVoice = $voice ?? $realtimeProvider->defaultRealtimeVoice();
+            $resolvedTimeout = $this->getTimeout($timeout);
+
+            $tools = $this instanceof HasTools ? [...$this->tools()] : [];
+
+            $prompt = new RealtimePrompt(
+                agent: $this,
+                provider: $realtimeProvider,
+                model: $providerModel,
+                voice: $resolvedVoice,
+                modalities: $options['modalities'] ?? ['text', 'audio'],
+                instructions: (string) $this->instructions(),
+                tools: $tools,
+                options: $options,
+                timeout: $resolvedTimeout,
+            );
+
+            try {
+                return $realtimeProvider->createRealtimeSession($prompt);
+            } catch (FailoverableException $e) {
+                $lastException = $e;
+
+                event(new ProviderFailedOver($realtimeProvider, $providerModel, $e));
+
+                continue;
+            }
+        }
+
+        throw $lastException;
+    }
+
+    /**
+     * Create ephemeral client credentials for the agent.
+     */
+    public function clientCredentials(
+        Lab|array|string|null $provider = null,
+        ?string $model = null,
+        ?string $voice = null,
+        array $options = [],
+        ?int $timeout = null,
+    ): RealtimeSession {
+        return $this->realtime($provider, $model, $voice, $options, $timeout);
     }
 
     /**

--- a/src/Prompts/RealtimePrompt.php
+++ b/src/Prompts/RealtimePrompt.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Ai\Prompts;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\ToolNameResolver;
+
+class RealtimePrompt
+{
+    public readonly Agent $agent;
+
+    public readonly RealtimeProvider $provider;
+
+    public readonly string $model;
+
+    public readonly string $voice;
+
+    public readonly array $modalities;
+
+    public readonly ?string $instructions;
+
+    public readonly array $tools;
+
+    public readonly array $options;
+
+    public readonly int $timeout;
+
+    /**
+     * Create a new realtime prompt instance.
+     */
+    public function __construct(
+        Agent $agent,
+        RealtimeProvider $provider,
+        string $model,
+        string $voice,
+        array $modalities = ['text', 'audio'],
+        ?string $instructions = null,
+        array $tools = [],
+        array $options = [],
+        int $timeout = 30,
+    ) {
+        $this->agent = $agent;
+        $this->provider = $provider;
+        $this->model = $model;
+        $this->voice = $voice;
+        $this->modalities = $modalities;
+        $this->instructions = $instructions ?? (string) $agent->instructions();
+        $this->tools = $tools;
+        $this->options = $options;
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * Determine if the instructions contain the given string.
+     */
+    public function contains(string $string): bool
+    {
+        return Str::contains($this->instructions ?? '', $string);
+    }
+
+    /**
+     * Determine if the prompt contains a specific tool.
+     */
+    public function hasTool(string|Tool $tool): bool
+    {
+        $target = is_string($tool) ? $tool : ToolNameResolver::resolve($tool);
+
+        return (new Collection($this->tools))->contains(function ($t) use ($target): bool {
+            if (is_string($t)) {
+                return $t === $target;
+            }
+
+            if ($t instanceof Tool) {
+                return ToolNameResolver::resolve($t) === $target || $t::class === $target;
+            }
+
+            return false;
+        });
+    }
+}

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -7,11 +7,13 @@ use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
@@ -19,18 +21,21 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiFileGateway;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiGateway;
+use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiRealtimeGateway;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiStoreGateway;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsWebSearch, TextProvider
+class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FileProvider, ImageProvider, RealtimeProvider, StoreProvider, SupportsFileSearch, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;
+    use Concerns\GeneratesRealtimeSessions;
     use Concerns\GeneratesText;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasFileGateway;
     use Concerns\HasImageGateway;
+    use Concerns\HasRealtimeGateway;
     use Concerns\HasStoreGateway;
     use Concerns\HasTextGateway;
     use Concerns\ManagesFiles;
@@ -151,6 +156,30 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FilePro
     public function defaultEmbeddingsDimensions(): int
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 1536;
+    }
+
+    /**
+     * Get the name of the default realtime deployment.
+     */
+    public function defaultRealtimeModel(): string
+    {
+        return $this->config['realtime_deployment'] ?? $this->config['deployment'] ?? 'gpt-4o-realtime';
+    }
+
+    /**
+     * Get the name of the default realtime voice.
+     */
+    public function defaultRealtimeVoice(): string
+    {
+        return $this->config['models']['realtime']['voice'] ?? 'alloy';
+    }
+
+    /**
+     * Get the default realtime gateway.
+     */
+    protected function defaultRealtimeGateway(): RealtimeGateway
+    {
+        return new AzureOpenAiRealtimeGateway;
     }
 
     /**

--- a/src/Providers/Concerns/GeneratesRealtimeSessions.php
+++ b/src/Providers/Concerns/GeneratesRealtimeSessions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Laravel\Ai\Ai;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Responses\RealtimeSession;
+
+trait GeneratesRealtimeSessions
+{
+    /**
+     * Create an ephemeral realtime session.
+     */
+    public function createRealtimeSession(RealtimePrompt $prompt): RealtimeSession
+    {
+        if (Ai::realtimeIsFaked()) {
+            Ai::recordRealtimeSessionCreation($prompt);
+        }
+
+        return $this->realtimeGateway()->createRealtimeSession($this, $prompt);
+    }
+}

--- a/src/Providers/Concerns/HasRealtimeGateway.php
+++ b/src/Providers/Concerns/HasRealtimeGateway.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Ai\Providers\Concerns;
+
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
+
+trait HasRealtimeGateway
+{
+    protected RealtimeGateway $realtimeGateway;
+
+    /**
+     * Get the provider's realtime gateway.
+     */
+    public function realtimeGateway(): RealtimeGateway
+    {
+        return $this->realtimeGateway ?? $this->defaultRealtimeGateway();
+    }
+
+    /**
+     * Set the provider's realtime gateway.
+     */
+    public function useRealtimeGateway(RealtimeGateway $gateway): self
+    {
+        $this->realtimeGateway = $gateway;
+
+        return $this;
+    }
+}

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -4,11 +4,13 @@ namespace Laravel\Ai\Providers;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
+use Laravel\Ai\Contracts\Gateway\RealtimeGateway;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\RealtimeProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsToolSearch;
@@ -17,21 +19,24 @@ use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\OpenAi\OpenAiFileGateway;
+use Laravel\Ai\Gateway\OpenAi\OpenAiRealtimeGateway;
 use Laravel\Ai\Gateway\OpenAi\OpenAiStoreGateway;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsToolSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
+class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, RealtimeProvider, StoreProvider, SupportsFileSearch, SupportsToolSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;
+    use Concerns\GeneratesRealtimeSessions;
     use Concerns\GeneratesText;
     use Concerns\GeneratesTranscriptions;
     use Concerns\HasAudioGateway;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasFileGateway;
     use Concerns\HasImageGateway;
+    use Concerns\HasRealtimeGateway;
     use Concerns\HasStoreGateway;
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
@@ -162,6 +167,30 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     public function defaultEmbeddingsDimensions(): int
     {
         return $this->config['models']['embeddings']['dimensions'] ?? 1536;
+    }
+
+    /**
+     * Get the name of the default realtime model.
+     */
+    public function defaultRealtimeModel(): string
+    {
+        return $this->config['models']['realtime']['default'] ?? 'gpt-4o-realtime-preview';
+    }
+
+    /**
+     * Get the name of the default realtime voice.
+     */
+    public function defaultRealtimeVoice(): string
+    {
+        return $this->config['models']['realtime']['voice'] ?? 'alloy';
+    }
+
+    /**
+     * Get the default realtime gateway.
+     */
+    protected function defaultRealtimeGateway(): RealtimeGateway
+    {
+        return new OpenAiRealtimeGateway;
     }
 
     /**

--- a/src/Realtime.php
+++ b/src/Realtime.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Ai;
+
+use Closure;
+use Laravel\Ai\Gateway\FakeRealtimeGateway;
+
+class Realtime
+{
+    /**
+     * Fake realtime session creation.
+     */
+    public static function fake(Closure|array $responses = []): FakeRealtimeGateway
+    {
+        return Ai::fakeRealtime($responses);
+    }
+
+    /**
+     * Assert that a realtime session was created matching a given truth test.
+     */
+    public static function assertSessionCreated(Closure $callback): void
+    {
+        Ai::assertRealtimeSessionCreated($callback);
+    }
+
+    /**
+     * Assert that a realtime session was not created matching a given truth test.
+     */
+    public static function assertSessionNotCreated(Closure $callback): void
+    {
+        Ai::assertRealtimeSessionNotCreated($callback);
+    }
+
+    /**
+     * Assert that no realtime sessions were created.
+     */
+    public static function assertNothingCreated(): void
+    {
+        Ai::assertNoRealtimeSessionCreated();
+    }
+
+    /**
+     * Determine if realtime session creation is faked.
+     */
+    public static function isFaked(): bool
+    {
+        return Ai::realtimeIsFaked();
+    }
+}

--- a/src/Responses/RealtimeSession.php
+++ b/src/Responses/RealtimeSession.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+use Laravel\Ai\Responses\Data\Meta;
+
+class RealtimeSession implements Arrayable, JsonSerializable
+{
+    /**
+     * Create a new realtime session instance.
+     */
+    public function __construct(
+        public string $id,
+        public string $clientSecret,
+        public int $expiresAt,
+        public string $model,
+        public Meta $meta,
+        public ?string $voice = null,
+        public array $modalities = ['text', 'audio'],
+        public array $raw = [],
+    ) {
+        //
+    }
+
+    /**
+     * Get the session ID.
+     */
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the ephemeral client secret (token).
+     */
+    public function clientSecret(): string
+    {
+        return $this->clientSecret;
+    }
+
+    /**
+     * Get the expiration timestamp of the client secret.
+     */
+    public function expiresAt(): int
+    {
+        return $this->expiresAt;
+    }
+
+    /**
+     * Get the model configured for the session.
+     */
+    public function model(): string
+    {
+        return $this->model;
+    }
+
+    /**
+     * Get the voice configured for the session.
+     */
+    public function voice(): ?string
+    {
+        return $this->voice;
+    }
+
+    /**
+     * Get the modalities enabled for the session.
+     */
+    public function modalities(): array
+    {
+        return $this->modalities;
+    }
+
+    /**
+     * Get the raw provider response.
+     */
+    public function raw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * Convert the session to an array.
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'client_secret' => $this->clientSecret,
+            'expires_at' => $this->expiresAt,
+            'model' => $this->model,
+            'voice' => $this->voice,
+            'modalities' => $this->modalities,
+        ];
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/tests/Feature/AgentRealtimeTest.php
+++ b/tests/Feature/AgentRealtimeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Realtime;
+use Laravel\Ai\Responses\RealtimeSession;
+use Laravel\Ai\Tools\Request;
+
+use function Laravel\Ai\agent;
+
+class DummyRealtimeTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'A dummy tool for search';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        return 'search result';
+    }
+
+    public function schema($factory): array
+    {
+        return [
+            'query' => $factory->string()->description('The search query'),
+        ];
+    }
+}
+
+test('agent can create realtime session and alias clientCredentials', function (): void {
+    Realtime::fake();
+
+    $agent = agent(
+        instructions: 'You are a customer service assistant',
+        tools: [new DummyRealtimeTool],
+    );
+
+    $session1 = $agent->realtime(
+        voice: 'alloy',
+        options: ['temperature' => 0.6],
+    );
+
+    expect($session1)->toBeInstanceOf(RealtimeSession::class);
+
+    Realtime::assertSessionCreated(function (RealtimePrompt $prompt): bool {
+        return $prompt->contains('You are a customer service assistant')
+            && $prompt->voice === 'alloy'
+            && $prompt->options['temperature'] === 0.6
+            && $prompt->hasTool('DummyRealtimeTool');
+    });
+
+    $session2 = $agent->clientCredentials(
+        voice: 'echo',
+    );
+
+    expect($session2)->toBeInstanceOf(RealtimeSession::class);
+
+    Realtime::assertSessionCreated(function (RealtimePrompt $prompt): bool {
+        return $prompt->voice === 'echo';
+    });
+});

--- a/tests/Feature/Providers/AzureOpenAi/RealtimeTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/RealtimeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Responses\RealtimeSession;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function (): void {
+    config(['ai.providers.azure' => [
+        ...config('ai.providers.azure'),
+        'key' => 'azure-test-key',
+        'url' => 'https://test-azure.openai.azure.com',
+        'realtime_deployment' => 'my-realtime-deployment',
+    ]]);
+});
+
+function fakeAzureRealtimeSessionResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'sess_azure_98765',
+        'object' => 'realtime.session',
+        'model' => 'my-realtime-deployment',
+        'modalities' => ['text', 'audio'],
+        'instructions' => 'You are an Azure support agent.',
+        'voice' => 'alloy',
+        'client_secret' => [
+            'value' => 'ek_azure_secret_789',
+            'expires_at' => 1795000000,
+        ],
+    ]);
+}
+
+test('azure realtime session sends request with api-key and deployment', function (): void {
+    Http::fake(['*' => fakeAzureRealtimeSessionResponse()]);
+
+    $agent = agent(instructions: 'You are an Azure support agent.');
+
+    $session = $agent->realtime(
+        provider: 'azure',
+        voice: 'alloy',
+    );
+
+    expect($session)->toBeInstanceOf(RealtimeSession::class)
+        ->and($session->id())->toBe('sess_azure_98765')
+        ->and($session->clientSecret())->toBe('ek_azure_secret_789')
+        ->and($session->expiresAt())->toBe(1795000000)
+        ->and($session->model())->toBe('my-realtime-deployment')
+        ->and($session->meta->provider)->toBe('azure');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://test-azure.openai.azure.com/openai/v1/realtime/sessions'
+            && $request->hasHeader('api-key', 'azure-test-key')
+            && $body['model'] === 'my-realtime-deployment'
+            && $body['instructions'] === 'You are an Azure support agent.';
+    });
+});

--- a/tests/Feature/Providers/AzureOpenAi/RealtimeTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/RealtimeTest.php
@@ -20,14 +20,19 @@ function fakeAzureRealtimeSessionResponse(): PromiseInterface
 {
     return Http::response([
         'id' => 'sess_azure_98765',
-        'object' => 'realtime.session',
-        'model' => 'my-realtime-deployment',
-        'modalities' => ['text', 'audio'],
-        'instructions' => 'You are an Azure support agent.',
-        'voice' => 'alloy',
-        'client_secret' => [
-            'value' => 'ek_azure_secret_789',
-            'expires_at' => 1795000000,
+        'object' => 'realtime.client_secret',
+        'value' => 'ek_azure_secret_789',
+        'expires_at' => 1795000000,
+        'session' => [
+            'type' => 'realtime',
+            'model' => 'my-realtime-deployment',
+            'modalities' => ['text', 'audio'],
+            'instructions' => 'You are an Azure support agent.',
+            'audio' => [
+                'output' => [
+                    'voice' => 'alloy',
+                ],
+            ],
         ],
     ]);
 }
@@ -51,10 +56,12 @@ test('azure realtime session sends request with api-key and deployment', functio
 
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);
+        $session = $body['session'] ?? [];
 
-        return $request->url() === 'https://test-azure.openai.azure.com/openai/v1/realtime/sessions'
+        return $request->url() === 'https://test-azure.openai.azure.com/openai/v1/realtime/client_secrets'
             && $request->hasHeader('api-key', 'azure-test-key')
-            && $body['model'] === 'my-realtime-deployment'
-            && $body['instructions'] === 'You are an Azure support agent.';
+            && $session['type'] === 'realtime'
+            && $session['model'] === 'my-realtime-deployment'
+            && $session['instructions'] === 'You are an Azure support agent.';
     });
 });

--- a/tests/Feature/Providers/OpenAi/RealtimeTest.php
+++ b/tests/Feature/Providers/OpenAi/RealtimeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Responses\RealtimeSession;
+use Laravel\Ai\Tools\Request as ToolRequest;
+
+use function Laravel\Ai\agent;
+
+beforeEach(function (): void {
+    config(['ai.providers.openai' => [
+        ...config('ai.providers.openai'),
+        'key' => 'test-key',
+    ]]);
+});
+
+function fakeOpenAiRealtimeSessionResponse(): PromiseInterface
+{
+    return Http::response([
+        'id' => 'sess_test_12345',
+        'object' => 'realtime.session',
+        'model' => 'gpt-4o-realtime-preview',
+        'modalities' => ['text', 'audio'],
+        'instructions' => 'You are a helpful assistant.',
+        'voice' => 'alloy',
+        'input_audio_format' => 'pcm16',
+        'output_audio_format' => 'pcm16',
+        'turn_detection' => [
+            'type' => 'server_vad',
+            'threshold' => 0.5,
+        ],
+        'client_secret' => [
+            'value' => 'ek_secret_abc123',
+            'expires_at' => 1790000000,
+        ],
+    ]);
+}
+
+class TestSearchTool implements Tool
+{
+    public function description(): Stringable|string
+    {
+        return 'Search database';
+    }
+
+    public function handle(ToolRequest $request): Stringable|string
+    {
+        return 'database result';
+    }
+
+    public function schema($factory): array
+    {
+        return [
+            'query' => $factory->string()->description('Search query term'),
+        ];
+    }
+}
+
+test('openai realtime session sends request with model, voice, instructions, and tools', function (): void {
+    Http::fake(['*' => fakeOpenAiRealtimeSessionResponse()]);
+
+    $agent = agent(
+        instructions: 'You are a support assistant.',
+        tools: [new TestSearchTool],
+    );
+
+    $session = $agent->realtime(
+        provider: 'openai',
+        model: 'gpt-4o-realtime-preview',
+        voice: 'alloy',
+        options: [
+            'turn_detection' => ['type' => 'server_vad'],
+        ],
+    );
+
+    expect($session)->toBeInstanceOf(RealtimeSession::class)
+        ->and($session->id())->toBe('sess_test_12345')
+        ->and($session->clientSecret())->toBe('ek_secret_abc123')
+        ->and($session->expiresAt())->toBe(1790000000)
+        ->and($session->model())->toBe('gpt-4o-realtime-preview')
+        ->and($session->voice())->toBe('alloy');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.openai.com/v1/realtime/sessions'
+            && $request->hasHeader('Authorization', 'Bearer test-key')
+            && $body['model'] === 'gpt-4o-realtime-preview'
+            && $body['voice'] === 'alloy'
+            && $body['instructions'] === 'You are a support assistant.'
+            && $body['turn_detection'] === ['type' => 'server_vad']
+            && count($body['tools']) === 1
+            && $body['tools'][0]['name'] === 'TestSearchTool'
+            && $body['tools'][0]['description'] === 'Search database';
+    });
+});
+
+test('openai realtime session maps default-female and default-male voices', function (): void {
+    Http::fake(['*' => fakeOpenAiRealtimeSessionResponse()]);
+
+    $agent = agent(instructions: 'Voice check');
+
+    $agent->realtime(provider: 'openai', voice: 'default-female');
+    Http::assertSent(fn (Request $req) => json_decode($req->body(), true)['voice'] === 'alloy');
+
+    $agent->realtime(provider: 'openai', voice: 'default-male');
+    Http::assertSent(fn (Request $req) => json_decode($req->body(), true)['voice'] === 'ash');
+});

--- a/tests/Feature/Providers/OpenAi/RealtimeTest.php
+++ b/tests/Feature/Providers/OpenAi/RealtimeTest.php
@@ -20,20 +20,19 @@ function fakeOpenAiRealtimeSessionResponse(): PromiseInterface
 {
     return Http::response([
         'id' => 'sess_test_12345',
-        'object' => 'realtime.session',
-        'model' => 'gpt-4o-realtime-preview',
-        'modalities' => ['text', 'audio'],
-        'instructions' => 'You are a helpful assistant.',
-        'voice' => 'alloy',
-        'input_audio_format' => 'pcm16',
-        'output_audio_format' => 'pcm16',
-        'turn_detection' => [
-            'type' => 'server_vad',
-            'threshold' => 0.5,
-        ],
-        'client_secret' => [
-            'value' => 'ek_secret_abc123',
-            'expires_at' => 1790000000,
+        'object' => 'realtime.client_secret',
+        'value' => 'ek_secret_abc123',
+        'expires_at' => 1790000000,
+        'session' => [
+            'type' => 'realtime',
+            'model' => 'gpt-4o-realtime-preview',
+            'modalities' => ['text', 'audio'],
+            'instructions' => 'You are a helpful assistant.',
+            'audio' => [
+                'output' => [
+                    'voice' => 'alloy',
+                ],
+            ],
         ],
     ]);
 }
@@ -84,16 +83,18 @@ test('openai realtime session sends request with model, voice, instructions, and
 
     Http::assertSent(function (Request $request): bool {
         $body = json_decode($request->body(), true);
+        $session = $body['session'] ?? [];
 
-        return $request->url() === 'https://api.openai.com/v1/realtime/sessions'
+        return $request->url() === 'https://api.openai.com/v1/realtime/client_secrets'
             && $request->hasHeader('Authorization', 'Bearer test-key')
-            && $body['model'] === 'gpt-4o-realtime-preview'
-            && $body['voice'] === 'alloy'
-            && $body['instructions'] === 'You are a support assistant.'
-            && $body['turn_detection'] === ['type' => 'server_vad']
-            && count($body['tools']) === 1
-            && $body['tools'][0]['name'] === 'TestSearchTool'
-            && $body['tools'][0]['description'] === 'Search database';
+            && $session['type'] === 'realtime'
+            && $session['model'] === 'gpt-4o-realtime-preview'
+            && $session['audio']['output']['voice'] === 'alloy'
+            && $session['instructions'] === 'You are a support assistant.'
+            && $session['audio']['input']['turn_detection'] === ['type' => 'server_vad']
+            && count($session['tools']) === 1
+            && $session['tools'][0]['name'] === 'TestSearchTool'
+            && $session['tools'][0]['description'] === 'Search database';
     });
 });
 
@@ -103,8 +104,8 @@ test('openai realtime session maps default-female and default-male voices', func
     $agent = agent(instructions: 'Voice check');
 
     $agent->realtime(provider: 'openai', voice: 'default-female');
-    Http::assertSent(fn (Request $req) => json_decode($req->body(), true)['voice'] === 'alloy');
+    Http::assertSent(fn (Request $req) => (json_decode($req->body(), true)['session']['audio']['output']['voice'] ?? null) === 'alloy');
 
     $agent->realtime(provider: 'openai', voice: 'default-male');
-    Http::assertSent(fn (Request $req) => json_decode($req->body(), true)['voice'] === 'ash');
+    Http::assertSent(fn (Request $req) => (json_decode($req->body(), true)['session']['audio']['output']['voice'] ?? null) === 'ash');
 });

--- a/tests/Feature/RealtimeFakeTest.php
+++ b/tests/Feature/RealtimeFakeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Laravel\Ai\Prompts\RealtimePrompt;
+use Laravel\Ai\Realtime;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\RealtimeSession;
+
+use function Laravel\Ai\agent;
+
+test('realtime session can be faked with default response', function (): void {
+    Realtime::fake();
+
+    $session = agent(instructions: 'You are a support bot')->realtime();
+
+    expect($session)->toBeInstanceOf(RealtimeSession::class)
+        ->and($session->id())->toStartWith('sess_fake_')
+        ->and($session->clientSecret())->toStartWith('ek_fake_')
+        ->and($session->expiresAt())->toBeGreaterThan(time());
+
+    Realtime::assertSessionCreated(fn (RealtimePrompt $prompt) => $prompt->contains('You are a support bot'));
+});
+
+test('realtime session can be faked with custom array responses', function (): void {
+    Realtime::fake([
+        [
+            'id' => 'sess_custom_1',
+            'client_secret' => 'ek_custom_secret_1',
+            'expires_at' => 1790000000,
+            'model' => 'gpt-4o-realtime-preview',
+            'voice' => 'alloy',
+        ],
+        new RealtimeSession(
+            id: 'sess_custom_2',
+            clientSecret: 'ek_custom_secret_2',
+            expiresAt: 1790000001,
+            model: 'gpt-4o-realtime-preview',
+            meta: new Meta('openai', 'gpt-4o-realtime-preview'),
+            voice: 'verse',
+        ),
+    ]);
+
+    $session1 = agent(instructions: 'First agent')->realtime();
+    expect($session1->id())->toBe('sess_custom_1')
+        ->and($session1->clientSecret())->toBe('ek_custom_secret_1');
+
+    $session2 = agent(instructions: 'Second agent')->realtime();
+    expect($session2->id())->toBe('sess_custom_2')
+        ->and($session2->voice())->toBe('verse');
+
+    Realtime::assertSessionCreated(fn (RealtimePrompt $p) => $p->contains('First agent'));
+    Realtime::assertSessionCreated(fn (RealtimePrompt $p) => $p->contains('Second agent'));
+    Realtime::assertSessionNotCreated(fn (RealtimePrompt $p) => $p->contains('Third agent'));
+});
+
+test('realtime session can be faked with a closure', function (): void {
+    Realtime::fake(function (RealtimePrompt $prompt): array {
+        return [
+            'id' => 'sess_dynamic_'.$prompt->voice,
+            'client_secret' => 'ek_secret_'.$prompt->voice,
+            'expires_at' => 1790000000,
+            'voice' => $prompt->voice,
+        ];
+    });
+
+    $session = agent(instructions: 'Voice test')->realtime(voice: 'marin');
+
+    expect($session->id())->toBe('sess_dynamic_marin')
+        ->and($session->clientSecret())->toBe('ek_secret_marin')
+        ->and($session->voice())->toBe('marin');
+});
+
+test('can assert no realtime sessions were created', function (): void {
+    Realtime::fake();
+
+    Realtime::assertNothingCreated();
+});
+
+test('realtime session creation can prevent stray requests', function (): void {
+    Realtime::fake()->preventStrayRealtime();
+
+    agent(instructions: 'Unfaked agent')->realtime();
+})->throws(RuntimeException::class, 'Attempted realtime session creation without a fake response.');
+
+test('realtime session serializes to array and json', function (): void {
+    $session = new RealtimeSession(
+        id: 'sess_123',
+        clientSecret: 'ek_secret_123',
+        expiresAt: 1790000000,
+        model: 'gpt-4o-realtime-preview',
+        meta: new Meta('openai', 'gpt-4o-realtime-preview'),
+        voice: 'alloy',
+        modalities: ['text', 'audio'],
+    );
+
+    expect($session->toArray())->toEqual([
+        'id' => 'sess_123',
+        'client_secret' => 'ek_secret_123',
+        'expires_at' => 1790000000,
+        'model' => 'gpt-4o-realtime-preview',
+        'voice' => 'alloy',
+        'modalities' => ['text', 'audio'],
+    ]);
+
+    expect(json_encode($session))->toBe(json_encode($session->toArray()));
+});


### PR DESCRIPTION
This pull request adds support for long-lived, bidirectional **Realtime sessions** (for speech-to-speech voice agents, real-time transcription, translation, and WebRTC streaming) to Laravel AI, addressing #928.

### Motivation
Laravel AI previously supported request-response generation and one-way SSE streaming, but lacked an abstraction for long-lived Realtime sessions offered by providers like OpenAI and Azure OpenAI.

Instead of proxying high-bandwidth media streams through PHP, Laravel acts as the secure **session broker & ephemeral credential minter**. The backend securely resolves the agent's instructions, voice configurations, and tool schemas using the master API keys, and mints short-lived client credentials that browsers or mobile clients use to connect directly to the provider via WebRTC.

### Usage

#### 1. Creating Realtime Sessions from Agents
```php
use App\Ai\Tools\CheckOrderStatus;
use function Laravel\Ai\agent;

$agent = agent(
    instructions: 'You are a friendly voice support assistant.',
    tools: [new CheckOrderStatus],
);

// Generates short-lived credentials for client WebRTC connection
$session = $agent->realtime(
    provider: 'openai', // or 'azure'
    model: 'gpt-4o-realtime-preview',
    voice: 'alloy',
    options: [
        'turn_detection' => ['type' => 'server_vad'],
        'temperature' => 0.7,
    ],
);

return response()->json([
    'client_secret' => $session->clientSecret(),
    'expires_at'    => $session->expiresAt(),
    'session_id'    => $session->id(),
]);
```

#### 2. Alternative Syntax: `clientCredentials()`
```php
$credentials = $agent->clientCredentials(
    provider: 'azure',
    model: 'my-realtime-deployment',
    voice: 'marin',
);

return [
    'token'      => $credentials->clientSecret(),
    'expires_at' => $credentials->expiresAt(),
];
```

#### 3. Testing with Fakes & Assertions
```php
use Laravel\Ai\Prompts\RealtimePrompt;
use Laravel\Ai\Realtime;

Realtime::fake();

$agent->realtime(voice: 'alloy');

Realtime::assertSessionCreated(fn (RealtimePrompt $prompt) => $prompt->voice === 'alloy');
```

### Breaking Changes
None. This is purely additive to the `0.x` branch.
