### PR TITLE
[0.x] Add withProviderOptions() support to Audio generation

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -83,6 +83,7 @@ class AiServiceProvider extends ServiceProvider
             ?string $instructions = null,
             ?string $model = null,
             ?int $timeout = null,
+            array|Closure $providerOptions = [],
         ): AudioResponse {
             $request = Audio::of($this->value());
 
@@ -96,6 +97,10 @@ class AiServiceProvider extends ServiceProvider
 
             if (! is_null($timeout)) {
                 $request->timeout($timeout);
+            }
+
+            if (filled($providerOptions)) {
+                $request->withProviderOptions($providerOptions);
             }
 
             return $request->generate(provider: $provider, model: $model);

--- a/src/Contracts/Gateway/AudioGateway.php
+++ b/src/Contracts/Gateway/AudioGateway.php
@@ -9,6 +9,8 @@ interface AudioGateway
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -17,5 +19,6 @@ interface AudioGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse;
 }

--- a/src/Contracts/Providers/AudioProvider.php
+++ b/src/Contracts/Providers/AudioProvider.php
@@ -9,6 +9,8 @@ interface AudioProvider extends Provider
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function audio(
         string $text,
@@ -16,6 +18,7 @@ interface AudioProvider extends Provider
         ?string $instructions = null,
         ?string $model = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse;
 
     /**

--- a/src/Gateway/Anthropic/AnthropicGateway.php
+++ b/src/Gateway/Anthropic/AnthropicGateway.php
@@ -135,6 +135,8 @@ class AnthropicGateway implements Gateway, StepTextGateway
     /**
      * Generate audio from the given text.
      *
+     * @param  array<string, mixed>  $providerOptions
+     *
      * @throws LogicException
      */
     public function generateAudio(
@@ -144,6 +146,7 @@ class AnthropicGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         throw new LogicException('Anthropic does not support audio generation.');
     }

--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -23,6 +23,8 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -31,6 +33,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'onwK4e9ZLuTAKqWW03F9',
@@ -39,15 +42,15 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
         };
 
         $response = $this->withErrorHandling($provider->name(), fn () => $this->client($provider, $timeout)
-            ->post('text-to-speech/'.$voice, [
+            ->post('text-to-speech/'.$voice, array_merge([
                 'model_id' => $model,
                 'text' => $text,
-            ])->throw());
+            ], $providerOptions))->throw());
 
         return new AudioResponse(
             base64_encode((string) $response),
             new Meta($provider->name(), $model),
-            'audio/mpeg'
+            $response->header('Content-Type') ?: 'audio/mpeg'
         );
     }
 

--- a/src/Gateway/FakeAudioGateway.php
+++ b/src/Gateway/FakeAudioGateway.php
@@ -22,6 +22,8 @@ class FakeAudioGateway implements AudioGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -30,8 +32,9 @@ class FakeAudioGateway implements AudioGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
-        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout);
+        $audioPrompt = new AudioPrompt($text, $voice, $instructions, $provider, $model, $timeout, $providerOptions);
 
         return $this->nextResponse($provider, $model, $audioPrompt);
     }

--- a/src/Gateway/Gemini/GeminiGateway.php
+++ b/src/Gateway/Gemini/GeminiGateway.php
@@ -200,6 +200,8 @@ class GeminiGateway implements Gateway, StepTextGateway
     /**
      * Generate audio from the given text.
      *
+     * @param  array<string, mixed>  $providerOptions
+     *
      * @throws RuntimeException if Gemini returns no audio data or invalid base64 audio.
      */
     public function generateAudio(
@@ -209,6 +211,7 @@ class GeminiGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $response = $this->withErrorHandling(
             $provider->name(),

--- a/src/Gateway/Mistral/MistralGateway.php
+++ b/src/Gateway/Mistral/MistralGateway.php
@@ -65,6 +65,8 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
 
     /**
      * {@inheritdoc}
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -73,6 +75,7 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'en_paul_neutral',
@@ -82,12 +85,12 @@ class MistralGateway implements AudioGateway, EmbeddingGateway, StepTextGateway,
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', [
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge([
                 'model' => $model,
                 'input' => $text,
                 'voice_id' => $voice,
                 'response_format' => 'mp3',
-            ]),
+            ], $providerOptions)),
         );
 
         $encodedAudio = $response->json('audio_data');

--- a/src/Gateway/OpenAi/OpenAiGateway.php
+++ b/src/Gateway/OpenAi/OpenAiGateway.php
@@ -154,6 +154,8 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -162,6 +164,7 @@ class OpenAiGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $voice = match ($voice) {
             'default-male' => 'ash',
@@ -171,20 +174,21 @@ class OpenAiGateway implements Gateway, StepTextGateway
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $voice,
                 'response_format' => 'mp3',
                 'speed' => 1.0,
+            ], array_filter([
                 'instructions' => $instructions,
-            ])),
+            ]), $providerOptions)),
         );
 
         return new AudioResponse(
             base64_encode($response->body()),
             new Meta($provider->name(), $model),
-            'audio/mpeg',
+            $response->header('Content-Type') ?: 'audio/mpeg',
         );
     }
 

--- a/src/Gateway/OpenRouter/OpenRouterGateway.php
+++ b/src/Gateway/OpenRouter/OpenRouterGateway.php
@@ -169,6 +169,8 @@ class OpenRouterGateway implements Gateway, StepTextGateway
 
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function generateAudio(
         AudioProvider $provider,
@@ -177,19 +179,21 @@ class OpenRouterGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
-        $format = $this->audioResponseFormat($model);
+        $format = $providerOptions['response_format'] ?? $this->audioResponseFormat($model);
 
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider, $timeout)->post('audio/speech', array_filter([
+            fn () => $this->client($provider, $timeout)->post('audio/speech', array_merge([
                 'model' => $model,
                 'input' => $text,
                 'voice' => $this->resolveVoice($model, $voice),
                 'response_format' => $format,
                 'speed' => 1.0,
+            ], array_filter([
                 'instructions' => $instructions,
-            ])),
+            ]), $providerOptions)),
         );
 
         return new AudioResponse(

--- a/src/Gateway/Xai/XaiGateway.php
+++ b/src/Gateway/Xai/XaiGateway.php
@@ -115,6 +115,8 @@ class XaiGateway implements Gateway, StepTextGateway
     }
 
     /**
+     * @param  array<string, mixed>  $providerOptions
+     *
      * @throws LogicException
      */
     public function generateAudio(
@@ -124,6 +126,7 @@ class XaiGateway implements Gateway, StepTextGateway
         string $voice,
         ?string $instructions = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         throw new LogicException('xAI does not support audio generation.');
     }

--- a/src/PendingResponses/PendingAudioGeneration.php
+++ b/src/PendingResponses/PendingAudioGeneration.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Events\ProviderFailedOver;
 use Laravel\Ai\Exceptions\FailoverableException;
 use Laravel\Ai\Jobs\GenerateAudio;
+use Laravel\Ai\PendingResponses\Concerns\ResolvesProviderOptions;
 use Laravel\Ai\Prompts\QueuedAudioPrompt;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Responses\AudioResponse;
@@ -18,6 +19,7 @@ use Laravel\Ai\Responses\QueuedAudioResponse;
 class PendingAudioGeneration
 {
     use Conditionable;
+    use ResolvesProviderOptions;
 
     protected string $voice = 'default-female';
 
@@ -101,9 +103,16 @@ class PendingAudioGeneration
 
             $model ??= $provider->defaultAudioModel();
 
+            $providerOptions = $this->resolveProviderOptions($provider);
+
             try {
                 return $provider->audio(
-                    $this->text, $this->voice, $this->instructions, $model, $this->timeout
+                    $this->text,
+                    $this->voice,
+                    $this->instructions,
+                    $model,
+                    $this->timeout,
+                    $providerOptions,
                 );
             } catch (FailoverableException $e) {
                 $lastException = $e;
@@ -131,6 +140,7 @@ class PendingAudioGeneration
                     $provider,
                     $model,
                     $this->timeout,
+                    is_array($this->providerOptions) ? $this->providerOptions : [],
                 )
             );
         }

--- a/src/Prompts/AudioPrompt.php
+++ b/src/Prompts/AudioPrompt.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Contracts\Providers\AudioProvider;
 
 class AudioPrompt
 {
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $text,
         public readonly string $voice,
@@ -14,6 +17,7 @@ class AudioPrompt
         public readonly AudioProvider $provider,
         public readonly string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Prompts/QueuedAudioPrompt.php
+++ b/src/Prompts/QueuedAudioPrompt.php
@@ -7,6 +7,9 @@ use Laravel\Ai\Enums\Lab;
 
 class QueuedAudioPrompt
 {
+    /**
+     * @param  array<string, mixed>  $providerOptions
+     */
     public function __construct(
         public readonly string $text,
         public readonly string $voice,
@@ -14,6 +17,7 @@ class QueuedAudioPrompt
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
         public readonly int $timeout = 30,
+        public readonly array $providerOptions = [],
     ) {}
 
     /**

--- a/src/Providers/Concerns/GeneratesAudio.php
+++ b/src/Providers/Concerns/GeneratesAudio.php
@@ -13,6 +13,8 @@ trait GeneratesAudio
 {
     /**
      * Generate audio from the given text.
+     *
+     * @param  array<string, mixed>  $providerOptions
      */
     public function audio(
         string $text,
@@ -20,12 +22,13 @@ trait GeneratesAudio
         ?string $instructions = null,
         ?string $model = null,
         int $timeout = 30,
+        array $providerOptions = [],
     ): AudioResponse {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultAudioModel();
 
-        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout);
+        $prompt = new AudioPrompt($text, $voice, $instructions, $this, $model, $timeout, $providerOptions);
 
         if (Ai::audioIsFaked()) {
             Ai::recordAudioGeneration($prompt);
@@ -36,7 +39,7 @@ trait GeneratesAudio
         ));
 
         return tap($this->audioGateway()->generateAudio(
-            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $timeout,
+            $this, $model, $prompt->text, $prompt->voice, $prompt->instructions, $prompt->timeout ?? 30, $prompt->providerOptions,
         ), function (AudioResponse $response) use ($invocationId, $model, $prompt): void {
             $this->events->dispatch(new AudioGenerated(
                 $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/AudioFakeTest.php
+++ b/tests/Feature/AudioFakeTest.php
@@ -112,6 +112,7 @@ test('stringable audio macro passes through options', function (): void {
         instructions: 'Speak slowly',
         model: 'custom-model',
         timeout: 45,
+        providerOptions: ['speed' => 1.5],
     );
 
     Audio::assertGenerated(fn (AudioPrompt $prompt): bool => $prompt->text === 'Hello world'
@@ -119,7 +120,8 @@ test('stringable audio macro passes through options', function (): void {
         && $prompt->voice === 'alloy'
         && $prompt->instructions === 'Speak slowly'
         && $prompt->model === 'custom-model'
-        && $prompt->timeout === 45);
+        && $prompt->timeout === 45
+        && $prompt->providerOptions === ['speed' => 1.5]);
 });
 
 test('audio can prevent stray generations', function (): void {
@@ -144,6 +146,15 @@ test('audio voice and instructions are recorded', function (): void {
     Audio::assertGenerated(fn (AudioPrompt $prompt): bool => $prompt->text === 'Hello world'
         && $prompt->voice === 'alloy'
         && $prompt->instructions === 'Speak slowly');
+});
+
+test('audio provider options are recorded', function (): void {
+    Audio::fake();
+
+    Audio::of('Hello world')->withProviderOptions(['speed' => 1.75, 'response_format' => 'aac'])->generate();
+
+    Audio::assertGenerated(fn (AudioPrompt $prompt): bool => $prompt->text === 'Hello world'
+        && $prompt->providerOptions === ['speed' => 1.75, 'response_format' => 'aac']);
 });
 
 test('audio is stored under a random name derived from its mime type', function (): void {
@@ -285,6 +296,15 @@ test('queued audio voice and instructions are recorded', function (): void {
     Audio::assertQueued(fn (QueuedAudioPrompt $prompt): bool => $prompt->text === 'Hello world'
         && $prompt->voice === 'default-male'
         && $prompt->instructions === 'Speak quickly');
+});
+
+test('queued audio provider options are recorded', function (): void {
+    Audio::fake();
+
+    Audio::of('Hello world')->withProviderOptions(['speed' => 1.25, 'response_format' => 'wav'])->queue();
+
+    Audio::assertQueued(fn (QueuedAudioPrompt $prompt): bool => $prompt->text === 'Hello world'
+        && $prompt->providerOptions === ['speed' => 1.25, 'response_format' => 'wav']);
 });
 
 test('queued audio timeout is recorded', function (): void {

--- a/tests/Feature/Providers/ElevenLabs/AudioTest.php
+++ b/tests/Feature/Providers/ElevenLabs/AudioTest.php
@@ -44,6 +44,20 @@ test('audio request passes custom voice id through unchanged', function (): void
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.elevenlabs.io/v1/text-to-speech/my-custom-voice-id');
 });
 
+test('audio request merges provider options when provided', function (): void {
+    Http::fake(['*' => fakeElevenAudioResponse()]);
+
+    Audio::of('Hello')
+        ->withProviderOptions(['voice_settings' => ['speed' => 1.2]])
+        ->generate(provider: 'eleven', model: 'eleven_multilingual_v2');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return isset($body['voice_settings']['speed']) && $body['voice_settings']['speed'] == 1.2;
+    });
+});
+
 test('audio request sends xi-api-key header', function (): void {
     Http::fake(['*' => fakeElevenAudioResponse()]);
 

--- a/tests/Feature/Providers/Mistral/AudioTest.php
+++ b/tests/Feature/Providers/Mistral/AudioTest.php
@@ -47,6 +47,16 @@ test('audio request passes custom voice id through unchanged', function (): void
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['voice_id'] === 'my-custom-voice-id');
 });
 
+test('audio request merges provider options when provided', function (): void {
+    Http::fake(['*' => fakeMistralAudioResponse()]);
+
+    Audio::of('Hello')
+        ->withProviderOptions(['response_format' => 'wav'])
+        ->generate(provider: 'mistral', model: 'voxtral-mini-tts-2603');
+
+    Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['response_format'] === 'wav');
+});
+
 test('audio request omits instructions since the Mistral API does not accept them', function (): void {
     Http::fake(['*' => fakeMistralAudioResponse()]);
 

--- a/tests/Feature/Providers/OpenAi/AudioTest.php
+++ b/tests/Feature/Providers/OpenAi/AudioTest.php
@@ -68,6 +68,30 @@ test('audio request includes instructions when provided', function (): void {
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['instructions'] === 'Speak slowly');
 });
 
+test('audio request merges provider options when provided', function (): void {
+    Http::fake(['*' => fakeOpenAiAudioResponse()]);
+
+    Audio::of('Hello')
+        ->withProviderOptions(['speed' => 1.5, 'response_format' => 'wav'])
+        ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['speed'] == 1.5 && $body['response_format'] === 'wav';
+    });
+});
+
+test('audio response uses content-type header for mime type', function (): void {
+    Http::fake(['*' => Http::response('fake-audio-bytes', 200, ['Content-Type' => 'audio/wav'])]);
+
+    $response = Audio::of('Hello')
+        ->withProviderOptions(['response_format' => 'wav'])
+        ->generate(provider: 'openai', model: 'gpt-4o-mini-tts');
+
+    expect($response->mimeType())->toBe('audio/wav');
+});
+
 test('audio response is base64-encoded with audio/mpeg mime type', function (): void {
     Http::fake(['*' => fakeOpenAiAudioResponse()]);
 

--- a/tests/Feature/Providers/OpenRouter/AudioTest.php
+++ b/tests/Feature/Providers/OpenRouter/AudioTest.php
@@ -77,6 +77,20 @@ test('audio request omits instructions when not provided', function (): void {
     Http::assertSent(fn (Request $request): bool => ! array_key_exists('instructions', json_decode($request->body(), true)));
 });
 
+test('audio request merges provider options when provided', function (): void {
+    Http::fake(['*' => fakeOpenRouterAudioResponse()]);
+
+    Audio::of('Hello')
+        ->withProviderOptions(['speed' => 1.25, 'response_format' => 'opus'])
+        ->generate(provider: 'openrouter', model: 'openai/gpt-4o-mini-tts-2025-12-15');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return $body['speed'] == 1.25 && $body['response_format'] === 'opus';
+    });
+});
+
 test('audio uses default model when none specified', function (): void {
     Http::fake(['*' => fakeOpenRouterAudioResponse()]);
 


### PR DESCRIPTION
This PR adds `withProviderOptions()` support to the Audio (TTS) generation builder using the standard `ResolvesProviderOptions` trait, bringing parity with Transcription and Embeddings as requested in #950 / #936.

### Summary of Changes

1. **Builder & Trait**:
   - Added `ResolvesProviderOptions` trait to `PendingAudioGeneration`.
   - Forwarded resolved `$providerOptions` array to `AudioProvider::audio(...)` and `QueuedAudioPrompt`.
2. **Prompts & Contracts**:
   - Updated `AudioPrompt` and `QueuedAudioPrompt` constructors to accept `array $providerOptions = []`.
   - Updated `AudioProvider` and `AudioGateway` interface signatures to accept `array $providerOptions = []`.
   - Updated `GeneratesAudio` trait to forward `$providerOptions`.
3. **Provider Gateways**:
   - `OpenAiGateway`, `OpenRouterGateway`, `ElevenLabsGateway`, and `MistralGateway` merge `$providerOptions` into their requests.
   - Updated response MIME type detection in `OpenAiGateway` to read from `$response->header('Content-Type')`.
   - Updated `Stringable::toAudio` macro to accept `array|Closure $providerOptions = []`.
4. **Tests**:
   - Added test coverage for provider options merging and MIME type headers across OpenAI, OpenRouter, ElevenLabs, Mistral, and Fake audio prompts.

Supersedes #950
Closes #936