### PR TITLE
[1.x] Persist the reasoning a turn produced

### DIFF
--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -11,12 +11,16 @@ use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Gateway\StepTextGateway;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
@@ -79,6 +83,23 @@ class FakeTextGateway implements StepTextGateway
         $messageId = ulid();
 
         yield (new StreamStart(ulid(), $provider->name(), $model, time()))->withInvocationId($invocationId);
+
+        if (filled($step->reasoning)) {
+            $reasoningId = ulid();
+
+            yield (new ReasoningStart(ulid(), $reasoningId, time()))->withInvocationId($invocationId);
+
+            foreach (Str::of($step->reasoning)->explode(' ') as $index => $word) {
+                yield (new ReasoningDelta(
+                    ulid(),
+                    $reasoningId,
+                    $index > 0 ? ' '.$word : $word,
+                    time(),
+                ))->withInvocationId($invocationId);
+            }
+
+            yield (new ReasoningEnd(ulid(), $reasoningId, time()))->withInvocationId($invocationId);
+        }
 
         if (filled($step->text)) {
             yield (new TextStart(ulid(), $messageId, time()))->withInvocationId($invocationId);
@@ -145,7 +166,8 @@ class FakeTextGateway implements StepTextGateway
         }
 
         return new StepResponse(
-            $response->text, [], FinishReason::Stop, $response->usage, $response->meta
+            $response->text, [], FinishReason::Stop, $response->usage, $response->meta,
+            reasoning: $response instanceof AgentResponse ? $response->reasoning : '',
         );
     }
 

--- a/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
+++ b/src/Gateway/OpenAi/Concerns/HandlesTextGeneration.php
@@ -132,7 +132,7 @@ trait HandlesTextGeneration
                 continue;
             }
 
-            if ($type === 'response.reasoning_summary_text.delta') {
+            if (in_array($type, ['response.reasoning_summary_text.delta', 'response.reasoning_text.delta'], true)) {
                 $delta = (string) ($data['delta'] ?? '');
 
                 if ($delta !== '') {

--- a/src/Gateway/StepResponse.php
+++ b/src/Gateway/StepResponse.php
@@ -31,6 +31,7 @@ class StepResponse implements Arrayable, JsonSerializable
         public ?string $continuationToken = null,
         public array $providerContentBlocks = [],
         public array $pendingApprovals = [],
+        public string $reasoning = '',
     ) {}
 
     /**

--- a/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Xai/Concerns/HandlesTextStreaming.php
@@ -115,7 +115,7 @@ trait HandlesTextStreaming
                 continue;
             }
 
-            if ($type === 'response.reasoning_summary_text.delta') {
+            if (in_array($type, ['response.reasoning_summary_text.delta', 'response.reasoning_text.delta'], true)) {
                 $delta = (string) ($data['delta'] ?? '');
 
                 if ($delta !== '') {

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -20,11 +20,23 @@ class AgentResponse extends TextResponse
 
     public ?string $assistantMessageId = null;
 
+    public string $reasoning = '';
+
     public function __construct(string $invocationId, string $text, Usage $usage, Meta $meta)
     {
         $this->invocationId = $invocationId;
 
         parent::__construct($text, $usage, $meta);
+    }
+
+    /**
+     * Create a fake response that reasoned before answering.
+     */
+    public static function fakeWithReasoning(string $reasoning, string $text = ''): self
+    {
+        return tap(new self('fake-invocation', $text, new Usage, new Meta), function (self $response) use ($reasoning): void {
+            $response->reasoning = $reasoning;
+        });
     }
 
     /**

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use IteratorAggregate;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -34,6 +35,8 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     public ?string $userMessageId = null;
 
     public ?string $assistantMessageId = null;
+
+    public string $reasoning = '';
 
     protected array $thenCallbacks = [];
 
@@ -199,6 +202,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
         $this->events = new Collection($events);
         $this->text = TextDelta::combine($events);
+        $this->reasoning = ReasoningDelta::combine($events);
         $this->usage = StreamEnd::combineUsage($events);
 
         $this->streamedResponse = new StreamedAgentResponse(

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -34,6 +35,8 @@ class StreamedAgentResponse extends AgentResponse
         );
 
         $this->events = $events;
+
+        $this->reasoning = ReasoningDelta::combine($events);
 
         $this->withPendingApprovals(
             $events->whereInstanceOf(ToolApprovalRequest::class)

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -210,6 +210,10 @@ class DatabaseConversationStore implements ConversationStore
             $meta['provider_content_blocks'] = $blocks;
         }
 
+        if (filled($response->reasoning)) {
+            $meta['reasoning'] = $response->reasoning;
+        }
+
         return $meta;
     }
 

--- a/src/Streaming/Events/ReasoningDelta.php
+++ b/src/Streaming/Events/ReasoningDelta.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Ai\Streaming\Events;
 
+use Illuminate\Support\Collection;
+
 class ReasoningDelta extends StreamEvent
 {
     public function __construct(
@@ -12,6 +14,19 @@ class ReasoningDelta extends StreamEvent
         public ?array $summary = null,
     ) {
         //
+    }
+
+    /**
+     * Combine reasoning deltas by block, separating each block with a blank line.
+     */
+    public static function combine(Collection|array $events): string
+    {
+        return Collection::wrap($events)
+            ->whereInstanceOf(ReasoningDelta::class)
+            ->groupBy(fn (ReasoningDelta $event) => $event->reasoningId)
+            ->map(fn (Collection $deltas) => $deltas->pluck('delta')->implode(''))
+            ->filter(fn (string $reasoning) => trim($reasoning) !== '')
+            ->implode("\n\n");
     }
 
     /**

--- a/src/Vercel/Vercel.php
+++ b/src/Vercel/Vercel.php
@@ -98,6 +98,10 @@ class Vercel
     {
         $parts = [];
 
+        if ($message instanceof ConversationMessage && filled($reasoning = $message->meta['reasoning'] ?? null)) {
+            $parts[] = ['type' => 'reasoning', 'text' => $reasoning];
+        }
+
         if (filled($message->content)) {
             $parts[] = ['type' => 'text', 'text' => $message->content];
         }

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -18,6 +18,9 @@ use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
@@ -191,6 +194,30 @@ describe('stream responses', function (): void {
         $response->each(fn (): true => true);
         expect($response->text)->toEqual('Third response')
             ->and($response->events)->toHaveCount(6);
+    });
+
+    test('faked agents can stream the reasoning that preceded an answer', function (): void {
+        AssistantAgent::fake([
+            AgentResponse::fakeWithReasoning('They want the temperature.', 'It is 12°C.'),
+        ]);
+
+        $response = (new AssistantAgent)->stream('How cold is it?');
+        $response->each(fn (): true => true);
+
+        expect($response->reasoning)->toBe('They want the temperature.')
+            ->and($response->text)->toBe('It is 12°C.')
+            ->and($response->events->whereInstanceOf(ReasoningStart::class))->toHaveCount(1)
+            ->and($response->events->whereInstanceOf(ReasoningEnd::class))->toHaveCount(1);
+    });
+
+    test('a faked stream reports no reasoning when the model did not reason', function (): void {
+        AssistantAgent::fake(['It is 12°C.']);
+
+        $response = (new AssistantAgent)->stream('How cold is it?');
+        $response->each(fn (): true => true);
+
+        expect($response->reasoning)->toBe('')
+            ->and($response->events->whereInstanceOf(ReasoningDelta::class))->toBeEmpty();
     });
 
     test('faked stream events share the response invocation id', function (): void {

--- a/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/AzureOpenAi/StreamingTest.php
@@ -4,6 +4,9 @@ use Illuminate\Support\Facades\Http;
 use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -44,6 +47,38 @@ test('streaming emits text events', function (): void {
         ->and($events[3])->toBeInstanceOf(TextDelta::class)->delta->toBe(' world')
         ->and($events[4])->toBeInstanceOf(TextEnd::class)
         ->and($events[count($events) - 1])->toBeInstanceOf(StreamEnd::class);
+});
+
+test('streaming handles reasoning text events', function (): void {
+    Http::fake([
+        'my-resource.cognitiveservices.azure.com/*' => Http::response(
+            body: $this->ssePayload([
+                $this->responseCreated(),
+                ['type' => 'response.reasoning_text.delta', 'delta' => 'Let me think...', 'item_id' => 'rs_1'],
+                [
+                    'type' => 'response.output_item.done',
+                    'item' => ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => []],
+                ],
+                $this->outputTextDelta('Answer'),
+                $this->outputTextDone('Answer'),
+                $this->responseCompleted(10, 15),
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    $types = array_map(fn ($event) => $event::class, $events);
+
+    expect($types)->toContain(ReasoningStart::class)
+        ->toContain(ReasoningDelta::class)
+        ->toContain(ReasoningEnd::class);
+
+    $reasoningDelta = collect($events)->first(fn ($event): bool => $event instanceof ReasoningDelta);
+
+    expect($reasoningDelta->delta)->toBe('Let me think...');
 });
 
 test('streaming handles tool calls', function (): void {

--- a/tests/Feature/Providers/OpenAi/StreamingTest.php
+++ b/tests/Feature/Providers/OpenAi/StreamingTest.php
@@ -161,12 +161,12 @@ test('streaming handles tool calls', function (): void {
         ->and($streamEnd->usage->completionTokens)->toBe(15);
 });
 
-test('streaming handles reasoning events', function (): void {
+test('streaming handles reasoning events', function (string $eventType): void {
     Http::fake([
         'api.openai.com/*' => Http::response(
             body: $this->ssePayload([
                 $this->responseCreated(),
-                ['type' => 'response.reasoning_summary_text.delta', 'delta' => 'Let me think...', 'item_id' => 'rs_1'],
+                ['type' => $eventType, 'delta' => 'Let me think...', 'item_id' => 'rs_1'],
                 [
                     'type' => 'response.output_item.done',
                     'item' => ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => [['type' => 'summary_text', 'text' => 'Let me think...']]],
@@ -190,7 +190,10 @@ test('streaming handles reasoning events', function (): void {
 
     $reasoningDelta = array_values(array_filter($events, fn ($e): bool => $e instanceof ReasoningDelta))[0];
     expect($reasoningDelta->delta)->toBe('Let me think...');
-});
+})->with([
+    'reasoning summary' => 'response.reasoning_summary_text.delta',
+    'reasoning text' => 'response.reasoning_text.delta',
+]);
 
 test('streaming error event stops stream', function (): void {
     Http::fake([

--- a/tests/Feature/Providers/Xai/StreamingTest.php
+++ b/tests/Feature/Providers/Xai/StreamingTest.php
@@ -5,6 +5,9 @@ use Laravel\Ai\Exceptions\StreamErrorException;
 use Laravel\Ai\Responses\Data\FinishReason;
 use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\Error;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -45,6 +48,35 @@ test('streaming emits text events', function (): void {
         ->and($events[4])->toBeInstanceOf(TextEnd::class)
         ->and($events[5])->toBeInstanceOf(StreamEnd::class);
 });
+
+test('streaming emits reasoning events', function (string $eventType): void {
+    Http::fake([
+        '*' => Http::response(
+            body: $this->ssePayload([
+                ['type' => 'response.created', 'response' => ['id' => 'resp_123', 'model' => 'grok-4-1-fast-reasoning']],
+                ['type' => $eventType, 'delta' => 'Let me think...', 'item_id' => 'rs_1'],
+                ['type' => 'response.output_item.done', 'item' => ['type' => 'reasoning', 'id' => 'rs_1', 'summary' => []]],
+                ['type' => 'response.output_text.delta', 'delta' => 'Answer'],
+                ['type' => 'response.output_text.done'],
+                ['type' => 'response.completed', 'response' => ['id' => 'resp_123', 'status' => 'completed', 'output' => [['type' => 'message', 'status' => 'completed', 'role' => 'assistant', 'content' => [['type' => 'output_text', 'text' => 'Answer']]]], 'usage' => ['input_tokens' => 10, 'output_tokens' => 5, 'input_tokens_details' => ['cached_tokens' => 0], 'output_tokens_details' => ['reasoning_tokens' => 3]]]],
+            ]),
+            status: 200,
+            headers: ['Content-Type' => 'text/event-stream'],
+        ),
+    ]);
+
+    $events = $this->collectStreamEvents();
+
+    expect(collect($events)->contains(fn ($event): bool => $event instanceof ReasoningStart))->toBeTrue()
+        ->and(collect($events)->contains(fn ($event): bool => $event instanceof ReasoningEnd))->toBeTrue();
+
+    $reasoningDelta = collect($events)->first(fn ($event): bool => $event instanceof ReasoningDelta);
+
+    expect($reasoningDelta->delta)->toBe('Let me think...');
+})->with([
+    'reasoning summary' => 'response.reasoning_summary_text.delta',
+    'reasoning text' => 'response.reasoning_text.delta',
+]);
 
 test('streaming emits citation events from the completed response', function (): void {
     Http::fake([

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -25,6 +25,10 @@ use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\ReasoningEnd;
+use Laravel\Ai\Streaming\Events\ReasoningStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -1145,6 +1149,57 @@ test('it scopes conversations by participant type so shared ids no longer collid
     expect($store->latestConversationId('user', $user->id, ToolUsingAgent::class))->toBe($userConversation)
         ->and($store->latestConversationId('admin', $admin->id, ToolUsingAgent::class))->toBe($adminConversation)
         ->and($userConversation)->not->toBe($adminConversation);
+});
+
+test('it records the reasoning a streamed turn produced into the message meta', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Reasoning conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'How cold is it?',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new StreamedAgentResponse('invocation-id', collect([
+        new ReasoningStart(uniqid(), 'reasoning-1', time()),
+        new ReasoningDelta(uniqid(), 'reasoning-1', 'They want ', time()),
+        new ReasoningDelta(uniqid(), 'reasoning-1', 'the temperature.', time()),
+        new ReasoningEnd(uniqid(), 'reasoning-1', time()),
+        new TextDelta(uniqid(), 'message-1', 'It is 12°C.', time()),
+    ]), new Meta);
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    expect(json_decode((string) $record->meta, true))
+        ->toHaveKey('reasoning', 'They want the temperature.');
+});
+
+test('it omits reasoning from the message meta when the model did not reason', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Quiet conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'How cold is it?',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new StreamedAgentResponse('invocation-id', collect([
+        new TextDelta(uniqid(), 'message-1', 'It is 12°C.', time()),
+    ]), new Meta);
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    expect(json_decode((string) $record->meta, true))->not->toHaveKey('reasoning');
 });
 
 function createConversationSchema(?string $connection = null): void

--- a/tests/Feature/UiMessageTest.php
+++ b/tests/Feature/UiMessageTest.php
@@ -375,6 +375,22 @@ describe('hydrating useChat from stored messages', function () {
         ]);
     });
 
+    test('conversation message models hydrate stored reasoning before text', function () {
+        $ui = Vercel::toUiMessages([
+            new ConversationMessage([
+                'id' => 'msg-2',
+                'role' => 'assistant',
+                'content' => 'It is 12°C.',
+                'meta' => ['reasoning' => 'They want the temperature.'],
+            ]),
+        ]);
+
+        expect($ui[0]['parts'])->toBe([
+            ['type' => 'reasoning', 'text' => 'They want the temperature.'],
+            ['type' => 'text', 'text' => 'It is 12°C.'],
+        ]);
+    });
+
     test('a completed tool turn hydrates as a settled tool part instead of a blank bubble', function () {
         $ui = Vercel::toUiMessages([
             new ConversationMessage([

--- a/tests/Unit/Streaming/ReasoningDeltaTest.php
+++ b/tests/Unit/Streaming/ReasoningDeltaTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Laravel\Ai\Streaming\Events\ReasoningDelta;
+use Laravel\Ai\Streaming\Events\StreamStart;
+use Laravel\Ai\Streaming\Events\TextDelta;
+
+function reasoningDelta(string $reasoningId, string $delta): ReasoningDelta
+{
+    return new ReasoningDelta(uniqid(), $reasoningId, $delta, time());
+}
+
+test('combine joins deltas of a single reasoning block without separators', function () {
+    $events = [
+        reasoningDelta('reasoning-1', 'The user'),
+        reasoningDelta('reasoning-1', ' wants'),
+        reasoningDelta('reasoning-1', ' the weather.'),
+    ];
+
+    expect(ReasoningDelta::combine($events))->toBe('The user wants the weather.');
+});
+
+test('combine separates reasoning from different steps with a blank line', function () {
+    $events = [
+        reasoningDelta('reasoning-1', 'I should look this up.'),
+        reasoningDelta('reasoning-2', 'The tool answered, so I can reply.'),
+    ];
+
+    expect(ReasoningDelta::combine($events))->toBe("I should look this up.\n\nThe tool answered, so I can reply.");
+});
+
+test('combine drops whitespace-only reasoning blocks', function () {
+    $events = [
+        reasoningDelta('reasoning-1', 'First.'),
+        reasoningDelta('reasoning-2', "\n"),
+        reasoningDelta('reasoning-3', 'Second.'),
+    ];
+
+    expect(ReasoningDelta::combine($events))->toBe("First.\n\nSecond.");
+});
+
+test('combine ignores events that are not reasoning deltas', function () {
+    $events = [
+        new StreamStart(uniqid(), 'fake', 'fake-model', time()),
+        new TextDelta(uniqid(), 'message-1', 'The answer.', time()),
+        reasoningDelta('reasoning-1', 'Only reasoning.'),
+    ];
+
+    expect(ReasoningDelta::combine($events))->toBe('Only reasoning.');
+});
+
+test('combine returns an empty string when there are no reasoning deltas', function () {
+    expect(ReasoningDelta::combine([]))->toBe('');
+});


### PR DESCRIPTION
A streamed turn reports the model's reasoning through `ReasoningStart`, `ReasoningDelta` and `ReasoningEnd`, but nothing persists it. This PR combines the deltas the same way `TextDelta::combine()` combines text (grouped per block, blocks separated by a blank line) and exposes it on the response:

```php
$response = (new SalesCoach)->forUser($user)->stream('Hello!');

foreach ($response as $event) {
    // ...
}

$response->reasoning; // "They're asking about pricing, so I should check the plan first."
```

It's an empty string when the model didn't reason, and it's populated once the stream has been consumed.

`DatabaseConversationStore` writes it to the message's `meta`, so no migration is needed. A reloaded transcript now reports the same reasoning the live one did:

```php
$message = ConversationMessage::find($response->assistantMessageId);

$message->meta['reasoning']; // "They're asking about pricing, so I should check the plan first."
```

`FakeTextGateway` now emits the reasoning events too, which is what makes any of this testable through `Agent::fake()`:

```php
SalesCoach::fake([
    AgentResponse::fakeWithReasoning('They want pricing.', 'Plans start at $10.'),
]);
```

This only covers streamed runs. On the non-streaming path the reasoning text never reaches the SDK.