### PR TITLE
[1.x] Report the prompt's stored row on RUN_FINISHED

### DIFF
--- a/src/Streaming/Protocols/AgentUserInteractionProtocol.php
+++ b/src/Streaming/Protocols/AgentUserInteractionProtocol.php
@@ -212,12 +212,14 @@ class AgentUserInteractionProtocol extends StreamProtocol
     protected function runFinishedPart(array $attributes = []): array
     {
         $assistantMessageId = $this->response?->assistantMessageId;
+        $userMessageId = $this->response?->userMessageId;
 
         return [
             'type' => 'RUN_FINISHED',
             'threadId' => $this->threadId,
             'runId' => $this->runId,
             ...($assistantMessageId ? ['messageId' => $assistantMessageId] : []),
+            ...($userMessageId ? ['userMessageId' => $userMessageId] : []),
             ...$attributes,
         ];
     }

--- a/tests/Feature/AgentUserInteractionProtocolStreamTest.php
+++ b/tests/Feature/AgentUserInteractionProtocolStreamTest.php
@@ -195,10 +195,27 @@ test('a remembered stream reports the assistant row it wrote', function () {
     $finished = end($events);
 
     expect($response->assistantMessageId)->not->toBeNull()
-        ->and(array_keys($finished))->toBe(['type', 'threadId', 'runId', 'messageId', 'usage', 'metadata'])
+        ->and(array_keys($finished))->toBe(['type', 'threadId', 'runId', 'messageId', 'userMessageId', 'usage', 'metadata'])
         ->and($finished['threadId'])->toBe($response->conversationId)
         ->and($finished['runId'])->toBe($response->invocationId)
         ->and($finished['messageId'])->toBe($response->assistantMessageId);
+});
+
+test('a stored run reports the row it wrote for the prompt', function () {
+    RememberingAssistantAgent::fake(['Fake response']);
+
+    $user = new class
+    {
+        public int $id = 1;
+    };
+
+    $response = (new RememberingAssistantAgent)->forUser($user)->stream('Hello');
+
+    $events = agUiEvents($response->usingProtocol(new AgentUserInteractionProtocol)->toResponse(request()));
+
+    expect($response->userMessageId)->not->toBeNull()
+        ->and(end($events)['userMessageId'])->toBe($response->userMessageId)
+        ->and($response->userMessageId)->not->toBe($response->assistantMessageId);
 });
 
 test('a stream that persists nothing omits the message id', function () {
@@ -209,7 +226,8 @@ test('a stream that persists nothing omits the message id', function () {
         new StreamEnd('event-4', 'stop', new Usage, time()),
     ]);
 
-    expect(end($events))->not->toHaveKey('messageId');
+    expect(end($events))->not->toHaveKey('messageId')
+        ->and(end($events))->not->toHaveKey('userMessageId');
 });
 
 test('an ownerless approval stream persists the thread id it emits', function () {


### PR DESCRIPTION
`RUN_FINISHED` already carries `messageId` for the answer's stored row (#961, #976), but not the prompt's. A client that renders a turn optimistically holds both messages under IDs it invented, so reporting only one leaves the prompt with nothing to reconcile against. It can swap the assistant message for its stored row but not the user message it just drew.

`AgentResponse` already tracks `userMessageId`, this reports it alongside `messageId`. It is absent on a resume, which writes no user row, and on a run that persists nothing.

Checked live against Anthropic and OpenAI. Both reported a `userMessageId` matching the stored user row and a `messageId` matching the stored assistant row.