### PR TITLE
[1.x] Report the conversation rows a turn wrote

### DIFF
--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -74,8 +74,10 @@ class RememberConversation
             }
 
             // Record user message...
+            $userMessageId = null;
+
             if (! $prompt->hasApprovalDecisions()) {
-                $this->store->storeUserMessage(
+                $userMessageId = $this->store->storeUserMessage(
                     $agent->currentConversation(),
                     $participantType,
                     $participantId,
@@ -84,7 +86,7 @@ class RememberConversation
             }
 
             // Record assistant message...
-            $this->store->storeAssistantMessage(
+            $assistantMessageId = $this->store->storeAssistantMessage(
                 $agent->currentConversation(),
                 $participantType,
                 $participantId,
@@ -95,7 +97,7 @@ class RememberConversation
             $completedResponse->withinConversation(
                 $agent->currentConversation(),
                 $participant,
-            );
+            )->withStoredMessages($userMessageId, $assistantMessageId);
         });
     }
 

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -16,6 +16,10 @@ class AgentResponse extends TextResponse
 
     public ?object $conversationUser = null;
 
+    public ?string $userMessageId = null;
+
+    public ?string $assistantMessageId = null;
+
     public function __construct(string $invocationId, string $text, Usage $usage, Meta $meta)
     {
         $this->invocationId = $invocationId;
@@ -41,6 +45,17 @@ class AgentResponse extends TextResponse
     {
         $this->conversationId = $conversationId;
         $this->conversationUser = $conversationUser;
+
+        return $this;
+    }
+
+    /**
+     * Set the conversation message rows this turn wrote.
+     */
+    public function withStoredMessages(?string $userMessageId, ?string $assistantMessageId): self
+    {
+        $this->userMessageId = $userMessageId;
+        $this->assistantMessageId = $assistantMessageId;
 
         return $this;
     }

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -31,6 +31,10 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
     public ?object $conversationUser = null;
 
+    public ?string $userMessageId = null;
+
+    public ?string $assistantMessageId = null;
+
     protected array $thenCallbacks = [];
 
     protected ?StreamProtocol $protocol = null;
@@ -216,6 +220,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     {
         $this->conversationId = $this->streamedResponse->conversationId;
         $this->conversationUser = $this->streamedResponse->conversationUser;
+        $this->userMessageId = $this->streamedResponse->userMessageId;
+        $this->assistantMessageId = $this->streamedResponse->assistantMessageId;
     }
 
     /**

--- a/tests/Feature/StoredMessageIdsTest.php
+++ b/tests/Feature/StoredMessageIdsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Tests\Fixtures\Agents\RememberingAssistantAgent;
+
+test('a remembered turn reports the rows it wrote', function (): void {
+    RememberingAssistantAgent::fake(['Hello world']);
+
+    $participant = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)->forUser($participant)->prompt('Hi');
+
+    expect($response->conversationId)->not->toBeNull()
+        ->and($response->userMessageId)->not->toBeNull()
+        ->and($response->assistantMessageId)->not->toBeNull();
+
+    // The IDs name real rows, not just the stream's own identifiers...
+    expect(DB::table('agent_conversation_messages')->where('id', $response->userMessageId)->value('role'))->toBe('user')
+        ->and(DB::table('agent_conversation_messages')->where('id', $response->assistantMessageId)->value('role'))->toBe('assistant');
+});
+
+test('a streamed turn reports the rows it wrote once it has been consumed', function (): void {
+    RememberingAssistantAgent::fake(['Hello world']);
+
+    $participant = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)->forUser($participant)->stream('Hi');
+
+    foreach ($response as $event) {
+        expect($event)->not->toBeNull();
+    }
+
+    expect($response->assistantMessageId)->not->toBeNull()
+        ->and(DB::table('agent_conversation_messages')->where('id', $response->assistantMessageId)->value('role'))
+        ->toBe('assistant');
+});
+
+test('a turn that stores nothing reports no ids', function (): void {
+    RememberingAssistantAgent::fake(['Hello world']);
+
+    // No participant and no conversation, so nothing is remembered...
+    $response = (new RememberingAssistantAgent)->prompt('Hi');
+
+    expect($response->conversationId)->toBeNull()
+        ->and($response->userMessageId)->toBeNull()
+        ->and($response->assistantMessageId)->toBeNull();
+});


### PR DESCRIPTION
A remembered turn stores a user message and an assistant message, but the response reports neither, so a client that has already rendered a turn can't recognise it when it reads the conversation back and renders it twice.

Looking up the newest assistant row instead isn't reliable. E.g.: A resume that only rejects a tool call writes no new assistant message, so the lookup returns the paused row from the earlier turn.

Both store methods already return the ID they wrote and `RememberConversation` discards them. This PR surfaces them on `AgentResponse` and `StreamableAgentResponse`, so it doesn't add any queries:

```php
$response = (new SalesCoach)->forUser($user)->prompt('Hello!');

$response->userMessageId;       // "01a05472-fd4a-71be-8495-46ce922902ee"
$response->assistantMessageId;  // "01a05480-2c19-73a1-b0e2-8f1d4c77e310"
```

Both are `null` when nothing was stored, and on a streamed response they're populated once the stream has been consumed.