### PR TITLE
[1.x] Stop proxies buffering native streamed responses

### DIFF
--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -155,7 +155,12 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
             }
 
             yield "data: [DONE]\n\n";
-        }, headers: ['Content-Type' => 'text/event-stream']);
+        }, headers: [
+            // Without these a proxy may buffer or transcode the body, holding every event back until the run ends...
+            'Cache-Control' => 'no-cache, no-transform',
+            'Content-Type' => 'text/event-stream',
+            'X-Accel-Buffering' => 'no',
+        ]);
     }
 
     /**

--- a/tests/Feature/NativeStreamResponseTest.php
+++ b/tests/Feature/NativeStreamResponseTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Tests\Fixtures\Agents\AssistantAgent;
+
+test('a streamed response is sent with headers that stop a proxy buffering it', function (): void {
+    AssistantAgent::fake(['Hello world']);
+
+    $response = (new AssistantAgent)->stream('Hi')->toResponse(request());
+
+    expect($response->headers->get('Content-Type'))->toContain('text/event-stream')
+        ->and($response->headers->get('Cache-Control'))->toContain('no-transform')
+        ->and($response->headers->get('Cache-Control'))->toContain('no-cache')
+        ->and($response->headers->get('X-Accel-Buffering'))->toBe('no');
+});


### PR DESCRIPTION
A native streamed response is sent with `Content-Type` alone, so a proxy sitting between the app and the browser is free to buffer or transcode the body.

This sends `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no` alongside it. Laravel's own `response()->eventStream()` sets the same three headers, and the Vercel and Agent User Interaction protocol responses in this package already send the cache header, so the native path was the only streaming response left without them. The `no-transform` follows the two protocol responses rather than the framework, which sends a bare `no-cache`.