### PR TITLE
Preserve structured output format when merging provider options (Anthropic)

### DIFF
--- a/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/Anthropic/Concerns/BuildsTextRequests.php
@@ -70,7 +70,38 @@ trait BuildsTextRequests
             'top_p' => $options?->topP,
         ]));
 
-        return $this->applyPromptCacheBreakpoints(array_merge($body, $providerOptions), $options);
+        return $this->applyPromptCacheBreakpoints(
+            $this->mergeProviderOptions($body, $providerOptions),
+            $options,
+        );
+    }
+
+    /**
+     * Merge provider options into the request body.
+     *
+     * Provider options are shallow-merged, except for the "output_config" key,
+     * which is merged one level deeper so that options sharing it (e.g. an
+     * "effort" level) do not discard the structured-output "format" the request
+     * builder places there.
+     *
+     * @param  array<string, mixed>  $body
+     * @param  array<string, mixed>  $providerOptions
+     * @return array<string, mixed>
+     */
+    protected function mergeProviderOptions(array $body, array $providerOptions): array
+    {
+        $merged = array_merge($body, $providerOptions);
+
+        if (isset($body['output_config'], $providerOptions['output_config'])
+            && is_array($body['output_config'])
+            && is_array($providerOptions['output_config'])) {
+            $merged['output_config'] = array_merge(
+                $body['output_config'],
+                $providerOptions['output_config'],
+            );
+        }
+
+        return $merged;
     }
 
     /**

--- a/tests/Feature/Providers/Anthropic/ProviderOptionsTest.php
+++ b/tests/Feature/Providers/Anthropic/ProviderOptionsTest.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fixtures\Agents\AssistantAgent;
 use Tests\Fixtures\Agents\ProviderOptionsAgent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Agents\StructuredWithOutputConfigOptionsAgent;
 
 test('provider options are included in anthropic request body', function (): void {
     Http::fake([
@@ -35,6 +36,24 @@ test('request body does not contain provider options when agent does not impleme
     );
 
     Http::assertSent(fn ($request): bool => ! isset($request->data()['thinking']));
+});
+
+test('output_config provider options merge with structured output format instead of replacing it', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeStructuredResponse(['name' => 'Ada', 'age' => 36]),
+    ]);
+
+    (new StructuredWithOutputConfigOptionsAgent)->prompt(
+        'Give me a person',
+        provider: 'anthropic',
+    );
+
+    Http::assertSent(function ($request): bool {
+        $outputConfig = $request->data()['output_config'] ?? [];
+
+        return ($outputConfig['format']['type'] ?? null) === 'json_schema'
+            && ($outputConfig['effort'] ?? null) === 'medium';
+    });
 });
 
 test('provider options are persisted in tool call follow up requests', function (): void {

--- a/tests/Fixtures/Agents/StructuredWithOutputConfigOptionsAgent.php
+++ b/tests/Fixtures/Agents/StructuredWithOutputConfigOptionsAgent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+class StructuredWithOutputConfigOptionsAgent implements Agent, HasProviderOptions, HasStructuredOutput
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that uses structured output.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->required(),
+            'age' => $schema->integer()->required(),
+        ];
+    }
+
+    public function providerOptions(Lab|string $provider): array
+    {
+        $provider = is_string($provider) ? Lab::tryFrom($provider) : $provider;
+
+        return match ($provider) {
+            Lab::Anthropic => [
+                'output_config' => [
+                    'effort' => 'medium',
+                ],
+            ],
+            default => [],
+        };
+    }
+}


### PR DESCRIPTION
### Problem

`Gateway/Anthropic/Concerns/BuildsTextRequests::buildTextRequestBody()` places the native structured-output schema under `output_config.format`:

```php
$body['output_config'] = [
    'format' => ['type' => 'json_schema', 'schema' => /* … */],
];
```

and then finishes with:

```php
return $this->applyPromptCacheBreakpoints(array_merge($body, $providerOptions), $options);
```

`array_merge` is **shallow** on string keys, so any agent whose `providerOptions()` also returns an `output_config` key replaces the entire value and silently drops `format`. For example an agent that lowers the effort level:

```php
public function providerOptions(Lab|string $provider): array
{
    return ['output_config' => ['effort' => 'medium']];
}
```

produces a request where `output_config` is `['effort' => 'medium']` — the structured-output `format` is gone. The request is sent without its schema, the model no longer returns the structured payload, and the parsed response is missing the expected keys. **No error is raised** — the caller just gets an array without its structured keys (e.g. `Undefined array key "…"` downstream).

This makes `output_config`-based provider options (such as `effort`) mutually exclusive with structured output, even though the two settings are meant to coexist in a single `output_config` object.

### Fix

Merge `output_config` one level deeper so provider-option keys coexist with the builder-supplied `format`, while every other provider option keeps its existing shallow-merge (override) behaviour:

```php
$merged = array_merge($body, $providerOptions);

if (isset($body['output_config'], $providerOptions['output_config'])
    && is_array($body['output_config'])
    && is_array($providerOptions['output_config'])) {
    $merged['output_config'] = array_merge(
        $body['output_config'],
        $providerOptions['output_config'],
    );
}
```

Leaf keys in `providerOptions` still win (so an explicitly provided `format` would still override), but sibling keys like `format` are no longer discarded.

### Tests

Adds a regression test (`tests/Feature/Providers/Anthropic/ProviderOptionsTest.php`) and a fixture agent (`StructuredWithOutputConfigOptionsAgent`) that combines structured output with an `output_config` provider option, asserting the sent request body carries **both** `output_config.format` (`json_schema`) and `output_config.effort` (`medium`).

> Note: I was unable to run the full Pest suite locally (dependency install kept timing out on network in my environment), so I'm relying on CI to run the added test. The merge behaviour itself was verified in isolation. Happy to adjust the approach — e.g. a more general recursive merge — if you'd prefer.