### PR TITLE
Allow ad-hoc message history on conversational agents

### DIFF
--- a/src/Promptable.php
+++ b/src/Promptable.php
@@ -18,7 +18,6 @@ use Laravel\Ai\Attributes\UseCheapestModel;
 use Laravel\Ai\Attributes\UseSmartestModel;
 use Laravel\Ai\Attributes\WithoutBroadcasting;
 use Laravel\Ai\Contracts\AgentInput;
-use Laravel\Ai\Contracts\Conversational;
 use Laravel\Ai\Contracts\HasProviderOptions;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
@@ -39,7 +38,6 @@ use Laravel\Ai\Responses\StreamableAgentResponse;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Vercel\Vercel;
-use LogicException;
 use ReflectionClass;
 use RuntimeException;
 
@@ -277,10 +275,6 @@ trait Promptable
      */
     public function withMessages(iterable $messages): static
     {
-        if ($this instanceof Conversational) {
-            throw new LogicException('Ad-hoc message history may not be combined with a conversational agent.');
-        }
-
         $this->adHocMessages = Collection::make($messages)
             ->flatMap(fn ($message) => is_array($message) && isset($message['parts'])
                 ? Vercel::fromUiMessages([$message])

--- a/tests/Feature/AgentInputTest.php
+++ b/tests/Feature/AgentInputTest.php
@@ -10,7 +10,6 @@ use Laravel\Ai\Messages\UserMessage;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\QueuedAgentPrompt;
 use Tests\Fixtures\Agents\AssistantAgent;
-use Tests\Fixtures\Agents\ConversationalAgent;
 
 function agentInput(?UserMessage $message = null, ?Decisions $decisions = null): AgentInput
 {
@@ -113,10 +112,6 @@ test('ad-hoc message history may be given as UI message arrays', function () {
     AssistantAgent::assertPrompted(fn (AgentPrompt $prompt): bool => count($prompt->messages) === 1
         && $prompt->messages[0]->content === 'Hello');
 });
-
-test('ad-hoc message history may not be combined with a conversational agent', function () {
-    (new ConversationalAgent)->withMessages([new UserMessage('Hello')]);
-})->throws(LogicException::class);
 
 test('ad-hoc message history does not leak into a later prompt', function () {
     AssistantAgent::fake(['First.', 'Second.']);

--- a/tests/Feature/Providers/Anthropic/AdHocMessagesWithConversationTest.php
+++ b/tests/Feature/Providers/Anthropic/AdHocMessagesWithConversationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Tests\Fixtures\Agents\RememberingConversationalAgent;
+
+beforeEach(function () {
+    Config::set('ai.conversations.generate_title', false);
+});
+
+function conversationOwner(): object
+{
+    return new class
+    {
+        public int $id = 7;
+    };
+}
+
+function adHocSeed(): array
+{
+    return [
+        new UserMessage('Seed question'),
+        new AssistantMessage('Seed answer'),
+    ];
+}
+
+function anthropicMessageTexts(): array
+{
+    $body = json_decode(Http::recorded()->last()[0]->body(), true);
+
+    return array_map(
+        fn (array $message): array => [$message['role'], $message['content'][0]['text']],
+        $body['messages'],
+    );
+}
+
+test('ad-hoc messages are sent ahead of the prompt but never stored in the conversation', function () {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse('Laravel is a framework.')]);
+
+    (new RememberingConversationalAgent)
+        ->forUser(conversationOwner())
+        ->withMessages(adHocSeed())
+        ->prompt('What is Laravel?', provider: 'anthropic');
+
+    expect(anthropicMessageTexts())->toBe([
+        ['user', 'Seed question'],
+        ['assistant', 'Seed answer'],
+        ['user', 'What is Laravel?'],
+    ]);
+
+    expect(DB::table('agent_conversation_messages')->orderBy('created_at')->pluck('content', 'role')->all())
+        ->toBe(['user' => 'What is Laravel?', 'assistant' => 'Laravel is a framework.']);
+});
+
+test('a replayed seed precedes stored history on a continued conversation and is still not stored', function () {
+    Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse('Answer.')]);
+
+    $first = (new RememberingConversationalAgent)
+        ->forUser(conversationOwner())
+        ->withMessages(adHocSeed())
+        ->prompt('First prompt', provider: 'anthropic');
+
+    (new RememberingConversationalAgent)
+        ->continue($first->conversationId, conversationOwner())
+        ->withMessages(adHocSeed())
+        ->prompt('Second prompt', provider: 'anthropic');
+
+    expect(anthropicMessageTexts())->toBe([
+        ['user', 'Seed question'],
+        ['assistant', 'Seed answer'],
+        ['user', 'First prompt'],
+        ['assistant', 'Answer.'],
+        ['user', 'Second prompt'],
+    ]);
+
+    expect(DB::table('agent_conversation_messages')->pluck('content')->all())
+        ->toBe(['First prompt', 'Answer.', 'Second prompt', 'Answer.']);
+});
+
+test('ad-hoc messages are sent ahead of the prompt but never stored when streaming', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response($this->ssePayload([
+            $this->messageStart(),
+            $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+            $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'Streamed.']),
+            $this->contentBlockStop(0),
+            $this->messageDelta('end_turn', 5),
+            ['type' => 'message_stop'],
+        ])),
+    ]);
+
+    iterator_to_array(
+        (new RememberingConversationalAgent)
+            ->forUser(conversationOwner())
+            ->withMessages(adHocSeed())
+            ->stream('What is Laravel?', provider: 'anthropic')
+    );
+
+    expect(anthropicMessageTexts())->toBe([
+        ['user', 'Seed question'],
+        ['assistant', 'Seed answer'],
+        ['user', 'What is Laravel?'],
+    ]);
+
+    expect(DB::table('agent_conversation_messages')->orderBy('created_at')->pluck('content', 'role')->all())
+        ->toBe(['user' => 'What is Laravel?', 'assistant' => 'Streamed.']);
+});

--- a/tests/Feature/Providers/Anthropic/AdHocMessagesWithConversationTest.php
+++ b/tests/Feature/Providers/Anthropic/AdHocMessagesWithConversationTest.php
@@ -11,20 +11,21 @@ beforeEach(function () {
     Config::set('ai.conversations.generate_title', false);
 });
 
-function conversationOwner(): object
-{
-    return new class
-    {
-        public int $id = 7;
-    };
-}
-
 function adHocSeed(): array
 {
     return [
         new UserMessage('Seed question'),
         new AssistantMessage('Seed answer'),
     ];
+}
+
+function storedConversationMessages(): array
+{
+    return DB::table('agent_conversation_messages')
+        ->orderBy('id')
+        ->get(['role', 'content'])
+        ->map(fn (object $message): array => [$message->role, $message->content])
+        ->all();
 }
 
 function anthropicMessageTexts(): array
@@ -41,7 +42,7 @@ test('ad-hoc messages are sent ahead of the prompt but never stored in the conve
     Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse('Laravel is a framework.')]);
 
     (new RememberingConversationalAgent)
-        ->forUser(conversationOwner())
+        ->forUser((object) ['id' => 7])
         ->withMessages(adHocSeed())
         ->prompt('What is Laravel?', provider: 'anthropic');
 
@@ -51,20 +52,22 @@ test('ad-hoc messages are sent ahead of the prompt but never stored in the conve
         ['user', 'What is Laravel?'],
     ]);
 
-    expect(DB::table('agent_conversation_messages')->orderBy('created_at')->pluck('content', 'role')->all())
-        ->toBe(['user' => 'What is Laravel?', 'assistant' => 'Laravel is a framework.']);
+    expect(storedConversationMessages())->toBe([
+        ['user', 'What is Laravel?'],
+        ['assistant', 'Laravel is a framework.'],
+    ]);
 });
 
 test('a replayed seed precedes stored history on a continued conversation and is still not stored', function () {
     Http::fake(['api.anthropic.com/*' => $this->fakeTextResponse('Answer.')]);
 
     $first = (new RememberingConversationalAgent)
-        ->forUser(conversationOwner())
+        ->forUser((object) ['id' => 7])
         ->withMessages(adHocSeed())
         ->prompt('First prompt', provider: 'anthropic');
 
     (new RememberingConversationalAgent)
-        ->continue($first->conversationId, conversationOwner())
+        ->continue($first->conversationId, (object) ['id' => 7])
         ->withMessages(adHocSeed())
         ->prompt('Second prompt', provider: 'anthropic');
 
@@ -76,8 +79,12 @@ test('a replayed seed precedes stored history on a continued conversation and is
         ['user', 'Second prompt'],
     ]);
 
-    expect(DB::table('agent_conversation_messages')->pluck('content')->all())
-        ->toBe(['First prompt', 'Answer.', 'Second prompt', 'Answer.']);
+    expect(storedConversationMessages())->toBe([
+        ['user', 'First prompt'],
+        ['assistant', 'Answer.'],
+        ['user', 'Second prompt'],
+        ['assistant', 'Answer.'],
+    ]);
 });
 
 test('ad-hoc messages are sent ahead of the prompt but never stored when streaming', function () {
@@ -94,7 +101,7 @@ test('ad-hoc messages are sent ahead of the prompt but never stored when streami
 
     iterator_to_array(
         (new RememberingConversationalAgent)
-            ->forUser(conversationOwner())
+            ->forUser((object) ['id' => 7])
             ->withMessages(adHocSeed())
             ->stream('What is Laravel?', provider: 'anthropic')
     );
@@ -105,6 +112,8 @@ test('ad-hoc messages are sent ahead of the prompt but never stored when streami
         ['user', 'What is Laravel?'],
     ]);
 
-    expect(DB::table('agent_conversation_messages')->orderBy('created_at')->pluck('content', 'role')->all())
-        ->toBe(['user' => 'What is Laravel?', 'assistant' => 'Streamed.']);
+    expect(storedConversationMessages())->toBe([
+        ['user', 'What is Laravel?'],
+        ['assistant', 'Streamed.'],
+    ]);
 });

--- a/tests/Fixtures/Agents/RememberingConversationalAgent.php
+++ b/tests/Fixtures/Agents/RememberingConversationalAgent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\RemembersConversations as RemembersConversationsContract;
+use Laravel\Ai\Promptable;
+
+class RememberingConversationalAgent implements Agent, RemembersConversationsContract
+{
+    use Promptable;
+    use RemembersConversations;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that responds extremely concisely to all queries.';
+    }
+}


### PR DESCRIPTION
Today, `withMessages()` throws a `LogicException` when the agent is conversational, so a client that replays UI history can't seed context on an agent that also persists its conversation:

```php
(new SupportAgent)
    ->continue($conversationId, $user)
    ->withMessages($chat->history()) // LogicException
    ->prompt($chat);
```

This removes the guard. Ad-hoc messages stay ephemeral and per-run: they're sent ahead of any stored conversation history and the new prompt, but they're never written to the conversation store, so replaying the same seed each turn never duplicates. A byte-identical seed prefix across turns also benefits provider prompt caching.

```php
(new SupportAgent)
    ->continue($conversationId, $user)
    ->withMessages($seed) // sent first, then stored history, then the prompt
    ->prompt('Second turn');

// The store only gains the user prompt and the assistant reply.
```

No storage or middleware changes were needed. `RememberConversation` already persists only the prompt and response, and the providers already merge ad-hoc messages ahead of stored history. Tests cover both `prompt()` and `stream()` at the wire level against a faked Anthropic endpoint, asserting message order and that no seed rows land in `agent_conversation_messages`.
