### PR TITLE
[0.x] Add conversation pagination

### DIFF
--- a/src/Contracts/PaginatesConversations.php
+++ b/src/Contracts/PaginatesConversations.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use Illuminate\Contracts\Pagination\CursorPaginator;
+use Illuminate\Pagination\Cursor;
+use Laravel\Ai\Storage\StoredMessage;
+
+interface PaginatesConversations
+{
+    /**
+     * Paginate the given conversation's messages, newest first.
+     *
+     * @return CursorPaginator<int, StoredMessage>
+     */
+    public function paginateConversationMessages(string $conversationId, int $perPage = 15, string $cursorName = 'cursor', Cursor|string|null $cursor = null): CursorPaginator;
+}

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -2,12 +2,15 @@
 
 namespace Laravel\Ai\Storage;
 
+use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Pagination\Cursor;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Ai\Contracts\ConversationStore;
+use Laravel\Ai\Contracts\PaginatesConversations;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -19,7 +22,7 @@ use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 
-class DatabaseConversationStore implements ConversationStore
+class DatabaseConversationStore implements ConversationStore, PaginatesConversations
 {
     /**
      * Create a new conversation store instance.
@@ -266,6 +269,20 @@ class DatabaseConversationStore implements ConversationStore
             })
             ->skipWhile(fn (Message $message) => $message instanceof ToolResultMessage)
             ->values();
+    }
+
+    /**
+     * Paginate the given conversation's messages, newest first.
+     *
+     * @return CursorPaginator<int, StoredMessage>
+     */
+    public function paginateConversationMessages(string $conversationId, int $perPage = 15, string $cursorName = 'cursor', Cursor|string|null $cursor = null): CursorPaginator
+    {
+        return $this->table($this->messagesTable())
+            ->where('conversation_id', $conversationId)
+            ->orderByDesc('id')
+            ->cursorPaginate($perPage, ['*'], $cursorName, $cursor)
+            ->through(fn (object $record): StoredMessage => StoredMessage::fromArray((array) $record));
     }
 
     /**

--- a/src/Storage/StoredMessage.php
+++ b/src/Storage/StoredMessage.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Laravel\Ai\Storage;
+
+use Carbon\CarbonInterface;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Carbon;
+use JsonSerializable;
+
+/**
+ * A conversation message as it was persisted, with its JSON columns decoded.
+ *
+ * `Message` is what the model sees; this is what was stored, and it keeps the
+ * identity and timestamps a rendered transcript needs.
+ */
+class StoredMessage implements Arrayable, JsonSerializable
+{
+    /**
+     * @param  array<string, mixed>  $usage
+     * @param  array<string, mixed>  $meta
+     * @param  list<array<string, mixed>>  $toolCalls
+     * @param  list<array<string, mixed>>  $toolResults
+     * @param  array<string, mixed>|null  $approvalState
+     * @param  list<array<string, mixed>>  $attachments
+     */
+    public function __construct(
+        public string $id,
+        public string $role,
+        public string $content,
+        public ?CarbonInterface $createdAt = null,
+        public array $usage = [],
+        public array $meta = [],
+        public array $toolCalls = [],
+        public array $toolResults = [],
+        public ?array $approvalState = null,
+        public array $attachments = [],
+    ) {}
+
+    /**
+     * Reconstruct an instance from a stored row, decoding its JSON columns.
+     *
+     * @param  array<string, mixed>  $record
+     */
+    public static function fromArray(array $record): self
+    {
+        return new self(
+            id: (string) ($record['id'] ?? ''),
+            role: (string) ($record['role'] ?? ''),
+            content: (string) ($record['content'] ?? ''),
+            createdAt: blank($record['created_at'] ?? null) ? null : Carbon::parse($record['created_at']),
+            usage: static::decoded($record['usage'] ?? null),
+            meta: static::decoded($record['meta'] ?? null),
+            toolCalls: array_values(static::decoded($record['tool_calls'] ?? null)),
+            toolResults: array_values(static::decoded($record['tool_results'] ?? null)),
+            approvalState: blank($record['approval_state'] ?? null) ? null : static::decoded($record['approval_state']),
+            attachments: array_values(static::decoded($record['attachments'] ?? null)),
+        );
+    }
+
+    /**
+     * Get the instance as an array, in the shape it was stored in.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'role' => $this->role,
+            'content' => $this->content,
+            'created_at' => $this->createdAt?->toJSON(),
+            'usage' => $this->usage,
+            'meta' => $this->meta,
+            'tool_calls' => $this->toolCalls,
+            'tool_results' => $this->toolResults,
+            'approval_state' => $this->approvalState,
+            'attachments' => $this->attachments,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Decode a JSON column, tolerating null and malformed values.
+     *
+     * @return array<mixed>
+     */
+    protected static function decoded(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        $decoded = json_decode((string) ($value ?: '[]'), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\CarbonInterface;
+use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
@@ -9,6 +11,7 @@ use Illuminate\Support\Facades\Schema;
 use Laravel\Ai\Approvals\Decision;
 use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Contracts\PaginatesConversations;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Files\RemoteImage;
@@ -25,6 +28,7 @@ use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Laravel\Ai\Storage\StoredMessage;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -65,6 +69,92 @@ test('it routes queries through the configured connection', function (): void {
 
     expect(DB::connection('secondary')->table('agent_conversations')->where('id', $conversationId)->exists())->toBeTrue()
         ->and(DB::table('agent_conversations')->where('id', $conversationId)->exists())->toBeFalse();
+});
+
+test('it paginates conversation messages newest first, scoped to the conversation', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Target transcript');
+    $otherConversationId = $store->storeConversation('user', 1, 'Other transcript');
+
+    insertStoredConversationMessages($conversationId, ['message-001', 'message-003', 'message-005']);
+    insertStoredConversationMessages($otherConversationId, ['message-002', 'message-004']);
+
+    $page = $store->paginateConversationMessages($conversationId, 10);
+
+    expect($store)->toBeInstanceOf(PaginatesConversations::class)
+        ->and($page)->toBeInstanceOf(CursorPaginator::class)
+        ->and($page->items())->toContainOnlyInstancesOf(StoredMessage::class)
+        ->and(collect($page->items())->pluck('id')->all())->toBe(['message-005', 'message-003', 'message-001']);
+});
+
+test('it decodes the stored JSON columns', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Transcript');
+
+    // The JSON columns are why this returns a value object: a caller rendering a transcript should not be decoding storage...
+    DB::table('agent_conversation_messages')->insert([
+        ...storedConversationMessageAttributes('message-001', $conversationId, 'Saved the note.'),
+        'role' => 'assistant',
+        'meta' => json_encode(['provider' => 'openai', 'citations' => [['url' => 'https://laravel.com']]]),
+        'tool_calls' => json_encode([['id' => 'call-1', 'name' => 'save_note', 'arguments' => ['a' => 1]]]),
+        'usage' => json_encode(['input_tokens' => 12]),
+    ]);
+
+    $message = $store->paginateConversationMessages($conversationId, 1)->items()[0];
+
+    expect($message->meta['provider'])->toBe('openai')
+        ->and($message->meta['citations'][0]['url'])->toBe('https://laravel.com')
+        ->and($message->toolCalls[0]['name'])->toBe('save_note')
+        ->and($message->usage['input_tokens'])->toBe(12)
+        ->and($message->toolResults)->toBe([])
+        ->and($message->approvalState)->toBeNull()
+        ->and($message->createdAt)->toBeInstanceOf(CarbonInterface::class);
+});
+
+test('it advances to the next cursor page', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Transcript');
+
+    insertStoredConversationMessages($conversationId, ['message-001', 'message-002', 'message-003', 'message-004', 'message-005']);
+
+    $firstPage = $store->paginateConversationMessages($conversationId, 2);
+
+    request()->query->set('cursor', $firstPage->nextCursor()?->encode());
+
+    $secondPage = $store->paginateConversationMessages($conversationId, 2);
+
+    expect(collect($firstPage->items())->pluck('id')->all())->toBe(['message-005', 'message-004'])
+        ->and(collect($secondPage->items())->pluck('id')->all())->toBe(['message-003', 'message-002']);
+});
+
+test('it reads the cursor from the given query parameter name', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Transcript');
+
+    insertStoredConversationMessages($conversationId, ['message-001', 'message-002', 'message-003', 'message-004', 'message-005']);
+
+    $firstPage = $store->paginateConversationMessages($conversationId, 2, 'support');
+
+    // Two transcripts on one page would otherwise page in lockstep, both reading `?cursor=`...
+    request()->query->set('support', $firstPage->nextCursor()?->encode());
+    request()->query->set('cursor', 'ignored');
+
+    $secondPage = $store->paginateConversationMessages($conversationId, 2, 'support');
+
+    expect(collect($secondPage->items())->pluck('id')->all())->toBe(['message-003', 'message-002']);
+});
+
+test('it accepts a cursor passed directly, without a request', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Transcript');
+
+    insertStoredConversationMessages($conversationId, ['message-001', 'message-002', 'message-003', 'message-004', 'message-005']);
+
+    $firstPage = $store->paginateConversationMessages($conversationId, 2);
+
+    $secondPage = $store->paginateConversationMessages($conversationId, 2, cursor: $firstPage->nextCursor());
+
+    expect(collect($secondPage->items())->pluck('id')->all())->toBe(['message-003', 'message-002']);
 });
 
 test('it persists tool calls and results from a remembered agent prompt', function (): void {
@@ -1187,4 +1277,33 @@ function createConversationSchema(?string $connection = null): void
         $table->text('approval_state')->nullable();
         $table->timestamps();
     });
+}
+
+/** @return array<string, mixed> */
+function storedConversationMessageAttributes(string $id, string $conversationId, string $content): array
+{
+    return [
+        'id' => $id,
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'user',
+        'content' => $content,
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '[]',
+        'meta' => '[]',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ];
+}
+
+/** @param  list<string>  $ids */
+function insertStoredConversationMessages(string $conversationId, array $ids): void
+{
+    DB::table('agent_conversation_messages')->insert(
+        collect($ids)->map(fn (string $id): array => storedConversationMessageAttributes($id, $conversationId, "Content for {$id}"))->all()
+    );
 }


### PR DESCRIPTION
`ConversationStore` can hand back the latest messages for a conversation, but only as domain `Message` objects for the model to read. They carry no id, no timestamp and no tool state, so nothing rendering a transcript can use them. Paginating a conversation for display meant querying `ConversationMessage` directly, which ties the application to the database store.

This adds an opt-in `PaginatesConversations` contract that paginates a conversation's messages, newest first, using a cursor rather than an offset since a chat grows while it is being read. Pages return `StoredMessage`, a row as it was persisted with its JSON columns decoded, which keeps the contract free of Eloquent so a custom store can satisfy it.