### PR TITLE
[1.x] Report how a tool call ended on TOOL_CALL_RESULT

### DIFF
--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -316,6 +316,8 @@ class AgentUserInteractionProtocol extends StreamProtocol
                 'toolCallId' => $event->toolResult->id,
                 'content' => $this->toolResultContent($event),
                 'role' => 'tool',
+                ...(! $event->successful ? ['error' => $event->error ?? 'The tool call failed.'] : []),
+                ...($event->denied ? ['denied' => true] : []),
             ]],
             $event instanceof Error => [[
                 'type' => 'RUN_ERROR',

--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -310,15 +310,7 @@ class AgentUserInteractionProtocol extends StreamProtocol
                 ['type' => 'REASONING_END', 'messageId' => $event->reasoningId],
             ],
             $event instanceof ToolCall => $this->toolCallParts($event->toolCall),
-            $event instanceof ToolResult => [[
-                'type' => 'TOOL_CALL_RESULT',
-                'messageId' => $event->toolResult->resultId ?? $event->id,
-                'toolCallId' => $event->toolResult->id,
-                'content' => $this->toolResultContent($event),
-                'role' => 'tool',
-                ...(! $event->successful ? ['error' => $event->error ?? 'The tool call failed.'] : []),
-                ...($event->denied ? ['denied' => true] : []),
-            ]],
+            $event instanceof ToolResult => [$this->toolResultPart($event)],
             $event instanceof Error => [[
                 'type' => 'RUN_ERROR',
                 'message' => $event->message,
@@ -338,6 +330,29 @@ class AgentUserInteractionProtocol extends StreamProtocol
             ]],
             default => [],
         };
+    }
+
+    /**
+     * Get the protocol part that represents the given tool result event.
+     *
+     * @return array<string, mixed>
+     */
+    protected function toolResultPart(ToolResult $event): array
+    {
+        $content = $this->toolResultContent($event);
+
+        return [
+            'type' => 'TOOL_CALL_RESULT',
+            'messageId' => $event->toolResult->resultId ?? $event->id,
+            'toolCallId' => $event->toolResult->id,
+            'content' => $content,
+            'role' => 'tool',
+            // Reported as metadata because the AG-UI tool result event has no outcome field of its own...
+            ...($event->successful ? [] : ['metadata' => Arr::whereNotNull([
+                'error' => $content,
+                'denied' => $event->denied ?: null,
+            ])]),
+        ];
     }
 
     /**

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -447,12 +447,11 @@ test('a rejected approval streams the rejection as the tool result content', fun
         'toolCallId' => 'call-1',
         'content' => 'The user rejected this tool call.',
         'role' => 'tool',
-        'error' => 'The user rejected this tool call.',
-        'denied' => true,
+        'metadata' => ['error' => 'The user rejected this tool call.', 'denied' => true],
     ]);
 });
 
-test('a failed tool call streams an error without marking it denied', function () {
+test('a failed tool call reports an error without marking it denied', function () {
     $events = agUiProtocolEvents([
         new ToolResult('event-1', new Data\ToolResult('call-1', 'DeleteFile', ['path' => 'a.txt'], 'The tool call failed: disk unavailable.'), false, 'The tool call failed: disk unavailable.', time()),
         new StreamEnd('event-2', 'stop', new Usage, time()),
@@ -464,22 +463,7 @@ test('a failed tool call streams an error without marking it denied', function (
         'toolCallId' => 'call-1',
         'content' => 'The tool call failed: disk unavailable.',
         'role' => 'tool',
-        'error' => 'The tool call failed: disk unavailable.',
-    ]);
-});
-
-test('a successful tool call streams neither an error nor a denial', function () {
-    $events = agUiProtocolEvents([
-        new ToolResult('event-1', new Data\ToolResult('call-1', 'ReadFile', ['path' => 'a.txt'], 'Hello.'), true, null, time()),
-        new StreamEnd('event-2', 'stop', new Usage, time()),
-    ]);
-
-    expect($events[2])->toBe([
-        'type' => 'TOOL_CALL_RESULT',
-        'messageId' => 'event-1',
-        'toolCallId' => 'call-1',
-        'content' => 'Hello.',
-        'role' => 'tool',
+        'metadata' => ['error' => 'The tool call failed: disk unavailable.'],
     ]);
 });
 

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -447,6 +447,39 @@ test('a rejected approval streams the rejection as the tool result content', fun
         'toolCallId' => 'call-1',
         'content' => 'The user rejected this tool call.',
         'role' => 'tool',
+        'error' => 'The user rejected this tool call.',
+        'denied' => true,
+    ]);
+});
+
+test('a failed tool call streams an error without marking it denied', function () {
+    $events = agUiProtocolEvents([
+        new ToolResult('event-1', new Data\ToolResult('call-1', 'DeleteFile', ['path' => 'a.txt'], 'The tool call failed: disk unavailable.'), false, 'The tool call failed: disk unavailable.', time()),
+        new StreamEnd('event-2', 'stop', new Usage, time()),
+    ]);
+
+    expect($events[2])->toBe([
+        'type' => 'TOOL_CALL_RESULT',
+        'messageId' => 'event-1',
+        'toolCallId' => 'call-1',
+        'content' => 'The tool call failed: disk unavailable.',
+        'role' => 'tool',
+        'error' => 'The tool call failed: disk unavailable.',
+    ]);
+});
+
+test('a successful tool call streams neither an error nor a denial', function () {
+    $events = agUiProtocolEvents([
+        new ToolResult('event-1', new Data\ToolResult('call-1', 'ReadFile', ['path' => 'a.txt'], 'Hello.'), true, null, time()),
+        new StreamEnd('event-2', 'stop', new Usage, time()),
+    ]);
+
+    expect($events[2])->toBe([
+        'type' => 'TOOL_CALL_RESULT',
+        'messageId' => 'event-1',
+        'toolCallId' => 'call-1',
+        'content' => 'Hello.',
+        'role' => 'tool',
     ]);
 });
 


### PR DESCRIPTION
`toolResultContent()` flattens three different outcomes into one string:

```php
if (! $event->successful) {
    return $event->error ?? 'The tool call failed.';
}
```

So a failure, a refusal and an answer all arrive as `content`, and a client can't tell them apart, including the one that matters most, a human refusing permission, which is the observable result of the whole approval flow. The stream event has the facts to distinguish them (`successful`, `error`, `denied`); they just have nowhere to go.

Both keys are additive and absent on success:

```json
{"type":"TOOL_CALL_RESULT","toolCallId":"…","content":"…","role":"tool","error":"The user rejected this tool call.","denied":true}
```

`denied` is separate rather than folded into `error` because otherwise the two paths would mean different things by the same key: #964's hydrated row sets `error` *only* for denials, so a client reading `error` live would infer "refused" for an ordinary failure. `denied` is also the name already used on `Responses\Data\ToolResult` and in the persisted payload, so it stays one vocabulary.

Raised on #965; sending it separately so that stack doesn't have to widen.