### PR TITLE
Fix invalid Mistral cheapest text model default

### DIFF
--- a/src/Providers/MistralProvider.php
+++ b/src/Providers/MistralProvider.php
@@ -85,7 +85,7 @@ class MistralProvider extends Provider implements AudioProvider, EmbeddingProvid
      */
     public function cheapestTextModel(): string
     {
-        return $this->config['models']['text']['cheapest'] ?? 'mistral-small-4';
+        return $this->config['models']['text']['cheapest'] ?? 'mistral-small-2603';
     }
 
     /**


### PR DESCRIPTION
#951 (released in v0.11.1) changed the Mistral provider's cheapest text model default to `mistral-small-4`. That id does not exist on the Mistral API, so any agent using `#[UseCheapestModel]` with the Mistral provider now fails with a 400.

Mistral's `/v1/models` endpoint currently lists `mistral-small-2603` as the model behind the `mistral-small-latest` alias, so this PR uses that id. It follows the same dated naming as the `mistral-large-2512` default from #951.

Verified against the live Mistral API with a `#[UseCheapestModel]` agent: 400 before the change, successful response after.

