### PR TITLE
Add AG-UI approval interrupts and snapshot hydration to streams

### DIFF
--- a/src/AgentUserInteraction/AgentUserInteraction.php
+++ b/src/AgentUserInteraction/AgentUserInteraction.php
@@ -265,13 +265,11 @@ class AgentUserInteraction
     {
         return [
             'id' => $id,
-            // TanStack only resolves approvals reasoned this way, so it wins over AG-UI's core "tool_call"...
             'reason' => 'approval_required',
             ...(filled($reason) ? ['message' => $reason] : []),
             'toolCallId' => $id,
             'metadata' => [
                 'kind' => 'approval',
-                // A missing tool name would leave the interrupt unmatched by TanStack, and so unapprovable...
                 'toolName' => (string) $tool,
                 'input' => (object) $arguments,
             ],
@@ -306,7 +304,6 @@ class AgentUserInteraction
             'toolCallId' => $toolResult['id'],
             'content' => $content,
             ...($denied || $failed ? ['error' => $content] : []),
-            // The AG-UI tool message has an error field but no denied field, so refusal rides metadata as it does live...
             ...($denied ? ['metadata' => ['denied' => true]] : []),
         ];
     }

--- a/src/AgentUserInteraction/AgentUserInteraction.php
+++ b/src/AgentUserInteraction/AgentUserInteraction.php
@@ -265,12 +265,14 @@ class AgentUserInteraction
     {
         return [
             'id' => $id,
+            // TanStack only resolves approvals reasoned this way, so it wins over AG-UI's core "tool_call"...
             'reason' => 'approval_required',
             ...(filled($reason) ? ['message' => $reason] : []),
             'toolCallId' => $id,
             'metadata' => [
                 'kind' => 'approval',
-                ...(filled($tool) ? ['toolName' => $tool] : []),
+                // A missing tool name would leave the interrupt unmatched by TanStack, and so unapprovable...
+                'toolName' => (string) $tool,
                 'input' => (object) $arguments,
             ],
             'responseSchema' => [
@@ -290,6 +292,7 @@ class AgentUserInteraction
     protected static function toolMessageFrom(array $toolResult, ?string $messageId = null): array
     {
         $denied = ($toolResult['denied'] ?? false) === true;
+        $failed = ($toolResult['failed'] ?? false) === true;
 
         $content = match (true) {
             $denied => 'The tool call was denied.',
@@ -302,7 +305,9 @@ class AgentUserInteraction
             'role' => 'tool',
             'toolCallId' => $toolResult['id'],
             'content' => $content,
-            ...($denied ? ['error' => $content] : []),
+            ...($denied || $failed ? ['error' => $content] : []),
+            // The AG-UI tool message has an error field but no denied field, so refusal rides metadata as it does live...
+            ...($denied ? ['metadata' => ['denied' => true]] : []),
         ];
     }
 

--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -4,8 +4,11 @@ namespace Laravel\Ai\Streaming\Protocols;
 
 use Generator;
 use Illuminate\Support\Arr;
+use Laravel\Ai\AgentUserInteraction\AgentUserInteraction;
 use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Models\ConversationMessage;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
@@ -25,6 +28,7 @@ use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
+use Symfony\Component\HttpFoundation\Response;
 
 use function Laravel\Ai\ulid;
 
@@ -46,6 +50,36 @@ class AgentUserInteractionProtocol extends StreamProtocol
         protected ?string $runId = null,
     ) {
         //
+    }
+
+    /**
+     * Create an HTTP response that hydrates a client from stored messages as a snapshot run.
+     *
+     * @param  iterable<int, Message|ConversationMessage>  $messages
+     */
+    public function snapshotResponse(iterable $messages): Response
+    {
+        $state = AgentUserInteraction::toClientState($messages);
+
+        return response()->stream(function () use ($state) {
+            $this->threadId ??= ulid();
+            $this->runId ??= ulid();
+
+            yield $this->encode([
+                'type' => 'RUN_STARTED',
+                'threadId' => $this->threadId,
+                'runId' => $this->runId,
+            ]);
+
+            yield $this->encode([
+                'type' => 'MESSAGES_SNAPSHOT',
+                'messages' => $state['messages'],
+            ]);
+
+            yield $this->encode($this->runFinishedPart($state['interrupts'] === [] ? [] : [
+                'outcome' => ['type' => 'interrupt', 'interrupts' => $state['interrupts']],
+            ]));
+        }, headers: $this->headers());
     }
 
     /**
@@ -242,7 +276,7 @@ class AgentUserInteractionProtocol extends StreamProtocol
                 'reasoningTokens' => $usage->reasoningTokens,
                 'cachedInputTokens' => $usage->cacheReadInputTokens,
             ])]] : []),
-            ...($reason === null ? [] : ['metadata' => ['finishReason' => $reason]]),
+            ...($reason !== null ? ['metadata' => ['finishReason' => $reason]] : []),
         ];
     }
 
@@ -253,17 +287,11 @@ class AgentUserInteractionProtocol extends StreamProtocol
      */
     protected function interrupts(ToolApprovalRequest $event): array
     {
-        return $event->pendingApprovals->map(fn (PendingApproval $approval) => Arr::whereNotNull([
-            'id' => $approval->id,
-            'reason' => 'tool_call',
-            'message' => $approval->reason,
-            'toolCallId' => $approval->id,
-            'responseSchema' => [
-                'type' => 'object',
-                'properties' => ['approved' => ['type' => 'boolean']],
-                'required' => ['approved'],
-            ],
-        ]))->all();
+        return $event->pendingApprovals
+            ->map(fn (PendingApproval $approval) => AgentUserInteraction::interrupt(
+                $approval->id, $approval->reason, $approval->tool, $approval->arguments,
+            ))
+            ->all();
     }
 
     /**

--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -7,8 +7,6 @@ use Illuminate\Support\Arr;
 use Laravel\Ai\AgentUserInteraction\AgentUserInteraction;
 use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
-use Laravel\Ai\Messages\Message;
-use Laravel\Ai\Models\ConversationMessage;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
@@ -28,7 +26,6 @@ use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
-use Symfony\Component\HttpFoundation\Response;
 
 use function Laravel\Ai\ulid;
 
@@ -50,36 +47,6 @@ class AgentUserInteractionProtocol extends StreamProtocol
         protected ?string $runId = null,
     ) {
         //
-    }
-
-    /**
-     * Create an HTTP response that hydrates a client from stored messages as a snapshot run.
-     *
-     * @param  iterable<int, Message|ConversationMessage>  $messages
-     */
-    public function snapshotResponse(iterable $messages): Response
-    {
-        $state = AgentUserInteraction::toClientState($messages);
-
-        return response()->stream(function () use ($state) {
-            $this->threadId ??= ulid();
-            $this->runId ??= ulid();
-
-            yield $this->encode([
-                'type' => 'RUN_STARTED',
-                'threadId' => $this->threadId,
-                'runId' => $this->runId,
-            ]);
-
-            yield $this->encode([
-                'type' => 'MESSAGES_SNAPSHOT',
-                'messages' => $state['messages'],
-            ]);
-
-            yield $this->encode($this->runFinishedPart($state['interrupts'] === [] ? [] : [
-                'outcome' => ['type' => 'interrupt', 'interrupts' => $state['interrupts']],
-            ]));
-        }, headers: $this->headers());
     }
 
     /**
@@ -276,7 +243,7 @@ class AgentUserInteractionProtocol extends StreamProtocol
                 'reasoningTokens' => $usage->reasoningTokens,
                 'cachedInputTokens' => $usage->cacheReadInputTokens,
             ])]] : []),
-            ...($reason !== null ? ['metadata' => ['finishReason' => $reason]] : []),
+            ...($reason === null ? [] : ['metadata' => ['finishReason' => $reason]]),
         ];
     }
 

--- a/tests/Feature/AgentUserInteractionMessageTest.php
+++ b/tests/Feature/AgentUserInteractionMessageTest.php
@@ -419,7 +419,22 @@ describe('hydrating AG-UI from stored messages', function () {
         ])['messages'];
 
         expect($messages[1]['content'])->toBe('The tool call was denied.')
-            ->and($messages[1]['error'])->toBe('The tool call was denied.');
+            ->and($messages[1]['error'])->toBe('The tool call was denied.')
+            ->and($messages[1]['metadata'])->toBe(['denied' => true]);
+    });
+
+    test('a failed tool call hydrates as a tool error without the denied flag', function () {
+        $messages = AgentUserInteraction::toClientState([
+            new ConversationMessage([
+                'id' => 'msg-2',
+                'role' => 'assistant',
+                'tool_calls' => [['id' => 'call-1', 'name' => 'ReadFile', 'arguments' => ['path' => 'a.txt']]],
+                'tool_results' => [['id' => 'call-1', 'name' => 'ReadFile', 'arguments' => ['path' => 'a.txt'], 'result' => 'The tool call failed: boom.', 'failed' => true]],
+            ]),
+        ])['messages'];
+
+        expect($messages[1]['error'])->toBe('The tool call failed: boom.')
+            ->and($messages[1])->not->toHaveKey('metadata');
     });
 
     test('a paused turn hydrates its pending approvals as interrupts', function () {
@@ -472,7 +487,7 @@ describe('hydrating AG-UI from stored messages', function () {
             'id' => 'msg-2',
             'role' => 'assistant',
             'approval_state' => ['pending' => ['call-1' => null]],
-        ])]))->toHaveCount(1);
+        ])])[0]['metadata'])->toEqual(['kind' => 'approval', 'toolName' => '', 'input' => (object) []]);
     });
 
     test('message objects hydrate alongside conversation models', function () {

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -8,7 +8,6 @@ use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Exceptions\StreamErrorException;
-use Laravel\Ai\Models\ConversationMessage;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\Usage;
@@ -479,59 +478,6 @@ test('a resume the store cannot match ends the real stream with the mismatch cod
         ]);
 
     Exceptions::assertReported(ApprovalMismatchException::class);
-});
-
-test('a snapshot response hydrates stored messages and pending interrupts as a run', function () {
-    $events = agUiEvents((new AgentUserInteractionProtocol('thread-1', 'run-1'))->snapshotResponse([
-        new ConversationMessage(['id' => 'msg-1', 'role' => 'user', 'content' => 'Delete a.txt']),
-        new ConversationMessage([
-            'id' => 'msg-2',
-            'role' => 'assistant',
-            'tool_calls' => [['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'a.txt']]],
-            'approval_state' => ['pending' => ['call-1' => 'Deletes a file.']],
-        ]),
-    ]));
-
-    expect($events)->toBe([
-        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-1'],
-        ['type' => 'MESSAGES_SNAPSHOT', 'messages' => [
-            ['id' => 'msg-1', 'role' => 'user', 'content' => 'Delete a.txt'],
-            ['id' => 'msg-2', 'role' => 'assistant', 'toolCalls' => [[
-                'id' => 'call-1',
-                'type' => 'function',
-                'function' => ['name' => 'DeleteFile', 'arguments' => '{"path":"a.txt"}'],
-            ]]],
-        ]],
-        ['type' => 'RUN_FINISHED', 'threadId' => 'thread-1', 'runId' => 'run-1', 'outcome' => [
-            'type' => 'interrupt',
-            'interrupts' => [[
-                'id' => 'call-1',
-                'reason' => 'approval_required',
-                'message' => 'Deletes a file.',
-                'toolCallId' => 'call-1',
-                'metadata' => [
-                    'kind' => 'approval',
-                    'toolName' => 'DeleteFile',
-                    'input' => ['path' => 'a.txt'],
-                ],
-                'responseSchema' => [
-                    'type' => 'object',
-                    'properties' => ['approved' => ['type' => 'boolean']],
-                    'required' => ['approved'],
-                ],
-            ]],
-        ]],
-    ]);
-});
-
-test('a snapshot response without pending approvals finishes without an interrupt outcome', function () {
-    $events = agUiEvents((new AgentUserInteractionProtocol)->snapshotResponse([
-        new ConversationMessage(['id' => 'msg-1', 'role' => 'user', 'content' => 'Hello']),
-    ]));
-
-    expect(collect($events)->pluck('type')->all())->toBe(['RUN_STARTED', 'MESSAGES_SNAPSHOT', 'RUN_FINISHED'])
-        ->and($events[0]['threadId'])->not->toBeEmpty()
-        ->and($events[2])->not->toHaveKey('outcome');
 });
 
 test('a pending approval without a reason omits the interrupt message', function () {

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -8,6 +8,7 @@ use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Exceptions\StreamErrorException;
+use Laravel\Ai\Models\ConversationMessage;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Responses\Data\Usage;
@@ -102,15 +103,6 @@ test('a text stream emits run, step, and text message events', function () {
         ['type' => 'STEP_FINISHED', 'stepName' => '1'],
         agUiRunFinished(),
     ]);
-});
-
-test('the stream is not terminated by a done frame', function () {
-    $events = agUiProtocolEvents([
-        new StreamStart('msg-1', 'anthropic', 'claude-sonnet-4-6', time()),
-        new StreamEnd('event-1', 'stop', new Usage, time()),
-    ]);
-
-    expect(end($events))->toBe(agUiRunFinished());
 });
 
 test('the run finished event carries the combined usage and finish reason', function () {
@@ -415,9 +407,14 @@ test('a paused run finishes with an interrupt outcome for each pending approval'
             'type' => 'interrupt',
             'interrupts' => [[
                 'id' => 'call-1',
-                'reason' => 'tool_call',
+                'reason' => 'approval_required',
                 'message' => 'Destructive operation.',
                 'toolCallId' => 'call-1',
+                'metadata' => [
+                    'kind' => 'approval',
+                    'toolName' => 'DeleteFile',
+                    'input' => ['path' => 'a.txt'],
+                ],
                 'responseSchema' => [
                     'type' => 'object',
                     'properties' => ['approved' => ['type' => 'boolean']],
@@ -482,6 +479,59 @@ test('a resume the store cannot match ends the real stream with the mismatch cod
         ]);
 
     Exceptions::assertReported(ApprovalMismatchException::class);
+});
+
+test('a snapshot response hydrates stored messages and pending interrupts as a run', function () {
+    $events = agUiEvents((new AgentUserInteractionProtocol('thread-1', 'run-1'))->snapshotResponse([
+        new ConversationMessage(['id' => 'msg-1', 'role' => 'user', 'content' => 'Delete a.txt']),
+        new ConversationMessage([
+            'id' => 'msg-2',
+            'role' => 'assistant',
+            'tool_calls' => [['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'a.txt']]],
+            'approval_state' => ['pending' => ['call-1' => 'Deletes a file.']],
+        ]),
+    ]));
+
+    expect($events)->toBe([
+        ['type' => 'RUN_STARTED', 'threadId' => 'thread-1', 'runId' => 'run-1'],
+        ['type' => 'MESSAGES_SNAPSHOT', 'messages' => [
+            ['id' => 'msg-1', 'role' => 'user', 'content' => 'Delete a.txt'],
+            ['id' => 'msg-2', 'role' => 'assistant', 'toolCalls' => [[
+                'id' => 'call-1',
+                'type' => 'function',
+                'function' => ['name' => 'DeleteFile', 'arguments' => '{"path":"a.txt"}'],
+            ]]],
+        ]],
+        ['type' => 'RUN_FINISHED', 'threadId' => 'thread-1', 'runId' => 'run-1', 'outcome' => [
+            'type' => 'interrupt',
+            'interrupts' => [[
+                'id' => 'call-1',
+                'reason' => 'approval_required',
+                'message' => 'Deletes a file.',
+                'toolCallId' => 'call-1',
+                'metadata' => [
+                    'kind' => 'approval',
+                    'toolName' => 'DeleteFile',
+                    'input' => ['path' => 'a.txt'],
+                ],
+                'responseSchema' => [
+                    'type' => 'object',
+                    'properties' => ['approved' => ['type' => 'boolean']],
+                    'required' => ['approved'],
+                ],
+            ]],
+        ]],
+    ]);
+});
+
+test('a snapshot response without pending approvals finishes without an interrupt outcome', function () {
+    $events = agUiEvents((new AgentUserInteractionProtocol)->snapshotResponse([
+        new ConversationMessage(['id' => 'msg-1', 'role' => 'user', 'content' => 'Hello']),
+    ]));
+
+    expect(collect($events)->pluck('type')->all())->toBe(['RUN_STARTED', 'MESSAGES_SNAPSHOT', 'RUN_FINISHED'])
+        ->and($events[0]['threadId'])->not->toBeEmpty()
+        ->and($events[2])->not->toHaveKey('outcome');
 });
 
 test('a pending approval without a reason omits the interrupt message', function () {


### PR DESCRIPTION
Third of a four-PR stack that splits #939. Base: #964.

Builds on the AG-UI protocol streaming added in #913.

**Approval interrupts carry their tool.** `interrupts()` previously built the interrupt payload inline and emitted only an id and a message. It now delegates to `AgentUserInteraction::interrupt()` (added in #964), so a paused run tells the client *which* tool wants to run and *with what arguments* — enough to render a real approval prompt instead of an opaque "something is waiting".

The interrupt reports `reason: 'approval_required'`. `@ag-ui/core` types `Interrupt.reason` as a free-form `z.string()`, and `approval_required` is what TanStack AI's interrupt manager matches on to bind Approve/Reject controls. CopilotKit reads neither field and is unaffected.

**`snapshotResponse()`** streams a stored thread as a run without calling a model:

```
RUN_STARTED -> MESSAGES_SNAPSHOT -> RUN_FINISHED
```

with `outcome.interrupts` on the finish event when an approval is still pending, so a client reopening a thread lands in the same paused state it left. `MESSAGES_SNAPSHOT` is the one hydration shape both AG-UI clients already handle — `@ag-ui/client` replaces `agent.messages` from it, and TanStack's stream processor has a case for it.

Also drops the protocol's `headers()` override, now redundant against the base-class default from #963.
