### PR TITLE
[0.x] Add withProviderOptions() support to Audio generation

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -81,6 +81,8 @@ class AiServiceProvider extends ServiceProvider
             Lab|array|string|null $provider = null,
             ?string $voice = null,
             ?string $instructions = null,
+            ?float $speed = null,
+            ?string $format = null,
             ?string $model = null,
             ?int $timeout = null,
         ): AudioResponse {
@@ -92,6 +94,14 @@ class AiServiceProvider extends ServiceProvider
 
             if (! is_null($instructions)) {
                 $request->instructions($instructions);
+            }
+
+            if (! is_null($speed)) {
+                $request->speed($speed);
+            }
+
+            if (! is_null($format)) {
+                $request->format($format);
             }
 
             if (! is_null($timeout)) {

--- a/src/Contracts/Gateway/AudioGateway.php
+++ b/src/Contracts/Gateway/AudioGateway.php
@@ -16,6 +16,8 @@ interface AudioGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse;
 }

--- a/src/Contracts/Providers/AudioProvider.php
+++ b/src/Contracts/Providers/AudioProvider.php
@@ -14,6 +14,8 @@ interface AudioProvider extends Provider
         string $text,
         string $voice = 'default-female',
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         ?string $model = null,
         int $timeout = 30,
     ): AudioResponse;

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -143,6 +143,8 @@ class AnthropicGateway implements Gateway, StepTextGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
         throw new LogicException('Anthropic does not support audio generation.');

--- a/src/Gateway/Concerns/ResolvesAudioMimeTypes.php
+++ b/src/Gateway/Concerns/ResolvesAudioMimeTypes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Ai\Gateway\Concerns;
+
+trait ResolvesAudioMimeTypes
+{
+    /**
+     * Map an audio format to the HTTP audio MIME type.
+     */
+    protected function audioResponseMimeType(string $format): string
+    {
+        $format = strtolower(explode('_', $format)[0]);
+
+        return match ($format) {
+            'mp3' => 'audio/mpeg',
+            'pcm' => 'audio/pcm',
+            'wav' => 'audio/wav',
+            'opus' => 'audio/opus',
+            'aac' => 'audio/aac',
+            'flac' => 'audio/flac',
+            default => 'audio/mpeg',
+        };
+    }
+}

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -20,6 +20,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 {
     use Concerns\CreatesClient;
     use Concerns\HandlesFailoverErrors;
+    use Concerns\ResolvesAudioMimeTypes;
 
     /**
      * Generate audio from the given text.
@@ -30,6 +31,8 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
         $voice = match ($voice) {
@@ -38,16 +41,21 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
             default => $voice,
         };
 
+        $url = 'text-to-speech/'.$voice.($format ? '?output_format='.$format : '');
+
+        $payload = array_filter([
+            'model_id' => $model,
+            'text' => $text,
+            'voice_settings' => $speed !== null ? ['speed' => $speed] : null,
+        ]);
+
         $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
-            ->post('text-to-speech/'.$voice, [
-                'model_id' => $model,
-                'text' => $text,
-            ])->throw());
+            ->post($url, $payload)->throw());
 
         return new AudioResponse(
             base64_encode((string) $response),
             new Meta($provider->name(), $model),
-            'audio/mpeg'
+            $format ? $this->audioResponseMimeType($format) : 'audio/mpeg'
         );
     }
 

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -41,7 +41,9 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
             default => $voice,
         };
 
-        $url = 'text-to-speech/'.$voice.($format ? '?output_format='.$format : '');
+        $outputFormat = $format ? $this->resolveOutputFormat($format) : null;
+
+        $url = 'text-to-speech/'.$voice.($outputFormat ? '?output_format='.$outputFormat : '');
 
         $payload = array_filter([
             'model_id' => $model,
@@ -57,6 +59,20 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
             new Meta($provider->name(), $model),
             $format ? $this->audioResponseMimeType($format) : 'audio/mpeg'
         );
+    }
+
+    /**
+     * Resolve the output format for ElevenLabs API.
+     */
+    protected function resolveOutputFormat(string $format): string
+    {
+        return match ($format) {
+            'mp3' => 'mp3_44100_128',
+            'wav', 'pcm' => 'pcm_44100',
+            'opus' => 'opus_16000',
+            'aac' => 'aac_16000',
+            default => $format,
+        };
     }
 
     /**

--- a/src/Gateway/FakeAudioGateway.php
+++ b/src/Gateway/FakeAudioGateway.php
@@ -29,9 +29,11 @@ class FakeAudioGateway implements AudioGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
-        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout);
+        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $speed, $format, $provider, $model, $timeout);
 
         return $this->nextResponse($provider, $model, $audioPrompt);
     }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -208,6 +208,8 @@ class GeminiGateway implements Gateway, StepTextGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
         $response = $this->withErrorHandling(

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -15,6 +15,7 @@ use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioMimeTypes;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionMessages;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\PerformsChatCompletionSteps;
@@ -41,6 +42,7 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
     use ParsesServerSentEvents;
     use PerformsChatCompletionSteps;
     use ResolvesAudioFilenames;
+    use ResolvesAudioMimeTypes;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -72,6 +74,8 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
         $voice = match ($voice) {
@@ -80,14 +84,16 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
             default => $voice,
         };
 
+        $format ??= 'mp3';
+
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', [
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
                 'model' => $model,
                 'input' => $text,
                 'voice_id' => $voice,
-                'response_format' => 'mp3',
-            ]),
+                'response_format' => $format,
+            ])),
         );
 
         $encodedAudio = $response->json('audio_data');
@@ -99,7 +105,7 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
         return new AudioResponse(
             $encodedAudio,
             new Meta($provider->name(), $model),
-            'audio/mpeg',
+            $this->audioResponseMimeType($format),
         );
     }
 

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -21,6 +21,7 @@ use Laravel\Ai\Files\StoredImage;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
 use Laravel\Ai\Gateway\Concerns\ResolvesAudioFilenames;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioMimeTypes;
 use Laravel\Ai\Responses\AudioResponse;
 use Laravel\Ai\Responses\Data\GeneratedImage;
 use Laravel\Ai\Responses\Data\Meta;
@@ -44,6 +45,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
     use HandlesFailoverErrors;
     use ParsesServerSentEvents;
     use ResolvesAudioFilenames;
+    use ResolvesAudioMimeTypes;
 
     public function __construct(protected Dispatcher $events)
     {
@@ -161,6 +163,8 @@ class OpenAiGateway implements Gateway, StepTextGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
         $voice = match ($voice) {
@@ -169,14 +173,16 @@ class OpenAiGateway implements Gateway, StepTextGateway
             default => $voice,
         };
 
+        $format ??= 'mp3';
+
         $response = $this->withErrorHandling(
             $provider->name(),
             fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $voice,
-                'response_format' => 'mp3',
-                'speed' => 1.0,
+                'response_format' => $format,
+                'speed' => $speed ?? 1.0,
                 'instructions' => $instructions,
             ])),
         );
@@ -184,7 +190,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
         return new AudioResponse(
             base64_encode($response->body()),
             new Meta($provider->name(), $model),
-            'audio/mpeg',
+            $this->audioResponseMimeType($format),
         );
     }
 

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -18,6 +18,7 @@ use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Files\Image;
 use Laravel\Ai\Gateway\Concerns\HandlesFailoverErrors;
 use Laravel\Ai\Gateway\Concerns\ParsesServerSentEvents;
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioMimeTypes;
 use Laravel\Ai\Gateway\Concerns\WrapsPcmAudio;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionMessages;
 use Laravel\Ai\Gateway\OpenAiCompatible\Concerns\MapsChatCompletionTools;
@@ -48,6 +49,7 @@ class OpenRouterGateway implements Gateway, StepTextGateway
     use MapsChatCompletionTools;
     use ParsesServerSentEvents;
     use PerformsChatCompletionSteps;
+    use ResolvesAudioMimeTypes;
     use WrapsPcmAudio;
 
     public function __construct(protected Dispatcher $events)
@@ -176,9 +178,11 @@ class OpenRouterGateway implements Gateway, StepTextGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
-        $format = $this->audioResponseFormat($model);
+        $format ??= $this->audioResponseFormat($model);
 
         $response = $this->withErrorHandling(
             $provider->name(),
@@ -187,7 +191,7 @@ class OpenRouterGateway implements Gateway, StepTextGateway
                 'input' => $text,
                 'voice' => $this->resolveVoice($model, $voice),
                 'response_format' => $format,
-                'speed' => 1.0,
+                'speed' => $speed ?? 1.0,
                 'instructions' => $instructions,
             ])),
         );
@@ -225,22 +229,6 @@ class OpenRouterGateway implements Gateway, StepTextGateway
     protected function audioResponseFormat(string $model): string
     {
         return $this->isGeminiTtsModel($model) ? 'pcm' : 'mp3';
-    }
-
-    /**
-     * Map a response_format value to the HTTP audio MIME type.
-     */
-    protected function audioResponseMimeType(string $format): string
-    {
-        return match ($format) {
-            'mp3' => 'audio/mpeg',
-            'pcm' => 'audio/pcm',
-            'wav' => 'audio/wav',
-            'opus' => 'audio/opus',
-            'aac' => 'audio/aac',
-            'flac' => 'audio/flac',
-            default => 'audio/mpeg',
-        };
     }
 
     protected function isGeminiTtsModel(string $model): bool

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -123,6 +123,8 @@ class XaiGateway implements Gateway, StepTextGateway
         string $text,
         string $voice,
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         int $timeout = 30,
     ): AudioResponse {
         throw new LogicException('xAI does not support audio generation.');

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -23,6 +23,10 @@ class PendingAudioGeneration
 
     protected ?string $instructions = null;
 
+    protected ?float $speed = null;
+
+    protected ?string $format = null;
+
     protected int $timeout = 30;
 
     public function __construct(
@@ -74,6 +78,26 @@ class PendingAudioGeneration
     }
 
     /**
+     * Specify the playback speed of the generated audio.
+     */
+    public function speed(float $speed): self
+    {
+        $this->speed = $speed;
+
+        return $this;
+    }
+
+    /**
+     * Specify the audio format of the generated audio.
+     */
+    public function format(string $format): self
+    {
+        $this->format = $format;
+
+        return $this;
+    }
+
+    /**
      * Specify the timeout (in seconds) for the audio generation.
      */
     public function timeout(int $seconds = 30): self
@@ -103,7 +127,13 @@ class PendingAudioGeneration
 
             try {
                 return $provider->audio(
-                    $this->text, $this->voice, $this->instructions, $model, $this->timeout
+                    $this->text,
+                    $this->voice,
+                    $this->instructions,
+                    $this->speed,
+                    $this->format,
+                    $model,
+                    $this->timeout
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -128,6 +158,8 @@ class PendingAudioGeneration
                     $this->text,
                     $this->voice,
                     $this->instructions,
+                    $this->speed,
+                    $this->format,
                     $provider,
                     $model,
                     $this->timeout,

--- a/src/Prompts/AudioPrompt.php
+++ b/src/Prompts/AudioPrompt.php
@@ -11,6 +11,8 @@ class AudioPrompt
         public readonly string $text,
         public readonly string $voice,
         public readonly ?string $instructions,
+        public readonly ?float $speed,
+        public readonly ?string $format,
         public readonly AudioProvider $provider,
         public readonly string $model,
         public readonly int $timeout = 30,

--- a/src/Prompts/QueuedAudioPrompt.php
+++ b/src/Prompts/QueuedAudioPrompt.php
@@ -11,6 +11,8 @@ class QueuedAudioPrompt
         public readonly string $text,
         public readonly string $voice,
         public readonly ?string $instructions,
+        public readonly ?float $speed,
+        public readonly ?string $format,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
         public readonly int $timeout = 30,

--- a/src/Providers/Concerns/GeneratesAudio.php
+++ b/src/Providers/Concerns/GeneratesAudio.php
@@ -18,6 +18,8 @@ trait GeneratesAudio
         string $text,
         string $voice = 'default-female',
         ?string $instructions = null,
+        ?float $speed = null,
+        ?string $format = null,
         ?string $model = null,
         int $timeout = 30,
     ): AudioResponse {
@@ -25,7 +27,7 @@ trait GeneratesAudio
 
         $model ??= $this->defaultAudioModel();
 
-        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout);
+        $prompt = new AudioPrompt($text, $voice, $instructions, $speed, $format, $this, $model, $timeout);
 
         if (Ai::audioIsFaked()) {
             Ai::recordAudioGeneration($prompt);
@@ -36,7 +38,7 @@ trait GeneratesAudio
         ));
 
         return tap($this->audioGateway()->generateAudio(
-            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout,
+            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $prompt->speed, $prompt->format, $timeout,
         ), function (AudioResponse $response) use ($invocationId, $model, $prompt): void {
             $this->events->dispatch(new AudioGenerated(
                 $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/AudioFakeTest.php
+++ b/tests/Feature/AudioFakeTest.php
@@ -110,6 +110,8 @@ test('stringable audio macro passes through options', function (): void {
         provider: Lab::ElevenLabs,
         voice: 'alloy',
         instructions: 'Speak slowly',
+        speed: 1.5,
+        format: 'opus',
         model: 'custom-model',
         timeout: 45,
     );
@@ -118,6 +120,8 @@ test('stringable audio macro passes through options', function (): void {
         && $prompt->provider instanceof ElevenLabsProvider
         && $prompt->voice === 'alloy'
         && $prompt->instructions === 'Speak slowly'
+        && $prompt->speed === 1.5
+        && $prompt->format === 'opus'
         && $prompt->model === 'custom-model'
         && $prompt->timeout === 45);
 });
@@ -144,6 +148,16 @@ test('audio voice and instructions are recorded', function (): void {
     Audio::assertGenerated(fn (AudioPrompt $prompt): bool => $prompt->text === 'Hello world'
         && $prompt->voice === 'alloy'
         && $prompt->instructions === 'Speak slowly');
+});
+
+test('audio speed and format are recorded', function (): void {
+    Audio::fake();
+
+    Audio::of('Hello world')->speed(1.75)->format('aac')->generate();
+
+    Audio::assertGenerated(fn (AudioPrompt $prompt): bool => $prompt->text === 'Hello world'
+        && $prompt->speed === 1.75
+        && $prompt->format === 'aac');
 });
 
 test('audio is stored under a random name derived from its mime type', function (): void {
@@ -285,6 +299,16 @@ test('queued audio voice and instructions are recorded', function (): void {
     Audio::assertQueued(fn (QueuedAudioPrompt $prompt): bool => $prompt->text === 'Hello world'
         && $prompt->voice === 'default-male'
         && $prompt->instructions === 'Speak quickly');
+});
+
+test('queued audio speed and format are recorded', function (): void {
+    Audio::fake();
+
+    Audio::of('Hello world')->speed(1.25)->format('wav')->queue();
+
+    Audio::assertQueued(fn (QueuedAudioPrompt $prompt): bool => $prompt->text === 'Hello world'
+        && $prompt->speed === 1.25
+        && $prompt->format === 'wav');
 });
 
 test('queued audio timeout is recorded', function (): void {

--- a/tests/Feature/Providers/ElevenLabs/AudioTest.php
+++ b/tests/Feature/Providers/ElevenLabs/AudioTest.php
@@ -44,6 +44,26 @@ test('audio request passes custom voice id through unchanged', function (): void
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/my-custom-voice-id');
 });
 
+test('audio request includes output_format query parameter when format is provided', function (): void {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->format('mp3_44100_128')->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/XrExE9yKIg1WjnnlVkGX?output_format=mp3_44100_128');
+});
+
+test('audio request includes voice_settings speed when speed is provided', function (): void {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->speed(1.2)->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return isset($body['voice_settings']['speed']) && $body['voice_settings']['speed'] == 1.2;
+    });
+});
+
 test('audio request sends xi-api-key header', function (): void {
     Http::fake(['*' => fakeElevenAudioResponse()]);
 

--- a/tests/Feature/Providers/ElevenLabs/AudioTest.php
+++ b/tests/Feature/Providers/ElevenLabs/AudioTest.php
@@ -52,6 +52,20 @@ test('audio request includes output_format query parameter when format is provid
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/XrExE9yKIg1WjnnlVkGX?output_format=mp3_44100_128');
 });
 
+test('audio request resolves format aliases for elevenlabs', function (string $format, string $expectedOutputFormat): void {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')->format($format)->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === "https://api.elevenlabs.io/v1/text-to-speech/XrExE9yKIg1WjnnlVkGX?output_format={$expectedOutputFormat}");
+})->with([
+    ['mp3', 'mp3_44100_128'],
+    ['wav', 'pcm_44100'],
+    ['pcm', 'pcm_44100'],
+    ['opus', 'opus_16000'],
+    ['aac', 'aac_16000'],
+]);
+
 test('audio request includes voice_settings speed when speed is provided', function (): void {
     Http::fake(['*' => fakeElevenAudioResponse()]);
 

--- a/tests/Feature/Providers/Mistral/AudioTest.php
+++ b/tests/Feature/Providers/Mistral/AudioTest.php
@@ -47,6 +47,15 @@ test('audio request passes custom voice id through unchanged', function (): void
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_id'] === 'my-custom-voice-id');
 });
 
+test('audio request includes format when provided', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    $response = Audio::of('Hello')->format('wav')->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['response_format'] === 'wav');
+    expect($response->mimeType())->toBe('audio/wav');
+});
+
 test('audio request omits instructions since the Mistral API does not accept them', function (): void {
     Http::fake(['*' => fakeMistralAudioResponse()]);
 

--- a/tests/Feature/Providers/OpenAi/AudioTest.php
+++ b/tests/Feature/Providers/OpenAi/AudioTest.php
@@ -68,6 +68,37 @@ test('audio request includes instructions when provided', function (): void {
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['instructions'] === 'Speak slowly');
 });
 
+test('audio request includes speed when provided', function (): void {
+    Http::fake(['*' => fakeOpenAiAudioResponse()]);
+
+    Audio::of('Hello')->speed(1.5)->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['speed'] == 1.5);
+});
+
+test('audio request includes format when provided', function (): void {
+    Http::fake(['*' => fakeOpenAiAudioResponse()]);
+
+    Audio::of('Hello')->format('aac')->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['response_format'] === 'aac');
+});
+
+test('audio response resolves correct mime type for custom format', function (string $format, string $expectedMimeType): void {
+    Http::fake(['*' => fakeOpenAiAudioResponse()]);
+
+    $response = Audio::of('Hello')->format($format)->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    expect($response->mimeType())->toBe($expectedMimeType);
+})->with([
+    ['mp3', 'audio/mpeg'],
+    ['wav', 'audio/wav'],
+    ['aac', 'audio/aac'],
+    ['flac', 'audio/flac'],
+    ['opus', 'audio/opus'],
+    ['pcm', 'audio/pcm'],
+]);
+
 test('audio response is base64-encoded with audio/mpeg mime type', function (): void {
     Http::fake(['*' => fakeOpenAiAudioResponse()]);
 

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -77,6 +77,22 @@ test('audio request omits instructions when not provided', function (): void {
     Http::assertSent(fn (Request $request): bool => ! array_key_exists('instructions', json_decode($request->body(), true)));
 });
 
+test('audio request includes speed when provided', function (): void {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->speed(1.25)->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['speed'] == 1.25);
+});
+
+test('audio request includes format when provided', function (): void {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')->format('opus')->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['response_format'] === 'opus');
+});
+
 test('audio uses default model when none specified', function (): void {
     Http::fake(['*' => fakeOpenRouterAudioResponse()]);
 

--- a/tests/Unit/Gateway/ResolvesAudioMimeTypesTest.php
+++ b/tests/Unit/Gateway/ResolvesAudioMimeTypesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Laravel\Ai\Gateway\Concerns\ResolvesAudioMimeTypes;
+
+function callAudioResponseMimeType(string $format): string
+{
+    $class = new class
+    {
+        use ResolvesAudioMimeTypes;
+
+        public function getMimeType(string $format): string
+        {
+            return $this->audioResponseMimeType($format);
+        }
+    };
+
+    return $class->getMimeType($format);
+}
+
+test('audio response mime type is correctly mapped from format', function (string $format, string $expectedMimeType): void {
+    expect(callAudioResponseMimeType($format))->toBe($expectedMimeType);
+})->with([
+    ['mp3', 'audio/mpeg'],
+    ['MP3', 'audio/mpeg'],
+    ['mp3_44100_128', 'audio/mpeg'],
+    ['wav', 'audio/wav'],
+    ['pcm', 'audio/pcm'],
+    ['pcm_44100', 'audio/pcm'],
+    ['opus', 'audio/opus'],
+    ['opus_16000', 'audio/opus'],
+    ['aac', 'audio/aac'],
+    ['aac_16000', 'audio/aac'],
+    ['flac', 'audio/flac'],
+    ['unknown_format', 'audio/mpeg'],
+]);


### PR DESCRIPTION
This PR adds `withProviderOptions()` support to the Audio (TTS) generation builder using the `ResolvesProviderOptions` trait (bringing parity with Transcription and Embeddings), addressing #936 as discussed.

### Summary of Changes

1. **Builder & Trait**:
   - Added `ResolvesProviderOptions` trait to `PendingAudioGeneration`.
   - Forwarded resolved `$providerOptions` array to `AudioProvider::audio(...)` and `QueuedAudioPrompt`.
2. **Prompts & Contracts**:
   - Updated `AudioPrompt` and `QueuedAudioPrompt` constructors to accept `array $providerOptions = []`.
   - Updated `AudioProvider` and `AudioGateway` interface signatures to accept `array $providerOptions = []`.
   - Updated `GeneratesAudio` trait to forward `$providerOptions`.
3. **Provider Gateways**:
   - `OpenAiGateway`, `OpenRouterGateway`, `ElevenLabsGateway`, and `MistralGateway` merge `$providerOptions` into their requests.
   - Updated response MIME type detection in `OpenAiGateway` to read from `$response->header('Content-Type')`.
   - Updated `Stringable::toAudio` macro to accept `array|Closure $providerOptions = []`.
4. **Tests**:
   - Added test coverage for provider options merging and MIME type headers across OpenAI, OpenRouter, ElevenLabs, Mistral, and Fake audio prompts.

Closes #936