### PR TITLE
Disable tools on the final OpenAI-compatible step

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade Guide
 
+## Upgrading To 0.12 From 0.11
+
+### Final OpenAI-Compatible Step Disables Tools
+
+**Likelihood Of Impact: Low**
+
+OpenAI-compatible text generation now sets `tool_choice` to `none` on the final configured model request. Tool definitions remain in the request so previous tool calls and results stay valid, but the model must produce a response instead of requesting a tool that the loop cannot run.
+
+`maxSteps` still sets the total number of model requests. For example, `maxSteps: 5` allows up to four tool-capable requests followed by one response request. With `maxSteps: 1`, tools cannot be called; configure at least two steps when an agent needs to call one.
+
 ## Upgrading To 0.11 From 0.10
 
 ### Connection Failures Throw `ProviderConnectionException`

--- a/src/Gateway/OpenAiCompatible/Concerns/BuildsTextRequests.php
+++ b/src/Gateway/OpenAiCompatible/Concerns/BuildsTextRequests.php
@@ -56,7 +56,11 @@ trait BuildsTextRequests
         $providerOptions = $options?->providerOptions($provider->name());
 
         if (filled($providerOptions)) {
-            return array_merge($body, $providerOptions);
+            $body = array_merge($body, $providerOptions);
+        }
+
+        if ($stepContext->isFinalStep && isset($body['tools'])) {
+            $body['tool_choice'] = 'none';
         }
 
         return $body;

--- a/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
+++ b/tests/Feature/Providers/OpenAiCompatible/OpenAiCompatibleTest.php
@@ -10,8 +10,10 @@ use Laravel\Ai\Responses\AgentResponse;
 use Tests\Fixtures\Agents\AttributeAgent;
 use Tests\Fixtures\Agents\AttributeToolChoiceAgent;
 use Tests\Fixtures\Agents\NestedStructuredAgent;
+use Tests\Fixtures\Agents\ProviderOptionsWithToolsAgent;
 use Tests\Fixtures\Agents\StructuredAgent;
 use Tests\Fixtures\Agents\ToolChoiceAgent;
+use Tests\Fixtures\Agents\ToolUsingAgent;
 
 use function Laravel\Ai\agent;
 
@@ -167,6 +169,33 @@ test('none tool choice prevents tool calls', function (): void {
     Http::assertSent(fn (Request $request): bool => json_decode($request->body(), true)['tool_choice'] === 'none');
 });
 
+test('final tool loop request disables tools and returns structured output', function (): void {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenAiCompatibleToolCallResponse(),
+            fakeOpenAiCompatibleResponse('{"number":72019}'),
+        ]),
+    ]);
+
+    $response = (new ToolUsingAgent(fixed: true))->prompt(
+        'Generate a number',
+        provider: 'openai-compatible',
+    );
+
+    $recorded = Http::recorded();
+    $firstBody = json_decode((string) $recorded[0][0]->body(), true);
+    $finalBody = json_decode((string) $recorded[1][0]->body(), true);
+
+    expect($recorded)->toHaveCount(2)
+        ->and($firstBody['tool_choice'])->toBe('auto')
+        ->and($finalBody['tools'])->not->toBeEmpty()
+        ->and($finalBody['tool_choice'])->toBe('none')
+        ->and($finalBody)->toHaveKey('response_format')
+        ->and($response->structured['number'])->toBe(72019)
+        ->and($response->toolResults)->toHaveCount(1)
+        ->and($response->toolResults[0]->result)->toBe('72019');
+});
+
 test('max tokens uses the max_tokens field by default', function (): void {
     Http::fake(['*' => fakeOpenAiCompatibleResponse('Hello')]);
 
@@ -219,6 +248,29 @@ test('streaming omits stream_options by default', function (): void {
         return $body['stream'] === true
             && ! array_key_exists('stream_options', $body);
     });
+});
+
+test('final streamed tool loop request disables tools', function (): void {
+    Http::fake([
+        '*' => Http::sequence([
+            fakeOpenAiCompatibleToolCallStream(),
+            fakeOpenAiCompatibleStream('The number is 72019'),
+        ]),
+    ]);
+
+    foreach ((new ProviderOptionsWithToolsAgent)->stream('Generate a number', provider: 'openai-compatible') as $event) {
+        // drain the stream
+    }
+
+    $recorded = Http::recorded();
+    $firstBody = json_decode((string) $recorded[0][0]->body(), true);
+    $finalBody = json_decode((string) $recorded[1][0]->body(), true);
+
+    expect($recorded)->toHaveCount(2)
+        ->and($firstBody['tool_choice'])->toBe('auto')
+        ->and($finalBody['tools'])->not->toBeEmpty()
+        ->and($finalBody['tool_choice'])->toBe('none')
+        ->and($finalBody['stream'])->toBeTrue();
 });
 
 test('streaming sends stream_options when configured on the instance', function (): void {
@@ -352,7 +404,59 @@ function fakeOpenAiCompatibleResponse(string $content)
     ]);
 }
 
-function fakeOpenAiCompatibleStream()
+function fakeOpenAiCompatibleToolCallResponse()
+{
+    return Http::response([
+        'id' => 'chatcmpl-tool-123',
+        'object' => 'chat.completion',
+        'model' => 'local-model',
+        'choices' => [[
+            'index' => 0,
+            'message' => [
+                'role' => 'assistant',
+                'content' => null,
+                'tool_calls' => [[
+                    'id' => 'call_123',
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'FixedNumberGenerator',
+                        'arguments' => '{}',
+                    ],
+                ]],
+            ],
+            'finish_reason' => 'tool_calls',
+        ]],
+        'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
+    ]);
+}
+
+function fakeOpenAiCompatibleToolCallStream()
+{
+    $chunk = fn (array $delta, ?string $finish = null): string => 'data: '.json_encode([
+        'id' => 'chatcmpl-tool-123',
+        'object' => 'chat.completion.chunk',
+        'model' => 'local-model',
+        'choices' => [['index' => 0, 'delta' => $delta, 'finish_reason' => $finish]],
+    ]);
+
+    $body = implode("\n\n", [
+        $chunk([
+            'role' => 'assistant',
+            'tool_calls' => [[
+                'index' => 0,
+                'id' => 'call_123',
+                'type' => 'function',
+                'function' => ['name' => 'FixedNumberGenerator', 'arguments' => '{}'],
+            ]],
+        ]),
+        $chunk([], 'tool_calls'),
+        'data: [DONE]',
+    ])."\n\n";
+
+    return Http::response($body, 200, ['Content-Type' => 'text/event-stream']);
+}
+
+function fakeOpenAiCompatibleStream(string $content = 'Hello')
 {
     $chunk = fn (array $delta, ?string $finish = null): string => 'data: '.json_encode([
         'id' => 'chatcmpl-123',
@@ -362,7 +466,7 @@ function fakeOpenAiCompatibleStream()
     ]);
 
     $body = implode("\n\n", [
-        $chunk(['role' => 'assistant', 'content' => 'Hello']),
+        $chunk(['role' => 'assistant', 'content' => $content]),
         $chunk([], 'stop'),
         'data: [DONE]',
     ])."\n\n";


### PR DESCRIPTION
## Summary

- set `tool_choice` to `none` on the final OpenAI-compatible generation step
- keep tool definitions so previous tool calls and results remain valid
- preserve `maxSteps` as the total model-request limit
- cover synchronous and streaming generation

When tools remain callable on the final request, a model can request one even though `TextGenerationLoop` will not execute it. The loop then ends without a final text response.

The final request now requires a response while retaining tool definitions and their prompt-cache prefix. With `maxSteps: 1`, tools cannot be called; agents that need one must configure at least two steps. The upgrade guide documents this behavior.

Fixes #973

## Tests

- `composer test` — 2318 passed, 260 skipped, 4915 assertions; 2 existing notices
- `composer test:lint` — passed
- `composer test:types` — passed

[gpt-5.6-sol(xhigh) agent, claude-opus-5(xhigh) reviewer, AnnoyingTechnology(human) reviewer]
