### PR TITLE
fix: preserve ResourceLink appResourceUri in McpServerTool output

### DIFF
--- a/src/Tools/McpServerTool.php
+++ b/src/Tools/McpServerTool.php
@@ -10,6 +10,7 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Concerns\NormalizesMcpResult;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Content\ResourceLink;
 
 class McpServerTool implements Tool
 {
@@ -136,22 +137,60 @@ class McpServerTool implements Tool
     }
 
     /**
-     * Reduce a list of responses to the last non-notification response's text.
+     * Reduce a list of responses to tool output, preserving MCP App resource links.
+     *
+     * When an MCP tool returns a `ResourceLink` with a `ui://` URI alongside
+     * text, the URI is included as `appResourceUri` in a JSON payload so the
+     * host can fetch the HTML via `resources/read` and render it in an iframe.
+     * Without a `ResourceLink`, returns plain text as before.
      *
      * @param  array<int, object>  $responses
      */
     protected function finalResponse(array $responses): string
     {
-        $final = collect($responses)->last(fn (object $response): bool => ! $response->isNotification());
+        $text = '';
+        $appUri = null;
+        $isError = false;
 
-        if ($final === null) {
+        foreach (array_reverse($responses) as $response) {
+            if ($response->isNotification()) {
+                continue;
+            }
+
+            $content = $response->content();
+
+            if ($content instanceof ResourceLink && str_starts_with((string) $content, 'ui://')) {
+                $appUri ??= (string) $content;
+                $isError = $isError || $response->isError();
+
+                continue;
+            }
+
+            if ($text === '') {
+                $text = (string) $content;
+                $isError = $response->isError();
+            }
+
+            if ($text !== '' && $appUri !== null) {
+                break;
+            }
+        }
+
+        if ($text === '' && $appUri === null) {
             return '';
         }
 
-        $text = (string) $final->content();
+        if ($isError) {
+            $text = $this->errorMessage($text);
+        }
 
-        return $final->isError()
-            ? $this->errorMessage($text)
-            : $text;
+        if ($appUri !== null) {
+            return json_encode([
+                'text' => $text,
+                'appResourceUri' => $appUri,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '';
+        }
+
+        return $text;
     }
 }

--- a/tests/Unit/Tools/McpServerToolTest.php
+++ b/tests/Unit/Tools/McpServerToolTest.php
@@ -119,3 +119,129 @@ test('the mcp request binding is cleared after the call', function (): void {
 
     expect(Container::getInstance()->bound(Laravel\Mcp\Request::class))->toBeFalse();
 });
+
+test('it includes app resource uri when tool returns text and ui resource link', function (): void {
+    $tool = new McpServerTool(new class extends Tool
+    {
+        public function handle(Laravel\Mcp\Request $request): mixed
+        {
+            return Response::make([
+                Response::text('dashboard loaded.'),
+                Response::resourceLink('ui://resources/weather-dashboard-app', 'weather-app'),
+            ]);
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    });
+
+    $result = $tool->handle(new Request);
+
+    expect($result)
+        ->toBeJson()
+        ->json()
+        ->toBe([
+            'text' => 'dashboard loaded.',
+            'appResourceUri' => 'ui://resources/weather-dashboard-app',
+        ]);
+});
+
+test('it resolves app resource uri regardless of content order', function (): void {
+    $tool = new McpServerTool(new class extends Tool
+    {
+        /**
+         * @return array<int, Response>
+         */
+        public function handle(Laravel\Mcp\Request $request): array
+        {
+            return [
+                Response::resourceLink('ui://resources/weather-dashboard-app', 'weather-app'),
+                Response::text('dashboard loaded.'),
+            ];
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    });
+
+    expect($tool->handle(new Request))->json()->toBe([
+        'text' => 'dashboard loaded.',
+        'appResourceUri' => 'ui://resources/weather-dashboard-app',
+    ]);
+});
+
+test('it ignores notifications when resolving app resource uri', function (): void {
+    $tool = new McpServerTool(new class extends Tool
+    {
+        public function handle(Laravel\Mcp\Request $request): Generator
+        {
+            yield Response::notification('processing/progress', ['step' => 1]);
+            yield Response::text('dashboard loaded.');
+            yield Response::resourceLink('ui://resources/weather-dashboard-app', 'weather-app');
+            yield Response::notification('processing/progress', ['step' => 2]);
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    });
+
+    expect($tool->handle(new Request))->json()->toBe([
+        'text' => 'dashboard loaded.',
+        'appResourceUri' => 'ui://resources/weather-dashboard-app',
+    ]);
+});
+
+test('it ignores non-ui resource links for app rendering', function (): void {
+    $tool = new McpServerTool(new class extends Tool
+    {
+        /**
+         * @return array<int, Response>
+         */
+        public function handle(Laravel\Mcp\Request $request): array
+        {
+            return [
+                Response::text('dashboard loaded.'),
+                Response::resourceLink('https://example.com/other', 'other'),
+            ];
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    });
+
+    expect($tool->handle(new Request))->toBe('https://example.com/other');
+});
+
+test('it preserves error prefix when app resource is present', function (): void {
+    $tool = new McpServerTool(new class extends Tool
+    {
+        /**
+         * @return array<int, Response>
+         */
+        public function handle(Laravel\Mcp\Request $request): array
+        {
+            return [
+                Response::error('Something went wrong.'),
+                Response::resourceLink('ui://resources/weather-dashboard-app', 'weather-app'),
+            ];
+        }
+
+        public function schema(JsonSchema $schema): array
+        {
+            return [];
+        }
+    });
+
+    expect($tool->handle(new Request))->json()->toBe([
+        'text' => 'MCP tool error: Something went wrong.',
+        'appResourceUri' => 'ui://resources/weather-dashboard-app',
+    ]);
+});


### PR DESCRIPTION
Fixes #933.

## Problem
`McpServerTool::finalResponse()` extracts only text from MCP responses. When an MCP tool returns a `ResourceLink` alongside text (e.g. a tool annotated with `#[RendersApp]`), the app URI is discarded. The agent and frontend never receive the app resource info needed to render interactive HTML iframes (MCP Apps).

## Change
- Detect `ResourceLink` content with `ui://` URI in MCP responses and include it as `appResourceUri` in a JSON payload: `{"text":"...","appResourceUri":"ui://..."}`
- Backward compatible: no `ResourceLink` returns plain text as before
- Ignores notifications, order-independent, preserves MCP tool error prefix

## Frontend contract
When tool output is JSON with `appResourceUri`:
1. Fetch HTML via `resources/read` JSON-RPC to the MCP endpoint
2. Render in iframe via `srcdoc`
3. Implement MCP host via `postMessage` to proxy `tools/call` back to the MCP server

## Tests
- it includes app resource uri when tool returns text and ui resource link
- it resolves app resource uri regardless of content order
- it ignores notifications when resolving app resource uri
- it ignores non-ui resource links for app rendering
- it preserves error prefix when app resource is present

All 14 tests in `McpServerToolTest` pass.
