### PR TITLE
Send the ElevenLabs transcription language hint as the documented language_code field

### DIFF
--- a/src/Gateway/ElevenLabsGateway.php
+++ b/src/Gateway/ElevenLabsGateway.php
@@ -69,7 +69,7 @@ class ElevenLabsGateway implements AudioGateway, TranscriptionGateway
             ->attach('file', $audio->content(), 'file', array_filter(['Content-Type' => $audio->mimeType()]))
             ->post('speech-to-text', array_merge($providerOptions, array_filter([
                 'model_id' => $model,
-                'language' => $language,
+                'language_code' => $language,
                 'diarize' => $diarize ? 'true' : 'false',
             ])))->throw());
 

--- a/tests/Feature/Providers/ElevenLabs/TranscriptionTest.php
+++ b/tests/Feature/Providers/ElevenLabs/TranscriptionTest.php
@@ -12,7 +12,7 @@ beforeEach(function (): void {
     ]]);
 });
 
-test('transcription request posts to speech-to-text with model, language, and diarize flag', function (): void {
+test('transcription request posts to speech-to-text with model, language code, and diarize flag', function (): void {
     Http::fake(['*' => fakeElevenTranscriptionResponse()]);
 
     Transcription::of(base64_encode('fake-audio'))
@@ -22,7 +22,7 @@ test('transcription request posts to speech-to-text with model, language, and di
     Http::assertSent(fn (Request $request): bool => $request->url() === 'https://api.elevenlabs.io/v1/speech-to-text'
         && $request->isMultipart()
         && collect($request->data())->contains(fn ($part): bool => $part['name'] === 'model_id' && $part['contents'] === 'scribe_v2')
-        && collect($request->data())->contains(fn ($part): bool => $part['name'] === 'language' && $part['contents'] === 'en')
+        && collect($request->data())->contains(fn ($part): bool => $part['name'] === 'language_code' && $part['contents'] === 'en')
         && collect($request->data())->contains(fn ($part): bool => $part['name'] === 'diarize' && $part['contents'] === 'false'));
 });
 


### PR DESCRIPTION
ElevenLabs transcription sends the language hint in a field called `language`, but the speech-to-text endpoint reads `language_code`. so `->language('en')` gets silently dropped and ElevenLabs just auto-detects instead.

confirmed against the live api: `language_code=zz` returns a 422 invalid-language error (so it's read and validated), `language=zz` returns 200 and is ignored, and `language_code=en` sets `language_probability` to 1.0 vs auto-detect otherwise.

the other providers (OpenAI/Groq/Mistral) use `language` which is right for their apis, ElevenLabs is the odd one out. this renames the field to `language_code` and updates the test.
