### PR TITLE
Allow creating a conversation without prompting

### DIFF
--- a/src/Concerns/RemembersConversations.php
+++ b/src/Concerns/RemembersConversations.php
@@ -31,6 +31,24 @@ trait RemembersConversations
     }
 
     /**
+     * Create a new conversation for the current participant without prompting.
+     */
+    public function startConversation(string $title = 'New conversation'): static
+    {
+        $participant = $this->conversationUser;
+        $participantType = $participant === null ? null : Conversation::participantType($participant);
+        $participantId = $participant === null ? null : Conversation::participantKey($participant);
+
+        $this->conversationId = resolve(ConversationStore::class)->storeConversation(
+            $participantType,
+            $participantId,
+            $title,
+        );
+
+        return $this;
+    }
+
+    /**
      * Continue an existing conversation, optionally as the given user.
      */
     public function continue(string $conversationId, ?object $as = null): static

--- a/tests/Feature/RemembersConversationsTest.php
+++ b/tests/Feature/RemembersConversationsTest.php
@@ -6,6 +6,8 @@ use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Tests\Fixtures\Agents\RememberingAssistantAgent;
+use Tests\Fixtures\ConversationStores\InMemoryConversationStore;
+use Tests\Fixtures\FakeConversationStore;
 
 test('it threads the participant type into latestConversationId when continuing the last conversation', function () {
     $participant = new class extends Model
@@ -169,4 +171,83 @@ test('it resolves the participant id via getKey for models with custom primary k
 
     // The participant's real primary key reaches the store, even when it is not named "id"...
     expect($store->receivedId)->toBe('uuid-123');
+});
+
+test('it creates a conversation for the current participant with the provided title', function () {
+    $participant = new class extends Model
+    {
+        protected $guarded = [];
+
+        public function getMorphClass(): string
+        {
+            return 'admin';
+        }
+    };
+
+    $participant->id = 7;
+
+    $store = new class extends FakeConversationStore
+    {
+        public ?string $receivedType = null;
+
+        public string|int|null $receivedId = null;
+
+        public ?string $receivedTitle = null;
+
+        public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+        {
+            $this->receivedType = $participantType;
+            $this->receivedId = $participantId;
+            $this->receivedTitle = $title;
+
+            return 'conversation-created';
+        }
+    };
+
+    app()->instance(ConversationStore::class, $store);
+
+    $agent = (new RememberingAssistantAgent)->forUser($participant)->startConversation('New chat');
+
+    expect($store->receivedType)->toBe('admin')
+        ->and($store->receivedId)->toBe(7)
+        ->and($store->receivedTitle)->toBe('New chat')
+        ->and($agent->currentConversation())->toBe('conversation-created');
+});
+
+test('it creates a conversation without a participant', function () {
+    $store = new InMemoryConversationStore;
+
+    app()->instance(ConversationStore::class, $store);
+
+    $agent = (new RememberingAssistantAgent)->startConversation('New chat');
+
+    expect($store->conversations)->toHaveCount(1)
+        ->and($store->conversations[$agent->currentConversation()])->toMatchArray([
+            'participant_type' => null,
+            'participant_id' => null,
+            'title' => 'New chat',
+        ]);
+});
+
+test('a prompt after startConversation continues the same conversation', function () {
+    $store = new InMemoryConversationStore;
+
+    app()->instance(ConversationStore::class, $store);
+
+    RememberingAssistantAgent::fake(['Fake response']);
+
+    $user = new class
+    {
+        public int $id = 1;
+    };
+
+    $agent = (new RememberingAssistantAgent)->forUser($user)->startConversation('New chat');
+
+    $conversationId = $agent->currentConversation();
+
+    $response = $agent->prompt('Hello');
+
+    expect($store->conversations)->toHaveCount(1)
+        ->and($response->conversationId)->toBe($conversationId)
+        ->and(collect($store->messages)->pluck('conversation_id')->unique()->values()->all())->toBe([$conversationId]);
 });


### PR DESCRIPTION
# Create a conversation before the first prompt

Adds `startConversation()` to the `RemembersConversations` trait so chat UIs can create an empty conversation before the first prompt.

```php
$agent = (new SalesCoach)->forUser($user)->startConversation(title: 'New chat');

$conversationId = $agent->currentConversation();
```

The method stores a conversation for the current participant through the `ConversationStore` and returns `static`, so the ID is read with `currentConversation()`, like `continueLastConversation()`. The first prompt after creating continues the same conversation, because `RememberConversation::handle()` only stores a conversation when the agent has none.

Closes #983