### PR TITLE
Add AG-UI hydration for TanStack AI clients

### DIFF
--- a/src/TanStack/TanStack.php
+++ b/src/TanStack/TanStack.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Laravel\Ai\TanStack;
+
+use Laravel\Ai\AgentUserInteraction\AgentUserInteraction;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Models\ConversationMessage;
+
+/**
+ * TanStack AI speaks AG-UI on the wire but stores history as its own UIMessage shape.
+ *
+ * See: https://tanstack.com/ai
+ */
+class TanStack extends AgentUserInteraction
+{
+    /**
+     * Convert messages or conversation message models into TanStack UI messages.
+     *
+     * @param  iterable<int, Message|ConversationMessage>  $messages
+     * @return list<array<string, mixed>>
+     */
+    public static function toUiMessages(iterable $messages): array
+    {
+        $ui = [];
+        $owners = [];
+        $results = [];
+
+        foreach (static::uiMessagesFrom($messages) as $message) {
+            // A resumed run replays tool results before the assistant message that follows them,
+            // so collect them by call id and attach them once their caller is known...
+            if ($message['role'] === 'tool') {
+                $results[$message['toolCallId']] = $message['content'];
+
+                continue;
+            }
+
+            // Multimodal content is skipped until a TanStack part type covers it...
+            $parts = is_string($message['content'] ?? null) && filled($message['content'])
+                ? [['type' => 'text', 'content' => $message['content']]]
+                : [];
+
+            foreach ($message['toolCalls'] ?? [] as $call) {
+                $owners[$call['id']] = count($ui);
+
+                $parts[] = [
+                    'type' => 'tool-call',
+                    'id' => $call['id'],
+                    'name' => $call['function']['name'],
+                    'arguments' => $call['function']['arguments'],
+                    'input' => json_decode($call['function']['arguments']) ?: (object) [],
+                    'state' => 'complete',
+                ];
+            }
+
+            if ($parts !== []) {
+                $ui[] = ['id' => $message['id'], 'role' => $message['role'], 'parts' => $parts];
+            }
+        }
+
+        foreach ($results as $callId => $content) {
+            if (! array_key_exists($callId, $owners)) {
+                continue;
+            }
+
+            $ui[$owners[$callId]]['parts'][] = [
+                'type' => 'tool-result',
+                'toolCallId' => $callId,
+                'content' => $content,
+                'state' => 'complete',
+            ];
+        }
+
+        return $ui;
+    }
+
+    /**
+     * Convert messages or conversation message models into state for hydrating a TanStack client.
+     *
+     * @param  iterable<int, Message|ConversationMessage>  $messages
+     * @return array{messages: list<array<string, mixed>>, interrupts: list<array<string, mixed>>}
+     */
+    public static function toClientState(iterable $messages): array
+    {
+        $messages = [...$messages];
+
+        return [
+            'messages' => static::toUiMessages($messages),
+            'interrupts' => static::toInterrupts($messages),
+        ];
+    }
+}

--- a/tests/Feature/TanStackMessageTest.php
+++ b/tests/Feature/TanStackMessageTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Laravel\Ai\Models\ConversationMessage;
+use Laravel\Ai\TanStack\TanStack;
+
+test('a completed tool turn folds its result into the assistant message that called it', function () {
+    $messages = TanStack::toUiMessages([
+        new ConversationMessage(['id' => 'msg-1', 'role' => 'user', 'content' => 'Delete draft.txt']),
+        new ConversationMessage([
+            'id' => 'msg-2',
+            'role' => 'assistant',
+            'content' => 'Deleting it now.',
+            'tool_calls' => [['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'draft.txt']]],
+            'tool_results' => [['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'draft.txt'], 'result' => 'Deleted.']],
+        ]),
+    ]);
+
+    expect($messages)->toEqual([
+        ['id' => 'msg-1', 'role' => 'user', 'parts' => [
+            ['type' => 'text', 'content' => 'Delete draft.txt'],
+        ]],
+        ['id' => 'msg-2', 'role' => 'assistant', 'parts' => [
+            ['type' => 'text', 'content' => 'Deleting it now.'],
+            [
+                'type' => 'tool-call',
+                'id' => 'call-1',
+                'name' => 'DeleteFile',
+                'arguments' => '{"path":"draft.txt"}',
+                'input' => (object) ['path' => 'draft.txt'],
+                'state' => 'complete',
+            ],
+            ['type' => 'tool-result', 'toolCallId' => 'call-1', 'content' => 'Deleted.', 'state' => 'complete'],
+        ]],
+    ]);
+});
+
+test('a resumed turn anchors its replayed tool result to the message that called it', function () {
+    $messages = TanStack::toUiMessages([
+        new ConversationMessage([
+            'id' => 'msg-1',
+            'role' => 'assistant',
+            'content' => 'Deleted it.',
+            'tool_calls' => [['id' => 'call-2', 'name' => 'ListFiles', 'arguments' => []]],
+            'tool_results' => [
+                ['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'draft.txt'], 'result' => 'Deleted.'],
+                ['id' => 'call-2', 'name' => 'ListFiles', 'arguments' => [], 'result' => 'a.txt'],
+            ],
+        ]),
+    ]);
+
+    expect($messages)->toHaveCount(1)
+        ->and(array_column($messages[0]['parts'], 'type'))->toBe(['text', 'tool-call', 'tool-result'])
+        ->and($messages[0]['parts'][2]['toolCallId'])->toBe('call-2');
+});
+
+test('client state carries UI messages alongside pending interrupts', function () {
+    $state = TanStack::toClientState([
+        new ConversationMessage([
+            'id' => 'msg-1',
+            'role' => 'assistant',
+            'tool_calls' => [['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'a.txt']]],
+            'approval_state' => ['pending' => ['call-1' => 'Deletes a file.']],
+        ]),
+    ]);
+
+    expect($state['messages'][0]['parts'][0]['name'])->toBe('DeleteFile')
+        ->and($state['interrupts'][0]['toolCallId'])->toBe('call-1');
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -40,6 +40,7 @@ Route::post('/chat/message', function (Request $request) {
     ]);
 });
 
+// CopilotKit and TanStack AI both speak AG-UI, so this route serves either with no client specific code...
 Route::post('/ag-ui', function (Request $request) {
     $chat = AgentUserInteraction::chat($request);
 


### PR DESCRIPTION
Top of a four-PR stack that splits #939. Base: #965.

CopilotKit and TanStack AI both speak AG-UI. After this stack, a Laravel app serves either one without writing protocol code — the workbench `/ag-ui` route is unchanged between them.

The naming rule this follows, so the package stays a *protocol* integration rather than accumulating a class per client:

> One class per protocol. A client gets its own class only if it deviates from that protocol.
> `Vercel` is its own wire format. `AgentUserInteraction` is AG-UI — CopilotKit uses it as-is, so **CopilotKit gets no class**. TanStack speaks AG-UI on the wire but stores history in its own shape, so it gets a thin class for that one deviation.

**The asterisk, stated plainly:** AG-UI specifies the *run* — `RunAgentInput` in, events out, `resume` for approvals. It has no message for "reopen this thread". Page-load hydration is therefore each client's own business, and is the only place clients differ:

- CopilotKit's `HttpAgent` stores AG-UI message rows verbatim, so `toClientState()` already fits.
- TanStack normalizes into `UIMessage { id, role, parts[] }`, which needs conversion.

`TanStack` extends `AgentUserInteraction` and converts what the parent returns. It re-implements no protocol: input parsing, streaming, and `resume` are all inherited. Extending also means it reaches `uiMessagesFrom()` as a subclass, so **no visibility change** and no new public surface on the AG-UI class.

Two rules in the conversion are load-bearing:

- **`role: 'tool'` is not a message.** TanStack's `UIMessage.role` is only `system | user | assistant`, so tool results become parts on the assistant message that called them.
- **Results anchor by `toolCallId`, never by position.** A resumed run replays a tool result *before* the assistant message that follows it, so "attach to the previous message" lands on the wrong one — or on nothing, when the result is the first row. Results are collected into a map and attached in a second pass. There's a test for exactly this ordering.

**Follow-up, not this PR:** TanStack already ships the AG-UI-rows-to-parts converter (`aguiSnapshotMessageToUIMessage`) but re-exports it from no public entry, and `@tanstack/ai-vue`'s `useChat` returns no mount-time hydration hook. I'll open an upstream issue asking for either. When it lands, this class deletes and hydration goes back to being their code tracking their own model — `snapshotResponse()` from #965 is the forward path.
