### PR TITLE
Rename Agent User Interaction protocol

### DIFF
--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -12,7 +12,7 @@ use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
-use Laravel\Ai\Streaming\Protocols\AgUiProtocol;
+use Laravel\Ai\Streaming\Protocols\AgentUserInteractionProtocol;
 use Laravel\Ai\Streaming\Protocols\StreamProtocol;
 use Laravel\Ai\Streaming\Protocols\VercelDataProtocol;
 use Symfony\Component\HttpFoundation\Response;
@@ -133,9 +133,9 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     /**
      * Stream the response using the Agent User Interaction protocol.
      */
-    public function usingAgUiProtocol(?string $threadId = null, ?string $runId = null): self
+    public function usingAgUIprotocol(?string $threadId = null, ?string $runId = null): self
     {
-        return $this->usingProtocol(new AgUiProtocol($threadId, $runId));
+        return $this->usingProtocol(new AgentUserInteractionProtocol($threadId, $runId));
     }
 
     /**

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -133,7 +133,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     /**
      * Stream the response using the Agent User Interaction protocol.
      */
-    public function usingAgUIprotocol(?string $threadId = null, ?string $runId = null): self
+    public function usingAgentUserInteractionProtocol(?string $threadId = null, ?string $runId = null): self
     {
         return $this->usingProtocol(new AgentUserInteractionProtocol($threadId, $runId));
     }

--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -32,7 +32,7 @@ use function Laravel\Ai\ulid;
  *
  * See: https://docs.ag-ui.com/concepts/events
  */
-class AgUiProtocol extends StreamProtocol
+class AgentUserInteractionProtocol extends StreamProtocol
 {
     protected int $step = 0;
 

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -22,7 +22,7 @@ use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
-use Laravel\Ai\Streaming\Protocols\AgUiProtocol;
+use Laravel\Ai\Streaming\Protocols\AgentUserInteractionProtocol;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Fixtures\Agents\MultiStepToolAgent;
 use Tests\Fixtures\Agents\RememberingApprovableAgent;
@@ -34,7 +34,7 @@ function agUiProtocolEvents(array|Closure $events, ?string $threadId = 'thread-1
     $stream = $events instanceof Closure ? $events : fn () => yield from $events;
 
     return agUiEvents((new StreamableAgentResponse('invocation-1', $stream, new Data\Meta('anthropic', 'claude-sonnet-4-6')))
-        ->usingAgUiProtocol($threadId, $runId)
+        ->usingAgUIprotocol($threadId, $runId)
         ->toResponse(request()));
 }
 
@@ -153,7 +153,7 @@ test('a multi step run combines the usage of every step', function () {
 
 test('the response is served as an unbuffered event stream', function () {
     $response = (new StreamableAgentResponse('invocation-1', fn () => yield from [], new Data\Meta('anthropic', 'claude-sonnet-4-6')))
-        ->usingProtocol(new AgUiProtocol)
+        ->usingProtocol(new AgentUserInteractionProtocol)
         ->toResponse(request());
 
     expect($response->headers->get('Content-Type'))->toBe('text/event-stream')
@@ -172,7 +172,7 @@ test('a first turn stream emits the thread id the conversation is stored under',
 
     $agent = (new RememberingAssistantAgent)->forUser($user);
 
-    $events = agUiEvents($agent->stream('Hello')->usingProtocol(new AgUiProtocol)->toResponse(request()));
+    $events = agUiEvents($agent->stream('Hello')->usingProtocol(new AgentUserInteractionProtocol)->toResponse(request()));
 
     expect($agent->currentConversation())->not->toBeNull()
         ->and($events[0]['threadId'])->toBe($agent->currentConversation())
@@ -189,7 +189,7 @@ test('an ownerless approval stream persists the thread id it emits', function ()
     ]);
 
     $agent = new RememberingApprovableAgent;
-    $events = agUiEvents($agent->stream('Generate a number')->usingProtocol(new AgUiProtocol)->toResponse(request()));
+    $events = agUiEvents($agent->stream('Generate a number')->usingProtocol(new AgentUserInteractionProtocol)->toResponse(request()));
 
     expect($events[0]['threadId'])->toBe($agent->currentConversation())
         ->and(end($events)['threadId'])->toBe($agent->currentConversation())
@@ -202,7 +202,7 @@ test('a run without an explicit identity falls back to the conversation and invo
         new StreamEnd('event-1', 'stop', new Usage, time()),
     ], new Data\Meta('anthropic', 'claude-sonnet-4-6')))
         ->withinConversation('conversation-1')
-        ->usingProtocol(new AgUiProtocol);
+        ->usingProtocol(new AgentUserInteractionProtocol);
 
     expect(agUiEvents($response->toResponse(request()))[0])->toBe([
         'type' => 'RUN_STARTED',
@@ -215,7 +215,7 @@ test('rendering the same response twice emits the same run', function () {
     $response = (new StreamableAgentResponse('invocation-1', fn () => yield from [
         new ToolResult('event-1', new Data\ToolResult('call-1', 'DeleteFile', ['path' => 'a.txt'], 'deleted'), true, null, time()),
         new StreamEnd('event-2', 'stop', new Usage, time()),
-    ], new Data\Meta('anthropic', 'claude-sonnet-4-6')))->usingProtocol(new AgUiProtocol);
+    ], new Data\Meta('anthropic', 'claude-sonnet-4-6')))->usingProtocol(new AgentUserInteractionProtocol);
 
     $render = fn (): array => agUiEvents($response->toResponse(request()));
 
@@ -529,7 +529,7 @@ test('the thread id adopts a conversation id surfaced after streaming begins', f
         yield new StreamEnd('event-1', 'stop', new Usage, time());
     }, new Data\Meta('anthropic', 'claude-sonnet-4-6'));
 
-    $events = agUiEvents($response->usingProtocol(new AgUiProtocol)->toResponse(request()));
+    $events = agUiEvents($response->usingProtocol(new AgentUserInteractionProtocol)->toResponse(request()));
 
     expect($events[0])->toBe([
         'type' => 'RUN_STARTED',
@@ -629,7 +629,7 @@ test('a faked multi step agent stream emits a well formed run', function () {
     ]);
 
     $response = (new MultiStepToolAgent)->stream('Generate a number')
-        ->usingProtocol(new AgUiProtocol('thread-1', 'run-1'))
+        ->usingProtocol(new AgentUserInteractionProtocol('thread-1', 'run-1'))
         ->toResponse(request());
 
     $types = collect(agUiEvents($response))->pluck('type');

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -34,7 +34,7 @@ function agUiProtocolEvents(array|Closure $events, ?string $threadId = 'thread-1
     $stream = $events instanceof Closure ? $events : fn () => yield from $events;
 
     return agUiEvents((new StreamableAgentResponse('invocation-1', $stream, new Data\Meta('anthropic', 'claude-sonnet-4-6')))
-        ->usingAgUIprotocol($threadId, $runId)
+        ->usingAgentUserInteractionProtocol($threadId, $runId)
         ->toResponse(request()));
 }
 


### PR DESCRIPTION
This renames `AgUiProtocol` to `AgentUserInteractionProtocol` and `usingAgUiProtocol()` to `usingAgUIprotocol()` for clearer naming.

The AG-UI protocol tests pass with the new names.
