### PR TITLE
[0.x] Persist the sources a streamed answer cited

### DIFF
--- a/src/Gateway/FakeTextGateway.php
+++ b/src/Gateway/FakeTextGateway.php
@@ -17,6 +17,7 @@ use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\StreamStart;
 use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\TextEnd;
@@ -93,6 +94,10 @@ class FakeTextGateway implements StepTextGateway
             }
 
             yield (new TextEnd(ulid(), $messageId, time()))->withInvocationId($invocationId);
+        }
+
+        foreach ($step->meta->citations as $citation) {
+            yield (new CitationEvent(ulid(), $messageId, $citation, time()))->withInvocationId($invocationId);
         }
 
         foreach ($step->toolCalls as $toolCall) {

--- a/src/Responses/StreamableAgentResponse.php
+++ b/src/Responses/StreamableAgentResponse.php
@@ -7,8 +7,10 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
+use Laravel\Ai\Responses\Data\Citation as CitationData;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Streaming\Events\Citation;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -25,6 +27,9 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
     /** @var Collection<int, StreamEvent> */
     public Collection $events;
+
+    /** @var Collection<int, CitationData> */
+    public Collection $citations;
 
     public ?string $conversationId = null;
 
@@ -49,6 +54,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
         protected ?Meta $meta = null,
     ) {
         $this->events = new Collection;
+        $this->citations = new Collection;
     }
 
     /**
@@ -175,6 +181,7 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
 
         $this->events = new Collection($events);
         $this->text = TextDelta::combine($events);
+        $this->citations = Citation::combine($events);
         $this->usage = StreamEnd::combineUsage($events);
 
         $this->streamedResponse = new StreamedAgentResponse(

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -4,6 +4,7 @@ namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Streaming\Events\Citation;
 use Laravel\Ai\Streaming\Events\StreamEnd;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Laravel\Ai\Streaming\Events\TextDelta;
@@ -34,6 +35,9 @@ class StreamedAgentResponse extends AgentResponse
         );
 
         $this->events = $events;
+
+        // A streamed run only ever sees its citations as events, not on the parsed body...
+        $this->meta->citations = Citation::combine($events);
 
         $this->withPendingApprovals(
             $events->whereInstanceOf(ToolApprovalRequest::class)

--- a/src/Streaming/Events/Citation.php
+++ b/src/Streaming/Events/Citation.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Ai\Streaming\Events;
 
+use Illuminate\Support\Collection;
 use Laravel\Ai\Responses\Data\Citation as CitationData;
 use Laravel\Ai\Responses\Data\UrlCitation;
 
@@ -14,6 +15,19 @@ class Citation extends StreamEvent
         public int $timestamp,
     ) {
         //
+    }
+
+    /**
+     * Combine citation events into the sources the run cited, in the order it cited them.
+     *
+     * @return Collection<int, CitationData>
+     */
+    public static function combine(Collection|array $events): Collection
+    {
+        return Collection::wrap($events)
+            ->whereInstanceOf(Citation::class)
+            ->map(fn (Citation $event) => $event->citation)
+            ->values();
     }
 
     /**

--- a/tests/Feature/AgentFakeTest.php
+++ b/tests/Feature/AgentFakeTest.php
@@ -14,10 +14,12 @@ use Laravel\Ai\QueuedAgentPrompt;
 use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StructuredAgentResponse;
 use Laravel\Ai\Responses\StructuredTextResponse;
 use Laravel\Ai\Responses\TextResponse;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
 use Laravel\Ai\Streaming\Events\TextStart;
 use Laravel\Ai\Streaming\Events\ToolCall as ToolCallEvent;
 use Laravel\Ai\Streaming\Events\ToolResult as ToolResultEvent;
@@ -191,6 +193,30 @@ describe('stream responses', function (): void {
         $response->each(fn (): true => true);
         expect($response->text)->toEqual('Third response')
             ->and($response->events)->toHaveCount(6);
+    });
+
+    test('faked agents can stream the sources an answer cited', function (): void {
+        AssistantAgent::fake([
+            new TextResponse('Laravel MCP ships an MCP server.', new Usage, new Meta('anthropic', 'test-model', collect([
+                new UrlCitation('https://laravel.com/docs/mcp', 'Laravel MCP'),
+            ]))),
+        ]);
+
+        $response = (new AssistantAgent)->stream('What does Laravel MCP do?');
+        $response->each(fn (): true => true);
+
+        expect($response->events->whereInstanceOf(CitationEvent::class))->toHaveCount(1)
+            ->and($response->citations->pluck('url')->all())->toBe(['https://laravel.com/docs/mcp']);
+    });
+
+    test('a faked stream reports no sources when the answer cited nothing', function (): void {
+        AssistantAgent::fake(['It is 12°C.']);
+
+        $response = (new AssistantAgent)->stream('How cold is it?');
+        $response->each(fn (): true => true);
+
+        expect($response->events->whereInstanceOf(CitationEvent::class))->toBeEmpty()
+            ->and($response->citations)->toBeEmpty();
     });
 
     test('faked stream events share the response invocation id', function (): void {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -22,9 +22,12 @@ use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\Meta;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\Data\UrlCitation;
 use Laravel\Ai\Responses\Data\Usage;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Storage\DatabaseConversationStore;
+use Laravel\Ai\Streaming\Events\Citation as CitationEvent;
+use Laravel\Ai\Streaming\Events\TextDelta;
 use Laravel\Ai\Streaming\Events\ToolApprovalRequest;
 use Tests\Fixtures\Agents\RememberingToolUsingAgent;
 use Tests\Fixtures\Agents\ToolUsingAgent;
@@ -1154,6 +1157,58 @@ test('it scopes conversations by participant type so shared ids no longer collid
     expect($store->latestConversationId('user', $user->id))->toBe($userConversation)
         ->and($store->latestConversationId('admin', $admin->id))->toBe($adminConversation)
         ->and($userConversation)->not->toBe($adminConversation);
+});
+
+test('it records the sources a streamed turn cited into the message meta', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Researched conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'What does Laravel MCP do?',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new StreamedAgentResponse('invocation-id', collect([
+        new TextDelta(uniqid(), 'message-1', 'Laravel MCP ships an MCP server.', time()),
+        new CitationEvent(uniqid(), 'message-1', new UrlCitation('https://laravel.com/docs/mcp', 'Laravel MCP'), time()),
+        new CitationEvent(uniqid(), 'message-1', new UrlCitation('https://laravel.com/docs/mcp', 'Laravel MCP'), time()),
+    ]), new Meta);
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    // Every mention is stored, matching what a generated turn records for the same answer...
+    expect(json_decode((string) $record->meta, true)['citations'])->toBe([
+        ['url' => 'https://laravel.com/docs/mcp', 'title' => 'Laravel MCP', 'start_index' => null, 'end_index' => null],
+        ['url' => 'https://laravel.com/docs/mcp', 'title' => 'Laravel MCP', 'start_index' => null, 'end_index' => null],
+    ]);
+});
+
+test('it stores no sources when a streamed turn cited nothing', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Unresearched conversation');
+
+    $prompt = new AgentPrompt(
+        new ToolUsingAgent,
+        'How cold is it?',
+        [],
+        Mockery::mock(TextProvider::class),
+        'test-model',
+    );
+
+    $response = new StreamedAgentResponse('invocation-id', collect([
+        new TextDelta(uniqid(), 'message-1', 'It is 12°C.', time()),
+    ]), new Meta);
+
+    $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
+
+    $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
+
+    expect(json_decode((string) $record->meta, true)['citations'])->toBe([]);
 });
 
 function createConversationSchema(?string $connection = null): void

--- a/tests/Unit/Streaming/CitationTest.php
+++ b/tests/Unit/Streaming/CitationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Laravel\Ai\Responses\Data\UrlCitation;
+use Laravel\Ai\Streaming\Events\Citation;
+use Laravel\Ai\Streaming\Events\TextDelta;
+
+function citation(string $url, ?string $title = null): Citation
+{
+    return new Citation(uniqid(), 'message-1', new UrlCitation($url, $title), time());
+}
+
+test('combine collects the sources a run cited', function () {
+    $citations = Citation::combine([
+        citation('https://laravel.com/docs', 'Laravel Documentation'),
+        citation('https://laravel.com/docs/mcp', 'Laravel MCP'),
+    ]);
+
+    expect($citations)->toHaveCount(2)
+        ->and($citations->first()->url)->toBe('https://laravel.com/docs')
+        ->and($citations->first()->title)->toBe('Laravel Documentation');
+});
+
+test('combine keeps every mention, the way a generated response does', function () {
+    // The generated path records every mention, so the streamed path does too...
+    $citations = Citation::combine([
+        citation('https://laravel.com/docs', 'Laravel Documentation'),
+        citation('https://laravel.com/docs/mcp', 'Laravel MCP'),
+        citation('https://laravel.com/docs', 'Laravel Documentation'),
+    ]);
+
+    expect($citations)->toHaveCount(3)
+        ->and($citations->pluck('url')->all())->toBe([
+            'https://laravel.com/docs',
+            'https://laravel.com/docs/mcp',
+            'https://laravel.com/docs',
+        ]);
+});
+
+test('combine ignores events that are not citations', function () {
+    $citations = Citation::combine([
+        new TextDelta(uniqid(), 'message-1', 'Laravel MCP ships a server.', time()),
+        citation('https://laravel.com/docs/mcp'),
+    ]);
+
+    expect($citations)->toHaveCount(1);
+});
+
+test('combine returns nothing when the run cited nothing', function () {
+    expect(Citation::combine([
+        new TextDelta(uniqid(), 'message-1', 'It is 12°C.', time()),
+    ]))->toBeEmpty();
+});


### PR DESCRIPTION
A generated response takes its citations from the parsed response body, but a streamed one only ever sees them as `Citation` events, so `meta.citations` was empty for every streamed turn and the sources were lost as soon as the run was stored. Reloading a conversation dropped every source the answer had cited.

A streamed run now collects its citation events into the meta it is stored with, and exposes them on the response as `citations`. Every mention is kept, in the order the answer cited them, which is what a generated response records for the same answer: both providers cite per claim rather than per source, so the same URL arrives repeatedly.

OpenAI annotates each cited span with its own `url_citation` carrying `start_index` and `end_index` ([web search](https://platform.openai.com/docs/guides/tools-web-search)), and Anthropic returns "multiple text blocks where each text block can contain a claim that Claude is making and a list of citations that support the claim" ([citations](https://platform.claude.com/docs/en/build-with-claude/citations)). A client showing a source list collapses them there. `FakeTextGateway` emits citation events for a faked step's meta, so a fake exercises the same path a real provider does rather than only setting the meta directly.