### PR TITLE
Return null for a remote file mime type when the response declares no content type

### DIFF
--- a/src/Files/Concerns/HasRemoteContent.php
+++ b/src/Files/Concerns/HasRemoteContent.php
@@ -33,7 +33,7 @@ trait HasRemoteContent
      */
     public function mimeType(): ?string
     {
-        return $this->mime ?? (new Stringable($this->response()->header('Content-Type')))->before(';')->trim()->toString();
+        return $this->mime ?? ((new Stringable($this->response()->header('Content-Type')))->before(';')->trim()->toString() ?: null);
     }
 
     /**


### PR DESCRIPTION
small one, the `RemoteFileTest` mime case is red on 0.x. `mimeType()` hands back `''` instead of `null` when there's no `Content-Type` header. this returns `null` when it's empty.