### PR TITLE
Map the Mistral model_length and error finish reasons to Length and Error

### DIFF
--- a/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
+++ b/src/Gateway/Mistral/Concerns/ParsesTextResponses.php
@@ -99,8 +99,9 @@ trait ParsesTextResponses
         return match ($choice['finish_reason'] ?? '') {
             'stop' => FinishReason::Stop,
             'tool_calls' => FinishReason::ToolCalls,
-            'length' => FinishReason::Length,
+            'length', 'model_length' => FinishReason::Length,
             'content_filter' => FinishReason::ContentFilter,
+            'error' => FinishReason::Error,
             default => FinishReason::Unknown,
         };
     }

--- a/tests/Feature/Providers/Mistral/StreamingTest.php
+++ b/tests/Feature/Providers/Mistral/StreamingTest.php
@@ -168,6 +168,8 @@ test('streaming finish reason maps correctly', function (string $apiReason, $exp
     'stop maps to Stop' => ['stop', FinishReason::Stop],
     'tool_calls maps to ToolCalls' => ['tool_calls', FinishReason::ToolCalls],
     'length maps to Length' => ['length', FinishReason::Length],
+    'model_length maps to Length' => ['model_length', FinishReason::Length],
     'content_filter maps to ContentFilter' => ['content_filter', FinishReason::ContentFilter],
+    'error maps to Error' => ['error', FinishReason::Error],
     'unknown maps to Unknown' => ['unknown_reason', FinishReason::Unknown],
 ]);


### PR DESCRIPTION
Mistral's finish_reason can be `model_length` (the model's context window ran out) or `error`, but the gateway only maps stop/tool_calls/length/content_filter, so both fall through to `FinishReason::Unknown`. so a caller checking for `Length` to spot a truncated answer never sees it.

both are in [Mistral's openapi spec](https://docs.mistral.ai/openapi.yaml) (the finish_reason enum), and the sibling gateways already handle the equivalent, Anthropic maps `model_context_window_exceeded` to `Length` and OpenAI maps `failed` to `Error`. this does the same for Mistral and adds the two test cases.
