### PR TITLE
Support hosted code execution as a provider tool

### DIFF
--- a/src/Contracts/Providers/SupportsCodeExecution.php
+++ b/src/Contracts/Providers/SupportsCodeExecution.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Ai\Contracts\Providers;
+
+use Laravel\Ai\Providers\Tools\CodeExecution;
+
+interface SupportsCodeExecution
+{
+    /**
+     * Get the code execution tool options for the provider.
+     */
+    public function codeExecutionToolOptions(CodeExecution $codeExecution): array;
+}

--- a/src/Gateway/Anthropic/Concerns/MapsTools.php
+++ b/src/Gateway/Anthropic/Concerns/MapsTools.php
@@ -112,7 +112,7 @@ trait MapsTools
         }
 
         return [
-            'type' => 'code_execution_20250825',
+            'type' => 'code_execution_20260120',
             'name' => 'code_execution',
             ...$provider->codeExecutionToolOptions($tool),
         ];

--- a/src/Gateway/Anthropic/Concerns/MapsTools.php
+++ b/src/Gateway/Anthropic/Concerns/MapsTools.php
@@ -3,12 +3,14 @@
 namespace Laravel\Ai\Gateway\Anthropic\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\ToolSearch;
 use Laravel\Ai\Providers\Tools\WebFetch;
@@ -93,10 +95,27 @@ trait MapsTools
     protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
     {
         return match (true) {
+            $tool instanceof CodeExecution => $this->mapCodeExecutionTool($tool, $provider),
             $tool instanceof WebFetch => $this->mapWebFetchTool($tool, $provider),
             $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
             default => throw new LogicException('Provider tool ['.$tool::class.'] is not supported by Anthropic.'),
         };
+    }
+
+    /**
+     * Map a code execution tool to an Anthropic server-side tool definition.
+     */
+    protected function mapCodeExecutionTool(CodeExecution $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsCodeExecution) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support code execution.');
+        }
+
+        return [
+            'type' => 'code_execution_20250825',
+            'name' => 'code_execution',
+            ...$provider->codeExecutionToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -162,7 +162,7 @@ trait HandlesTextStreaming
                         '',
                         'code_execution',
                         $part,
-                        isset($part['executableCode']) ? 'code_generated' : 'result_received',
+                        isset($part['executableCode']) ? 'completed' : 'result_received',
                         time(),
                         provider: $provider->name(),
                     ))->withInvocationId($invocationId);

--- a/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Gemini/Concerns/HandlesTextStreaming.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
@@ -151,6 +152,20 @@ trait HandlesTextStreaming
                     $modelParts[] = $part;
 
                     continue;
+                }
+
+                if (isset($part['executableCode']) || isset($part['codeExecutionResult'])) {
+                    $modelParts[] = $part;
+
+                    yield (new ProviderToolEvent(
+                        $this->generateEventId(),
+                        '',
+                        'code_execution',
+                        $part,
+                        isset($part['executableCode']) ? 'code_generated' : 'result_received',
+                        time(),
+                        provider: $provider->name(),
+                    ))->withInvocationId($invocationId);
                 }
             }
 

--- a/src/Gateway/Gemini/Concerns/MapsTools.php
+++ b/src/Gateway/Gemini/Concerns/MapsTools.php
@@ -4,12 +4,14 @@ namespace Laravel\Ai\Gateway\Gemini\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Illuminate\Support\Arr;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\WebFetch;
@@ -116,11 +118,26 @@ trait MapsTools
     protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
     {
         return match (true) {
+            $tool instanceof CodeExecution => $this->mapCodeExecutionTool($tool, $provider),
             $tool instanceof FileSearch => $this->mapFileSearchTool($tool, $provider),
             $tool instanceof WebFetch => $this->mapWebFetchTool($tool, $provider),
             $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
             default => [],
         };
+    }
+
+    /**
+     * Map a code execution tool to a Gemini code execution definition.
+     */
+    protected function mapCodeExecutionTool(CodeExecution $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsCodeExecution) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support code execution.');
+        }
+
+        return [
+            'code_execution' => (object) $provider->codeExecutionToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -195,22 +195,18 @@ trait HandlesTextGeneration
                 }
             }
 
-            if (str_starts_with((string) $type, 'response.') && str_contains((string) $type, '_call.')) {
-                $parts = explode('.', (string) $type, 3);
+            if (preg_match('/^response\.([a-z_]+_call)(_code)?\.(.+)$/', (string) $type, $matches) === 1) {
+                yield (new ProviderToolEvent(
+                    $this->generateEventId(),
+                    $data['item_id'] ?? '',
+                    $matches[1],
+                    $data,
+                    $matches[2] === '' ? $matches[3] : 'code_'.$matches[3],
+                    time(),
+                    provider: $provider->name(),
+                ))->withInvocationId($invocationId);
 
-                if (count($parts) === 3 && str_ends_with($parts[1], '_call')) {
-                    yield (new ProviderToolEvent(
-                        $this->generateEventId(),
-                        $data['item_id'] ?? '',
-                        $parts[1],
-                        $data,
-                        $parts[2],
-                        time(),
-                        provider: $provider->name(),
-                    ))->withInvocationId($invocationId);
-
-                    continue;
-                }
+                continue;
             }
 
             if (($data['item']['type'] ?? '') === 'function_call' && $type === 'response.output_item.added') {

--- a/src/Gateway/OpenAi/Concerns/MapsTools.php
+++ b/src/Gateway/OpenAi/Concerns/MapsTools.php
@@ -4,12 +4,14 @@ namespace Laravel\Ai\Gateway\OpenAi\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\ToolSearch;
@@ -104,10 +106,26 @@ trait MapsTools
     protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
     {
         return match (true) {
+            $tool instanceof CodeExecution => $this->mapCodeExecutionTool($tool, $provider),
             $tool instanceof FileSearch => $this->mapFileSearchTool($tool, $provider),
             $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
             default => throw new RuntimeException('Provider ['.$provider->name().'] does not support the ['.class_basename($tool).'] tool.'),
         };
+    }
+
+    /**
+     * Map a code execution tool to an OpenAI code interpreter definition.
+     */
+    protected function mapCodeExecutionTool(CodeExecution $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsCodeExecution) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support code execution.');
+        }
+
+        return [
+            'type' => 'code_interpreter',
+            ...$provider->codeExecutionToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -177,22 +177,18 @@ trait HandlesTextStreaming
                 }
             }
 
-            if (str_starts_with((string) $type, 'response.') && str_contains((string) $type, '_call.')) {
-                $parts = explode('.', (string) $type, 3);
+            if (preg_match('/^response\.([a-z_]+_call)(_code)?\.(.+)$/', (string) $type, $matches) === 1) {
+                yield (new ProviderToolEvent(
+                    $this->generateEventId(),
+                    $data['item_id'] ?? '',
+                    $matches[1],
+                    $data,
+                    $matches[2] === '' ? $matches[3] : 'code_'.$matches[3],
+                    time(),
+                    provider: $provider->name(),
+                ))->withInvocationId($invocationId);
 
-                if (count($parts) === 3 && str_ends_with($parts[1], '_call')) {
-                    yield (new ProviderToolEvent(
-                        $this->generateEventId(),
-                        $data['item_id'] ?? '',
-                        $parts[1],
-                        $data,
-                        $parts[2],
-                        time(),
-                        provider: $provider->name(),
-                    ))->withInvocationId($invocationId);
-
-                    continue;
-                }
+                continue;
             }
 
             if (($data['item']['type'] ?? '') === 'function_call' && $type === 'response.output_item.added') {

--- a/src/Gateway/Xai/Concerns/MapsTools.php
+++ b/src/Gateway/Xai/Concerns/MapsTools.php
@@ -4,11 +4,13 @@ namespace Laravel\Ai\Gateway\Xai\Concerns;
 
 use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 use Laravel\Ai\Attributes\Strict;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\ProviderTool;
 use Laravel\Ai\Providers\Tools\WebSearch;
@@ -43,10 +45,26 @@ trait MapsTools
     protected function mapProviderTool(ProviderTool $tool, Provider $provider): array
     {
         return match (true) {
+            $tool instanceof CodeExecution => $this->mapCodeExecutionTool($tool, $provider),
             $tool instanceof FileSearch => $this->mapFileSearchTool($tool, $provider),
             $tool instanceof WebSearch => $this->mapWebSearchTool($tool, $provider),
             default => [],
         };
+    }
+
+    /**
+     * Map a code execution tool to an xAI code interpreter definition.
+     */
+    protected function mapCodeExecutionTool(CodeExecution $tool, Provider $provider): array
+    {
+        if (! $provider instanceof SupportsCodeExecution) {
+            throw new RuntimeException('Provider ['.$provider->name().'] does not support code execution.');
+        }
+
+        return [
+            'type' => 'code_interpreter',
+            ...$provider->codeExecutionToolOptions($tool),
+        ];
     }
 
     /**

--- a/src/Providers/AnthropicProvider.php
+++ b/src/Providers/AnthropicProvider.php
@@ -4,22 +4,32 @@ namespace Laravel\Ai\Providers;
 
 use Laravel\Ai\Contracts\Gateway\FileGateway;
 use Laravel\Ai\Contracts\Providers\FileProvider;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsToolSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Anthropic\AnthropicFileGateway;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class AnthropicProvider extends Provider implements FileProvider, SupportsToolSearch, SupportsWebFetch, SupportsWebSearch, TextProvider
+class AnthropicProvider extends Provider implements FileProvider, SupportsCodeExecution, SupportsToolSearch, SupportsWebFetch, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesText;
     use Concerns\HasFileGateway;
     use Concerns\HasTextGateway;
     use Concerns\ManagesFiles;
     use Concerns\StreamsText;
+
+    /**
+     * Get the code execution tool options for the provider.
+     */
+    public function codeExecutionToolOptions(CodeExecution $codeExecution): array
+    {
+        return $codeExecution->providerOptions(Lab::Anthropic);
+    }
 
     /**
      * Get the web fetch tool options for the provider.

--- a/src/Providers/AzureOpenAiProvider.php
+++ b/src/Providers/AzureOpenAiProvider.php
@@ -13,6 +13,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
@@ -20,10 +21,11 @@ use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiFileGateway;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiGateway;
 use Laravel\Ai\Gateway\AzureOpenAi\AzureOpenAiStoreGateway;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsWebSearch, TextProvider
+class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsCodeExecution, SupportsFileSearch, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesEmbeddings;
     use Concerns\GeneratesImages;
@@ -165,6 +167,16 @@ class AzureOpenAiProvider extends Provider implements EmbeddingProvider, FilePro
         return array_filter([
             'vector_store_ids' => $search->ids(),
         ]);
+    }
+
+    /**
+     * Get the code execution tool options for the provider.
+     */
+    public function codeExecutionToolOptions(CodeExecution $codeExecution): array
+    {
+        return $codeExecution->providerOptions(Lab::Azure) + [
+            'container' => ['type' => 'auto'],
+        ];
     }
 
     /**

--- a/src/Providers/GeminiProvider.php
+++ b/src/Providers/GeminiProvider.php
@@ -11,18 +11,21 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebFetch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Gemini\GeminiFileGateway;
 use Laravel\Ai\Gateway\Gemini\GeminiStoreGateway;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsWebFetch, SupportsWebSearch, TextProvider, TranscriptionProvider
+class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsCodeExecution, SupportsFileSearch, SupportsWebFetch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
@@ -70,6 +73,14 @@ class GeminiProvider extends Provider implements AudioProvider, EmbeddingProvide
             'in' => '('.(new Collection($filter['value']))->map(fn ($v): string => is_numeric($v) ? "{$filter['key']}={$v}" : "{$filter['key']}=\"{$v}\""
             )->implode(' OR ').')',
         })->implode(' AND ');
+    }
+
+    /**
+     * Get the code execution tool options for the provider.
+     */
+    public function codeExecutionToolOptions(CodeExecution $codeExecution): array
+    {
+        return $codeExecution->providerOptions(Lab::Gemini);
     }
 
     /**

--- a/src/Providers/OpenAiProvider.php
+++ b/src/Providers/OpenAiProvider.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
 use Laravel\Ai\Contracts\Providers\FileProvider;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
 use Laravel\Ai\Contracts\Providers\StoreProvider;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsToolSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
@@ -18,10 +19,11 @@ use Laravel\Ai\Contracts\Providers\TranscriptionProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\OpenAi\OpenAiFileGateway;
 use Laravel\Ai\Gateway\OpenAi\OpenAiStoreGateway;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsFileSearch, SupportsToolSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
+class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvider, FileProvider, ImageProvider, StoreProvider, SupportsCodeExecution, SupportsFileSearch, SupportsToolSearch, SupportsWebSearch, TextProvider, TranscriptionProvider
 {
     use Concerns\GeneratesAudio;
     use Concerns\GeneratesEmbeddings;
@@ -38,6 +40,16 @@ class OpenAiProvider extends Provider implements AudioProvider, EmbeddingProvide
     use Concerns\ManagesFiles;
     use Concerns\ManagesStores;
     use Concerns\StreamsText;
+
+    /**
+     * Get the code execution tool options for the provider.
+     */
+    public function codeExecutionToolOptions(CodeExecution $codeExecution): array
+    {
+        return $codeExecution->providerOptions(Lab::OpenAI) + [
+            'container' => ['type' => 'auto'],
+        ];
+    }
 
     /**
      * Get the file search tool options for the provider.

--- a/src/Providers/Tools/CodeExecution.php
+++ b/src/Providers/Tools/CodeExecution.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Ai\Providers\Tools;
+
+class CodeExecution extends ProviderTool
+{
+    //
+}

--- a/src/Providers/XaiProvider.php
+++ b/src/Providers/XaiProvider.php
@@ -7,16 +7,18 @@ use InvalidArgumentException;
 use Laravel\Ai\Contracts\Gateway\ImageGateway;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\ImageProvider;
+use Laravel\Ai\Contracts\Providers\SupportsCodeExecution;
 use Laravel\Ai\Contracts\Providers\SupportsFileSearch;
 use Laravel\Ai\Contracts\Providers\SupportsWebSearch;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Xai\XaiGateway;
 use Laravel\Ai\Gateway\Xai\XaiImageGateway;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 
-class XaiProvider extends Provider implements ImageProvider, SupportsFileSearch, SupportsWebSearch, TextProvider
+class XaiProvider extends Provider implements ImageProvider, SupportsCodeExecution, SupportsFileSearch, SupportsWebSearch, TextProvider
 {
     use Concerns\GeneratesImages;
     use Concerns\GeneratesText;
@@ -28,6 +30,14 @@ class XaiProvider extends Provider implements ImageProvider, SupportsFileSearch,
         protected array $config,
         protected Dispatcher $events,
     ) {}
+
+    /**
+     * Get the code execution tool options for the provider.
+     */
+    public function codeExecutionToolOptions(CodeExecution $codeExecution): array
+    {
+        return $codeExecution->providerOptions(Lab::xAI);
+    }
 
     /**
      * Get the file search tool options for the provider.

--- a/tests/Datasets/Providers.php
+++ b/tests/Datasets/Providers.php
@@ -96,3 +96,10 @@ dataset('tool-replay-providers', [
     // Non-reasoning model (backward compatibility)
     'openai-gpt-4-1' => ['openai', 'OPENAI_API_KEY', 'gpt-4.1', false],
 ]);
+
+dataset('code-execution-providers', [
+    'anthropic' => ['anthropic', 'ANTHROPIC_API_KEY', 'claude-haiku-4-5-20251001'],
+    'openai' => ['openai', 'OPENAI_API_KEY', 'gpt-5.4'],
+    'gemini' => ['gemini', 'GEMINI_API_KEY', 'gemini-3.1-flash-lite'],
+    'xai' => ['xai', 'XAI_API_KEY', 'grok-4.6'],
+]);

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -295,6 +295,6 @@ test('code execution tool sends dated type and name', function (): void {
     Http::assertSent(function ($request): bool {
         $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'code_execution');
 
-        return data_get($tool, 'type') === 'code_execution_20250825';
+        return data_get($tool, 'type') === 'code_execution_20260120';
     });
 });

--- a/tests/Feature/Providers/Anthropic/ToolMappingTest.php
+++ b/tests/Feature/Providers/Anthropic/ToolMappingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
@@ -281,5 +282,19 @@ test('empty schema still includes input schema with type object', function (): v
         }
 
         return false;
+    });
+});
+
+test('code execution tool sends dated type and name', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [new CodeExecution])->prompt('Run some code', provider: 'anthropic');
+
+    Http::assertSent(function ($request): bool {
+        $tool = collect($request->data()['tools'] ?? [])->firstWhere('name', 'code_execution');
+
+        return data_get($tool, 'type') === 'code_execution_20250825';
     });
 });

--- a/tests/Feature/Providers/AzureOpenAi/ToolMappingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/ToolMappingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
@@ -239,5 +240,20 @@ test('web search tool omits user_location when no location set', function (): vo
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
 
         return ! array_key_exists('user_location', $tool);
+    });
+});
+
+test('code execution tool sends type code_interpreter with auto container', function (): void {
+    Http::fake([
+        '*' => fakeAzureResponse('result'),
+    ]);
+
+    agent(tools: [new CodeExecution])->prompt('Run some code', provider: 'azure');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'code_interpreter');
+
+        return data_get($tool, 'container') === ['type' => 'auto'];
     });
 });

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
@@ -15,8 +17,63 @@ use Laravel\Ai\Streaming\Events\TextEnd;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+use function Laravel\Ai\agent;
 
 describe('text streaming', function (): void {
+    test('streaming emits provider tool events for code execution parts', function (): void {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->geminiChunk([['executableCode' => ['language' => 'PYTHON', 'code' => 'print(1)']]]),
+                    $this->geminiChunk([['codeExecutionResult' => ['outcome' => 'OUTCOME_OK', 'output' => '1']]]),
+                    $this->geminiChunkWithUsage([['text' => 'The answer is 1.']], 10, 5),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $providerEvents = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof ProviderToolEvent));
+
+        expect(array_map(fn (ProviderToolEvent $e): string => $e->status, $providerEvents))->toBe(['code_generated', 'result_received'])
+            ->and($providerEvents[0])->type->toBe('code_execution')->provider->toBe('gemini')
+            ->and($providerEvents[0]->data['executableCode']['code'])->toBe('print(1)')
+            ->and($providerEvents[1]->data['codeExecutionResult']['output'])->toBe('1');
+    });
+
+    test('streaming replays code execution parts when continuing after a function call', function (): void {
+        Http::fake([
+            'generativelanguage.googleapis.com/*' => Http::sequence()
+                ->push(
+                    body: $this->ssePayload([
+                        $this->geminiChunk([['executableCode' => ['language' => 'PYTHON', 'code' => 'print(1)']]]),
+                        $this->geminiChunk([['codeExecutionResult' => ['outcome' => 'OUTCOME_OK', 'output' => '1']]]),
+                        $this->geminiChunkWithUsage([['functionCall' => ['name' => 'FixedNumberGenerator', 'args' => []]]], 10, 5),
+                    ]),
+                    headers: ['Content-Type' => 'text/event-stream'],
+                )
+                ->push(
+                    body: $this->ssePayload([$this->geminiChunkWithUsage([['text' => 'Done.']], 10, 5)]),
+                    headers: ['Content-Type' => 'text/event-stream'],
+                ),
+        ]);
+
+        $this->collectStreamEvents(agent(tools: [new FixedNumberGenerator]));
+
+        Http::assertSentCount(2);
+
+        Http::assertSent(function (Request $request): bool {
+            $modelParts = collect(json_decode($request->body(), true)['contents'] ?? [])
+                ->firstWhere('role', 'model')['parts'] ?? [];
+
+            return array_column($modelParts, 'executableCode') !== []
+                && array_column($modelParts, 'codeExecutionResult') !== []
+                && array_column($modelParts, 'functionCall') !== [];
+        });
+    });
+
     test('streaming emits citation events for grounding metadata', function (): void {
         $finalChunk = [
             'candidates' => [[

--- a/tests/Feature/Providers/Gemini/StreamingTest.php
+++ b/tests/Feature/Providers/Gemini/StreamingTest.php
@@ -37,7 +37,7 @@ describe('text streaming', function (): void {
 
         $providerEvents = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof ProviderToolEvent));
 
-        expect(array_map(fn (ProviderToolEvent $e): string => $e->status, $providerEvents))->toBe(['code_generated', 'result_received'])
+        expect(array_map(fn (ProviderToolEvent $e): string => $e->status, $providerEvents))->toBe(['completed', 'result_received'])
             ->and($providerEvents[0])->type->toBe('code_execution')->provider->toBe('gemini')
             ->and($providerEvents[0]->data['executableCode']['code'])->toBe('print(1)')
             ->and($providerEvents[1]->data['codeExecutionResult']['output'])->toBe('1');

--- a/tests/Feature/Providers/Gemini/ToolMappingTest.php
+++ b/tests/Feature/Providers/Gemini/ToolMappingTest.php
@@ -232,19 +232,3 @@ test('code execution tool sends code_execution definition', function (): void {
 
     Http::assertSent(fn ($request): bool => str_contains($request->body(), '"code_execution":{}'));
 });
-
-test('code execution tool forwards gemini provider options into the tool payload', function (): void {
-    Http::fake([
-        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('ok'),
-    ]);
-
-    agent(tools: [(new CodeExecution)->withProviderOptions(['environment' => 'python'])])
-        ->prompt('Run some code', provider: 'gemini');
-
-    Http::assertSent(function ($request): bool {
-        $tool = collect($request->data()['tools'] ?? [])
-            ->first(fn ($tool): bool => array_key_exists('code_execution', $tool));
-
-        return data_get($tool, 'code_execution.environment') === 'python';
-    });
-});

--- a/tests/Feature/Providers/Gemini/ToolMappingTest.php
+++ b/tests/Feature/Providers/Gemini/ToolMappingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Agents\NamedToolAgent;
@@ -219,5 +220,31 @@ test('tools are wrapped in function declarations', function (): void {
         return isset($decl['name'])
             && isset($decl['description'])
             && is_string($decl['description']);
+    });
+});
+
+test('code execution tool sends code_execution definition', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [new CodeExecution])->prompt('Run some code', provider: 'gemini');
+
+    Http::assertSent(fn ($request): bool => str_contains($request->body(), '"code_execution":{}'));
+});
+
+test('code execution tool forwards gemini provider options into the tool payload', function (): void {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => $this->fakeTextResponse('ok'),
+    ]);
+
+    agent(tools: [(new CodeExecution)->withProviderOptions(['environment' => 'python'])])
+        ->prompt('Run some code', provider: 'gemini');
+
+    Http::assertSent(function ($request): bool {
+        $tool = collect($request->data()['tools'] ?? [])
+            ->first(fn ($tool): bool => array_key_exists('code_execution', $tool));
+
+        return data_get($tool, 'code_execution.environment') === 'python';
     });
 });

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -5,6 +5,7 @@ use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\ReasoningEnd;
 use Laravel\Ai\Streaming\Events\ReasoningStart;
@@ -291,4 +292,30 @@ test('streaming captures cache write tokens from response completed', function (
         ->and($streamEnd->usage->cacheReadInputTokens)->toBe(0)
         ->and($streamEnd->usage->promptTokens)->toBe(3)
         ->and($streamEnd->usage->completionTokens)->toBe(120);
+});
+
+test('streaming emits provider tool events for code interpreter code deltas', function (): void {
+    Http::fake([
+        'api.openai.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                ['type' => 'response.code_interpreter_call.in_progress', 'item_id' => 'ci_1', 'output_index' => 0],
+                ['type' => 'response.code_interpreter_call_code.delta', 'item_id' => 'ci_1', 'output_index' => 0, 'delta' => 'print(1)'],
+                ['type' => 'response.code_interpreter_call_code.done', 'item_id' => 'ci_1', 'output_index' => 0, 'code' => 'print(1)'],
+                ['type' => 'response.code_interpreter_call.completed', 'item_id' => 'ci_1', 'output_index' => 0],
+                $this->outputTextDelta('1'),
+                $this->outputTextDone('1'),
+                $this->responseCompleted(10, 5),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $providerEvents = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof ProviderToolEvent));
+
+    expect(array_map(fn (ProviderToolEvent $e): string => $e->status, $providerEvents))
+        ->toBe(['in_progress', 'code_delta', 'code_done', 'completed'])
+        ->and($providerEvents[1])->type->toBe('code_interpreter_call')->itemId->toBe('ci_1')
+        ->and($providerEvents[1]->data['delta'])->toBe('print(1)');
 });

--- a/tests/Feature/Providers/OpenAi/ToolMappingTest.php
+++ b/tests/Feature/Providers/OpenAi/ToolMappingTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\WebSearch;
 use Tests\Fixtures\Tools\FixedNumberGenerator;
 use Tests\Fixtures\Tools\NamedTool;
@@ -276,5 +277,39 @@ test('web search tool omits user_location when no location set', function (): vo
         $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'web_search');
 
         return ! array_key_exists('user_location', $tool);
+    });
+});
+
+test('code execution tool sends type code_interpreter with auto container', function (): void {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [new CodeExecution])->prompt('Run some code', provider: 'openai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'code_interpreter');
+
+        return data_get($tool, 'container') === ['type' => 'auto'];
+    });
+});
+
+test('code execution tool provider options may override the container', function (): void {
+    Http::fake([
+        '*' => fakeOpenAiResponse('result'),
+    ]);
+
+    agent(tools: [
+        (new CodeExecution)->withProviderOptions([
+            'container' => ['type' => 'auto', 'file_ids' => ['file_123']],
+        ]),
+    ])->prompt('Run some code', provider: 'openai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+        $tool = collect(data_get($body, 'tools'))->firstWhere('type', 'code_interpreter');
+
+        return data_get($tool, 'container.file_ids') === ['file_123'];
     });
 });

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -5,6 +5,7 @@ use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -258,3 +259,25 @@ test('streaming finish reason maps correctly', function (string $status, string 
     'unknown status maps to Unknown' => ['mystery_status', 'message', FinishReason::Unknown],
     'completed unknown type maps to Unknown' => ['completed', 'mystery_output', FinishReason::Unknown],
 ]);
+
+test('streaming emits provider tool events for code interpreter code deltas', function (): void {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.created', 'response' => ['id' => 'resp_123', 'model' => 'grok-4-1-fast-reasoning']],
+                ['type' => 'response.code_interpreter_call_code.delta', 'item_id' => 'ci_1', 'output_index' => 0, 'delta' => 'print(1)'],
+                ['type' => 'response.code_interpreter_call_code.done', 'item_id' => 'ci_1', 'output_index' => 0, 'code' => 'print(1)'],
+                ['type' => 'response.output_text.delta', 'delta' => '1'],
+                ['type' => 'response.output_text.done'],
+                ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'message', 'status' => 'completed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => '1']]]], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 0]]]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $providerEvents = array_values(array_filter($this->collectStreamEvents(), fn ($e): bool => $e instanceof ProviderToolEvent));
+
+    expect(array_map(fn (ProviderToolEvent $e): string => $e->status, $providerEvents))->toBe(['code_delta', 'code_done'])
+        ->and($providerEvents[0])->type->toBe('code_interpreter_call')->itemId->toBe('ci_1');
+});

--- a/tests/Feature/Providers/Xai/ToolMappingTest.php
+++ b/tests/Feature/Providers/Xai/ToolMappingTest.php
@@ -4,6 +4,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Ai;
+use Laravel\Ai\Providers\Tools\CodeExecution;
 use Laravel\Ai\Providers\Tools\FileSearch;
 use Laravel\Ai\Providers\Tools\WebFetch;
 use Laravel\Ai\Providers\Tools\WebSearch;
@@ -227,3 +228,15 @@ function fakeXaiToolMappingResponse(string $text): PromiseInterface
         ],
     ]);
 }
+
+test('code execution tool sends type code_interpreter', function (): void {
+    Http::fake(['*' => fakeXaiToolMappingResponse('result')]);
+
+    agent(tools: [new CodeExecution])->prompt('Run some code', provider: 'xai');
+
+    Http::assertSent(function (Request $request): bool {
+        $body = json_decode($request->body(), true);
+
+        return collect(data_get($body, 'tools'))->firstWhere('type', 'code_interpreter') !== null;
+    });
+});

--- a/tests/Integration/CodeExecutionTest.php
+++ b/tests/Integration/CodeExecutionTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Laravel\Ai\Providers\Tools\CodeExecution;
+use Laravel\Ai\Streaming\Events\ProviderToolEvent;
+use Laravel\Ai\Streaming\Events\TextDelta;
 
 use function Laravel\Ai\agent;
 
@@ -17,4 +19,34 @@ test('agents answer using the hosted code execution tool', function (string $pro
     );
 
     expect($response->text)->toContain('914b82ea0d8d6269b1eb6a8ea80c929ea3035c7286daa71bfafb051a16fd3a9e');
+})->with('code-execution-providers');
+
+test('agents stream provider tool events while using the hosted code execution tool', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
+    $response = agent(
+        'Use the code execution tool to compute the answer. Reply with the hex digest only.',
+        tools: [new CodeExecution],
+    )->stream(
+        'What is the SHA-256 hex digest of the exact ASCII string laravel-ai-code-execution?',
+        provider: $provider,
+        model: $model,
+    );
+
+    $providerEvents = [];
+    $text = '';
+
+    foreach ($response as $event) {
+        if ($event instanceof ProviderToolEvent) {
+            $providerEvents[] = $event;
+        } elseif ($event instanceof TextDelta) {
+            $text .= $event->delta;
+        }
+    }
+
+    $streamedCode = array_filter($providerEvents, fn (ProviderToolEvent $event): bool => str_contains(json_encode($event->data), 'sha256'));
+
+    expect($streamedCode)->not->toBeEmpty()
+        ->and($providerEvents[0]->provider)->toBe($provider)
+        ->and($text)->toContain('914b82ea0d8d6269b1eb6a8ea80c929ea3035c7286daa71bfafb051a16fd3a9e');
 })->with('code-execution-providers');

--- a/tests/Integration/CodeExecutionTest.php
+++ b/tests/Integration/CodeExecutionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\Ai\Providers\Tools\CodeExecution;
+
+use function Laravel\Ai\agent;
+
+test('agents answer using the hosted code execution tool', function (string $provider, string $apiKey, string $model) {
+    requiresApiKey($apiKey);
+
+    $response = agent(
+        'Use the code execution tool to compute the answer. Reply with the hex digest only.',
+        tools: [new CodeExecution],
+    )->prompt(
+        'What is the SHA-256 hex digest of the exact ASCII string laravel-ai-code-execution?',
+        provider: $provider,
+        model: $model,
+    );
+
+    expect($response->text)->toContain('914b82ea0d8d6269b1eb6a8ea80c929ea3035c7286daa71bfafb051a16fd3a9e');
+})->with('code-execution-providers');


### PR DESCRIPTION
Anthropic, OpenAI, Gemini and xAI all host a sandboxed code interpreter that runs Python server side, but the SDK had no way to reach it. The only option was `ProviderTool` with a hand written payload per provider.

This adds `CodeExecution` alongside the existing provider tools:

```php
use Laravel\Ai\Providers\Tools\CodeExecution;

// The model writes and runs Python in the provider's sandbox.
agent(tools: [new CodeExecution])->prompt('What is the SHA-256 of "laravel"?');
```

Each provider gets the wire format its API expects, so the same tool works everywhere:

| Provider | Sent as |
|---|---|
| Anthropic | `{"type": "code_execution_20250825", "name": "code_execution"}` |
| OpenAI, Azure | `{"type": "code_interpreter", "container": {"type": "auto"}}` |
| Gemini | `{"code_execution": {}}` |
| xAI | `{"type": "code_interpreter"}` |

Provider options work the way they do on `WebSearch`, and on OpenAI and Azure they take precedence over the default container, which is how you attach files:

```php
(new CodeExecution)->withProviderOptions([
    'container' => ['type' => 'auto', 'file_ids' => ['file_123']],
]);
```
