### PR TITLE
Store uploaded files from their path instead of base64 encoding them

### DIFF
--- a/src/Files.php
+++ b/src/Files.php
@@ -33,7 +33,10 @@ class Files
     {
         $file = match (true) {
             is_string($file) => new Base64Document(base64_encode($file), $mimeType),
-            $file instanceof UploadedFile => (new LocalDocument($file->getRealPath() ?: $file->getPathname(), $file->getClientMimeType()))->as($file->getClientOriginalName()),
+            $file instanceof UploadedFile => (new LocalDocument(
+                $file->getPathname(),
+                $file->getClientMimeType(),
+            ))->as($file->getClientOriginalName()),
             default => $file,
         };
 

--- a/src/Files.php
+++ b/src/Files.php
@@ -7,6 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files\Base64Document;
 use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Gateway\FakeFileGateway;
 use Laravel\Ai\Responses\FileResponse;
 use Laravel\Ai\Responses\StoredFileResponse;
@@ -32,7 +33,7 @@ class Files
     {
         $file = match (true) {
             is_string($file) => new Base64Document(base64_encode($file), $mimeType),
-            $file instanceof UploadedFile => Base64Document::fromUpload($file)->as($file->getClientOriginalName()),
+            $file instanceof UploadedFile => (new LocalDocument($file->getRealPath() ?: $file->getPathname(), $file->getClientMimeType()))->as($file->getClientOriginalName()),
             default => $file,
         };
 

--- a/src/Store.php
+++ b/src/Store.php
@@ -8,7 +8,7 @@ use Laravel\Ai\Contracts\Files\HasProviderId;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
-use Laravel\Ai\Files\Base64Document;
+use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Responses\AddedDocumentResponse;
 use Laravel\Ai\Responses\Data\StoreFileCounts;
@@ -31,8 +31,10 @@ class Store
         array $metadata = [],
     ): AddedDocumentResponse {
         if ($file instanceof UploadedFile) {
-            $file = Base64Document::fromUpload($file)
-                ->as($file->getClientOriginalName());
+            $file = (new LocalDocument(
+                $file->getPathname(),
+                $file->getClientMimeType(),
+            ))->as($file->getClientOriginalName());
         }
 
         $originalFile = $file;

--- a/tests/Feature/FileFakeTest.php
+++ b/tests/Feature/FileFakeTest.php
@@ -85,6 +85,23 @@ test('can assert no files were stored', function (): void {
     Files::assertNothingStored();
 });
 
+test('can store an uploaded file from its path', function (): void {
+    Files::fake();
+
+    Files::put(new UploadedFile(__DIR__.'/../Fixtures/report.txt', 'report.txt', 'text/plain'));
+
+    Files::assertStored(fn (StorableFile $file): bool => $file instanceof LocalDocument);
+    Files::assertStored(fn (StorableFile $file): bool => $file->name() === 'report.txt');
+    Files::assertStored(fn (StorableFile $file): bool => $file->mimeType() === 'text/plain');
+    Files::assertStored(fn (StorableFile $file): bool => trim((string) $file) === 'I am an expense report.');
+});
+
+test('cannot store an uploaded file that failed to upload', function (): void {
+    Files::fake();
+
+    Files::put(new UploadedFile('', 'report.txt', 'text/plain', UPLOAD_ERR_NO_TMP_DIR));
+})->throws(InvalidArgumentException::class);
+
 test('can override the filename when storing files from each document constructor', function (): void {
     Files::fake();
 
@@ -104,17 +121,6 @@ test('can override the filename when storing an existing storable file', functio
     Files::put(Document::fromPath(__DIR__.'/../Fixtures/document.txt'), name: 'override.txt');
 
     Files::assertStored(fn (StorableFile $file): bool => $file->name() === 'override.txt');
-});
-
-test('uploaded files are stored from their path instead of their base64 contents', function (): void {
-    Files::fake();
-
-    Files::put(new UploadedFile(__DIR__.'/../Fixtures/report.txt', 'report.txt', 'text/plain'));
-
-    Files::assertStored(fn (StorableFile $file): bool => $file instanceof LocalDocument);
-    Files::assertStored(fn (StorableFile $file): bool => $file->name() === 'report.txt');
-    Files::assertStored(fn (StorableFile $file): bool => $file->mimeType() === 'text/plain');
-    Files::assertStored(fn (StorableFile $file): bool => trim((string) $file) === 'I am an expense report.');
 });
 
 test('can override the filename when storing files from a local path', function (): void {

--- a/tests/Feature/FileFakeTest.php
+++ b/tests/Feature/FileFakeTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Responses\FileResponse;
 
 test('files can be faked', function (): void {
@@ -103,6 +104,17 @@ test('can override the filename when storing an existing storable file', functio
     Files::put(Document::fromPath(__DIR__.'/../Fixtures/document.txt'), name: 'override.txt');
 
     Files::assertStored(fn (StorableFile $file): bool => $file->name() === 'override.txt');
+});
+
+test('uploaded files are stored from their path instead of their base64 contents', function (): void {
+    Files::fake();
+
+    Files::put(new UploadedFile(__DIR__.'/../Fixtures/report.txt', 'report.txt', 'text/plain'));
+
+    Files::assertStored(fn (StorableFile $file): bool => $file instanceof LocalDocument);
+    Files::assertStored(fn (StorableFile $file): bool => $file->name() === 'report.txt');
+    Files::assertStored(fn (StorableFile $file): bool => $file->mimeType() === 'text/plain');
+    Files::assertStored(fn (StorableFile $file): bool => trim((string) $file) === 'I am an expense report.');
 });
 
 test('can override the filename when storing files from a local path', function (): void {

--- a/tests/Feature/StoreFakeTest.php
+++ b/tests/Feature/StoreFakeTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Laravel\Ai\Contracts\Files\StorableFile;
 use Laravel\Ai\Files;
 use Laravel\Ai\Files\Document;
+use Laravel\Ai\Files\LocalDocument;
 use Laravel\Ai\Files\ProviderDocument;
 use Laravel\Ai\Stores;
 
@@ -147,6 +149,25 @@ describe('file operations', function (): void {
             fn (StorableFile $file): bool => $file->content() === 'Hello, world!'
         );
     });
+
+    test('can add an uploaded file to store from its path', function (): void {
+        Stores::fake();
+
+        Stores::create('My Store')
+            ->add(new UploadedFile(__DIR__.'/../Fixtures/report.txt', 'report.txt', 'text/plain'));
+
+        Files::assertStored(fn (StorableFile $file): bool => $file instanceof LocalDocument);
+        Files::assertStored(fn (StorableFile $file): bool => $file->name() === 'report.txt');
+        Files::assertStored(fn (StorableFile $file): bool => $file->mimeType() === 'text/plain');
+        Files::assertStored(fn (StorableFile $file): bool => trim((string) $file) === 'I am an expense report.');
+    });
+
+    test('cannot add an uploaded file that failed to upload to store', function (): void {
+        Stores::fake();
+
+        Stores::create('My Store')
+            ->add(new UploadedFile('', 'report.txt', 'text/plain', UPLOAD_ERR_NO_TMP_DIR));
+    })->throws(InvalidArgumentException::class);
 });
 
 describe('file assertions', function (): void {


### PR DESCRIPTION
`Files::put()` turns an `UploadedFile` into a `Base64Document`, but an uploaded file always sits on disk with a readable path already, so the base64 round-trip buys nothing. The bytes get read in full, expanded ~1.33x into base64 and held on the object, then decoded back into a second full copy when the gateway calls `content()`.

Measured on a 32 MiB upload up to that `content()` call: `Base64Document` peaks at 2.67x the file size, `LocalDocument` at 1.00x. Same ratio at 8 MiB, so it scales with the file rather than being a fixed cost. On a shared FPM pool that turns a 32 MiB upload into 85 MiB of the worker's `memory_limit`, which is enough to push unrelated requests in the same pool into an OOM.

`LocalDocument` already implements `StorableFile`, accepts a MIME type and supports `->as()`, so the client MIME type and original filename both survive the swap and `content()` becomes a single `file_get_contents()`. `getClientMimeType()` is non-nullable, so `LocalDocument` never falls back to sniffing the file, and `->as()` always sets the name, so it never falls back to `basename()`. All three gateways call `content()` synchronously inside `putFile()`, so nothing outlives the request's temp file.

The path comes from `getPathname()` rather than `getRealPath()` on purpose. When an upload fails with something like `UPLOAD_ERR_NO_TMP_DIR`, PHP leaves `tmp_name` empty, and `realpath('')` resolves to the current working directory instead of returning `false`, which would have quietly stored an empty file under the client's filename. `getPathname()` stays empty and hits `LocalDocument`'s blank-path guard, so a failed upload still throws the way it does today.

This doesn't make uploads streaming, `content(): string` still forces one full copy, but it drops the two extra ones without changing any contract.

Fixes #943
