### PR TITLE
Throw when array-backed fake gateways run out of scripted responses

### DIFF
--- a/resources/boost/skills/ai-sdk-development/SKILL.md
+++ b/resources/boost/skills/ai-sdk-development/SKILL.md
@@ -487,7 +487,7 @@ Calling a capability not supported by a provider throws a `LogicException`. Refe
 | ---------- | --------------------------------------------------------------- |
 | Text       | OpenAI, Anthropic, Gemini, Azure, Groq, xAI, DeepSeek, Mistral, Ollama, OpenRouter, OpenAI-compatible |
 | Images     | OpenAI, Gemini, xAI                                            |
-| TTS        | OpenAI, ElevenLabs                                              |
+| TTS        | OpenAI, ElevenLabs, Mistral                                     |
 | STT        | OpenAI, ElevenLabs, Mistral, Groq, OpenAI-compatible            |
 | Embeddings | OpenAI, OpenAI-compatible, Gemini, Azure, Cohere, Mistral, Jina, VoyageAI |
 | Reranking  | Cohere, Jina                                                    |

--- a/src/Gateway/Concerns/ScriptsFakeResponses.php
+++ b/src/Gateway/Concerns/ScriptsFakeResponses.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+use RuntimeException;
+
+trait ScriptsFakeResponses
+{
+    protected int $currentResponseIndex = 0;
+
+    /**
+     * Get the next scripted response, or null when the fake was given no script.
+     *
+     * @throws RuntimeException if a non-empty script has already been consumed.
+     */
+    protected function nextScriptedResponse(mixed ...$arguments): mixed
+    {
+        $index = $this->currentResponseIndex++;
+
+        if (! is_array($this->responses)) {
+            return call_user_func($this->responses, ...$arguments);
+        }
+
+        $responses = array_values($this->responses);
+
+        if ($responses === []) {
+            return null;
+        }
+
+        if ($index >= count($responses)) {
+            throw new RuntimeException(sprintf(
+                'Fake %s responses exhausted: [%d] response(s) were supplied but call [%d] was made. '
+                .'Add the missing responses, or pass a Closure to answer every call.',
+                $this->scriptNoun,
+                count($responses),
+                $index + 1,
+            ));
+        }
+
+        return $responses[$index];
+    }
+}

--- a/src/Gateway/FakeAudioGateway.php
+++ b/src/Gateway/FakeAudioGateway.php
@@ -5,6 +5,7 @@ namespace Laravel\Ai\Gateway;
 use Closure;
 use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Providers\AudioProvider;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Prompts\AudioPrompt;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\Meta;
@@ -12,7 +13,9 @@ use RuntimeException;
 
 class FakeAudioGateway implements AudioGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'audio';
 
     protected bool $preventStrayGenerations = false;
 
@@ -41,13 +44,11 @@ class FakeAudioGateway implements AudioGateway
      */
     protected function nextResponse(AudioProvider $provider, string $model, AudioPrompt $prompt): AudioResponse
     {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $prompt);
+        $response = $this->nextScriptedResponse($prompt);
 
-        return tap($this->marshalResponse(
+        return $this->marshalResponse(
             $response, $provider, $model, $prompt
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeEmbeddingGateway.php
+++ b/src/Gateway/FakeEmbeddingGateway.php
@@ -6,6 +6,7 @@ use Closure;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Embeddings;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Prompts\EmbeddingsPrompt;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\EmbeddingsResponse;
@@ -13,7 +14,9 @@ use RuntimeException;
 
 class FakeEmbeddingGateway implements EmbeddingGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'embedding';
 
     protected bool $preventStrayGenerations = false;
 
@@ -48,13 +51,11 @@ class FakeEmbeddingGateway implements EmbeddingGateway
         string $model,
         EmbeddingsPrompt $prompt
     ): EmbeddingsResponse {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $prompt);
+        $response = $this->nextScriptedResponse($prompt);
 
-        return tap($this->marshalResponse(
+        return $this->marshalResponse(
             $response, $provider, $model, $prompt
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeFileGateway.php
+++ b/src/Gateway/FakeFileGateway.php
@@ -7,13 +7,16 @@ use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Files;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Responses\FileResponse;
 use Laravel\Ai\Responses\StoredFileResponse;
 use RuntimeException;
 
 class FakeFileGateway implements FileGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'file';
 
     protected bool $preventStrayOperations = false;
 
@@ -34,13 +37,11 @@ class FakeFileGateway implements FileGateway
      */
     protected function nextGetResponse(string $fileId): FileResponse
     {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $fileId);
+        $response = $this->nextScriptedResponse($fileId);
 
-        return tap($this->marshalGetResponse(
+        return $this->marshalGetResponse(
             $response, $fileId
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeImageGateway.php
+++ b/src/Gateway/FakeImageGateway.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Files\Image;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Prompts\ImagePrompt;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
@@ -16,7 +17,9 @@ use RuntimeException;
 
 class FakeImageGateway implements ImageGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'image';
 
     protected bool $preventStrayGenerations = false;
 
@@ -49,13 +52,11 @@ class FakeImageGateway implements ImageGateway
      */
     protected function nextResponse(ImageProvider $provider, string $model, ImagePrompt $prompt): ImageResponse
     {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $prompt);
+        $response = $this->nextScriptedResponse($prompt);
 
-        return tap($this->marshalResponse(
+        return $this->marshalResponse(
             $response, $provider, $model, $prompt
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeRerankingGateway.php
+++ b/src/Gateway/FakeRerankingGateway.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Arr;
 use Laravel\Ai\Contracts\Gateway\RerankingGateway;
 use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Prompts\RerankingPrompt;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\RankedDocument;
@@ -14,7 +15,9 @@ use RuntimeException;
 
 class FakeRerankingGateway implements RerankingGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'reranking';
 
     protected bool $preventStrayRerankings = false;
 
@@ -47,13 +50,11 @@ class FakeRerankingGateway implements RerankingGateway
         string $model,
         RerankingPrompt $prompt
     ): RerankingResponse {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $prompt);
+        $response = $this->nextScriptedResponse($prompt);
 
-        return tap($this->marshalResponse(
+        return $this->marshalResponse(
             $response, $provider, $model, $prompt
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeStoreGateway.php
+++ b/src/Gateway/FakeStoreGateway.php
@@ -7,6 +7,7 @@ use DateInterval;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Gateway\StoreGateway;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Responses\Data\StoreFileCounts;
 use Laravel\Ai\Store;
 use Laravel\Ai\Stores;
@@ -14,7 +15,9 @@ use RuntimeException;
 
 class FakeStoreGateway implements StoreGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'store';
 
     protected bool $preventStrayOperations = false;
 
@@ -35,13 +38,11 @@ class FakeStoreGateway implements StoreGateway
      */
     protected function nextGetResponse(StoreProvider $provider, string $storeId): Store
     {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $storeId);
+        $response = $this->nextScriptedResponse($storeId);
 
-        return tap($this->marshalGetResponse(
+        return $this->marshalGetResponse(
             $provider, $response, $storeId
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -154,6 +154,17 @@ class FakeTextGateway implements StepTextGateway
      */
     protected function nextResponse(TextProvider $provider, string $model, string $prompt, Collection $attachments, ?array $schema): mixed
     {
+        if (is_array($this->responses)
+            && $this->responses !== []
+            && ! array_key_exists($this->currentResponseIndex, $this->responses)) {
+            throw new RuntimeException(sprintf(
+                'Fake agent responses exhausted: [%d] response(s) were supplied but response [%d] was requested. '
+                .'Add the missing responses, or pass a Closure to answer every call.',
+                count($this->responses),
+                $this->currentResponseIndex,
+            ));
+        }
+
         $response = is_array($this->responses)
             ? ($this->responses[$this->currentResponseIndex] ?? null)
             : call_user_func($this->responses, $prompt, $attachments, $provider, $model);

--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
@@ -29,7 +30,9 @@ use function Laravel\Ai\ulid;
 
 class FakeTextGateway implements StepTextGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'agent';
 
     protected bool $preventStrayPrompts = false;
 
@@ -154,24 +157,11 @@ class FakeTextGateway implements StepTextGateway
      */
     protected function nextResponse(TextProvider $provider, string $model, string $prompt, Collection $attachments, ?array $schema): mixed
     {
-        if (is_array($this->responses)
-            && $this->responses !== []
-            && ! array_key_exists($this->currentResponseIndex, $this->responses)) {
-            throw new RuntimeException(sprintf(
-                'Fake agent responses exhausted: [%d] response(s) were supplied but response [%d] was requested. '
-                .'Add the missing responses, or pass a Closure to answer every call.',
-                count($this->responses),
-                $this->currentResponseIndex,
-            ));
-        }
+        $response = $this->nextScriptedResponse($prompt, $attachments, $provider, $model);
 
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $prompt, $attachments, $provider, $model);
-
-        return tap($this->marshalResponse(
+        return $this->marshalResponse(
             $response, $provider, $model, $prompt, $attachments, $schema
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/FakeTranscriptionGateway.php
+++ b/src/Gateway/FakeTranscriptionGateway.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Gateway\Concerns\ScriptsFakeResponses;
 use Laravel\Ai\Prompts\TranscriptionPrompt;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
@@ -16,7 +17,9 @@ use RuntimeException;
 
 class FakeTranscriptionGateway implements TranscriptionGateway
 {
-    protected int $currentResponseIndex = 0;
+    use ScriptsFakeResponses;
+
+    protected string $scriptNoun = 'transcription';
 
     protected bool $preventStrayGenerations = false;
 
@@ -48,13 +51,11 @@ class FakeTranscriptionGateway implements TranscriptionGateway
      */
     protected function nextResponse(TranscriptionProvider $provider, string $model, TranscriptionPrompt $prompt): TranscriptionResponse
     {
-        $response = is_array($this->responses)
-            ? ($this->responses[$this->currentResponseIndex] ?? null)
-            : call_user_func($this->responses, $prompt);
+        $response = $this->nextScriptedResponse($prompt);
 
-        return tap($this->marshalResponse(
+        return $this->marshalResponse(
             $response, $provider, $model, $prompt
-        ), fn (): int => $this->currentResponseIndex++);
+        );
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -43,6 +43,7 @@ trait HandlesTextStreaming
         $modelParts = [];
         $usage = null;
         $data = [];
+        $citationData = [];
 
         foreach ($this->parseServerSentEvents($streamBody) as $data) {
             if (isset($data['error'])) {
@@ -70,6 +71,11 @@ trait HandlesTextStreaming
 
             $candidate = $data['candidates'][0] ?? [];
             $parts = $candidate['content']['parts'] ?? [];
+
+            // Citation metadata may arrive on any chunk, not necessarily the last...
+            if (isset($candidate['groundingMetadata']) || isset($candidate['citationMetadata'])) {
+                $citationData = $data;
+            }
 
             foreach ($parts as $part) {
                 if (isset($part['text']) && $this->isThinkingPart($part)) {
@@ -186,8 +192,8 @@ trait HandlesTextStreaming
             }
         }
 
-        // Emit citations from the grounding metadata on the final chunk...
-        foreach ($this->extractCitations($data) as $citation) {
+        // Emit citations from the last chunk that carried citation metadata...
+        foreach ($this->extractCitations($citationData) as $citation) {
             yield (new CitationEvent(
                 $this->generateEventId(),
                 $messageId,

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -8,6 +8,7 @@ use Laravel\Ai\Gateway\StepResponse;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
@@ -183,6 +184,16 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
             }
+        }
+
+        // Emit citations from the grounding metadata on the final chunk...
+        foreach ($this->extractCitations($data) as $citation) {
+            yield (new CitationEvent(
+                $this->generateEventId(),
+                $messageId,
+                $citation,
+                time(),
+            ))->withInvocationId($invocationId);
         }
 
         return new StepResponse(

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -42,8 +42,8 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
      */
     protected function overloadedStatusCodes(): array
     {
-        // 498 is Groq's "flex tier capacity exceeded" status, plus the shared transient gateway and Cloudflare codes.
-        return [498, 502, 503, 504, 520, 522, 524];
+        // The status codes Groq documents as transient: 498 is "flex tier capacity exceeded", alongside 502 and 503.
+        return [498, 502, 503];
     }
 
     /**

--- a/src/Gateway/Groq/GroqGateway.php
+++ b/src/Gateway/Groq/GroqGateway.php
@@ -36,6 +36,17 @@ class GroqGateway implements StepTextGateway, TranscriptionGateway
     public function __construct(protected Dispatcher $events) {}
 
     /**
+     * The status codes that indicate Groq is transiently unavailable and the request should fail over.
+     *
+     * @return list<int>
+     */
+    protected function overloadedStatusCodes(): array
+    {
+        // 498 is Groq's "flex tier capacity exceeded" status, plus the shared transient gateway and Cloudflare codes.
+        return [498, 502, 503, 504, 520, 522, 524];
+    }
+
+    /**
      * Generate text from the given audio.
      *
      * @param  array<string, mixed>  $providerOptions

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -4,9 +4,11 @@ namespace Laravel\Ai\Gateway\Mistral;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Ai\Contracts\Files\TranscribableAudio;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
@@ -18,13 +20,15 @@ use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
 use Laravel\Ai\Gateway\StepContext;
 use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\TranscriptionSegment;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\EmbeddingsResponse;
 use Laravel\Ai\Responses\TranscriptionResponse;
+use RuntimeException;
 
-class MistralGateway implements EmbeddingGateway, StepTextGateway, TranscriptionGateway
+class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway, TranscriptionGateway
 {
     use Concerns\BuildsTextRequests;
     use Concerns\CreatesMistralClient;
@@ -57,6 +61,46 @@ class MistralGateway implements EmbeddingGateway, StepTextGateway, Transcription
         StepContext $stepContext,
     ): array {
         return $this->buildTextRequestBody($provider, $model, $instructions, $messages, $tools, $schema, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateAudio(
+        AudioProvider $provider,
+        string $model,
+        string $text,
+        string $voice,
+        ?string $instructions = null,
+        int $timeout = 30,
+    ): AudioResponse {
+        $voice = match ($voice) {
+            'default-male' => 'en_paul_neutral',
+            'default-female' => 'gb_jane_neutral',
+            default => $voice,
+        };
+
+        $response = $this->withErrorHandling(
+            $provider->name(),
+            fn () => $this->client($provider, $timeout)->post('audio/speech', [
+                'model' => $model,
+                'input' => $text,
+                'voice_id' => $voice,
+                'response_format' => 'mp3',
+            ]),
+        );
+
+        $encodedAudio = $response->json('audio_data');
+
+        if (! is_string($encodedAudio) || $encodedAudio === '') {
+            throw new RuntimeException('No audio data received from Mistral API.');
+        }
+
+        return new AudioResponse(
+            $encodedAudio,
+            new Meta($provider->name(), $model),
+            'audio/mpeg',
+        );
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
@@ -276,6 +277,15 @@ trait HandlesTextStreaming
                     $responseUsage['input_tokens_details']['cached_tokens'] ?? 0,
                     $responseUsage['output_tokens_details']['reasoning_tokens'] ?? 0,
                 );
+
+                foreach ($this->extractCitations($response['output'] ?? []) as $citation) {
+                    yield (new CitationEvent(
+                        $this->generateEventId(),
+                        $messageId,
+                        $citation,
+                        time(),
+                    ))->withInvocationId($invocationId);
+                }
             }
         }
 

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -41,6 +41,7 @@ trait HandlesTextStreaming
         $toolCalls = [];
         $pendingToolCalls = [];
         $reasoningItems = [];
+        $lastTextMessageId = null;
         $usage = null;
         $responseData = [];
 
@@ -107,6 +108,7 @@ trait HandlesTextStreaming
                     time(),
                 ))->withInvocationId($invocationId);
 
+                $lastTextMessageId = $messageId;
                 $textStartEmitted = false;
                 $messageId = $this->generateEventId();
 
@@ -281,7 +283,7 @@ trait HandlesTextStreaming
                 foreach ($this->extractCitations($response['output'] ?? []) as $citation) {
                     yield (new CitationEvent(
                         $this->generateEventId(),
-                        $messageId,
+                        $lastTextMessageId ?? $messageId,
                         $citation,
                         time(),
                     ))->withInvocationId($invocationId);

--- a/src/PendingResponses/PendingEmbeddingsGeneration.php
+++ b/src/PendingResponses/PendingEmbeddingsGeneration.php
@@ -470,6 +470,6 @@ class PendingEmbeddingsGeneration
         }
 
         return $this->cacheIndividually
-            ?? (bool) config('ai.caching.embeddings.individually', false);
+            ?? (bool) config('ai.caching.embeddings.individually', true);
     }
 }

--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -3,19 +3,23 @@
 namespace Laravel\Ai\Providers;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\Contracts\Gateway\AudioGateway;
 use Laravel\Ai\Contracts\Gateway\EmbeddingGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Gateway\TranscriptionGateway;
+use Laravel\Ai\Contracts\Providers\AudioProvider;
 use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Mistral\MistralGateway;
 
-class MistralProvider extends Provider implements EmbeddingProvider, TextProvider, TranscriptionProvider
+class MistralProvider extends Provider implements AudioProvider, EmbeddingProvider, TextProvider, TranscriptionProvider
 {
+    use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesText;
     use Concerns\GeneratesTranscriptions;
+    use Concerns\HasAudioGateway;
     use Concerns\HasEmbeddingGateway;
     use Concerns\HasTextGateway;
     use Concerns\HasTranscriptionGateway;
@@ -34,6 +38,14 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     protected function mistralGateway(): MistralGateway
     {
         return $this->mistralGateway ??= new MistralGateway($this->events);
+    }
+
+    /**
+     * Get the provider's audio gateway.
+     */
+    public function audioGateway(): AudioGateway
+    {
+        return $this->audioGateway ??= $this->mistralGateway();
     }
 
     /**
@@ -82,6 +94,14 @@ class MistralProvider extends Provider implements EmbeddingProvider, TextProvide
     public function smartestTextModel(): string
     {
         return $this->config['models']['text']['smartest'] ?? 'mistral-large-latest';
+    }
+
+    /**
+     * Get the name of the default audio (TTS) model.
+     */
+    public function defaultAudioModel(): string
+    {
+        return $this->config['models']['audio']['default'] ?? 'voxtral-mini-tts-2603';
     }
 
     /**

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -92,6 +92,30 @@ describe('prompt responses', function (): void {
         expect($response->text)->toEqual('Fake response for prompt: Second prompt');
     });
 
+    test('agents throw once their scripted responses are exhausted', function (): void {
+        AssistantAgent::fake(['Only response']);
+
+        expect((new AssistantAgent)->prompt('First prompt')->text)->toEqual('Only response');
+
+        (new AssistantAgent)->prompt('Second prompt');
+    })->throws(RuntimeException::class, 'Fake agent responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
+    test('structured agents throw once their scripted responses are exhausted', function (): void {
+        StructuredAgent::fake([['symbol' => 'Au']]);
+
+        expect((new StructuredAgent)->prompt('Gold prompt')['symbol'])->toEqual('Au');
+
+        (new StructuredAgent)->prompt('Silver prompt');
+    })->throws(RuntimeException::class, 'Fake agent responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
+    test('faked tool calls consume a scripted response for the follow up answer', function (): void {
+        MultiStepToolAgent::fake([
+            new ToolCall('call_123', 'FixedNumberGenerator', []),
+        ]);
+
+        (new MultiStepToolAgent)->prompt('Generate a number');
+    })->throws(RuntimeException::class, 'Fake agent responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
     test('agents can prevent stray prompts', function (): void {
         AssistantAgent::fake()->preventStrayPrompts();
 
@@ -192,6 +216,14 @@ describe('stream responses', function (): void {
         expect($response->text)->toEqual('Third response')
             ->and($response->events)->toHaveCount(6);
     });
+
+    test('streamed agents throw once their scripted responses are exhausted', function (): void {
+        AssistantAgent::fake(['Only response']);
+
+        (new AssistantAgent)->stream('First prompt')->each(fn (): true => true);
+
+        (new AssistantAgent)->stream('Second prompt')->each(fn (): true => true);
+    })->throws(RuntimeException::class, 'Fake agent responses exhausted: [1] response(s) were supplied but call [2] was made.');
 
     test('faked stream events share the response invocation id', function (): void {
         AssistantAgent::fake(['Hello world']);

--- a/tests/Feature/AudioFakeTest.php
+++ b/tests/Feature/AudioFakeTest.php
@@ -122,6 +122,14 @@ test('stringable audio macro passes through options', function (): void {
         && $prompt->timeout === 45);
 });
 
+test('audio throws once its scripted responses are exhausted', function (): void {
+    Audio::fake([base64_encode('only-audio')]);
+
+    Audio::of('First text')->generate();
+
+    Audio::of('Second text')->generate();
+})->throws(RuntimeException::class, 'Fake audio responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
 test('audio can prevent stray generations', function (): void {
     Audio::fake()->preventStrayAudio();
 

--- a/tests/Feature/EmbeddingsCacheTest.php
+++ b/tests/Feature/EmbeddingsCacheTest.php
@@ -119,6 +119,18 @@ test('individual caching can be enabled globally via config', function (): void 
     expect(Http::recorded())->toHaveCount(1);
 });
 
+test('individual caching is enabled when the config value is missing', function (): void {
+    config(['ai.caching.embeddings' => [
+        'cache' => false,
+        'store' => 'array',
+    ]]);
+
+    Embeddings::for(['a', 'b'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+    Embeddings::for(['b'])->cache(3600)->generate(provider: 'cohere', model: 'embed-v4.0');
+
+    expect(Http::recorded())->toHaveCount(1);
+});
+
 test('fully individually cached requests are served in any input order without a provider call', function (): void {
     Embeddings::for(['a', 'b'])->cache(3600, individually: true)->generate(provider: 'cohere', model: 'embed-v4.0');
 

--- a/tests/Feature/EmbeddingsFakeTest.php
+++ b/tests/Feature/EmbeddingsFakeTest.php
@@ -224,6 +224,14 @@ describe('generating embeddings', function (): void {
         expect($magnitude)->toEqualWithDelta(1.0, 0.0001);
     });
 
+    test('embeddings throw once their scripted responses are exhausted', function (): void {
+        Embeddings::fake([[array_fill(0, 3, 0.1)]]);
+
+        Embeddings::for(['Hello world'])->dimensions(3)->generate();
+
+        Embeddings::for(['Goodbye world'])->dimensions(3)->generate();
+    })->throws(RuntimeException::class, 'Fake embedding responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
     test('can prevent stray embeddings generations', function (): void {
         Embeddings::fake()->preventStrayEmbeddings();
 

--- a/tests/Feature/FileFakeTest.php
+++ b/tests/Feature/FileFakeTest.php
@@ -51,6 +51,14 @@ test('files can be faked with a closure', function (): void {
         ->and($response->content)->toEqual('content-for-file_2');
 });
 
+test('files throw once their scripted responses are exhausted', function (): void {
+    Files::fake(['only-content']);
+
+    Files::get('file_1');
+
+    Files::get('file_2');
+})->throws(RuntimeException::class, 'Fake file responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
 test('files can prevent stray operations', function (): void {
     Files::fake()->preventStrayOperations();
 

--- a/tests/Feature/ImageFakeTest.php
+++ b/tests/Feature/ImageFakeTest.php
@@ -80,6 +80,14 @@ test('images can be faked with a single closure that is invoked for every genera
     expect($response->firstImage()->image)->toEqual(base64_encode('image-for-Second prompt'));
 });
 
+test('images throw once their scripted responses are exhausted', function (): void {
+    Image::fake([base64_encode('only-image')]);
+
+    Image::of('First prompt')->generate();
+
+    Image::of('Second prompt')->generate();
+})->throws(RuntimeException::class, 'Fake image responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
 test('images can prevent stray generations', function (): void {
     Image::fake()->preventStrayImages();
 

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
@@ -16,6 +17,43 @@ use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 
 describe('text streaming', function (): void {
+    test('streaming emits citation events for grounding metadata', function (): void {
+        $finalChunk = [
+            'candidates' => [[
+                'content' => ['parts' => [['text' => '']], 'role' => 'model'],
+                'finishReason' => 'STOP',
+                'groundingMetadata' => [
+                    'groundingChunks' => [
+                        ['web' => ['uri' => 'https://example.com/euro', 'title' => 'Euro 2024']],
+                        ['web' => ['uri' => 'https://example.com/spain', 'title' => 'Spain Wins']],
+                    ],
+                    'groundingSupports' => [
+                        ['segment' => ['startIndex' => 0, 'endIndex' => 20, 'text' => 'Spain won Euro 2024.'], 'groundingChunkIndices' => [0, 1]],
+                    ],
+                ],
+            ]],
+            'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5, 'totalTokenCount' => 15],
+            'modelVersion' => 'gemini-3.7-flash',
+        ];
+
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->geminiChunk([['text' => 'Spain won Euro 2024.']]),
+                    $finalChunk,
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+
+        expect($citations)->toHaveCount(2)
+            ->and($citations[0]->citation->url)->toBe('https://example.com/euro')
+            ->and($citations[1]->citation->url)->toBe('https://example.com/spain');
+    });
+
     test('streaming emits text events', function (): void {
         Http::fake([
             'generativelanguage.googleapis.com/*' => Http::response(

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -54,6 +54,41 @@ describe('text streaming', function (): void {
             ->and($citations[1]->citation->url)->toBe('https://example.com/spain');
     });
 
+    test('streaming emits citation events when grounding metadata is followed by a candidate-less chunk', function (): void {
+        $groundedChunk = [
+            'candidates' => [[
+                'content' => ['parts' => [['text' => 'Spain won Euro 2024.']], 'role' => 'model'],
+                'finishReason' => 'STOP',
+                'groundingMetadata' => [
+                    'groundingChunks' => [
+                        ['web' => ['uri' => 'https://example.com/euro', 'title' => 'Euro 2024']],
+                    ],
+                    'groundingSupports' => [
+                        ['segment' => ['startIndex' => 0, 'endIndex' => 20, 'text' => 'Spain won Euro 2024.'], 'groundingChunkIndices' => [0]],
+                    ],
+                ],
+            ]],
+        ];
+
+        $usageOnlyChunk = [
+            'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5, 'totalTokenCount' => 15],
+            'modelVersion' => 'gemini-3.7-flash',
+        ];
+
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response(
+                body: $this->ssePayload([$groundedChunk, $usageOnlyChunk]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+
+        expect($citations)->toHaveCount(1)
+            ->and($citations[0]->citation->url)->toBe('https://example.com/euro');
+    });
+
     test('streaming emits text events', function (): void {
         Http::fake([
             'generativelanguage.googleapis.com/*' => Http::response(

--- a/tests/Feature/Providers/Groq/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Groq/ErrorHandlingTest.php
@@ -62,6 +62,22 @@ test('overloaded response throws provider overloaded exception', function (): vo
     );
 })->throws(ProviderOverloadedException::class);
 
+test('flex tier capacity exceeded response throws provider overloaded exception', function (): void {
+    Http::fake([
+        'api.groq.com/*' => Http::response([
+            'error' => [
+                'type' => 'capacity_exceeded',
+                'message' => 'Flex tier capacity exceeded. Please try again later.',
+            ],
+        ], 498),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'groq',
+    );
+})->throws(ProviderOverloadedException::class);
+
 test('error in 200 response throws ai exception', function (): void {
     Http::fake([
         'api.groq.com/*' => Http::response([

--- a/tests/Feature/Providers/Groq/ErrorHandlingTest.php
+++ b/tests/Feature/Providers/Groq/ErrorHandlingTest.php
@@ -78,6 +78,17 @@ test('flex tier capacity exceeded response throws provider overloaded exception'
     );
 })->throws(ProviderOverloadedException::class);
 
+test('undocumented gateway status code does not fail over', function (): void {
+    Http::fake([
+        'api.groq.com/*' => Http::response('gateway timeout', 524),
+    ]);
+
+    (new AssistantAgent)->prompt(
+        'Hi',
+        provider: 'groq',
+    );
+})->throws(RequestException::class);
+
 test('error in 200 response throws ai exception', function (): void {
     Http::fake([
         'api.groq.com/*' => Http::response([

--- a/tests/Feature/Providers/Mistral/AudioTest.php
+++ b/tests/Feature/Providers/Mistral/AudioTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Audio;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
+
+beforeEach(function (): void {
+    config(['ai.providers.mistral' => [
+        ...config('ai.providers.mistral'),
+        'key' => 'test-key',
+    ]]);
+});
+
+test('audio request includes model, input, voice_id, and resolves default-female voice', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello world')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $request->url() === 'https://api.mistral.ai/v1/audio/speech'
+            && $body['model'] === 'voxtral-mini-tts-2603'
+            && $body['input'] === 'Hello world'
+            && $body['voice_id'] === 'gb_jane_neutral'
+            && $body['response_format'] === 'mp3';
+    });
+});
+
+test('audio request resolves default-male voice alias', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->male()->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_id'] === 'en_paul_neutral');
+});
+
+test('audio request passes custom voice id through unchanged', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->voice('my-custom-voice-id')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_id'] === 'my-custom-voice-id');
+});
+
+test('audio request omits instructions since the Mistral API does not accept them', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->instructions('Speak warmly')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => ! str_contains($request->body(), 'Speak warmly')
+        && ! array_key_exists('instructions', json_decode($request->body(), true)));
+});
+
+test('audio request sends bearer token', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+test('audio response passes base64 audio data through with audio/mpeg mime type', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse(base64_encode('raw-audio-bytes'))]);
+
+    $response = Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    expect($response->audio)->toBe(base64_encode('raw-audio-bytes'))
+        ->and($response->mimeType())->toBe('audio/mpeg')
+        ->and($response->meta->provider)->toBe('mistral')
+        ->and($response->meta->model)->toBe('voxtral-mini-tts-2603');
+});
+
+test('audio uses default model when none specified', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')->generate(provider: 'mistral');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['model'] === 'voxtral-mini-tts-2603');
+});
+
+test('audio throws when the response contains no audio data', function (): void {
+    Http::fake(['*' => Http::response(['audio_data' => null])]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(RuntimeException::class, 'No audio data received from Mistral API.');
+
+test('audio throws when the API returns an error', function (): void {
+    Http::fake(['*' => Http::response(['message' => 'unauthorized'], 401)]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(RequestException::class);
+
+test('audio rate limit response throws rate limited exception', function (): void {
+    Http::fake(['api.mistral.ai/*' => Http::response(['message' => 'rate limit exceeded'], 429)]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(RateLimitedException::class);
+
+test('audio overloaded response throws provider overloaded exception', function (): void {
+    Http::fake(['api.mistral.ai/*' => Http::response(['message' => 'service unavailable'], 503)]);
+
+    Audio::of('Hello')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+})->throws(ProviderOverloadedException::class);
+
+test('audio gateway is shared with the other Mistral gateways', function (): void {
+    $provider = Ai::audioProvider('mistral');
+
+    expect($provider->audioGateway())->toBe($provider->transcriptionGateway())
+        ->and($provider->audioGateway())->toBe($provider->embeddingGateway());
+});
+
+function fakeMistralAudioResponse(?string $audioData = null)
+{
+    return Http::response([
+        'audio_data' => $audioData ?? base64_encode('fake-audio-bytes'),
+    ]);
+}

--- a/tests/Feature/Providers/Mistral/BaseUrlTest.php
+++ b/tests/Feature/Providers/Mistral/BaseUrlTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Audio;
 
 use function Laravel\Ai\agent;
 
@@ -40,6 +41,19 @@ test('mistral requests fall back to the default base url', function (): void {
 
     Http::assertSentCount(1);
     mistralAssertRequestSent('POST', 'https://api.mistral.ai/v1/chat/completions');
+});
+
+test('mistral audio requests use the configured base url', function (): void {
+    configureMistralProvider($this->customUrl);
+
+    Http::fake([
+        '*' => Http::response(['audio_data' => base64_encode('fake-audio-bytes')]),
+    ]);
+
+    Audio::of('Hello')->generate(provider: 'mistral');
+
+    Http::assertSentCount(1);
+    mistralAssertRequestSent('POST', "{$this->customUrl}/audio/speech");
 });
 
 function configureMistralProvider(?string $url = null): void

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
@@ -43,6 +44,32 @@ test('streaming emits text events', function (): void {
         ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
         ->and($events[4])->toBeInstanceOf(TextEnd::class)
         ->and($events[5])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming emits citation events from the completed response', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.created', 'response' => ['id' => 'resp_123', 'model' => 'grok-4-1-fast-reasoning']],
+                ['type' => 'response.output_text.delta', 'delta' => 'Here are sources'],
+                ['type' => 'response.output_text.done'],
+                ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'message', 'status' => 'completed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'Here are sources', 'annotations' => [
+                    ['type' => 'url_citation', 'url' => 'https://example.com/one', 'title' => 'Example One', 'start_index' => 0, 'end_index' => 10],
+                    ['type' => 'url_citation', 'url' => 'https://example.com/two', 'title' => 'Example Two', 'start_index' => 11, 'end_index' => 25],
+                ]]]]], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+
+    expect($citations)->toHaveCount(2)
+        ->and($citations[0]->citation->url)->toBe('https://example.com/one')
+        ->and($citations[0]->citation->title)->toBe('Example One')
+        ->and($citations[0]->citation->startIndex)->toBe(0)
+        ->and($citations[1]->citation->url)->toBe('https://example.com/two');
 });
 
 test('streaming starts a new text part after each text end in the same step', function (): void {

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -63,9 +63,13 @@ test('streaming emits citation events from the completed response', function ():
         ),
     ]);
 
-    $citations = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof CitationEvent));
+    $events = $this->collectStreamEvents();
+    $textStart = collect($events)->first(fn ($event): bool => $event instanceof TextStart);
+    $citations = array_values(array_filter($events, fn ($event): bool => $event instanceof CitationEvent));
 
     expect($citations)->toHaveCount(2)
+        ->and($citations[0]->messageId)->toBe($textStart->messageId)
+        ->and($citations[1]->messageId)->toBe($textStart->messageId)
         ->and($citations[0]->citation->url)->toBe('https://example.com/one')
         ->and($citations[0]->citation->title)->toBe('Example One')
         ->and($citations[0]->citation->startIndex)->toBe(0)

--- a/tests/Feature/RerankingFakeTest.php
+++ b/tests/Feature/RerankingFakeTest.php
@@ -118,6 +118,16 @@ test('can assert nothing reranked', function (): void {
     Reranking::assertNothingReranked();
 });
 
+test('reranking throws once its scripted responses are exhausted', function (): void {
+    Reranking::fake([
+        [new RankedDocument(index: 0, document: 'Only doc', score: 0.9)],
+    ]);
+
+    Reranking::of(['Only doc'])->rerank('query');
+
+    Reranking::of(['Only doc'])->rerank('another query');
+})->throws(RuntimeException::class, 'Fake reranking responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
 test('can prevent stray rerankings', function (): void {
     Reranking::fake()->preventStrayRerankings();
 

--- a/tests/Feature/StoreFakeTest.php
+++ b/tests/Feature/StoreFakeTest.php
@@ -43,6 +43,14 @@ describe('store operations', function (): void {
         expect($response)->id->toEqual('vs_1')->name->toEqual('name-for-vs_1');
     });
 
+    test('stores throw once their scripted responses are exhausted', function (): void {
+        Stores::fake(['only-store']);
+
+        Stores::get('vs_1');
+
+        Stores::get('vs_2');
+    })->throws(RuntimeException::class, 'Fake store responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
     test('stores can prevent stray operations', function (): void {
         Stores::fake()->preventStrayOperations();
 

--- a/tests/Feature/TranscriptionFakeTest.php
+++ b/tests/Feature/TranscriptionFakeTest.php
@@ -82,6 +82,14 @@ test('transcriptions can be faked with a single closure that is invoked for ever
     expect($response->text)->toEqual('Transcription 2');
 });
 
+test('transcriptions throw once their scripted responses are exhausted', function (): void {
+    Transcription::fake(['Only transcription']);
+
+    Transcription::of(base64_encode('audio-1'))->generate();
+
+    Transcription::of(base64_encode('audio-2'))->generate();
+})->throws(RuntimeException::class, 'Fake transcription responses exhausted: [1] response(s) were supplied but call [2] was made.');
+
 test('transcriptions can prevent stray generations', function (): void {
     Transcription::fake()->preventStrayTranscriptions();
 


### PR DESCRIPTION
Scripting fewer fake responses than a code path actually consumes gives you generated data instead of a failure. An array of responses is a finite script, but an exhausted script reads as `null`, and `null` is the same sentinel the fakes use for "nothing was faked". So the fake falls through to generating a value, and for a structured agent that value is random:

```php
StructuredAgent::fake([['symbol' => 'Au']]);

(new StructuredAgent)->prompt('Gold');   // ['symbol' => 'Au']
(new StructuredAgent)->prompt('Silver'); // ['symbol' => 'kQ8mZ2p'], generated by Str::random()
```

That second call is the problem. The assertion fails against a random value with nothing pointing at the fake, or it passes because the generated value happened not to collide with the field under test.

A non-empty script now throws once it runs dry:

```
Fake agent responses exhausted: [1] response(s) were supplied but call [2] was made.
Add the missing responses, or pass a Closure to answer every call.
```

Script every call, or hand over a closure when the call count is not fixed:

```php
StructuredAgent::fake([['symbol' => 'Au'], ['symbol' => 'Ag']]);

// Answers any number of calls.
StructuredAgent::fake(fn ($prompt) => ['symbol' => str_contains($prompt, 'Gold') ? 'Au' : 'Ag']);
```

An empty array still generates, so `Ai::fakeAgent('X')` with no responses behaves as before and the `preventStray*` guards keep covering the never-faked case. Closures stay repeatable, which is now the documented way to answer an unbounded number of calls.

This is the same contract `Http::fake()` already has, where an exhausted `ResponseSequence` throws unless you opt into `whenEmpty()`.

One warning for anyone upgrading. Suites that under-script a fake will start failing where they previously passed against generated data. Faked tool calls are the case most likely to surface, because a faked `ToolCall` consumes one entry and the follow-up answer consumes another, so a single-entry script is now one short.

Every fake gateway gets an exhaustion test asserting the message, and streaming has its own. The existing tests for empty fakes and closure fakes pin the paths that did not change.

Opened to continue #934 by @JanMencl, whose original commit is preserved here. 