### PR TITLE
Allow custom columns on conversations

### DIFF
--- a/src/Concerns/RemembersConversations.php
+++ b/src/Concerns/RemembersConversations.php
@@ -12,6 +12,11 @@ trait RemembersConversations
     protected ?object $conversationUser = null;
 
     /**
+     * @var array<string, mixed>
+     */
+    protected array $conversationAttributes = [];
+
+    /**
      * Start a new conversation for the given participant.
      */
     public function forParticipant(object $participant): static
@@ -52,6 +57,28 @@ trait RemembersConversations
             ->latestConversationId(Conversation::participantType($as), Conversation::participantKey($as));
 
         return $this;
+    }
+
+    /**
+     * Set the extra columns to persist when a new conversation is created.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function withConversationAttributes(array $attributes): static
+    {
+        $this->conversationAttributes = array_merge($this->conversationAttributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Get the extra columns to persist when a new conversation is created.
+     *
+     * @return array<string, mixed>
+     */
+    public function conversationAttributes(): array
+    {
+        return $this->conversationAttributes;
     }
 
     /**

--- a/src/Contracts/ConversationStore.php
+++ b/src/Contracts/ConversationStore.php
@@ -18,8 +18,10 @@ interface ConversationStore
 
     /**
      * Store a new conversation and return its ID.
+     *
+     * @param  array<string, mixed>  $attributes  Additional conversation columns to persist.
      */
-    public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string;
+    public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string;
 
     /**
      * Store a new user message for the given conversation and return its ID.

--- a/src/Contracts/RemembersConversations.php
+++ b/src/Contracts/RemembersConversations.php
@@ -38,4 +38,18 @@ interface RemembersConversations extends Conversational
      * Get the user having the current conversation.
      */
     public function conversationParticipant(): ?object;
+
+    /**
+     * Set the extra columns to persist when a new conversation is created.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function withConversationAttributes(array $attributes): static;
+
+    /**
+     * Get the extra columns to persist when a new conversation is created.
+     *
+     * @return array<string, mixed>
+     */
+    public function conversationAttributes(): array;
 }

--- a/src/Middleware/RememberConversation.php
+++ b/src/Middleware/RememberConversation.php
@@ -47,6 +47,7 @@ class RememberConversation
                     $participantType,
                     $participantId,
                     $this->generateTitle($prompt->prompt),
+                    $agent->conversationAttributes(),
                 );
 
                 $agent->continue($conversationId, $participant);

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -43,19 +43,21 @@ class DatabaseConversationStore implements ConversationStore
 
     /**
      * Store a new conversation and return its ID.
+     *
+     * @param  array<string, mixed>  $attributes  Additional conversation columns to persist.
      */
-    public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+    public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string
     {
         $conversationId = (string) Str::uuid7();
 
-        $this->table($this->conversationsTable())->insert([
+        $this->table($this->conversationsTable())->insert(array_merge([
             'id' => $conversationId,
             'participant_type' => $participantType,
             'participant_id' => $participantId,
             'title' => $title,
             'created_at' => now(),
             'updated_at' => now(),
-        ]);
+        ], $attributes));
 
         return $conversationId;
     }

--- a/tests/Feature/RemembersConversationsTest.php
+++ b/tests/Feature/RemembersConversationsTest.php
@@ -6,6 +6,7 @@ use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Prompts\AgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Tests\Fixtures\Agents\RememberingAssistantAgent;
+use Tests\Fixtures\ConversationStores\InMemoryConversationStore;
 
 test('it threads the participant type into latestConversationId when continuing the last conversation', function () {
     $participant = new class extends Model
@@ -31,7 +32,7 @@ test('it threads the participant type into latestConversationId when continuing 
             return $participantType === 'admin' ? 'conversation-admin' : null;
         }
 
-        public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+        public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string
         {
             return 'conversation-1';
         }
@@ -79,7 +80,7 @@ test('it continues the last conversation through a store that ignores the partic
             return 'conversation-1';
         }
 
-        public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+        public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string
         {
             return 'conversation-1';
         }
@@ -137,7 +138,7 @@ test('it resolves the participant id via getKey for models with custom primary k
             return 'conversation-1';
         }
 
-        public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+        public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string
         {
             return 'conversation-1';
         }
@@ -169,4 +170,37 @@ test('it resolves the participant id via getKey for models with custom primary k
 
     // The participant's real primary key reaches the store, even when it is not named "id"...
     expect($store->receivedId)->toBe('uuid-123');
+});
+
+test('it accumulates conversation attributes to persist on the next conversation', function (): void {
+    $agent = (new RememberingAssistantAgent)->withConversationAttributes(['organization_id' => 1, 'source' => 'web']);
+
+    expect($agent->conversationAttributes())->toBe(['organization_id' => 1, 'source' => 'web']);
+
+    // Later calls merge into the attributes, with the later value winning...
+    $agent->withConversationAttributes(['source' => 'dashboard']);
+
+    expect($agent->conversationAttributes())->toBe(['organization_id' => 1, 'source' => 'dashboard']);
+});
+
+test('conversation attributes reach the store when the first prompt creates the conversation', function (): void {
+    $store = new InMemoryConversationStore;
+
+    app()->instance(ConversationStore::class, $store);
+
+    RememberingAssistantAgent::fake(['Fake response', 'A Nice Title']);
+
+    $user = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)
+        ->withConversationAttributes(['organization_id' => 5, 'source' => 'web'])
+        ->forUser($user)
+        ->prompt('Test prompt');
+
+    $conversation = $store->conversations[$response->conversationId];
+
+    expect($conversation['attributes'])->toBe(['organization_id' => 5, 'source' => 'web']);
 });

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -50,6 +50,18 @@ test('it writes to overridden table names from config', function (): void {
         ->and(DB::table('agent_conversations')->where('id', $conversationId)->exists())->toBeFalse();
 });
 
+test('it persists additional conversation attributes on the conversation row', function (): void {
+    Config::set('ai.conversations.tables.conversations', 'custom_conversations');
+    Config::set('ai.conversations.tables.messages', 'custom_conversation_messages');
+
+    createConversationSchema();
+
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Hello', ['custom_attribute' => 'team-42']);
+
+    expect(DB::table('custom_conversations')->where('id', $conversationId)->value('custom_attribute'))->toBe('team-42');
+});
+
 test('it routes queries through the configured connection', function (): void {
     Config::set('database.connections.secondary', [
         'driver' => 'sqlite',
@@ -1168,6 +1180,7 @@ function createConversationSchema(?string $connection = null): void
         $table->string('participant_type');
         $table->string('participant_id');
         $table->string('title');
+        $table->string('custom_attribute')->nullable();
         $table->timestamps();
     });
 

--- a/tests/Fixtures/ConversationStores/InMemoryConversationStore.php
+++ b/tests/Fixtures/ConversationStores/InMemoryConversationStore.php
@@ -23,11 +23,16 @@ class InMemoryConversationStore implements ConversationStore
             ->last();
     }
 
-    public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+    public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string
     {
         $id = (string) Str::uuid7();
 
-        $this->conversations[$id] = ['participant_type' => $participantType, 'participant_id' => $participantId, 'title' => $title];
+        $this->conversations[$id] = [
+            'participant_type' => $participantType,
+            'participant_id' => $participantId,
+            'title' => $title,
+            'attributes' => $attributes,
+        ];
 
         return $id;
     }

--- a/tests/Fixtures/FakeConversationStore.php
+++ b/tests/Fixtures/FakeConversationStore.php
@@ -14,7 +14,7 @@ class FakeConversationStore implements ConversationStore
         return null;
     }
 
-    public function storeConversation(?string $participantType, string|int|null $participantId, string $title): string
+    public function storeConversation(?string $participantType, string|int|null $participantId, string $title, array $attributes = []): string
     {
         return 'conversation-123';
     }


### PR DESCRIPTION
# Allow custom columns on conversations

## What

`RemembersConversations` gains `withConversationAttributes()` to set extra columns before a conversation is created, and `conversationAttributes()` to read them. `storeConversation()` on the `ConversationStore` contract and every implementation takes an `array $attributes` (defaulting to `[]`) and `DatabaseConversationStore` merges them into the insert.

```php
(new SalesCoach)
    ->forUser($user)
    ->withConversationAttributes(['organization_id' => $organization->id])
    ->prompt('Hello');

// or pre-creating without a prompt...
$agent = (new SalesCoach)
    ->forUser($user)
    ->withConversationAttributes(['organization_id' => $organization->id])
    ->startConversation(title: 'New chat');
```

This lets apps scope conversations to an organization (or any custom column) on both creation paths, instead of hand-inserting rows through the unguarded model.

## Tests

- Trait setter merges and the getter returns accumulated attributes.
- Attributes reach the store when the first `prompt()` creates the conversation (via `InMemoryConversationStore`).
- `DatabaseConversationStore` persists the attributes on the conversation row.

The interface signature change is reflected across the in-repo fixtures and anonymous test stores.

Closes #985