### PR TITLE
Add agent instruction views

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,6 +30,14 @@ function agent(
 }
 
 /**
+ * Render agent instructions from the "resources/agents/instructions" directory.
+ */
+function instructions(string $instructions, array $data = []): string
+{
+    return view("instructions::{$instructions}", $data)->render();
+}
+
+/**
  * Get a new pipeline instance.
  */
 function pipeline(): Pipeline

--- a/functions.php
+++ b/functions.php
@@ -30,14 +30,6 @@ function agent(
 }
 
 /**
- * Render agent instructions from the "resources/agents/instructions" directory.
- */
-function instructions(string $instructions, array $data = []): string
-{
-    return view("instructions::{$instructions}", $data)->render();
-}
-
-/**
  * Get a new pipeline instance.
  */
 function pipeline(): Pipeline

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -7,8 +7,9 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\Engines\CompilerEngine;
 use Laravel\Ai\Agents\SummarizeAgent;
-use Laravel\Ai\Console\Commands\ChatCommand;
 use Laravel\Ai\Console\Commands\MakeAgentCommand;
 use Laravel\Ai\Console\Commands\MakeAgentMiddlewareCommand;
 use Laravel\Ai\Console\Commands\MakeToolCommand;
@@ -35,6 +36,23 @@ class AiServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register the "instructions" view namespace and its Markdown templates.
+     */
+    protected function registerInstructionViews(): void
+    {
+        $this->callAfterResolving('view', function ($view, $app): void {
+            $view->addNamespace('instructions', resource_path('agents/instructions'));
+
+            $compiler = new BladeCompiler($app['files'], $app['config']['view.compiled']);
+
+            // Instructions are plain text, so echoed values must not be HTML escaped...
+            $compiler->setEchoFormat('%s');
+
+            $view->addExtension('blade.md', 'instructions', fn (): CompilerEngine => new CompilerEngine($compiler, $app['files']));
+        });
+    }
+
+    /**
      * Bootstrap the package's services.
      */
     public function boot(): void
@@ -43,6 +61,8 @@ class AiServiceProvider extends ServiceProvider
             $this->registerCommands();
             $this->registerPublishing();
         }
+
+        $this->registerInstructionViews();
 
         // Embeddings macro...
         Stringable::macro('toEmbeddings', function (

--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -41,7 +41,7 @@ class AiServiceProvider extends ServiceProvider
     protected function registerInstructionViews(): void
     {
         $this->callAfterResolving('view', function ($view, $app): void {
-            $view->addNamespace('instructions', resource_path('agents/instructions'));
+            $view->addNamespace('instructions', resource_path('instructions'));
 
             $compiler = new BladeCompiler($app['files'], $app['config']['view.compiled']);
 

--- a/tests/Feature/InstructionViewTest.php
+++ b/tests/Feature/InstructionViewTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use function Laravel\Ai\instructions;
+
+beforeEach(fn () => is_dir(resource_path('agents/instructions')) || mkdir(resource_path('agents/instructions'), recursive: true));
+
+afterEach(function () {
+    array_map(unlink(...), glob(resource_path('agents/instructions/*')));
+
+    rmdir(resource_path('agents/instructions'));
+    rmdir(resource_path('agents'));
+});
+
+it('renders markdown instructions from the resources/agents/instructions directory', function () {
+    file_put_contents(resource_path('agents/instructions/greeting.blade.md'), '# Hello, {{ $name }}.');
+
+    expect(instructions('greeting', ['name' => 'Taylor']))->toBe('# Hello, Taylor.');
+});
+
+it('does not html escape instruction data', function () {
+    file_put_contents(resource_path('agents/instructions/summarize.blade.md'), 'Summarize: {{ $text }}');
+
+    expect(instructions('summarize', ['text' => 'Ben & Jerry\'s "best" <flavor>']))
+        ->toBe('Summarize: Ben & Jerry\'s "best" <flavor>');
+});
+
+it('renders blade directives in instructions', function () {
+    file_put_contents(resource_path('agents/instructions/tools.blade.md'), '@foreach ($tools as $tool)- {{ $tool }}
+@endforeach');
+
+    expect(instructions('tools', ['tools' => ['search', 'fetch']]))->toContain('- search', '- fetch');
+});
+
+it('does not affect html escaping in application views', function () {
+    file_put_contents(resource_path('views/escaped.blade.php'), '{{ $text }}');
+
+    expect(view('escaped', ['text' => '<b>'])->render())->toBe('&lt;b&gt;');
+
+    unlink(resource_path('views/escaped.blade.php'));
+});

--- a/tests/Feature/InstructionViewTest.php
+++ b/tests/Feature/InstructionViewTest.php
@@ -1,34 +1,31 @@
 <?php
 
-use function Laravel\Ai\instructions;
-
-beforeEach(fn () => is_dir(resource_path('agents/instructions')) || mkdir(resource_path('agents/instructions'), recursive: true));
+beforeEach(fn () => is_dir(resource_path('instructions')) || mkdir(resource_path('instructions'), recursive: true));
 
 afterEach(function () {
-    array_map(unlink(...), glob(resource_path('agents/instructions/*')));
+    array_map(unlink(...), glob(resource_path('instructions/*')));
 
-    rmdir(resource_path('agents/instructions'));
-    rmdir(resource_path('agents'));
+    rmdir(resource_path('instructions'));
 });
 
-it('renders markdown instructions from the resources/agents/instructions directory', function () {
-    file_put_contents(resource_path('agents/instructions/greeting.blade.md'), '# Hello, {{ $name }}.');
+it('renders markdown instructions from the resources/instructions directory', function () {
+    file_put_contents(resource_path('instructions/greeting.blade.md'), '# Hello, {{ $name }}.');
 
-    expect(instructions('greeting', ['name' => 'Taylor']))->toBe('# Hello, Taylor.');
+    expect(view('instructions::greeting', ['name' => 'Taylor'])->render())->toBe('# Hello, Taylor.');
 });
 
 it('does not html escape instruction data', function () {
-    file_put_contents(resource_path('agents/instructions/summarize.blade.md'), 'Summarize: {{ $text }}');
+    file_put_contents(resource_path('instructions/summarize.blade.md'), 'Summarize: {{ $text }}');
 
-    expect(instructions('summarize', ['text' => 'Ben & Jerry\'s "best" <flavor>']))
+    expect(view('instructions::summarize', ['text' => 'Ben & Jerry\'s "best" <flavor>'])->render())
         ->toBe('Summarize: Ben & Jerry\'s "best" <flavor>');
 });
 
 it('renders blade directives in instructions', function () {
-    file_put_contents(resource_path('agents/instructions/tools.blade.md'), '@foreach ($tools as $tool)- {{ $tool }}
+    file_put_contents(resource_path('instructions/tools.blade.md'), '@foreach ($tools as $tool)- {{ $tool }}
 @endforeach');
 
-    expect(instructions('tools', ['tools' => ['search', 'fetch']]))->toContain('- search', '- fetch');
+    expect(view('instructions::tools', ['tools' => ['search', 'fetch']])->render())->toContain('- search', '- fetch');
 });
 
 it('does not affect html escaping in application views', function () {


### PR DESCRIPTION
Right now, if you want to keep an agent's instructions in a file, you have to use a regular view in `resources/view/`

```php
public function instructions(): Stringable|string
{
    return view('instructions');
}
```

That never felt right to me:

- Agent prompts end up mixed in with the app's HTML views and PHP templates.
- Most prompts are just Markdown that needs a little bit of dynamism, not the full power of Blade.


```php
public function instructions(): Stringable|string
{
    return view('instructions::support', ['user' => $this->user]);
}
```

`resources/instructions/support.blade.md`:

```markdown
You are a support agent helping {{ $user->name }}.

@foreach ($user->orders as $order)
- Order {{ $order->id }} ({{ $order->status }})
@endforeach
```

Decisions i made along the way.

1. Also Only `*.blade.md` is registered so user get the md syntax highlight and does not interfere with anything else in the view finder.

3. I picked `resources/instructions/` so we have a clear place to expand later with things like `resources/skills/`, `agents/prompts/`, and convention based autoloading of instructions in agent. We can tackle those separately in a follow-up PR if this direction makes sense.



