### PR TITLE
[1.x] Report the persisted message id on RUN_FINISHED

### DIFF
--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -211,10 +211,13 @@ class AgentUserInteractionProtocol extends StreamProtocol
      */
     protected function runFinishedPart(array $attributes = []): array
     {
+        $assistantMessageId = $this->response?->assistantMessageId;
+
         return [
             'type' => 'RUN_FINISHED',
             'threadId' => $this->threadId,
             'runId' => $this->runId,
+            ...($assistantMessageId ? ['messageId' => $assistantMessageId] : []),
             ...$attributes,
         ];
     }

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -179,6 +179,39 @@ test('a first turn stream emits the thread id the conversation is stored under',
         ->and(end($events)['threadId'])->toBe($agent->currentConversation());
 });
 
+test('a remembered stream reports the assistant row it wrote', function () {
+    app()->instance(ConversationStore::class, new FakeConversationStore);
+
+    RememberingAssistantAgent::fake(['Fake response']);
+
+    $user = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)->forUser($user)->stream('Hello');
+
+    $events = agUiEvents($response->usingProtocol(new AgentUserInteractionProtocol)->toResponse(request()));
+    $finished = end($events);
+
+    expect($response->assistantMessageId)->not->toBeNull()
+        ->and(array_keys($finished))->toBe(['type', 'threadId', 'runId', 'messageId', 'usage', 'metadata'])
+        ->and($finished['threadId'])->toBe($response->conversationId)
+        ->and($finished['runId'])->toBe($response->invocationId)
+        ->and($finished['messageId'])->toBe($response->assistantMessageId);
+});
+
+test('a stream that persists nothing omits the message id', function () {
+    $events = agUiProtocolEvents([
+        new TextStart('event-1', 'msg-1', time()),
+        new TextDelta('event-2', 'msg-1', 'Hello', time()),
+        new TextEnd('event-3', 'msg-1', time()),
+        new StreamEnd('event-4', 'stop', new Usage, time()),
+    ]);
+
+    expect(end($events))->not->toHaveKey('messageId');
+});
+
 test('an ownerless approval stream persists the thread id it emits', function () {
     app()->instance(ConversationStore::class, new FakeConversationStore);
 


### PR DESCRIPTION
The live frames and a hydrated thread use different ids for the same message. `uiMessagesFrom()` in #964 hydrates from the stored row:

```php
$id = $message instanceof ConversationMessage ? $message->id : (string) Str::ulid();
```

while the live frames use the stream event's:

```php
'messageId' => $event->messageId,
```

Those come from different places, so a client that rendered a turn as it streamed shares no id with the row that comes back and can't tell they're the same message, both copies render.

`StreamableAgentResponse::$assistantMessageId` already holds the persisted id by the time the run completes (#961), and `runFinishedPart()` spreads attributes, so it's one key:

```json
{"type":"RUN_FINISHED","threadId":"…","runId":"…","messageId":"01a05480-2c19-73a1-b0e2-8f1d4c77e310"}
```

Absent when the run stored nothing (a resume that only rejects writes no assistant message) so existing clients are unaffected. It isn't part of AG-UI's `RUN_FINISHED` schema, so it's additive in the same way `error` is on a tool result.

Raised on #965; sending it separately so that stack doesn't have to widen.