### PR TITLE
Throw when array-backed fake gateways run out of scripted responses

### DIFF
--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -167,6 +167,17 @@ class FakeTextGateway implements TextGateway
      */
     protected function nextResponse(TextProvider $provider, string $model, string $prompt, Collection $attachments, ?array $schema): mixed
     {
+        if (is_array($this->responses)
+            && $this->responses !== []
+            && ! array_key_exists($this->currentResponseIndex, $this->responses)) {
+            throw new RuntimeException(sprintf(
+                'Fake agent responses exhausted: [%d] response(s) were supplied but response [%d] was requested. '
+                .'Add the missing responses, or pass a Closure to answer every call.',
+                count($this->responses),
+                $this->currentResponseIndex,
+            ));
+        }
+
         $response = is_array($this->responses)
             ? ($this->responses[$this->currentResponseIndex] ?? null)
             : call_user_func($this->responses, $prompt, $attachments, $provider, $model);


### PR DESCRIPTION
Scripting fewer fake responses than a code path actually consumes gives you generated data instead of a failure. An array of responses is a finite script, but an exhausted script reads as `null`, and `null` is the same sentinel the fakes use for "nothing was faked". So the fake falls through to generating a value, and for a structured agent that value is random:

```php
StructuredAgent::fake([['symbol' => 'Au']]);

(new StructuredAgent)->prompt('Gold');   // ['symbol' => 'Au']
(new StructuredAgent)->prompt('Silver'); // ['symbol' => 'kQ8mZ2p'], generated by Str::random()
```

That second call is the problem. The assertion fails against a random value with nothing pointing at the fake, or it passes because the generated value happened not to collide with the field under test. We chased this through two subsystems before finding it here.

A non-empty script now throws once it runs dry:

```
Fake agent responses exhausted: [1] response(s) were supplied but call [2] was made.
Add the missing responses, or pass a Closure to answer every call.
```

Script every call, or hand over a closure when the call count is not fixed:

```php
StructuredAgent::fake([['symbol' => 'Au'], ['symbol' => 'Ag']]);

// Answers any number of calls.
StructuredAgent::fake(fn ($prompt) => ['symbol' => str_contains($prompt, 'Gold') ? 'Au' : 'Ag']);
```

An empty array still generates, so `Ai::fakeAgent('X')` with no responses behaves as before and the `preventStray*` guards keep covering the never-faked case. Closures stay repeatable, which is now the documented way to answer an unbounded number of calls.

This is the same contract `Http::fake()` already has, where an exhausted `ResponseSequence` throws unless you opt into `whenEmpty()`.

One warning for anyone upgrading. Suites that under-script a fake will start failing where they previously passed against generated data. Faked tool calls are the case most likely to surface, because a faked `ToolCall` consumes one entry and the follow-up answer consumes another, so a single-entry script is now one short.

Every fake gateway gets an exhaustion test asserting the message, and streaming has its own. The existing tests for empty fakes and closure fakes pin the paths that did not change.
