### PR TITLE
Read the cumulative usage reported on Anthropic message_delta

### DIFF
--- a/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
+++ b/src/Gateway/Anthropic/Concerns/HandlesTextStreaming.php
@@ -325,6 +325,11 @@ trait HandlesTextStreaming
                 $stopReason = $data['delta']['stop_reason'] ?? '';
                 $deltaUsage = $data['usage'] ?? [];
 
+                // Usage on message_delta is cumulative for the whole message...
+                $inputTokens = $deltaUsage['input_tokens'] ?? $inputTokens;
+                $cacheCreationTokens = $deltaUsage['cache_creation_input_tokens'] ?? $cacheCreationTokens;
+                $cacheReadTokens = $deltaUsage['cache_read_input_tokens'] ?? $cacheReadTokens;
+
                 $usage = new Usage(
                     $inputTokens,
                     $deltaUsage['output_tokens'] ?? 0,

--- a/tests/Feature/Providers/Anthropic/StreamingTest.php
+++ b/tests/Feature/Providers/Anthropic/StreamingTest.php
@@ -315,6 +315,55 @@ describe('usage tracking', function (): void {
             ->cacheReadInputTokens->toBe(50);
     });
 
+    test('streaming prefers the cumulative usage reported on message delta', function (): void {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(
+                body: $this->ssePayload([
+                    [
+                        'type' => 'message_start',
+                        'message' => [
+                            'id' => 'msg_1',
+                            'model' => 'claude-sonnet-4-6',
+                            'role' => 'assistant',
+                            'content' => [],
+                            'usage' => [
+                                'input_tokens' => 2679,
+                                'output_tokens' => 3,
+                                'cache_creation_input_tokens' => 0,
+                                'cache_read_input_tokens' => 0,
+                            ],
+                        ],
+                    ],
+                    $this->contentBlockStart(0, ['type' => 'text', 'text' => '']),
+                    $this->contentBlockDelta(0, ['type' => 'text_delta', 'text' => 'Hello']),
+                    $this->contentBlockStop(0),
+                    [
+                        'type' => 'message_delta',
+                        'delta' => ['stop_reason' => 'end_turn'],
+                        'usage' => [
+                            'input_tokens' => 10682,
+                            'output_tokens' => 510,
+                            'cache_creation_input_tokens' => 25,
+                            'cache_read_input_tokens' => 75,
+                        ],
+                    ],
+                ]),
+                status: 200,
+                headers: ['Content-Type' => 'text/event-stream'],
+            ),
+        ]);
+
+        $events = $this->collectStreamEvents();
+
+        $streamEnd = array_values(array_filter($events, fn ($e) => $e instanceof StreamEnd))[0];
+
+        expect($streamEnd->usage)
+            ->promptTokens->toBe(10682)
+            ->completionTokens->toBe(510)
+            ->cacheWriteInputTokens->toBe(25)
+            ->cacheReadInputTokens->toBe(75);
+    });
+
     test('streaming tool loop emits a single stream end with accumulated usage', function (): void {
         Http::fake([
             'api.anthropic.com/*' => Http::sequence([


### PR DESCRIPTION
When using provider tools like web fetch, web search, or code execution while streaming the response, `HandlesTextStreaming` takes the initial input and cache token counts from `message_start` and only updates `output_tokens` from `message_delta`. This is usually fine for a normal response, but provider tools can have several server-side iterations, causing the cumulative input usage to increase.

The fix is to use the values from `message_delta`, which include the [cumulative total](https://platform.claude.com/docs/en/build-with-claude/streaming#:~:text=The%20token%20counts%20shown%20in%20the%20usage%20field%20of%20the%20message_delta%20event%20are%20cumulative.).