### PR TITLE
[1.x] Thread request timeouts through reranking, image, and transcription

### DIFF
--- a/src/AiServiceProvider.php
+++ b/src/AiServiceProvider.php
@@ -125,7 +125,8 @@ class AiServiceProvider extends ServiceProvider
             string $query,
             ?int $limit = null,
             Lab|array|string|null $provider = null,
-            ?string $model = null
+            ?string $model = null,
+            int $timeout = 30,
         ) {
             $resolver = match (true) {
                 $by instanceof Closure => $by,
@@ -137,6 +138,7 @@ class AiServiceProvider extends ServiceProvider
 
             $response = Reranking::of($this->map($resolver)->values()->all())
                 ->limit($limit)
+                ->timeout($timeout)
                 ->rerank($query, $provider, $model);
 
             return (new Collection($response->results))->map(

--- a/src/Contracts/Gateway/RerankingGateway.php
+++ b/src/Contracts/Gateway/RerankingGateway.php
@@ -19,6 +19,7 @@ interface RerankingGateway
         array $documents,
         string $query,
         ?int $limit = null,
+        int $timeout = 30,
         array $providerOptions = [],
     ): RerankingResponse;
 }

--- a/src/Contracts/Providers/RerankingProvider.php
+++ b/src/Contracts/Providers/RerankingProvider.php
@@ -13,7 +13,7 @@ interface RerankingProvider extends Provider
      * @param  array<int, string>  $documents
      * @param  array<string, mixed>  $providerOptions
      */
-    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null, array $providerOptions = []): RerankingResponse;
+    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): RerankingResponse;
 
     /**
      * Get the provider's reranking gateway.

--- a/src/Gateway/Bedrock/BedrockRerankingGateway.php
+++ b/src/Gateway/Bedrock/BedrockRerankingGateway.php
@@ -29,9 +29,10 @@ class BedrockRerankingGateway implements RerankingGateway
         array $documents,
         string $query,
         ?int $limit = null,
+        int $timeout = 30,
         array $providerOptions = []
     ): RerankingResponse {
-        $client = $this->createBedrockClient($provider);
+        $client = $this->createBedrockClient($provider, $timeout);
 
         try {
             $response = $this->withErrorHandling(

--- a/src/Gateway/CohereGateway.php
+++ b/src/Gateway/CohereGateway.php
@@ -71,11 +71,12 @@ class CohereGateway implements EmbeddingGateway, RerankingGateway
         array $documents,
         string $query,
         ?int $limit = null,
+        int $timeout = 30,
         array $providerOptions = [],
     ): RerankingResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('/rerank', array_merge($providerOptions, array_filter([
+            fn () => $this->client($provider, $timeout)->post('/rerank', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'query' => $query,
                 'documents' => $documents,

--- a/src/Gateway/FakeImageGateway.php
+++ b/src/Gateway/FakeImageGateway.php
@@ -41,7 +41,7 @@ class FakeImageGateway implements ImageGateway
         ?int $timeout = null,
         array $providerOptions = [],
     ): ImageResponse {
-        $imagePrompt = new ImagePrompt($prompt, $attachments, $size, $quality, $provider, $model, $providerOptions);
+        $imagePrompt = new ImagePrompt($prompt, $attachments, $size, $quality, $provider, $model, $timeout, $providerOptions);
 
         return $this->nextResponse($provider, $model, $imagePrompt);
     }

--- a/src/Gateway/FakeRerankingGateway.php
+++ b/src/Gateway/FakeRerankingGateway.php
@@ -34,9 +34,10 @@ class FakeRerankingGateway implements RerankingGateway
         array $documents,
         string $query,
         ?int $limit = null,
+        int $timeout = 30,
         array $providerOptions = [],
     ): RerankingResponse {
-        $prompt = new RerankingPrompt($documents, $query, $limit, $provider, $model, $providerOptions);
+        $prompt = new RerankingPrompt($documents, $query, $limit, $provider, $model, $timeout, $providerOptions);
 
         return $this->nextResponse($provider, $model, $prompt);
     }

--- a/src/Gateway/JinaGateway.php
+++ b/src/Gateway/JinaGateway.php
@@ -69,11 +69,12 @@ class JinaGateway implements EmbeddingGateway, RerankingGateway
         array $documents,
         string $query,
         ?int $limit = null,
+        int $timeout = 30,
         array $providerOptions = [],
     ): RerankingResponse {
         $response = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('/rerank', array_merge($providerOptions, array_filter([
+            fn () => $this->client($provider, $timeout)->post('/rerank', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'query' => $query,
                 'documents' => $documents,

--- a/src/Gateway/VoyageAi/VoyageAiGateway.php
+++ b/src/Gateway/VoyageAi/VoyageAiGateway.php
@@ -62,11 +62,12 @@ class VoyageAiGateway implements EmbeddingGateway, RerankingGateway
         array $documents,
         string $query,
         ?int $limit = null,
+        int $timeout = 30,
         array $providerOptions = [],
     ): RerankingResponse {
         $data = $this->withErrorHandling(
             $provider->name(),
-            fn () => $this->client($provider)->post('/rerank', array_merge($providerOptions, array_filter([
+            fn () => $this->client($provider, $timeout)->post('/rerank', array_merge($providerOptions, array_filter([
                 'model' => $model,
                 'query' => $query,
                 'documents' => $documents,

--- a/src/PendingResponses/PendingImageGeneration.php
+++ b/src/PendingResponses/PendingImageGeneration.php
@@ -171,6 +171,7 @@ class PendingImageGeneration
                     $this->quality,
                     $provider,
                     $model,
+                    $this->timeout,
                     $this->queuedProviderOptions(),
                 )
             );

--- a/src/PendingResponses/PendingReranking.php
+++ b/src/PendingResponses/PendingReranking.php
@@ -21,6 +21,8 @@ class PendingReranking
 
     protected ?int $limit = null;
 
+    protected int $timeout = 30;
+
     /**
      * Create a new pending reranking instance.
      *
@@ -57,6 +59,16 @@ class PendingReranking
     }
 
     /**
+     * Specify the timeout (in seconds) for the reranking request.
+     */
+    public function timeout(int $seconds = 30): self
+    {
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    /**
      * Rerank the documents based on their relevance to the query.
      *
      * @throws FailoverableException if every configured provider fails to rerank the documents.
@@ -79,7 +91,7 @@ class PendingReranking
             $model ??= $provider->defaultRerankingModel();
 
             try {
-                return $provider->withHeaders($headers)->rerank($this->documents, $query, $this->limit, $model, $providerOptions);
+                return $provider->withHeaders($headers)->rerank($this->documents, $query, $this->limit, $model, $this->timeout, $providerOptions);
             } catch (FailoverableException $e) {
                 $lastException = $e;
 

--- a/src/PendingResponses/PendingTranscriptionGeneration.php
+++ b/src/PendingResponses/PendingTranscriptionGeneration.php
@@ -121,6 +121,7 @@ class PendingTranscriptionGeneration
                     $this->diarize,
                     $provider,
                     $model,
+                    $this->timeout,
                     $this->queuedProviderOptions(),
                 )
             );

--- a/src/Prompts/ImagePrompt.php
+++ b/src/Prompts/ImagePrompt.php
@@ -20,6 +20,7 @@ class ImagePrompt
         public readonly ?string $quality,
         public readonly ImageProvider $provider,
         public readonly string $model,
+        public readonly ?int $timeout = null,
         public readonly array $providerOptions = [],
     ) {
         $this->attachments = Collection::make($attachments);

--- a/src/Prompts/QueuedImagePrompt.php
+++ b/src/Prompts/QueuedImagePrompt.php
@@ -20,6 +20,7 @@ class QueuedImagePrompt
         public readonly ?string $quality,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
+        public readonly ?int $timeout = null,
         public readonly array $providerOptions = [],
     ) {
         $this->attachments = Collection::make($attachments);

--- a/src/Prompts/QueuedTranscriptionPrompt.php
+++ b/src/Prompts/QueuedTranscriptionPrompt.php
@@ -16,6 +16,7 @@ class QueuedTranscriptionPrompt
         public readonly bool $diarize,
         public readonly Lab|array|string|null $provider,
         public readonly ?string $model,
+        public readonly int $timeout = 30,
         public readonly array $providerOptions = [],
     ) {}
 

--- a/src/Prompts/RerankingPrompt.php
+++ b/src/Prompts/RerankingPrompt.php
@@ -20,6 +20,7 @@ class RerankingPrompt implements Countable
         public readonly ?int $limit,
         public readonly RerankingProvider $provider,
         public readonly string $model,
+        public readonly int $timeout = 30,
         public readonly array $providerOptions = [],
     ) {}
 

--- a/src/Providers/Concerns/GeneratesImages.php
+++ b/src/Providers/Concerns/GeneratesImages.php
@@ -32,7 +32,7 @@ trait GeneratesImages
 
         $model ??= $this->defaultImageModel();
 
-        $prompt = new ImagePrompt($prompt, $attachments, $size, $quality, $this, $model, $providerOptions);
+        $prompt = new ImagePrompt($prompt, $attachments, $size, $quality, $this, $model, $timeout, $providerOptions);
 
         if (Ai::imagesAreFaked()) {
             Ai::recordImageGeneration($prompt);

--- a/src/Providers/Concerns/Reranks.php
+++ b/src/Providers/Concerns/Reranks.php
@@ -17,13 +17,13 @@ trait Reranks
      * @param  array<int, string>  $documents
      * @param  array<string, mixed>  $providerOptions
      */
-    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null, array $providerOptions = []): RerankingResponse
+    public function rerank(array $documents, string $query, ?int $limit = null, ?string $model = null, int $timeout = 30, array $providerOptions = []): RerankingResponse
     {
         $invocationId = (string) Str::uuid7();
 
         $model ??= $this->defaultRerankingModel();
 
-        $prompt = new RerankingPrompt($documents, $query, $limit, $this, $model, $providerOptions);
+        $prompt = new RerankingPrompt($documents, $query, $limit, $this, $model, $timeout, $providerOptions);
 
         if (Ai::rerankingIsFaked()) {
             Ai::recordReranking($prompt);
@@ -39,6 +39,7 @@ trait Reranks
             $documents,
             $query,
             $limit,
+            $timeout,
             $providerOptions,
         ), fn (RerankingResponse $response) => $this->events->dispatch(new Reranked(
             $invocationId, $this, $model, $prompt, $response,

--- a/tests/Feature/ImageFakeTest.php
+++ b/tests/Feature/ImageFakeTest.php
@@ -259,3 +259,13 @@ test('queued image size and quality are recorded', function (): void {
         && $prompt->size === '3:2'
         && $prompt->quality === 'low');
 });
+
+test('image timeout is recorded for generated and queued prompts', function (): void {
+    Image::fake();
+
+    Image::of('First prompt')->timeout(45)->generate();
+    Image::of('Second prompt')->timeout(90)->queue();
+
+    Image::assertGenerated(fn (ImagePrompt $prompt): bool => $prompt->timeout === 45);
+    Image::assertQueued(fn (QueuedImagePrompt $prompt): bool => $prompt->timeout === 90);
+});

--- a/tests/Feature/Providers/Cohere/RerankingTest.php
+++ b/tests/Feature/Providers/Cohere/RerankingTest.php
@@ -1,10 +1,15 @@
 <?php
 
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\RerankingProvider;
 use Laravel\Ai\Exceptions\ProviderOverloadedException;
 use Laravel\Ai\Exceptions\RateLimitedException;
+use Laravel\Ai\Gateway\CohereGateway;
 use Laravel\Ai\Reranking;
 use Laravel\Ai\Responses\Data\RankedDocument;
 
@@ -121,3 +126,25 @@ function fakeCohereRerankingResponse()
         ],
     ]);
 }
+
+test('reranking request uses the configured timeout', function (): void {
+    Http::fake(['*' => fakeCohereRerankingResponse()]);
+
+    $spy = new class extends CohereGateway
+    {
+        public array $timeouts = [];
+
+        protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
+        {
+            $this->timeouts[] = $timeout;
+
+            return parent::client($provider, $timeout);
+        }
+    };
+
+    Ai::instance('cohere')->useRerankingGateway($spy);
+
+    Reranking::of(['Doc A', 'Doc B'])->timeout(45)->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+
+    expect($spy->timeouts)->toBe([45]);
+});

--- a/tests/Feature/RerankingFakeTest.php
+++ b/tests/Feature/RerankingFakeTest.php
@@ -181,3 +181,11 @@ test('prompt records limit', function (): void {
 
     Reranking::assertReranked(fn (RerankingPrompt $prompt): bool => $prompt->limit === 2 && $prompt->count() === 3);
 });
+
+test('prompt records timeout', function (): void {
+    Reranking::fake();
+
+    Reranking::of(['Doc A'])->timeout(45)->rerank('query');
+
+    Reranking::assertReranked(fn (RerankingPrompt $prompt): bool => $prompt->timeout === 45);
+});

--- a/tests/Feature/RerankingFakeTest.php
+++ b/tests/Feature/RerankingFakeTest.php
@@ -189,3 +189,11 @@ test('prompt records timeout', function (): void {
 
     Reranking::assertReranked(fn (RerankingPrompt $prompt): bool => $prompt->timeout === 45);
 });
+
+test('collection rerank macro records timeout', function (): void {
+    Reranking::fake();
+
+    collect([['body' => 'Doc A']])->rerank(by: 'body', query: 'query', timeout: 45);
+
+    Reranking::assertReranked(fn (RerankingPrompt $prompt): bool => $prompt->timeout === 45);
+});

--- a/tests/Feature/RerankingProviderOptionsTest.php
+++ b/tests/Feature/RerankingProviderOptionsTest.php
@@ -1,7 +1,12 @@
 <?php
 
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Laravel\Ai\Ai;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\RerankingProvider;
+use Laravel\Ai\Gateway\CohereGateway;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Reranking;
 
@@ -86,4 +91,26 @@ test('the limit still wins over a voyage top_k provider option', function (): vo
 
         return $body['top_k'] === 1 && $body['truncation'] === false;
     });
+});
+
+test('rerank timeout is passed to the http client', function (): void {
+    Http::fake(['*' => Http::response(fakeRerankingResponse())]);
+
+    $spy = new class extends CohereGateway
+    {
+        public array $timeouts = [];
+
+        protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
+        {
+            $this->timeouts[] = $timeout;
+
+            return parent::client($provider, $timeout);
+        }
+    };
+
+    Ai::instance('cohere')->useRerankingGateway($spy);
+
+    Reranking::of(['Doc A'])->timeout(45)->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
+
+    expect($spy->timeouts)->toBe([45]);
 });

--- a/tests/Feature/RerankingProviderOptionsTest.php
+++ b/tests/Feature/RerankingProviderOptionsTest.php
@@ -1,12 +1,7 @@
 <?php
 
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
-use Laravel\Ai\Ai;
-use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
-use Laravel\Ai\Contracts\Providers\RerankingProvider;
-use Laravel\Ai\Gateway\CohereGateway;
 use Laravel\Ai\Providers\Provider;
 use Laravel\Ai\Reranking;
 
@@ -91,26 +86,4 @@ test('the limit still wins over a voyage top_k provider option', function (): vo
 
         return $body['top_k'] === 1 && $body['truncation'] === false;
     });
-});
-
-test('rerank timeout is passed to the http client', function (): void {
-    Http::fake(['*' => Http::response(fakeRerankingResponse())]);
-
-    $spy = new class extends CohereGateway
-    {
-        public array $timeouts = [];
-
-        protected function client(EmbeddingProvider|RerankingProvider $provider, int $timeout = 30): PendingRequest
-        {
-            $this->timeouts[] = $timeout;
-
-            return parent::client($provider, $timeout);
-        }
-    };
-
-    Ai::instance('cohere')->useRerankingGateway($spy);
-
-    Reranking::of(['Doc A'])->timeout(45)->rerank('query', provider: 'cohere', model: 'rerank-v3.5');
-
-    expect($spy->timeouts)->toBe([45]);
 });

--- a/tests/Feature/TranscriptionFakeTest.php
+++ b/tests/Feature/TranscriptionFakeTest.php
@@ -216,3 +216,11 @@ test('transcription can have timeouts', function (): void {
 
     Transcription::assertGenerated(fn (TranscriptionPrompt $prompt): bool => $prompt->timeout === 60);
 });
+
+test('queued transcription timeout is recorded', function (): void {
+    Transcription::fake();
+
+    Transcription::fromPath('/path/to/audio.mp3')->timeout(90)->queue();
+
+    Transcription::assertQueued(fn (QueuedTranscriptionPrompt $prompt): bool => $prompt->timeout === 90);
+});


### PR DESCRIPTION
Reranking has no timeout control. Cohere, Jina, and Voyage requests use the gateway's fixed 30 seconds, and Bedrock rerank requests have no timeout at all.

This adds `timeout()` to the reranking builder and a `timeout` argument to the `Collection::rerank` macro. The value passes through the provider contract, the gateway contract, and the Cohere, Jina, Voyage, and Bedrock gateways.

```php
Reranking::of($documents)->timeout(45)->rerank('query', provider: 'cohere');

$articles->rerank(by: 'body', query: 'PHP frameworks', limit: 5, timeout: 60);
```

The image and transcription builders already accept `timeout()`, but the value never reaches the prompt objects. `ImagePrompt`, `QueuedImagePrompt`, and `QueuedTranscriptionPrompt` now carry `timeout`, so fakes and events can assert on it like the audio and embeddings prompts.

> [!WARNING]
> `RerankingProvider::rerank()` and `RerankingGateway::rerank()` gain `int $timeout = 30` before `$providerOptions`. Custom reranking gateways must add the parameter.

> [!NOTE]
> Bedrock rerank requests previously had no HTTP timeout. They now default to 30 seconds, matching the other reranking gateways.
