### PR TITLE
[0.x] Combine streamed text by step rather than by message ID

### DIFF
--- a/src/Streaming/Events/TextDelta.php
+++ b/src/Streaming/Events/TextDelta.php
@@ -18,18 +18,19 @@ class TextDelta extends StreamEvent
     /**
      * Combine the text deltas in the given collection of events into a single string.
      *
-     * Deltas from a multi-step generation carry a distinct message ID per step,
-     * and each step's text is a self-contained utterance (typically narration
-     * around a tool call). Steps are therefore joined with a blank line instead
-     * of being run together mid-sentence.
+     * Each step of a multi-step generation is a self-contained utterance
+     * (typically narration around a tool call), so steps are joined with a blank
+     * line instead of being run together mid-sentence. The boundary is the step's
+     * own `StreamStart` rather than a change of message ID, which Anthropic rotates
+     * per content block — web search splits one answer across several, mid-sentence.
      */
     public static function combine(Collection|array $events): string
     {
-        $events = is_array($events) ? new Collection($events) : $events;
-
-        return $events->whereInstanceOf(TextDelta::class)
-            ->groupBy(fn (TextDelta $event) => $event->messageId)
-            ->map(fn (Collection $deltas) => $deltas->map(fn (TextDelta $event) => $event->delta)->join(''))
+        return Collection::wrap($events)
+            ->chunkWhile(fn (StreamEvent $event) => ! $event instanceof StreamStart)
+            ->map(fn (Collection $step) => $step->whereInstanceOf(TextDelta::class)
+                ->map(fn (TextDelta $event) => $event->delta)
+                ->join(''))
             ->filter(fn (string $text) => trim($text) !== '')
             ->values()
             ->join("\n\n");

--- a/tests/Unit/Streaming/TextDeltaTest.php
+++ b/tests/Unit/Streaming/TextDeltaTest.php
@@ -3,6 +3,8 @@
 use Laravel\Ai\Responses\Data;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\TextEnd;
+use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall;
 use Laravel\Ai\Streaming\Events\ToolResult;
 
@@ -11,8 +13,17 @@ function textDelta(string $messageId, string $delta): TextDelta
     return new TextDelta(uniqid(), $messageId, $delta, time());
 }
 
-test('combine joins deltas of a single message without separators', function () {
+/**
+ * Build the stream start that every gateway yields exactly once at the top of a step.
+ */
+function stepStart(): StreamStart
+{
+    return new StreamStart(uniqid(), 'fake', 'fake-model', time());
+}
+
+test('combine joins the deltas of a single step without separators', function () {
     $events = [
+        stepStart(),
         textDelta('message-1', 'Hello'),
         textDelta('message-1', ' there'),
         textDelta('message-1', '!'),
@@ -21,11 +32,13 @@ test('combine joins deltas of a single message without separators', function () 
     expect(TextDelta::combine($events))->toBe('Hello there!');
 });
 
-test('combine separates text from different messages with a blank line', function () {
+test('combine separates the text of different steps with a blank line', function () {
     $events = [
+        stepStart(),
         textDelta('message-1', 'Let me look that up.'),
         new ToolCall(uniqid(), new Data\ToolCall('call-1', 'get_weather', ['city' => 'Copenhagen']), time()),
         new ToolResult(uniqid(), new Data\ToolResult('call-1', 'get_weather', ['city' => 'Copenhagen'], '12°C'), true, null, time()),
+        stepStart(),
         textDelta('message-2', 'It is '),
         textDelta('message-2', '12°C in Copenhagen.'),
     ];
@@ -33,10 +46,25 @@ test('combine separates text from different messages with a blank line', functio
     expect(TextDelta::combine($events))->toBe("Let me look that up.\n\nIt is 12°C in Copenhagen.");
 });
 
-test('combine drops whitespace-only messages', function () {
+test('combine keeps a step whole when a provider splits it around a citation', function () {
+    // Anthropic opens a new message ID per content block, and web search splits one answer across several of them. A live run returned seven IDs in a single step, breaking mid-sentence; grouping by ID gave each fragment a paragraph of its own, and a lone full stop after...
     $events = [
+        stepStart(),
+        textDelta('message-1', 'Laravel 13 is current, which'),
+        textDelta('message-2', ' shipped in March'),
+        textDelta('message-3', '.'),
+    ];
+
+    expect(TextDelta::combine($events))->toBe('Laravel 13 is current, which shipped in March.');
+});
+
+test('combine drops a step that produced only whitespace', function () {
+    $events = [
+        stepStart(),
         textDelta('message-1', 'First.'),
+        stepStart(),
         textDelta('message-2', "\n"),
+        stepStart(),
         textDelta('message-3', 'Second.'),
     ];
 
@@ -45,11 +73,23 @@ test('combine drops whitespace-only messages', function () {
 
 test('combine ignores events that are not text deltas', function () {
     $events = [
-        new StreamStart(uniqid(), 'fake', 'fake-model', time()),
+        stepStart(),
+        new TextStart(uniqid(), 'message-1', time()),
         textDelta('message-1', 'Only text.'),
+        new TextEnd(uniqid(), 'message-1', time()),
     ];
 
     expect(TextDelta::combine($events))->toBe('Only text.');
+});
+
+test('combine joins deltas that arrive before any step start', function () {
+    // A stream that never announced a step still has to yield its text rather than drop it...
+    $events = [
+        textDelta('message-1', 'Hello'),
+        textDelta('message-2', ' there!'),
+    ];
+
+    expect(TextDelta::combine($events))->toBe('Hello there!');
 });
 
 test('combine returns an empty string when there are no text deltas', function () {


### PR DESCRIPTION
Anthropic returns a separate text content block for every claim it cites, so an answer produced with web search on arrives as several blocks that open and close mid-sentence. The gateway mints a fresh message ID per block, and `TextDelta::combine()` grouped deltas by that ID, so one answer was stored as a paragraph per fragment. A live run came back as seven paragraphs, one of them a full stop on its own.

Deltas are now grouped by the step's own `StreamStart`, which every gateway yields exactly once per step. Blocks within a step join with nothing and steps still join with a blank line, so narration around a tool call keeps its paragraph break. Checked live against Anthropic and OpenAI, which already sent one ID per step and is unchanged.

Anthropic [documents the splitting](https://platform.claude.com/docs/en/build-with-claude/citations): responses "include multiple text blocks where each text block can contain a claim that Claude is making and a list of citations that support the claim".