### PR TITLE
Support validating tool request arguments

### DIFF
--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -35,10 +35,8 @@ trait InvokesTools
             try {
                 $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
             } catch (ValidationException $exception) {
-                $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
-
                 // Validation failures are returned to the model so it can correct the arguments and retry...
-                return implode(' ', $exception->validator->errors()->all()) ?: $exception->getMessage();
+                $result = implode(' ', $exception->validator->errors()->all()) ?: $exception->getMessage();
             } catch (Throwable $exception) {
                 $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Ai\Gateway\Concerns;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Contracts\Tool;
@@ -39,7 +38,7 @@ trait InvokesTools
                 $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 
                 // Validation failures are returned to the model so it can correct the arguments and retry...
-                return implode(' ', Arr::flatten($exception->errors())) ?: 'The given data was invalid.';
+                return implode(' ', $exception->validator->errors()->all()) ?: $exception->getMessage();
             } catch (Throwable $exception) {
                 $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 

--- a/src/Gateway/Concerns/InvokesTools.php
+++ b/src/Gateway/Concerns/InvokesTools.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Ai\Gateway\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Gateway\ParentInvocation;
 use Laravel\Ai\Gateway\RunContext;
@@ -33,6 +35,11 @@ trait InvokesTools
             // Only the handler itself may fail the tool call, so a listener that throws is never reported as a tool failure...
             try {
                 $result = $tool->handle(new Request($arguments, $toolCallId, $toolInvocationId));
+            } catch (ValidationException $exception) {
+                $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
+
+                // Validation failures are returned to the model so it can correct the arguments and retry...
+                return implode(' ', Arr::flatten($exception->errors())) ?: 'The given data was invalid.';
             } catch (Throwable $exception) {
                 $context?->toolFailed($tool, $arguments, $exception, $toolInvocationId, $this->elapsedMilliseconds($startedAt));
 

--- a/src/Tools/Request.php
+++ b/src/Tools/Request.php
@@ -4,9 +4,11 @@ namespace Laravel\Ai\Tools;
 
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\InteractsWithData;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\ValidationException;
 
 class Request implements Arrayable, ArrayAccess
 {
@@ -36,6 +38,19 @@ class Request implements Arrayable, ArrayAccess
     public function toolInvocationId(): ?string
     {
         return $this->toolInvocationId;
+    }
+
+    /**
+     * @param  array<string, mixed>  $rules
+     * @param  array<string, mixed>  $messages
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    public function validate(array $rules, array $messages = [], array $attributes = []): array
+    {
+        return Validator::validate($this->all(), $rules, $messages, $attributes);
     }
 
     /**

--- a/tests/Feature/ToolRequestValidationTest.php
+++ b/tests/Feature/ToolRequestValidationTest.php
@@ -7,6 +7,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Events\ToolFailed;
+use Laravel\Ai\Events\ToolInvoked;
 use Laravel\Ai\Gateway\Concerns\InvokesTools;
 use Laravel\Ai\Gateway\RunContext;
 use Laravel\Ai\Tools\Request;
@@ -24,11 +25,15 @@ test('invalid tool request arguments throw a validation exception', function ():
 })->throws(ValidationException::class);
 
 test('a validation failure is returned to the model as the tool result', function (): void {
-    $failure = null;
+    $invoked = null;
+    $failed = 0;
 
     $events = new Dispatcher;
-    $events->listen(ToolFailed::class, function (ToolFailed $event) use (&$failure): void {
-        $failure = $event;
+    $events->listen(ToolInvoked::class, function (ToolInvoked $event) use (&$invoked): void {
+        $invoked = $event;
+    });
+    $events->listen(ToolFailed::class, function () use (&$failed): void {
+        $failed++;
     });
 
     $gateway = new class
@@ -72,5 +77,6 @@ test('a validation failure is returned to the model as the tool result', functio
     $result = $gateway->invoke($tool, [], $context);
 
     expect($result)->toBe('The city field is required.')
-        ->and($failure->exception)->toBeInstanceOf(ValidationException::class);
+        ->and($invoked->result)->toBe('The city field is required.')
+        ->and($failed)->toBe(0);
 });

--- a/tests/Feature/ToolRequestValidationTest.php
+++ b/tests/Feature/ToolRequestValidationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Validation\ValidationException;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\ToolFailed;
+use Laravel\Ai\Gateway\Concerns\InvokesTools;
+use Laravel\Ai\Gateway\RunContext;
+use Laravel\Ai\Tools\Request;
+
+test('tool request arguments can be validated', function (): void {
+    $validated = (new Request(['city' => 'Lisbon', 'extra' => 'ignored']))->validate([
+        'city' => 'required|string',
+    ]);
+
+    expect($validated)->toBe(['city' => 'Lisbon']);
+});
+
+test('invalid tool request arguments throw a validation exception', function (): void {
+    (new Request(['days' => 'tomorrow']))->validate(['days' => 'required|integer']);
+})->throws(ValidationException::class);
+
+test('a validation failure is returned to the model as the tool result', function (): void {
+    $failure = null;
+
+    $events = new Dispatcher;
+    $events->listen(ToolFailed::class, function (ToolFailed $event) use (&$failure): void {
+        $failure = $event;
+    });
+
+    $gateway = new class
+    {
+        use InvokesTools;
+
+        public function invoke(Tool $tool, array $arguments, RunContext $context): string
+        {
+            return $this->executeTool($tool, $arguments, null, $context);
+        }
+    };
+
+    $tool = new class implements Tool
+    {
+        public function description(): string
+        {
+            return 'Validating tool.';
+        }
+
+        public function handle(Request $request): string
+        {
+            $request->validate(['city' => 'required|string']);
+
+            return 'never reached';
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    };
+
+    $context = new RunContext(
+        'inv_1',
+        Mockery::mock(Agent::class),
+        Mockery::mock(TextProvider::class),
+        'stub-model',
+        $events,
+    );
+
+    $result = $gateway->invoke($tool, [], $context);
+
+    expect($result)->toBe('The city field is required.')
+        ->and($failure->exception)->toBeInstanceOf(ValidationException::class);
+});


### PR DESCRIPTION
Laravel MCP lets a tool validate its incoming arguments with `$request->validate()`. This adds the same method to the AI SDK's tool `Request`:

```php
public function handle(Request $request): string
{
    $validated = $request->validate([
        'city' => 'required|string',
    ]);

    // ...
}
```

When validation fails, the messages are returned to the model as the tool result, so it can correct the arguments and retry:

```text
The city field is required.
```
