### PR TITLE
[1.x] Add a continueOrStart() shortcut

### DIFF
--- a/src/Concerns/RemembersConversations.php
+++ b/src/Concerns/RemembersConversations.php
@@ -42,6 +42,16 @@ trait RemembersConversations
     }
 
     /**
+     * Continue the given conversation for the participant, or start a new one when there is none.
+     */
+    public function continueOrStart(?string $conversationId, object $as): static
+    {
+        return $conversationId === null
+            ? $this->forParticipant($as)
+            : $this->continue($conversationId, as: $as);
+    }
+
+    /**
      * Continue an existing conversation as the given user.
      */
     public function continueLastConversation(object $as): static

--- a/src/Contracts/RemembersConversations.php
+++ b/src/Contracts/RemembersConversations.php
@@ -20,6 +20,11 @@ interface RemembersConversations extends Conversational
     public function continue(string $conversationId, ?object $as = null): static;
 
     /**
+     * Continue the given conversation for the participant, or start a new one when there is none.
+     */
+    public function continueOrStart(?string $conversationId, object $as): static;
+
+    /**
      * Continue the last conversation as the given user.
      */
     public function continueLastConversation(object $as): static;

--- a/tests/Feature/RemembersConversationsTest.php
+++ b/tests/Feature/RemembersConversationsTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
@@ -169,4 +170,53 @@ test('it resolves the participant id via getKey for models with custom primary k
 
     // The participant's real primary key reaches the store, even when it is not named "id"...
     expect($store->receivedId)->toBe('uuid-123');
+});
+
+test('it starts a conversation for the participant when no conversation id is given', function () {
+    $participant = new class
+    {
+        public int $id = 7;
+    };
+
+    $agent = (new RememberingAssistantAgent)->continueOrStart(null, as: $participant);
+
+    expect($agent->currentConversation())->toBeNull()
+        ->and($agent->conversationParticipant())->toBe($participant);
+});
+
+test('it continues the given conversation for the participant', function () {
+    $participant = new class
+    {
+        public int $id = 7;
+    };
+
+    $agent = (new RememberingAssistantAgent)->continueOrStart('conversation-1', as: $participant);
+
+    expect($agent->currentConversation())->toBe('conversation-1')
+        ->and($agent->conversationParticipant())->toBe($participant);
+});
+
+test('it starts a conversation on the first turn and continues it on the next', function () {
+    config(['ai.conversations.generate_title' => false]);
+
+    $participant = new class
+    {
+        public int $id = 7;
+    };
+
+    RememberingAssistantAgent::fake(['First answer.', 'Second answer.']);
+
+    // A route passes whatever the request carried, which is nothing on the first turn...
+    $first = (new RememberingAssistantAgent)
+        ->continueOrStart(null, as: $participant)
+        ->prompt('Hello.');
+
+    $second = (new RememberingAssistantAgent)
+        ->continueOrStart($first->conversationId, as: $participant)
+        ->prompt('Tell me more.');
+
+    expect($first->conversationId)->not->toBeNull()
+        ->and($second->conversationId)->toBe($first->conversationId)
+        ->and(DB::table('agent_conversations')->count())->toBe(1)
+        ->and(DB::table('agent_conversation_messages')->count())->toBe(4);
 });


### PR DESCRIPTION
Starting a conversation and continuing one are separate methods, so you have to check the conversation ID first to know which one to call. `continueOrStart()` picks for you:

```php
$agent->continueOrStart($conversationId, as: $user);

// instead of
$conversationId
    ? $agent->continue($conversationId, as: $user)
    : $agent->forParticipant($user);
```

Like `continue()`, it doesn't verify the conversation belongs to the participant. Your application should authorize access before continuing it.