### PR TITLE
Replay earlier tool steps ahead of a paused step's provider blocks

### DIFF
--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -308,6 +308,7 @@ class TextGenerationLoop
                     $pendingApprovals,
                     time(),
                     $result->providerContentBlocks,
+                    array_map(fn ($toolCall): string => $toolCall->id, $result->toolCalls),
                 ))->withInvocationId($invocationId);
 
                 break;

--- a/src/Gateway/TextGenerationLoop.php
+++ b/src/Gateway/TextGenerationLoop.php
@@ -227,6 +227,8 @@ class TextGenerationLoop
             $allMessages = $this->settleAbandonedToolCalls($messages);
         }
 
+        $providerSteps = [];
+
         for ($step = 0; $step < $maxSteps; $step++) {
             $stepContext = new StepContext(
                 stepNumber: $step,
@@ -298,6 +300,11 @@ class TextGenerationLoop
 
             $allMessages[] = $this->buildAssistantMessage($result);
 
+            $providerSteps[] = [
+                'blocks' => $result->providerContentBlocks,
+                'tool_call_ids' => array_map(fn (ToolCall $toolCall): string => $toolCall->id, $result->toolCalls),
+            ];
+
             if (filled($toolResults)) {
                 $allMessages[] = new ToolResultMessage(collect($toolResults));
             }
@@ -308,7 +315,7 @@ class TextGenerationLoop
                     $pendingApprovals,
                     time(),
                     $result->providerContentBlocks,
-                    array_map(fn ($toolCall): string => $toolCall->id, $result->toolCalls),
+                    $providerSteps,
                 ))->withInvocationId($invocationId);
 
                 break;

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -97,16 +97,23 @@ class AgentResponse extends TextResponse
     }
 
     /**
-     * Get the IDs of the tool calls made by the paused assistant step, if any.
+     * Get every assistant step of a paused turn with the raw provider state needed to replay it.
      *
-     * @return array<int, string>
+     * @return array<int, array{blocks: array<int, array<string, mixed>>, tool_call_ids: array<int, string>}>
      */
-    public function pausedToolCallIds(): array
+    public function pausedSteps(): array
     {
         if (! $this->hasPendingApprovals()) {
             return [];
         }
 
-        return $this->messages->whereInstanceOf(AssistantMessage::class)->last()?->toolCalls->pluck('id')->all() ?? [];
+        return $this->messages
+            ->whereInstanceOf(AssistantMessage::class)
+            ->map(fn (AssistantMessage $message): array => [
+                'blocks' => $message->providerContentBlocks,
+                'tool_call_ids' => $message->toolCalls->pluck('id')->all(),
+            ])
+            ->values()
+            ->all();
     }
 }

--- a/src/Responses/AgentResponse.php
+++ b/src/Responses/AgentResponse.php
@@ -95,4 +95,18 @@ class AgentResponse extends TextResponse
 
         return $this->messages->whereInstanceOf(AssistantMessage::class)->last()?->providerContentBlocks ?? [];
     }
+
+    /**
+     * Get the IDs of the tool calls made by the paused assistant step, if any.
+     *
+     * @return array<int, string>
+     */
+    public function pausedToolCallIds(): array
+    {
+        if (! $this->hasPendingApprovals()) {
+            return [];
+        }
+
+        return $this->messages->whereInstanceOf(AssistantMessage::class)->last()?->toolCalls->pluck('id')->all() ?? [];
+    }
 }

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -56,12 +56,12 @@ class StreamedAgentResponse extends AgentResponse
     }
 
     /**
-     * Get the IDs of the tool calls made by the paused assistant step, if any.
+     * Get every assistant step of a paused turn with the raw provider state needed to replay it.
      *
-     * @return array<int, string>
+     * @return array<int, array{blocks: array<int, array<string, mixed>>, tool_call_ids: array<int, string>}>
      */
-    public function pausedToolCallIds(): array
+    public function pausedSteps(): array
     {
-        return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->toolCallIds ?? [];
+        return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->steps ?? [];
     }
 }

--- a/src/Responses/StreamedAgentResponse.php
+++ b/src/Responses/StreamedAgentResponse.php
@@ -54,4 +54,14 @@ class StreamedAgentResponse extends AgentResponse
     {
         return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->providerContentBlocks ?? [];
     }
+
+    /**
+     * Get the IDs of the tool calls made by the paused assistant step, if any.
+     *
+     * @return array<int, string>
+     */
+    public function pausedToolCallIds(): array
+    {
+        return $this->events->whereInstanceOf(ToolApprovalRequest::class)->last()?->toolCallIds ?? [];
+    }
 }

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -226,9 +226,8 @@ class DatabaseConversationStore implements ConversationStore
     {
         $meta = (array) json_decode(json_encode($response->meta), true);
 
-        if (filled($blocks = $response->pausedProviderContentBlocks())) {
-            $meta['provider_content_blocks'] = $blocks;
-            $meta['paused_step_tool_call_ids'] = $response->pausedToolCallIds();
+        if (filled($response->pausedProviderContentBlocks())) {
+            $meta['provider_steps'] = $response->pausedSteps();
         }
 
         if (filled($response->reasoning)) {
@@ -333,31 +332,18 @@ class DatabaseConversationStore implements ConversationStore
 
         $meta = (array) json_decode($record->meta ?? '[]', true);
 
-        $providerContentBlocks = $meta['provider_content_blocks'] ?? [];
+        $provider = $meta['provider'] ?? null;
 
-        if ($isPause && filled($providerContentBlocks)) {
-            // The blocks only cover the step that paused, so calls answered in earlier steps replay ahead of them...
-            $pausedStepCallIds = ($meta['paused_step_tool_call_ids'] ?? []) ?: $callIds;
+        if ($isPause && filled($providerSteps = $meta['provider_steps'] ?? [])) {
+            return array_merge($messages, $this->replayPausedSteps($record, $providerSteps, $toolCalls, $ownResults, $provider));
+        }
 
-            [$pausedStepResults, $earlierStepResults] = $ownResults->partition(
-                fn (array $toolResult) => in_array($toolResult['id'], $pausedStepCallIds, true)
-            );
+        // Rows written before per-step replay state carry only the paused step's blocks, so the whole turn replays as one message...
+        if ($isPause && filled($providerContentBlocks = $meta['provider_content_blocks'] ?? [])) {
+            $messages[] = new AssistantMessage($record->content, $toolCalls->map(ToolCall::fromArray(...))->values(), $providerContentBlocks, $provider);
 
-            $earlierStepCallIds = $earlierStepResults->pluck('id');
-
-            if ($earlierStepResults->isNotEmpty()) {
-                $earlierCalls = $toolCalls->whereIn('id', $earlierStepCallIds)->values();
-
-                $messages[] = new AssistantMessage('', $earlierCalls->map(ToolCall::fromArray(...))->values());
-                $messages[] = new ToolResultMessage($earlierStepResults->map(ToolResult::fromArray(...))->values());
-            }
-
-            $pausedStepCalls = $toolCalls->whereNotIn('id', $earlierStepCallIds)->values();
-
-            $messages[] = new AssistantMessage($record->content, $pausedStepCalls->map(ToolCall::fromArray(...))->values(), $providerContentBlocks, $meta['provider'] ?? null);
-
-            if ($pausedStepResults->isNotEmpty()) {
-                $messages[] = new ToolResultMessage($pausedStepResults->map(ToolResult::fromArray(...))->values());
+            if ($ownResults->isNotEmpty()) {
+                $messages[] = new ToolResultMessage($ownResults->map(ToolResult::fromArray(...))->values());
             }
 
             return $messages;
@@ -378,6 +364,42 @@ class DatabaseConversationStore implements ConversationStore
             $messages[] = new AssistantMessage($record->content, $keptCalls->map(ToolCall::fromArray(...))->values());
         } elseif (filled($record->content)) {
             $messages[] = new AssistantMessage($record->content);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Replay a paused turn one assistant step at a time, each carrying the raw provider blocks it produced.
+     *
+     * @param  array<int, array{blocks?: array<int, array<string, mixed>>, tool_call_ids?: array<int, string>}>  $providerSteps
+     * @param  Collection<int, array<string, mixed>>  $toolCalls
+     * @param  Collection<int, array<string, mixed>>  $ownResults
+     * @return array<int, Message>
+     */
+    protected function replayPausedSteps(object $record, array $providerSteps, Collection $toolCalls, Collection $ownResults, ?string $provider): array
+    {
+        $callsById = $toolCalls->keyBy('id');
+        $resultsById = $ownResults->keyBy('id');
+        $lastStep = array_key_last($providerSteps);
+
+        $messages = [];
+
+        foreach ($providerSteps as $index => $step) {
+            $stepCallIds = collect($step['tool_call_ids'] ?? []);
+
+            $messages[] = new AssistantMessage(
+                $index === $lastStep ? $record->content : '',
+                $stepCallIds->map(fn (string $id) => $callsById[$id] ?? null)->filter()->map(ToolCall::fromArray(...))->values(),
+                $step['blocks'] ?? [],
+                $provider,
+            );
+
+            $stepResults = $stepCallIds->map(fn (string $id) => $resultsById[$id] ?? null)->filter()->values();
+
+            if ($stepResults->isNotEmpty()) {
+                $messages[] = new ToolResultMessage($stepResults->map(ToolResult::fromArray(...))->values());
+            }
         }
 
         return $messages;

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -228,6 +228,7 @@ class DatabaseConversationStore implements ConversationStore
 
         if (filled($blocks = $response->pausedProviderContentBlocks())) {
             $meta['provider_content_blocks'] = $blocks;
+            $meta['provider_content_block_call_ids'] = $response->pausedToolCallIds();
         }
 
         if (filled($response->reasoning)) {
@@ -335,10 +336,28 @@ class DatabaseConversationStore implements ConversationStore
         $providerContentBlocks = $meta['provider_content_blocks'] ?? [];
 
         if ($isPause && filled($providerContentBlocks)) {
-            $messages[] = new AssistantMessage($record->content, $toolCalls->map(ToolCall::fromArray(...))->values(), $providerContentBlocks, $meta['provider'] ?? null);
+            // The blocks only cover the step that paused, so calls answered in earlier steps replay ahead of them...
+            $pausedStepCallIds = ($meta['provider_content_block_call_ids'] ?? []) ?: $callIds;
 
-            if ($ownResults->isNotEmpty()) {
-                $messages[] = new ToolResultMessage($ownResults->map(ToolResult::fromArray(...))->values());
+            [$pausedStepResults, $earlierStepResults] = $ownResults->partition(
+                fn (array $toolResult) => in_array($toolResult['id'], $pausedStepCallIds, true)
+            );
+
+            $earlierStepCallIds = $earlierStepResults->pluck('id');
+
+            if ($earlierStepResults->isNotEmpty()) {
+                $earlierCalls = $toolCalls->whereIn('id', $earlierStepCallIds)->values();
+
+                $messages[] = new AssistantMessage('', $earlierCalls->map(ToolCall::fromArray(...))->values());
+                $messages[] = new ToolResultMessage($earlierStepResults->map(ToolResult::fromArray(...))->values());
+            }
+
+            $pausedStepCalls = $toolCalls->whereNotIn('id', $earlierStepCallIds)->values();
+
+            $messages[] = new AssistantMessage($record->content, $pausedStepCalls->map(ToolCall::fromArray(...))->values(), $providerContentBlocks, $meta['provider'] ?? null);
+
+            if ($pausedStepResults->isNotEmpty()) {
+                $messages[] = new ToolResultMessage($pausedStepResults->map(ToolResult::fromArray(...))->values());
             }
 
             return $messages;

--- a/src/Storage/DatabaseConversationStore.php
+++ b/src/Storage/DatabaseConversationStore.php
@@ -228,7 +228,7 @@ class DatabaseConversationStore implements ConversationStore
 
         if (filled($blocks = $response->pausedProviderContentBlocks())) {
             $meta['provider_content_blocks'] = $blocks;
-            $meta['provider_content_block_call_ids'] = $response->pausedToolCallIds();
+            $meta['paused_step_tool_call_ids'] = $response->pausedToolCallIds();
         }
 
         if (filled($response->reasoning)) {
@@ -337,7 +337,7 @@ class DatabaseConversationStore implements ConversationStore
 
         if ($isPause && filled($providerContentBlocks)) {
             // The blocks only cover the step that paused, so calls answered in earlier steps replay ahead of them...
-            $pausedStepCallIds = ($meta['provider_content_block_call_ids'] ?? []) ?: $callIds;
+            $pausedStepCallIds = ($meta['paused_step_tool_call_ids'] ?? []) ?: $callIds;
 
             [$pausedStepResults, $earlierStepResults] = $ownResults->partition(
                 fn (array $toolResult) => in_array($toolResult['id'], $pausedStepCallIds, true)

--- a/src/Streaming/Events/ToolApprovalRequest.php
+++ b/src/Streaming/Events/ToolApprovalRequest.php
@@ -10,14 +10,14 @@ class ToolApprovalRequest extends StreamEvent
     /**
      * @param  Collection<int, PendingApproval>  $pendingApprovals
      * @param  array<int, array<string, mixed>>  $providerContentBlocks  raw provider replay state for the paused turn; never serialized to clients
-     * @param  array<int, string>  $toolCallIds  every tool call the paused step made, including those that already ran
+     * @param  array<int, array{blocks: array<int, array<string, mixed>>, tool_call_ids: array<int, string>}>  $steps  every assistant step of the paused turn, in order
      */
     public function __construct(
         public string $id,
         public Collection $pendingApprovals,
         public int $timestamp,
         public array $providerContentBlocks = [],
-        public array $toolCallIds = [],
+        public array $steps = [],
     ) {}
 
     /**

--- a/src/Streaming/Events/ToolApprovalRequest.php
+++ b/src/Streaming/Events/ToolApprovalRequest.php
@@ -10,12 +10,14 @@ class ToolApprovalRequest extends StreamEvent
     /**
      * @param  Collection<int, PendingApproval>  $pendingApprovals
      * @param  array<int, array<string, mixed>>  $providerContentBlocks  raw provider replay state for the paused turn; never serialized to clients
+     * @param  array<int, string>  $toolCallIds  every tool call the paused step made, including those that already ran
      */
     public function __construct(
         public string $id,
         public Collection $pendingApprovals,
         public int $timestamp,
         public array $providerContentBlocks = [],
+        public array $toolCallIds = [],
     ) {}
 
     /**

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -795,7 +795,9 @@ test('it records provider content blocks into the message meta when a turn pause
 
     $response = (new AgentResponse('invocation-id', '', new Usage, new Meta))
         ->withMessages(collect([
-            new AssistantMessage('Let me think about that', null, [['type' => 'thinking', 'signature' => 'sig-1']]),
+            new AssistantMessage('', collect([new ToolCall('call-0', 'ReadFile', ['path' => 'config/app.php'])])),
+            new ToolResultMessage(collect([new ToolResult('call-0', 'ReadFile', ['path' => 'config/app.php'], 'contents')])),
+            new AssistantMessage('Let me think about that', collect([new ToolCall('call-1', 'DeleteFile', ['path' => 'config/app.php'])]), [['type' => 'thinking', 'signature' => 'sig-1']]),
         ]));
 
     $response->withPendingApprovals(collect([
@@ -807,7 +809,8 @@ test('it records provider content blocks into the message meta when a turn pause
     $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
 
     expect(json_decode((string) $record->meta, true))
-        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']]);
+        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']])
+        ->toHaveKey('provider_content_block_call_ids', ['call-1']);
 });
 
 test('it omits provider content blocks when the assistant turn is not paused', function (): void {
@@ -849,7 +852,7 @@ test('it records provider content blocks into the message meta when a stream pau
     $response = new StreamedAgentResponse('invocation-id', collect([
         new ToolApprovalRequest('event-1', collect([
             new PendingApproval('call-1', 'DeleteFile', ['path' => 'config/app.php'], 'Deletes a file'),
-        ]), 0, [['type' => 'thinking', 'signature' => 'sig-1']]),
+        ]), 0, [['type' => 'thinking', 'signature' => 'sig-1']], ['call-1']),
     ]), new Meta);
 
     $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
@@ -857,7 +860,8 @@ test('it records provider content blocks into the message meta when a stream pau
     $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
 
     expect(json_decode((string) $record->meta, true))
-        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']]);
+        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']])
+        ->toHaveKey('provider_content_block_call_ids', ['call-1']);
 });
 
 test('it preserves provider content blocks when a mixed pause carries an executed and a gated call', function (): void {
@@ -895,6 +899,59 @@ test('it preserves provider content blocks when a mixed pause carries an execute
         ->and($messages[0]->providerContentBlocks)->toBe([['type' => 'thinking', 'signature' => 'sig-1']])
         ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[1]->toolResults[0]->id)->toBe('call-1');
+});
+
+test('it replays earlier-step results ahead of the paused step blocks', function (): void {
+    $store = new DatabaseConversationStore;
+    $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
+
+    DB::table('agent_conversation_messages')->insert([
+        'id' => 'message-1',
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => 1,
+        'agent' => ToolUsingAgent::class,
+        'role' => 'assistant',
+        'content' => 'Read a, now deleting b',
+        'attachments' => '[]',
+        'tool_calls' => json_encode([
+            ['id' => 'call-1', 'name' => 'read_file', 'arguments' => ['path' => 'a']],
+            ['id' => 'call-2', 'name' => 'read_file', 'arguments' => ['path' => 'b']],
+            ['id' => 'call-3', 'name' => 'delete_file', 'arguments' => ['path' => 'b']],
+        ]),
+        'tool_results' => json_encode([
+            ['id' => 'call-1', 'name' => 'read_file', 'arguments' => ['path' => 'a'], 'result' => 'contents of a'],
+            ['id' => 'call-2', 'name' => 'read_file', 'arguments' => ['path' => 'b'], 'result' => 'contents of b'],
+        ]),
+        'usage' => '[]',
+        'meta' => json_encode([
+            'provider' => 'anthropic',
+            'provider_content_blocks' => [
+                ['type' => 'thinking', 'thinking' => '', 'signature' => 'sig-1'],
+                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'read_file', 'input' => ['path' => 'b']],
+                ['type' => 'tool_use', 'id' => 'call-3', 'name' => 'delete_file', 'input' => ['path' => 'b']],
+            ],
+            'provider_content_block_call_ids' => ['call-2', 'call-3'],
+        ]),
+        'approval_state' => json_encode(['pending' => ['call-3' => null]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = $store->getLatestConversationMessages($conversationId, 10);
+
+    expect($messages)->toHaveCount(4)
+        ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[0]->providerContentBlocks)->toBe([])
+        ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
+        ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
+        ->and($messages[2]->content)->toBe('Read a, now deleting b')
+        ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2', 'call-3'])
+        ->and($messages[2]->providerContentBlocks[0]['signature'])->toBe('sig-1')
+        ->and($messages[3])->toBeInstanceOf(ToolResultMessage::class)
+        ->and($messages[3]->toolResults->pluck('id')->all())->toBe(['call-2']);
 });
 
 test('it drops a leading orphaned tool_result when the row window splits a pause from its resume', function (): void {

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -781,7 +781,7 @@ test('it splits a mid-run pause row so an executed call is answered before the s
         ->and($messages[2]->toolCalls[0]->id)->toBe('call-2');
 });
 
-test('it records provider content blocks into the message meta when a turn pauses', function (): void {
+test('it records every step of a paused turn into the message meta', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -795,7 +795,7 @@ test('it records provider content blocks into the message meta when a turn pause
 
     $response = (new AgentResponse('invocation-id', '', new Usage, new Meta))
         ->withMessages(collect([
-            new AssistantMessage('', collect([new ToolCall('call-0', 'ReadFile', ['path' => 'config/app.php'])])),
+            new AssistantMessage('', collect([new ToolCall('call-0', 'ReadFile', ['path' => 'config/app.php'])]), [['type' => 'thinking', 'signature' => 'sig-0']]),
             new ToolResultMessage(collect([new ToolResult('call-0', 'ReadFile', ['path' => 'config/app.php'], 'contents')])),
             new AssistantMessage('Let me think about that', collect([new ToolCall('call-1', 'DeleteFile', ['path' => 'config/app.php'])]), [['type' => 'thinking', 'signature' => 'sig-1']]),
         ]));
@@ -809,8 +809,10 @@ test('it records provider content blocks into the message meta when a turn pause
     $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
 
     expect(json_decode((string) $record->meta, true))
-        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']])
-        ->toHaveKey('paused_step_tool_call_ids', ['call-1']);
+        ->toHaveKey('provider_steps', [
+            ['blocks' => [['type' => 'thinking', 'signature' => 'sig-0']], 'tool_call_ids' => ['call-0']],
+            ['blocks' => [['type' => 'thinking', 'signature' => 'sig-1']], 'tool_call_ids' => ['call-1']],
+        ]);
 });
 
 test('it omits provider content blocks when the assistant turn is not paused', function (): void {
@@ -834,10 +836,10 @@ test('it omits provider content blocks when the assistant turn is not paused', f
 
     $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
 
-    expect(json_decode((string) $record->meta, true))->not->toHaveKey('provider_content_blocks');
+    expect(json_decode((string) $record->meta, true))->not->toHaveKey('provider_steps');
 });
 
-test('it records provider content blocks into the message meta when a stream pauses', function (): void {
+test('it records every step of a paused stream into the message meta', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -852,7 +854,10 @@ test('it records provider content blocks into the message meta when a stream pau
     $response = new StreamedAgentResponse('invocation-id', collect([
         new ToolApprovalRequest('event-1', collect([
             new PendingApproval('call-1', 'DeleteFile', ['path' => 'config/app.php'], 'Deletes a file'),
-        ]), 0, [['type' => 'thinking', 'signature' => 'sig-1']], ['call-1']),
+        ]), 0, [['type' => 'thinking', 'signature' => 'sig-1']], [
+            ['blocks' => [['type' => 'thinking', 'signature' => 'sig-0']], 'tool_call_ids' => ['call-0']],
+            ['blocks' => [['type' => 'thinking', 'signature' => 'sig-1']], 'tool_call_ids' => ['call-1']],
+        ]),
     ]), new Meta);
 
     $store->storeAssistantMessage($conversationId, 'user', 1, $prompt, $response);
@@ -860,11 +865,13 @@ test('it records provider content blocks into the message meta when a stream pau
     $record = DB::table('agent_conversation_messages')->where('role', 'assistant')->first();
 
     expect(json_decode((string) $record->meta, true))
-        ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']])
-        ->toHaveKey('paused_step_tool_call_ids', ['call-1']);
+        ->toHaveKey('provider_steps', [
+            ['blocks' => [['type' => 'thinking', 'signature' => 'sig-0']], 'tool_call_ids' => ['call-0']],
+            ['blocks' => [['type' => 'thinking', 'signature' => 'sig-1']], 'tool_call_ids' => ['call-1']],
+        ]);
 });
 
-test('it replays a legacy pause row written before paused step tool call ids as one message', function (): void {
+test('it replays a legacy pause row written before per-step replay state as one message', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -901,7 +908,7 @@ test('it replays a legacy pause row written before paused step tool call ids as 
         ->and($messages[1]->toolResults[0]->id)->toBe('call-1');
 });
 
-test('it replays earlier-step results ahead of the paused step blocks', function (): void {
+test('it replays each step of a paused turn with the blocks that step produced', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -926,12 +933,23 @@ test('it replays earlier-step results ahead of the paused step blocks', function
         'usage' => '[]',
         'meta' => json_encode([
             'provider' => 'anthropic',
-            'provider_content_blocks' => [
-                ['type' => 'thinking', 'thinking' => '', 'signature' => 'sig-1'],
-                ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'read_file', 'input' => ['path' => 'b']],
-                ['type' => 'tool_use', 'id' => 'call-3', 'name' => 'delete_file', 'input' => ['path' => 'b']],
+            'provider_steps' => [
+                [
+                    'blocks' => [
+                        ['type' => 'thinking', 'thinking' => '', 'signature' => 'sig-1'],
+                        ['type' => 'tool_use', 'id' => 'call-1', 'name' => 'read_file', 'input' => ['path' => 'a']],
+                    ],
+                    'tool_call_ids' => ['call-1'],
+                ],
+                [
+                    'blocks' => [
+                        ['type' => 'thinking', 'thinking' => '', 'signature' => 'sig-2'],
+                        ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'read_file', 'input' => ['path' => 'b']],
+                        ['type' => 'tool_use', 'id' => 'call-3', 'name' => 'delete_file', 'input' => ['path' => 'b']],
+                    ],
+                    'tool_call_ids' => ['call-2', 'call-3'],
+                ],
             ],
-            'paused_step_tool_call_ids' => ['call-2', 'call-3'],
         ]),
         'approval_state' => json_encode(['pending' => ['call-3' => null]]),
         'created_at' => now(),
@@ -943,13 +961,14 @@ test('it replays earlier-step results ahead of the paused step blocks', function
     expect($messages)->toHaveCount(4)
         ->and($messages[0])->toBeInstanceOf(AssistantMessage::class)
         ->and($messages[0]->toolCalls->pluck('id')->all())->toBe(['call-1'])
-        ->and($messages[0]->providerContentBlocks)->toBe([])
+        ->and($messages[0]->providerContentBlocks[0]['signature'])->toBe('sig-1')
+        ->and($messages[0]->providerContentBlocksProvider)->toBe('anthropic')
         ->and($messages[1])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[1]->toolResults->pluck('id')->all())->toBe(['call-1'])
         ->and($messages[2])->toBeInstanceOf(AssistantMessage::class)
         ->and($messages[2]->content)->toBe('Read a, now deleting b')
         ->and($messages[2]->toolCalls->pluck('id')->all())->toBe(['call-2', 'call-3'])
-        ->and($messages[2]->providerContentBlocks[0]['signature'])->toBe('sig-1')
+        ->and($messages[2]->providerContentBlocks[0]['signature'])->toBe('sig-2')
         ->and($messages[3])->toBeInstanceOf(ToolResultMessage::class)
         ->and($messages[3]->toolResults->pluck('id')->all())->toBe(['call-2']);
 });

--- a/tests/Feature/Storage/DatabaseConversationStoreTest.php
+++ b/tests/Feature/Storage/DatabaseConversationStoreTest.php
@@ -810,7 +810,7 @@ test('it records provider content blocks into the message meta when a turn pause
 
     expect(json_decode((string) $record->meta, true))
         ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']])
-        ->toHaveKey('provider_content_block_call_ids', ['call-1']);
+        ->toHaveKey('paused_step_tool_call_ids', ['call-1']);
 });
 
 test('it omits provider content blocks when the assistant turn is not paused', function (): void {
@@ -861,10 +861,10 @@ test('it records provider content blocks into the message meta when a stream pau
 
     expect(json_decode((string) $record->meta, true))
         ->toHaveKey('provider_content_blocks', [['type' => 'thinking', 'signature' => 'sig-1']])
-        ->toHaveKey('provider_content_block_call_ids', ['call-1']);
+        ->toHaveKey('paused_step_tool_call_ids', ['call-1']);
 });
 
-test('it preserves provider content blocks when a mixed pause carries an executed and a gated call', function (): void {
+test('it replays a legacy pause row written before paused step tool call ids as one message', function (): void {
     $store = new DatabaseConversationStore;
     $conversationId = $store->storeConversation('user', 1, 'Tool conversation');
 
@@ -931,7 +931,7 @@ test('it replays earlier-step results ahead of the paused step blocks', function
                 ['type' => 'tool_use', 'id' => 'call-2', 'name' => 'read_file', 'input' => ['path' => 'b']],
                 ['type' => 'tool_use', 'id' => 'call-3', 'name' => 'delete_file', 'input' => ['path' => 'b']],
             ],
-            'provider_content_block_call_ids' => ['call-2', 'call-3'],
+            'paused_step_tool_call_ids' => ['call-2', 'call-3'],
         ]),
         'approval_state' => json_encode(['pending' => ['call-3' => null]]),
         'created_at' => now(),

--- a/tests/Feature/ToolApprovalResumeTest.php
+++ b/tests/Feature/ToolApprovalResumeTest.php
@@ -189,7 +189,7 @@ test('a resumed approval replays the paused turn provider content blocks', funct
         ->and(collect($assistantTurn['content'])->firstWhere('type', 'tool_use')['id'])->toBe('toolu_1');
 });
 
-test('a resume after a multi-step pause answers every replayed tool_use in the preceding message', function () {
+test('a resume after a multi-step pause replays each step with its own signed thinking and answers its tool_use', function () {
     Config::set('ai.conversations.generate_title', false);
 
     $message = fn (array $content, string $stopReason) => Http::response([
@@ -204,7 +204,10 @@ test('a resume after a multi-step pause answers every replayed tool_use in the p
 
     Http::fake([
         'api.anthropic.com/*' => Http::sequence([
-            $message([['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'FixedNumberGenerator', 'input' => (object) []]], 'tool_use'),
+            $message([
+                ['type' => 'thinking', 'thinking' => 'First the fixed number.', 'signature' => 'signature-1'],
+                ['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'FixedNumberGenerator', 'input' => (object) []],
+            ], 'tool_use'),
             $message([
                 ['type' => 'thinking', 'thinking' => 'Now the gated number.', 'signature' => 'signature-2'],
                 ['type' => 'tool_use', 'id' => 'toolu_2', 'name' => 'ApprovableNumberGenerator', 'input' => (object) []],
@@ -230,14 +233,88 @@ test('a resume after a multi-step pause answers every replayed tool_use in the p
         collect($message['content'])->map(fn (array $block) => $block['tool_use_id'] ?? $block['id'] ?? $block['type'])->all(),
     ])->all();
 
+    $signatures = collect($resumeMessages)
+        ->flatMap(fn (array $message) => collect($message['content'])->pluck('signature')->filter())
+        ->all();
+
     expect($resumed->text)->toBe('Both numbers are 72019.')
         ->and($turns)->toBe([
             ['user', ['text']],
-            ['assistant', ['toolu_1']],
+            ['assistant', ['thinking', 'toolu_1']],
             ['user', ['toolu_1']],
             ['assistant', ['thinking', 'toolu_2']],
             ['user', ['toolu_2']],
-        ]);
+        ])
+        ->and($signatures)->toBe(['signature-1', 'signature-2']);
+});
+
+test('a streamed multi-step pause stores every step so the resume replays each one with its own blocks', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    $sse = fn (array $events) => Http::response(
+        implode("\n\n", array_map(fn (array $event) => 'data: '.json_encode($event), $events))."\n\n",
+        200,
+        ['Content-Type' => 'text/event-stream'],
+    );
+
+    $step = fn (string $signature, string $toolId, string $toolName) => $sse([
+        ['type' => 'message_start', 'message' => ['id' => 'msg_1', 'model' => 'claude-sonnet-4-6', 'role' => 'assistant', 'content' => [], 'usage' => ['input_tokens' => 10, 'output_tokens' => 0]]],
+        ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'thinking', 'thinking' => '']],
+        ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'thinking_delta', 'thinking' => 'Deciding.']],
+        ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'signature_delta', 'signature' => $signature]],
+        ['type' => 'content_block_stop', 'index' => 0],
+        ['type' => 'content_block_start', 'index' => 1, 'content_block' => ['type' => 'tool_use', 'id' => $toolId, 'name' => $toolName, 'input' => (object) []]],
+        ['type' => 'content_block_delta', 'index' => 1, 'delta' => ['type' => 'input_json_delta', 'partial_json' => '{}']],
+        ['type' => 'content_block_stop', 'index' => 1],
+        ['type' => 'message_delta', 'delta' => ['stop_reason' => 'tool_use'], 'usage' => ['output_tokens' => 5]],
+    ]);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            $step('signature-1', 'toolu_1', 'FixedNumberGenerator'),
+            $step('signature-2', 'toolu_2', 'ApprovableNumberGenerator'),
+            $sse([
+                ['type' => 'message_start', 'message' => ['id' => 'msg_2', 'model' => 'claude-sonnet-4-6', 'role' => 'assistant', 'content' => [], 'usage' => ['input_tokens' => 10, 'output_tokens' => 0]]],
+                ['type' => 'content_block_start', 'index' => 0, 'content_block' => ['type' => 'text', 'text' => '']],
+                ['type' => 'content_block_delta', 'index' => 0, 'delta' => ['type' => 'text_delta', 'text' => 'Both numbers are 72019.']],
+                ['type' => 'content_block_stop', 'index' => 0],
+                ['type' => 'message_delta', 'delta' => ['stop_reason' => 'end_turn'], 'usage' => ['output_tokens' => 5]],
+            ]),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingMultiStepApprovableAgent)->forUser($user)->stream('Generate both numbers', provider: 'anthropic');
+
+    $paused->each(fn () => true);
+
+    $meta = json_decode((string) DB::table('agent_conversation_messages')->where('role', 'assistant')->value('meta'), true);
+
+    expect(collect($meta['provider_steps'])->pluck('tool_call_ids')->all())->toBe([['toolu_1'], ['toolu_2']])
+        ->and($meta['provider_steps'][0]['blocks'][0]['signature'])->toBe('signature-1')
+        ->and($meta['provider_steps'][1]['blocks'][0]['signature'])->toBe('signature-2');
+
+    $resumed = (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->stream(Decisions::from(['toolu_2' => true]), provider: 'anthropic');
+
+    $resumed->each(fn () => true);
+
+    $resumeMessages = collect(Http::recorded())->last()[0]->data()['messages'];
+
+    $turns = collect($resumeMessages)->map(fn (array $message) => [
+        $message['role'],
+        collect($message['content'])->map(fn (array $block) => $block['tool_use_id'] ?? $block['id'] ?? $block['type'])->all(),
+    ])->all();
+
+    expect($turns)->toBe([
+        ['user', ['text']],
+        ['assistant', ['thinking', 'toolu_1']],
+        ['user', ['toolu_1']],
+        ['assistant', ['thinking', 'toolu_2']],
+        ['user', ['toolu_2']],
+    ]);
 });
 
 test('a resume on a different provider falls back to the generic mapping instead of replaying foreign blocks', function () {

--- a/tests/Feature/ToolApprovalResumeTest.php
+++ b/tests/Feature/ToolApprovalResumeTest.php
@@ -9,6 +9,7 @@ use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Messages\ToolResultMessage;
 use Laravel\Ai\Storage\DatabaseConversationStore;
 use Tests\Fixtures\Agents\RememberingApprovableAgent;
+use Tests\Fixtures\Agents\RememberingMultiStepApprovableAgent;
 use Tests\Fixtures\Tools\ApprovableNumberGenerator;
 
 test('a remembered agent pauses for approval, persists the tool_use, and resumes from history when approved', function () {
@@ -186,6 +187,57 @@ test('a resumed approval replays the paused turn provider content blocks', funct
     expect($assistantTurn['content'][0]['type'])->toBe('thinking')
         ->and($assistantTurn['content'][0]['signature'])->toBe('signature-1')
         ->and(collect($assistantTurn['content'])->firstWhere('type', 'tool_use')['id'])->toBe('toolu_1');
+});
+
+test('a resume after a multi-step pause answers every replayed tool_use in the preceding message', function () {
+    Config::set('ai.conversations.generate_title', false);
+
+    $message = fn (array $content, string $stopReason) => Http::response([
+        'id' => 'msg',
+        'type' => 'message',
+        'role' => 'assistant',
+        'model' => 'claude-sonnet-4-6',
+        'content' => $content,
+        'stop_reason' => $stopReason,
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ]);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::sequence([
+            $message([['type' => 'tool_use', 'id' => 'toolu_1', 'name' => 'FixedNumberGenerator', 'input' => (object) []]], 'tool_use'),
+            $message([
+                ['type' => 'thinking', 'thinking' => 'Now the gated number.', 'signature' => 'signature-2'],
+                ['type' => 'tool_use', 'id' => 'toolu_2', 'name' => 'ApprovableNumberGenerator', 'input' => (object) []],
+            ], 'tool_use'),
+            $message([['type' => 'text', 'text' => 'Both numbers are 72019.']], 'end_turn'),
+        ]),
+    ]);
+
+    $user = (object) ['id' => 1];
+
+    $paused = (new RememberingMultiStepApprovableAgent)->forUser($user)->prompt('Generate both numbers', provider: 'anthropic');
+
+    expect($paused->pendingApprovals->pluck('id')->all())->toBe(['toolu_2']);
+
+    $resumed = (new RememberingMultiStepApprovableAgent)
+        ->continue($paused->conversationId, $user)
+        ->prompt(Decisions::from(['toolu_2' => true]), provider: 'anthropic');
+
+    $resumeMessages = collect(Http::recorded())->last()[0]->data()['messages'];
+
+    $turns = collect($resumeMessages)->map(fn (array $message) => [
+        $message['role'],
+        collect($message['content'])->map(fn (array $block) => $block['tool_use_id'] ?? $block['id'] ?? $block['type'])->all(),
+    ])->all();
+
+    expect($resumed->text)->toBe('Both numbers are 72019.')
+        ->and($turns)->toBe([
+            ['user', ['text']],
+            ['assistant', ['toolu_1']],
+            ['user', ['toolu_1']],
+            ['assistant', ['thinking', 'toolu_2']],
+            ['user', ['toolu_2']],
+        ]);
 });
 
 test('a resume on a different provider falls back to the generic mapping instead of replaying foreign blocks', function () {

--- a/tests/Fixtures/Agents/RememberingMultiStepApprovableAgent.php
+++ b/tests/Fixtures/Agents/RememberingMultiStepApprovableAgent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Fixtures\Agents;
+
+use Laravel\Ai\Concerns\RemembersConversations;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Promptable;
+use Tests\Fixtures\Tools\ApprovableNumberGenerator;
+use Tests\Fixtures\Tools\FixedNumberGenerator;
+
+class RememberingMultiStepApprovableAgent implements Agent, Conversational, HasTools
+{
+    use Promptable;
+    use RemembersConversations;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant that generates a number, then generates a gated number.';
+    }
+
+    /**
+     * Get the tools available to the agent.
+     */
+    public function tools(): iterable
+    {
+        return [new FixedNumberGenerator, new ApprovableNumberGenerator];
+    }
+}


### PR DESCRIPTION
Fixes #809.

A turn that runs several tool steps and then pauses for approval is stored as one assistant row. That row holds the whole turn's tool calls and results, but `meta.provider_content_blocks` holds only the step that paused.

```
before                                          400: unexpected tool_use_id toolu_1
  assistant  [thinking, tool_use toolu_2]       raw blocks, paused step only
  user       [tool_result toolu_1, tool_result toolu_2]
                          ^ no matching tool_use above

after
  assistant  [thinking, tool_use toolu_1]       step 1, replayed unmodified
  user       [tool_result toolu_1]
  assistant  [thinking, tool_use toolu_2]       step 2, replayed unmodified
  user       [tool_result toolu_2]
```


> [!NOTE]
> Rows written before this change carry no per-step state. Those rows keep the old single message replay, so a conversation that paused before the upgrade still fails on resume. New pauses are correct.
