### PR TITLE
[1.x] Report a step's text as one message, not one per content block

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -55,7 +55,7 @@ trait HandlesTextStreaming
         $usage = null;
         $stopReason = '';
 
-        $emitTextStart = function () use (&$textStartEmitted, &$messageId, $invocationId): ?\Laravel\Ai\Streaming\Events\StreamEvent {
+        $emitTextStart = function () use (&$textStartEmitted, $messageId, $invocationId): ?\Laravel\Ai\Streaming\Events\StreamEvent {
             if ($textStartEmitted) {
                 return null;
             }
@@ -251,19 +251,13 @@ trait HandlesTextStreaming
             }
 
             if ($type === 'content_block_stop') {
-                if ($currentBlockType === 'text' && $textStartEmitted) {
+                if ($currentBlockType === 'text') {
+                    // The block closes, the message does not. Anthropic opens a text block per
+                    // citable span, so one answer arrives as several; the replay content keeps
+                    // them apart while the stream reports the step as a single message...
                     if (isset($responseContent[$currentBlockIndex])) {
                         $responseContent[$currentBlockIndex]['text'] = $currentBlockText;
                     }
-
-                    yield (new TextEnd(
-                        $this->generateEventId(),
-                        $messageId,
-                        time(),
-                    ))->withInvocationId($invocationId);
-
-                    $textStartEmitted = false;
-                    $messageId = $this->generateEventId();
                 } elseif ($currentBlockType === 'thinking' && $reasoningStartEmitted) {
                     if (isset($responseContent[$currentBlockIndex])) {
                         $responseContent[$currentBlockIndex]['thinking'] = $currentThinkingText;
@@ -332,6 +326,15 @@ trait HandlesTextStreaming
                     $cacheReadTokens,
                 );
             }
+        }
+
+        // Closed once the step is over rather than once per block, so the step is one message...
+        if ($textStartEmitted) {
+            yield (new TextEnd(
+                $this->generateEventId(),
+                $messageId,
+                time(),
+            ))->withInvocationId($invocationId);
         }
 
         return $this->buildStepResponse(

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -44,7 +44,7 @@ describe('text streaming', function (): void {
             ->and($events[5])->toBeInstanceOf(StreamEnd::class);
     });
 
-    test('streaming starts a new text part after each text block', function (): void {
+    test('streaming reports the text blocks of one step as a single message', function (): void {
         Http::fake([
             'api.anthropic.com/*' => Http::response(
                 body: $this->ssePayload([
@@ -70,14 +70,59 @@ describe('text streaming', function (): void {
         $textEnds = array_values(array_filter($events, fn ($e): bool => $e instanceof TextEnd));
         $textDeltas = array_values(array_filter($events, fn ($e): bool => $e instanceof TextDelta));
 
-        expect($textStarts)->toHaveCount(2)
-            ->and($textEnds)->toHaveCount(2)
+        // A web search closes the text block and reopens it mid-answer. Reporting each block as
+        // its own message made an AG-UI client draw one answer as several, so the step opens and
+        // closes exactly one message, and closes it only once the last block has been sent...
+        expect($textStarts)->toHaveCount(1)
+            ->and($textEnds)->toHaveCount(1)
             ->and($textDeltas)->toHaveCount(2)
-            ->and($textStarts[0]->messageId)->not->toBe($textStarts[1]->messageId)
             ->and($textEnds[0]->messageId)->toBe($textStarts[0]->messageId)
-            ->and($textEnds[1]->messageId)->toBe($textStarts[1]->messageId)
             ->and($textDeltas[0]->messageId)->toBe($textStarts[0]->messageId)
-            ->and($textDeltas[1]->messageId)->toBe($textStarts[1]->messageId);
+            ->and($textDeltas[1]->messageId)->toBe($textStarts[0]->messageId)
+            ->and(array_search($textEnds[0], $events, true))->toBeGreaterThan(array_search($textDeltas[1], $events, true));
+    });
+
+    test('streaming keeps a thinking block out of the message the step\'s text belongs to', function (): void {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    $this->messageStart(),
+                    $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'First']),
+                    $this->contentBlockStop(0),
+                    $this->contentBlockStart(1, ['type' => 'thinking', 'thinking' => '']),
+                    $this->contentBlockDelta(1, ['type' => 'thinking_delta', 'thinking' => 'Pondering']),
+                    $this->contentBlockStop(1),
+                    $this->contentBlockStart(2, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(2, ['type' => 'text_delta', 'text' => 'Second']),
+                    $this->contentBlockStop(2),
+                    $this->messageDelta('end_turn', 10),
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $textStarts = array_values(array_filter($events, fn ($e): bool => $e instanceof TextStart));
+        $textEnds = array_values(array_filter($events, fn ($e): bool => $e instanceof TextEnd));
+        $textDeltas = array_values(array_filter($events, fn ($e): bool => $e instanceof TextDelta));
+        $reasoningStarts = array_values(array_filter($events, fn ($e): bool => $e instanceof ReasoningStart));
+        $reasoningEnds = array_values(array_filter($events, fn ($e): bool => $e instanceof ReasoningEnd));
+        $reasoningDeltas = array_values(array_filter($events, fn ($e): bool => $e instanceof ReasoningDelta));
+
+        // Text spans that a thinking block interrupts still belong to one message, and the
+        // thinking carries its own ID so the two never merge into each other...
+        expect($textStarts)->toHaveCount(1)
+            ->and($textEnds)->toHaveCount(1)
+            ->and($reasoningStarts)->toHaveCount(1)
+            ->and($reasoningEnds)->toHaveCount(1)
+            ->and($textDeltas[0]->messageId)->toBe($textStarts[0]->messageId)
+            ->and($textDeltas[1]->messageId)->toBe($textStarts[0]->messageId)
+            ->and($reasoningDeltas[0]->reasoningId)->not->toBe($textStarts[0]->messageId)
+            ->and(TextDelta::combine($events))->toBe('FirstSecond')
+            ->and($reasoningDeltas[0]->delta)->toBe('Pondering');
     });
 });
 


### PR DESCRIPTION
#987 fixes this same Anthropic block splitting on the stored text, this is the streaming side. Anthropic opens a separate [text content block](https://platform.claude.com/docs/en/build-with-claude/citations) for every claim it cites, and each block was reported as its own message. AG-UI treats every `TEXT_MESSAGE_START` / `TEXT_MESSAGE_END` pair as a distinct message, so a live run drew one answer as fifteen messages, and the Vercel data protocol split that same answer into fifteen text parts.

A step now opens one message at its first text and closes it once the step is over. The replay content still records each block separately, so citation replay is unchanged, and a step boundary still starts a new message, so narration around a tool call keeps its own. Checked live against Anthropic and OpenAI, which already sent one message per step and is unchanged.

This changes the Anthropic event stream: one `TextStart` / `TextEnd` pair per step instead of one per block, and citations carry the step's message ID rather than their block's. Nothing in the SDK reads the per-block ID, and `startIndex` and `endIndex` are null on this path, so there are no offsets to reinterpret. It is fixed in the gateway rather than in each protocol so that AG-UI, the Vercel data protocol, and anything reading the events directly all get the corrected shape from one change.

This supersedes #854, which gave each block its own ID to stop blocks colliding on one. Holding the message open for the step resolves that too.