### PR TITLE
[0.x] Expose the tool calls a paused conversation is waiting on

### DIFF
--- a/src/Contracts/ResolvesPendingApprovals.php
+++ b/src/Contracts/ResolvesPendingApprovals.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Ai\Contracts;
+
+use Laravel\Ai\Approvals\PendingApproval;
+
+interface ResolvesPendingApprovals
+{
+    /**
+     * Get the tool calls the given conversation's newest turn is still waiting on.
+     *
+     * @return list<PendingApproval>
+     */
+    public function pendingApprovalsFor(string $conversationId): array;
+}

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -9,8 +9,10 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Contracts\ConversationStore;
 use Laravel\Ai\Contracts\PaginatesConversations;
+use Laravel\Ai\Contracts\ResolvesPendingApprovals;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Files\File;
 use Laravel\Ai\Messages\AssistantMessage;
@@ -22,7 +24,7 @@ use Laravel\Ai\Responses\AgentResponse;
 use Laravel\Ai\Responses\Data\ToolCall;
 use Laravel\Ai\Responses\Data\ToolResult;
 
-class DatabaseConversationStore implements ConversationStore, PaginatesConversations
+class DatabaseConversationStore implements ConversationStore, PaginatesConversations, ResolvesPendingApprovals
 {
     /**
      * Create a new conversation store instance.
@@ -283,6 +285,44 @@ class DatabaseConversationStore implements ConversationStore, PaginatesConversat
             ->orderByDesc('id')
             ->cursorPaginate($perPage, ['*'], $cursorName, $cursor)
             ->through(fn (object $record): StoredMessage => StoredMessage::fromArray((array) $record));
+    }
+
+    /**
+     * Get the tool calls the given conversation's newest turn is still waiting on.
+     *
+     * @return list<PendingApproval>
+     */
+    public function pendingApprovalsFor(string $conversationId): array
+    {
+        /** @var object{tool_calls: string, tool_results: string, approval_state: ?string}|null $newest */
+        $newest = $this->table($this->messagesTable())
+            ->where('conversation_id', $conversationId)
+            ->orderByDesc('id')
+            ->first(['tool_calls', 'tool_results', 'approval_state']);
+
+        if ($newest === null) {
+            return [];
+        }
+
+        $reasons = collect(data_get(json_decode($newest->approval_state ?? '{}', true), 'pending'));
+
+        if ($reasons->isEmpty()) {
+            return [];
+        }
+
+        $answered = Collection::fromJson($newest->tool_results)->pluck('id');
+
+        return Collection::fromJson($newest->tool_calls)
+            ->map(ToolCall::fromArray(...))
+            ->filter(fn (ToolCall $toolCall) => $reasons->has($toolCall->id) && $answered->doesntContain($toolCall->id))
+            ->map(fn (ToolCall $toolCall) => new PendingApproval(
+                $toolCall->id,
+                $toolCall->name,
+                $toolCall->arguments,
+                $reasons->get($toolCall->id),
+            ))
+            ->values()
+            ->all();
     }
 
     /**

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -13,6 +13,7 @@ use Laravel\Ai\Approvals\Decisions;
 use Laravel\Ai\Approvals\PendingApproval;
 use Laravel\Ai\Contracts\PaginatesConversations;
 use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\ResolvesPendingApprovals;
 use Laravel\Ai\Exceptions\ApprovalMismatchException;
 use Laravel\Ai\Files\RemoteImage;
 use Laravel\Ai\Files\StoredDocument;
@@ -158,6 +159,54 @@ test('it accepts a cursor passed directly, without a request', function (): void
     $secondPage = $store->paginateConversationMessages($conversationId, 2, cursor: $firstPage->nextCursor());
 
     expect(collect($secondPage->items())->pluck('id')->all())->toBe(['message-003', 'message-002']);
+});
+
+test('it reports the tool calls a paused turn is waiting on', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Paused');
+
+    insertPausedConversationTurn($conversationId, 'message-001', [
+        ['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => ['path' => 'a.txt']],
+        ['id' => 'call-2', 'name' => 'SendEmail', 'arguments' => ['to' => 'a@b.test']],
+    ], ['call-1' => 'Deletes a file.', 'call-2' => null]);
+
+    $pending = $store->pendingApprovalsFor($conversationId);
+
+    expect($store)->toBeInstanceOf(ResolvesPendingApprovals::class)
+        ->and($pending)->toHaveCount(2)
+        ->and($pending[0])->toBeInstanceOf(PendingApproval::class)
+        ->and($pending[0]->id)->toBe('call-1')
+        ->and($pending[0]->tool)->toBe('DeleteFile')
+        ->and($pending[0]->arguments)->toBe(['path' => 'a.txt'])
+        ->and($pending[0]->reason)->toBe('Deletes a file.')
+        ->and($pending[1]->reason)->toBeNull();
+});
+
+test('it drops a call that already has a result', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Resumed');
+
+    insertPausedConversationTurn($conversationId, 'message-001', [
+        ['id' => 'call-1', 'name' => 'DeleteFile', 'arguments' => []],
+        ['id' => 'call-2', 'name' => 'SendEmail', 'arguments' => []],
+    ], ['call-1' => null, 'call-2' => null]);
+
+    // A resolved call keeps its entry in the pending map until the resume records the decision, so the result is what says the pause is over for it...
+    DB::table('agent_conversation_messages')
+        ->where('id', 'message-001')
+        ->update(['tool_results' => json_encode([['id' => 'call-1', 'name' => 'DeleteFile', 'result' => 'Deleted.']])]);
+
+    expect(collect($store->pendingApprovalsFor($conversationId))->pluck('id')->all())->toBe(['call-2']);
+});
+
+test('it reports nothing when the newest turn is not paused', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Answered');
+
+    insertStoredConversationMessages($conversationId, ['message-001']);
+
+    expect($store->pendingApprovalsFor($conversationId))->toBe([])
+        ->and($store->pendingApprovalsFor('missing-conversation'))->toBe([]);
 });
 
 test('it persists tool calls and results from a remembered agent prompt', function (): void {
@@ -1361,4 +1410,15 @@ function insertStoredConversationMessages(string $conversationId, array $ids): v
     DB::table('agent_conversation_messages')->insert(
         collect($ids)->map(fn (string $id): array => storedConversationMessageAttributes($id, $conversationId, "Content for {$id}"))->all()
     );
+}
+
+/** @param  list<array<string, mixed>>  $toolCalls */
+function insertPausedConversationTurn(string $conversationId, string $id, array $toolCalls, array $pending): void
+{
+    DB::table('agent_conversation_messages')->insert([
+        ...storedConversationMessageAttributes($id, $conversationId, 'Waiting on you.'),
+        'role' => 'assistant',
+        'tool_calls' => json_encode($toolCalls),
+        'approval_state' => json_encode(['pending' => $pending]),
+    ]);
 }

--- a/tests/Feature/ToolApprovalResumeTest.php
+++ b/tests/Feature/ToolApprovalResumeTest.php
@@ -655,3 +655,70 @@ test('a resume that fails after the tool runs does not re-execute the tool on re
 
     expect(ApprovableNumberGenerator::$invocations)->toBe(1);
 });
+
+test('a resume settles the paused row before the run writes a newer one', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            Http::response([
+                'id' => 'msg_tool_1',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [[
+                    'type' => 'tool_use',
+                    'id' => 'toolu_1',
+                    'name' => 'ApprovableNumberGenerator',
+                    'input' => (object) [],
+                ], [
+                    'type' => 'tool_use',
+                    'id' => 'toolu_2',
+                    'name' => 'ApprovableNumberGenerator',
+                    'input' => (object) [],
+                ]],
+                'stop_reason' => 'tool_use',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+            Http::response([
+                'id' => 'msg_2',
+                'type' => 'message',
+                'role' => 'assistant',
+                'model' => 'claude-sonnet-4-6',
+                'content' => [['type' => 'text', 'text' => 'The number is 72019.']],
+                'stop_reason' => 'end_turn',
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+    $store = new DatabaseConversationStore;
+
+    $paused = (new RememberingApprovableAgent)->forUser($user)->prompt('Generate a number', provider: 'anthropic');
+
+    expect(collect($store->pendingApprovalsFor($paused->conversationId))->pluck('id')->all())
+        ->toBe(['toolu_1', 'toolu_2']);
+
+    $pausedRowId = DB::table('agent_conversation_messages')
+        ->where('conversation_id', $paused->conversationId)
+        ->where('role', 'assistant')
+        ->latest('id')
+        ->value('id');
+
+    (new RememberingApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_1' => true, 'toolu_2' => true]), provider: 'anthropic');
+
+    // Only the newest row is read for pending approvals, so a resume that settled some calls and left others behind on an older row would report a finished turn while the user still owed a decision...
+    $pausedRow = DB::table('agent_conversation_messages')->where('id', $pausedRowId)->first();
+
+    $newerRows = DB::table('agent_conversation_messages')
+        ->where('conversation_id', $paused->conversationId)
+        ->where('id', '>', $pausedRowId)
+        ->count();
+
+    expect($newerRows)->toBeGreaterThan(0)
+        ->and(json_decode($pausedRow->approval_state, true)['pending'])->toBe([])
+        ->and($store->pendingApprovalsFor($paused->conversationId))->toBe([]);
+});


### PR DESCRIPTION
`ConversationStore` records that a turn paused but cannot be asked what it is waiting on, so rendering an approval before the run restarts meant querying `ConversationMessage` directly and tying the application to the database store.

This adds an opt-in `ResolvesPendingApprovals` contract returning the newest turn's outstanding calls as `PendingApproval` (similar to #990), so a paused response and a reload hand a client the same shape. A decision is written back to the row that declared it and a resumed turn's results land on that row or a later one, so the newest row answers it in one query. A call that already carries a result is dropped, which is also what makes a replayed decision detectable.

Checked live against both Anthropic and OpenAI, paused and resumed.